### PR TITLE
fix: add end-odometer to the create/edit load form - closes #80

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
     "seed:dev": "dotenv -e .env.development -- node scripts/seed.js",
     "debug": "node src/utils/debug.js",
     "seed": "node scripts/seed.js",
-    "start": "node src/server.js"
+    "start": "node src/server.js",
+    "start:dev": "dotenv -e .env.development -- node src/server"
   },
   "author": "Jason Delgado",
   "license": "ISC",

--- a/frontend/src/components/LoadForm.tsx
+++ b/frontend/src/components/LoadForm.tsx
@@ -84,6 +84,7 @@ const LoadForm = ({
           deadhead_miles: initialData.deadhead_miles,
           loaded_miles: initialData.loaded_miles,
           odometer_start: initialData.odometer_start ?? null,
+          odometer_end: initialData.odometer_end ?? null,
           payment_status: initialData.payment_status,
         }
       : {
@@ -856,7 +857,7 @@ const LoadForm = ({
         {/* ---- MILEAGE ---- */}
         <div className="mt-4">
           <h3 className="text-sm font-semibold mb-2">Mileage</h3>
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-2 gap-3">
             <div>
               <Label htmlFor="loaded_miles">Loaded Miles</Label>
               <Input
@@ -885,6 +886,16 @@ const LoadForm = ({
                 id="odometer_start"
                 onChange={handleChange}
                 value={formData.odometer_start ?? ""}
+              ></Input>
+            </div>
+            <div>
+              <Label htmlFor="odometer_end">Odometer End</Label>
+              <Input
+                type="number"
+                name="odometer_end"
+                id="odometer_end"
+                onChange={handleChange}
+                value={formData.odometer_end ?? ""}
               ></Input>
             </div>
           </div>

--- a/frontend/src/types/LoadInput.ts
+++ b/frontend/src/types/LoadInput.ts
@@ -22,5 +22,6 @@ export interface LoadInput {
   deadhead_miles?: number | null;
   loaded_miles?: number | null;
   odometer_start?: number | null;
+  odometer_end?: number | null;
   payment_status: string;
 }


### PR DESCRIPTION
End odometer field is properly added to both the create and edit forms. It also displays the values on the load detail page. This issue is considered closed.