### PR TITLE
feat: month-over-month deadhead metric including trip miles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,16 @@
 
 Jason is the **learner**. My job is to **teach**, not to do the work for him. He has stated repeatedly, and corrected me when I drift: he writes the code himself to stay in touch with it and to learn.
 
-## 2. My role: instructor, not code vendor
+## 2. My role: mode depends on the track
 
-**Default teaching loop:** concept → pseudocode/plan → **Jason writes the code** → I review and nudge.
+**Mode is set per track (changed 2026-07-08):**
 
-- I do **NOT** hand over finished code unless Jason **explicitly** asks ("just give me the code," "build it for me"). When he asks, I comply fully — but the default is teaching.
+- **dash (Track A) → issue-driven BUILD mode.** Jason writes a GitHub issue (the spec); we align on scope + design/formula decisions; **I build it**; we verify together that it matches intent AND that the formulas compute correctly; test on dev; ship (PR → merge) and bump the version only if warranted. I still surface design/formula decisions one at a time before building, and I never rubber-stamp my own math — the verify gate is the whole point.
+- **dts-tools (Track B) → TEACHING mode.** It's a structured learning course, so the teaching loop below governs there.
+
+**Teaching loop (Track B, and any genuinely new concept):** concept → pseudocode/plan → **Jason writes the code** → I review and nudge.
+
+- In teaching mode I do **NOT** hand over finished code unless Jason **explicitly** asks ("just give me the code," "build it for me"). When he asks, I comply fully.
 - When Jason says he wants to work through something himself, I stop supplying answers and switch to review/hint mode immediately.
 - For genuinely **new** concepts, introduce them with a small throwaway **mini-project / exercise** BEFORE applying them to real project files. (Jason has corrected me for skipping this.)
 - I review his code honestly: point out real bugs, explain the _why_, and let him fix them. No rubber-stamping.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -17,16 +17,16 @@
 
 ## CURRENT FOCUS
 
-**Active arc:** `dash` — **Trips (non-revenue miles) feature, Option B.**
-Recording non-revenue "deadhead" miles. Building it lightweight: trips used ONLY for non-revenue movements (childless trips). Loads stay untouched. The full "trip-as-parent-of-loads" model stays deferred/dormant scaffolding.
+**Active arc:** `dash` — **Wire trips into the deadhead metric + make it month-over-month.** (Trips feature SHIPPED as v1.23.0 on 2026-07-08.) The deadhead % must now (a) include trip miles in total miles, and (b) display THIS month vs LAST month for tracking. FIRST feature under the new issue-driven build workflow. (Trips model recap: childless non-revenue trips, Option B; loads untouched.)
+  - **STATUS (2026-07-08): BUILT + tested, awaiting Jason's verify + dev render-check + ship.** GitHub issue **#157**. `getMonthlyDeadhead(loads, trips)` in `dashboard.ts` → `{thisMonth, lastMonth}`; per-month: loads (delivered, both odos, delivery_date in month) + ALL trips (both odos, trip_date in month); `total = Σ load+trip windows`, `loaded = Σ load.loaded_miles`, `deadhead% = (total−loaded)/total` or null. Display (per Jason 2026-07-08): raw percentages, NOT a relative delta — KpiCard `label="Deadhead · MTD"`, value = this month %, subtext = `Last month: X%` (value colored green/red by 20% target). `invertDelta` idea was reverted (unused). DashboardPage fetches trips via `useTrips`. 13 tests pass (6 new: math, null, trips-only, cancelled/tonu excluded, delivered-unpaid included, Jan→Dec rollover). Strict build green. NOT committed. Old `getDeadheadPercent` now unused by app (still exported/tested) — prune candidate. Ship will be a `feat` → **1.24.0**.
 
-**Teaching mode:** Build-it-yourself (concept → Jason writes → review). Resumed after a deliberate "dashboard rush" where Jason temporarily asked for direct code.
+**Working mode — dash (CHANGED 2026-07-08, durable):** Issue-driven **build mode**. Loop: (1) Jason creates a GitHub issue = the spec → (2) align on scope + design/formula decisions (instructor still surfaces these one at a time, doesn't railroad) → (3) **instructor builds it** → (4) verify together: matches intent AND formulas/calcs are provably correct (instructor brings the rigor — dates, numeric-string coercion, null-for-no-data, empty/edge cases, tests with a frozen clock) → (5) test on dev → (6) ship (PR→merge) + version bump only if warranted (semver additive-vs-corrective; not every change bumps). GitHub access: `gh` CLI authed as `delgado-jason` (repo scope). **NOTE:** this overrides CLAUDE.md §2's teaching default FOR dash only. **dts-tools / Track B stays TEACHING mode** (concept → Jason writes → review) — it's a learning course, not build-for-him.
 
 ---
 
 ## PROJECT STATE SNAPSHOT
 
-### dash — current version ~1.22.0 (dashboard arc complete)
+### dash — current version 1.23.0 (trips feature shipped 2026-07-08)
 
 Shipped recently:
 
@@ -67,22 +67,26 @@ Side Course B (Python). Backend recon phase. Next queued task: `notes/comdata-re
 
 **Trip categories contract — DONE on dev (2026-07-07), NOT yet on prod.** Migration `023_add_trip_purpose.sql` (CREATE TYPE trip_purpose enum + DELETE test rows + ADD COLUMN NOT NULL) ran clean on dev. Types (`Trip`, `TripInput`) carry `trip_purpose` required/non-null. Backend: `createTrip` allowedFields + two-part validation (presence check in `validateTripCreate` + value-check rule in shared `rules`) done & `.http`-tested. **PROD MIGRATION STILL PENDING — apply at ship time alongside the code deploy; re-run `SELECT count(*) FROM loads WHERE trip_id IS NOT NULL` on PROD (must be 0) before the DELETE runs there.** NOTE: `getDeadheadPercent` NOT yet wired to trips (still backlog).
 
-**Issue #3 — Trips page: NOT STARTED (categories now defined — UNBLOCKED, ready to build).** Route + "Trips" nav item, trips list, create form WITH: category selector (`trip_purpose`, required), odometer_start + odometer_end capture, and **odometer_start auto-prefill** (must-have this version — see below). Deadhead-wiring into dashboard stays backlog.
+**Issue #3 — Trips page: BUILT on dev, awaiting Jason's manual test (2026-07-08).** ✅ Slice 1+2 (route/nav/read-path list). ✅ Slice 3 built by instructor at Jason's explicit "build it for me" request:
+- Backend: `getLatestOdometer(user_id)` service (GREATEST of MAX(odometer_end) over loads+trips) + `GET /trips/latest-odometer` route (declared BEFORE `/:id`). Added cross-field validation: `odometer_end >= odometer_start` when both present.
+- Frontend: `createTrip` + `getLatestOdometer` added to `tripsService.ts` (createTrip surfaces backend error message). New `TripForm.tsx` (date, purpose select, odo start [prefilled], odo end, is_estimated Estimated/Actual select). Wired into `TripsPage.tsx` with a "Log Trip" toggle + list refresh on success.
+- Instructor judgment calls (Jason can veto): omitted truck/driver from the form (single-truck, nullable); added is_estimated select; added the cross-field odometer rule; prefill endpoint is GLOBAL across trucks (commented for future per-truck).
+- **Dev-tested by Jason (passed). SHIPPED 2026-07-08:** commit `2cf60ef`, `feat: add trips page with create form and odometer prefill - closes #150`, PR merged, tagged **v1.23.0**, prod migration `023` completed successfully, deployed. Trips feature DONE. Next: wire trips into the deadhead metric (now the active arc). **Trips was a CONFIRMED must-have for v1. Jason opted out of coding THIS feature (instructor builds it — teaching-mode exception, like the dashboard rush). Plan: build → test on dev → ship. No keep/cut question.**
 
 **ODOMETER MODEL (clarified 2026-07-07 — corrects a prior misread by the instructor):** `getDeadheadPercent` (`frontend/src/lib/metrics/dashboard.ts:70`) is computed PER LOAD: `Σ(odometer_end − odometer_start) − Σ(loaded_miles)` over delivered loads that have both odometers. It is NOT gap-inferred between consecutive loads. Consequence: empty miles NOT tied to fetching a load (home/shop/personal/repositioning) currently FALL THROUGH — a real, uncounted gap. Trips fill that gap by carrying their OWN `odometer_start/end`. Loads + trips must TILE the odometer line (each segment's start = prior segment's end; no gaps, no overlaps) or deadhead double-counts. Wiring trips INTO the deadhead metric stays deferred (backlog), but capture odometers now so that wiring is later a pure calc change (no migration/backfill).
 
 **DEADHEAD vs REPOSITIONING (Jason's vocabulary — governs, do NOT conflate):** *deadhead* = per-load empty miles to reach the next load's pickup (the odo-delta-minus-loaded above); automatic, lives on the load, NEVER a trip — cost forced by the load taken. *repositioning* = empty miles driven to a BETTER MARKET with NO booked load being fetched; speculative; REQUIRES a logged trip to capture the odo gap; is one of the four categories.
 
-**ODOMETER PREFILL (must-have this version — data protection; Brandie also inputs):** create-trip form auto-prefills `odometer_start` from the truck's LATEST recorded odometer = `MAX(odometer_end)` across BOTH loads AND trips (NOT just the last load's drop — else back-to-back repositioning trips overlap). Open build sub-decision (settle when building the form): source it via a small backend endpoint vs. frontend-derived from already-loaded data.
+**ODOMETER PREFILL (must-have this version — data protection; Brandie also inputs):** create-trip form auto-prefills `odometer_start` from the truck's LATEST recorded odometer = `MAX(odometer_end)` across BOTH loads AND trips (NOT just the last load's drop — else back-to-back repositioning trips overlap). RESOLVED (2026-07-08): sourced via a small backend endpoint `GET /trips/latest-odometer` (authoritative in SQL; the trips page has no loads client-side to derive from).
 
 ---
 
 ## OPEN DECISIONS (resolve at next session start)
 
 1. **TRIP CATEGORIES — RESOLVED 2026-07-07.** Final list: `repositioning | home | shop | personal`, **required**, as a new `trip_purpose` ENUM + column on trips. No "Other" bucket (add ENUM values later if a real one appears; near-empty table = trivial migration). "bobtail" rejected — it's a truck *configuration* (no trailer), not a purpose; would be a separate boolean if ever needed. Vocabulary: see DEADHEAD vs REPOSITIONING in the Trips Arc section.
-   - **Build touches:** (a) migration — `trip_purpose` ENUM + column (table ~empty, no backfill); (b) backend — add to `createTrip` allowedFields + validation (required); (c) types — add to `Trip` and `TripInput`; (d) Issue #3 page WITH the category selector from the start. **NEXT STEP: Jason writes the migration.**
+   - **Build touches:** (a) migration ✅ (`023` on dev); (b) backend ✅ (allowedFields + validation, tested); (c) types ✅; (d) Issue #3 page WITH the category selector from the start — **THIS IS THE ONLY REMAINING PIECE.**
 
-2. **Version cleanup:** Jason accidentally ran `npm version minor` (without `--no-git-tag-version`) and intended to undo it. CONFIRM version is at the correct number before the next bump.
+2. **Version cleanup — RESOLVED 2026-07-08.** Verified clean: `package.json` = `1.22.0` == tag `v1.22.0` (at PR #147 outstanding-loads); no stray bump. HEAD is 7 commits past v1.22.0 (trips backend/data/purpose, untagged). Trips page ships as a `feat` → **1.23.0**.
 
 ---
 
@@ -126,6 +130,8 @@ Side Course B (Python). Backend recon phase. Next queued task: `notes/comdata-re
 
 _Append a dated entry whenever Jason requests new behavior or functionality from me. Newest at top._
 
+- **2026-07-08** — **WORKFLOW CHANGE (dash).** Jason installed + authed `gh` (repo scope) and set a new durable working method for dash: issue-driven build mode — he creates a GitHub issue, instructor builds it, they verify intent + formula correctness together, test on dev, then ship + bump version if warranted. This replaces teaching-mode-default FOR dash (see CURRENT FOCUS). Track B (dts-tools) stays teaching mode. Amended CLAUDE.md §2 (done 2026-07-08) to scope build-mode to dash (Track A) while keeping dts-tools (Track B) in teaching mode.
+- **2026-07-08** — Jason clarified: he's not interested in CODING the trips feature (not lukewarm on it — it's a MUST-HAVE). Instructor-built slice 3 per his "build it for me": `latest-odometer` endpoint + prefill, `TripForm.tsx`, page wiring, `createTrip`/`getLatestOdometer` services, cross-field odometer validation. Strict build green, not committed. Next: Jason tests on dev, then ship (prod migration `023` + deploy). No keep/cut question — it ships.
 - **2026-07-07** — Trips arc decisions locked. (1) Categories = `repositioning | home | shop | personal`, **required**, new `trip_purpose` ENUM+column, no "Other", bobtail rejected. (2) Jason's vocabulary: *repositioning* (empty move to a better market, no booked load) needs a logged trip; *deadhead* (per-load empty miles to reach the next pickup = odo delta − loaded) is automatic, NOT a trip — distinct concepts, do not conflate. (3) Instructor corrected a misread of `getDeadheadPercent` — it's per-load, NOT gap-inferred, so home/repositioning miles fall through a real gap; trips fill it via their own odometer window; loads+trips must tile. (4) Odometer_start auto-prefill from the truck's LATEST recorded odometer (max odometer_end across loads AND trips) is a MUST-HAVE this version (data protection; Brandie also inputs). Issue #3 now unblocked — next step is Jason writing the migration.
 - **2026-07-05** — Established the two-file agent system: read `MEMORY.md` first, then `CLAUDE.md`, before any action. Update `MEMORY.md`'s BEHAVIOR LOG whenever new behavior/functionality is requested. (Initial setup.)
 - **(baseline)** — Teaching contract: instructor mode (concept → Jason writes → review); no finished code unless explicitly asked; mini-project new concepts before real files; direct/no-sycophancy/minimal-formatting; recon before building; reinforce "too heavy for v1" restraint. (See CLAUDE.md.)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.24.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/dashboard.test.ts
+++ b/frontend/src/lib/metrics/dashboard.test.ts
@@ -1,13 +1,72 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Load } from "@/types/load";
+import type { Trip } from "@/types/trip";
 import {
   getRevenueMTD,
   getRevenueLastMonth,
   getRevenueYTD,
   getDeadheadPercent,
+  getMonthlyDeadhead,
   getMonthlyRevenue,
   getMonthlyRPM,
   getOutstandingLoads,
 } from "./dashboard";
+
+// ---- typed factories: override only the fields a test cares about ----
+const baseLoad: Load = {
+  load_id: "L",
+  load_number: "1",
+  load_type: "standard flatbed",
+  load_status: "delivered",
+  broker_id: "b",
+  broker: "B",
+  agent_id: "a",
+  agent: "A",
+  agent_email: null,
+  pickup_date: "2026-06-01T04:00:00.000Z",
+  origin_market_id: "m",
+  origin_city: "X",
+  origin_state: "TX",
+  origin_market: "M",
+  destination_market_id: "m2",
+  destination_city: "Y",
+  destination_state: "TN",
+  delivery_market: "M2",
+  delivery_date: "2026-06-10T04:00:00.000Z",
+  deadhead_miles: 0,
+  loaded_miles: 0,
+  linehaul: "0",
+  fuel_surcharge: "0",
+  total_accessorials: "0",
+  commodity: null,
+  odometer_start: null,
+  odometer_end: null,
+  payment_status: "unpaid",
+  created_at: "",
+  updated_at: "",
+};
+
+const baseTrip: Trip = {
+  trip_id: "T",
+  trip_number: 1,
+  trip_purpose: "repositioning",
+  truck_id: null,
+  unit_number: null,
+  driver_id: null,
+  driver_name: null,
+  trip_type: "deadhead",
+  trip_source: "user",
+  trip_date: "2026-06-10",
+  status: "completed",
+  odometer_start: null,
+  odometer_end: null,
+  is_estimated: true,
+  created_at: "",
+  updated_at: "",
+};
+
+const makeLoad = (over: Partial<Load>): Load => ({ ...baseLoad, ...over });
+const makeTrip = (over: Partial<Trip>): Trip => ({ ...baseTrip, ...over });
 
 // Freeze the clock before each test, restore the real clock after each
 beforeEach(() => {
@@ -17,6 +76,126 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+// ---- GET MONTHLY DEADHEAD TEST ---- (clock frozen to 2026-06-22 → June vs May)
+describe("getMonthlyDeadhead", () => {
+  it("computes this month and last month, counting loads AND trips", () => {
+    const loads = [
+      // June: window 500, loaded 400 → 100 empty
+      makeLoad({
+        delivery_date: "2026-06-10T04:00:00.000Z",
+        odometer_start: 100000,
+        odometer_end: 100500,
+        loaded_miles: 400,
+      }),
+      // May: window 400, loaded 400 → 0 empty
+      makeLoad({
+        delivery_date: "2026-05-12T04:00:00.000Z",
+        odometer_start: 90000,
+        odometer_end: 90400,
+        loaded_miles: 400,
+      }),
+    ];
+    const trips = [
+      // June trip: window 100, all empty
+      makeTrip({
+        trip_date: "2026-06-15",
+        odometer_start: 100500,
+        odometer_end: 100600,
+      }),
+      // May trip: window 100, all empty
+      makeTrip({
+        trip_date: "2026-05-20",
+        odometer_start: 90400,
+        odometer_end: 90500,
+      }),
+    ];
+
+    const result = getMonthlyDeadhead(loads, trips);
+    // June: total 600, loaded 400 → 200/600
+    expect(result.thisMonth).toBeCloseTo(200 / 600, 5);
+    // May: total 500, loaded 400 → 0.2
+    expect(result.lastMonth).toBeCloseTo(0.2, 5);
+  });
+
+  it("returns null for months with no qualifying miles", () => {
+    const result = getMonthlyDeadhead([], []);
+    expect(result.thisMonth).toBeNull();
+    expect(result.lastMonth).toBeNull();
+  });
+
+  it("counts trips with no loads at all as 100% empty", () => {
+    const trips = [
+      makeTrip({
+        trip_date: "2026-06-15",
+        odometer_start: 100000,
+        odometer_end: 100200,
+      }),
+    ];
+    const result = getMonthlyDeadhead([], trips);
+    expect(result.thisMonth).toBe(1);
+  });
+
+  it("includes delivered-but-unpaid loads; excludes cancelled and tonu", () => {
+    const loads = [
+      makeLoad({
+        payment_status: "unpaid",
+        odometer_start: 100000,
+        odometer_end: 100500,
+        loaded_miles: 400,
+      }),
+      makeLoad({
+        load_status: "cancelled",
+        odometer_start: 100500,
+        odometer_end: 101000,
+      }),
+      makeLoad({
+        load_status: "tonu",
+        odometer_start: 101000,
+        odometer_end: 101500,
+      }),
+    ];
+    // Only the unpaid delivered load counts: 500 window, 400 loaded → 0.2
+    const result = getMonthlyDeadhead(loads, []);
+    expect(result.thisMonth).toBeCloseTo(0.2, 5);
+  });
+
+  it("excludes trips missing an odometer reading", () => {
+    const loads = [
+      makeLoad({
+        odometer_start: 100000,
+        odometer_end: 100500,
+        loaded_miles: 400,
+      }),
+    ];
+    const trips = [
+      makeTrip({
+        trip_date: "2026-06-15",
+        odometer_start: 100500,
+        odometer_end: null, // incomplete → ignored
+      }),
+    ];
+    const result = getMonthlyDeadhead(loads, trips);
+    // trip ignored → load-only: 100/500 = 0.2
+    expect(result.thisMonth).toBeCloseTo(0.2, 5);
+  });
+
+  it("handles the January → December year rollover for last month", () => {
+    vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+    const loads = [
+      // Dec 2025: window 300, loaded 200 → 100/300
+      makeLoad({
+        delivery_date: "2025-12-20T05:00:00.000Z",
+        odometer_start: 80000,
+        odometer_end: 80300,
+        loaded_miles: 200,
+      }),
+    ];
+    const result = getMonthlyDeadhead(loads, []);
+    expect(result.thisMonth).toBeNull(); // nothing in Jan 2026
+    expect(result.lastMonth).toBeCloseTo(100 / 300, 5); // Dec 2025 found
+  });
 });
 
 // ---- GET REVENUE MTD TEST ----

--- a/frontend/src/lib/metrics/dashboard.ts
+++ b/frontend/src/lib/metrics/dashboard.ts
@@ -1,4 +1,5 @@
 import type { Load } from "@/types/load";
+import type { Trip } from "@/types/trip";
 
 const getLoadRevenue = (loads: Load[] | null): number | null => {
   if (!loads) return null;
@@ -86,6 +87,89 @@ export const getDeadheadPercent = (loads: Load[]) => {
   if (totalOdometer === 0) return null;
 
   return (totalOdometer - totalLoaded) / totalOdometer;
+};
+
+// ---- MONTHLY DEADHEAD ---- (this month vs last month, trips included)
+
+export interface MonthlyDeadhead {
+  thisMonth: number | null;
+  lastMonth: number | null;
+}
+
+// Deadhead % for a single UTC month. Empty miles = delivered loads' odometer
+// windows minus their loaded miles, PLUS every qualifying trip's full odometer
+// window (trips are 100% non-revenue). Payment status is irrelevant — only
+// load_status "delivered" ran (cancelled/tonu did not); all trip purposes count.
+// Both loads and trips need both odometer readings. Returns null when the month
+// has no qualifying miles at all.
+const deadheadForMonth = (
+  loads: Load[],
+  trips: Trip[],
+  year: number,
+  month: number,
+): number | null => {
+  const monthLoads = loads.filter(
+    (load) =>
+      load.load_status === "delivered" &&
+      load.odometer_start != null &&
+      load.odometer_end != null &&
+      load.delivery_date &&
+      new Date(load.delivery_date).getUTCFullYear() === year &&
+      new Date(load.delivery_date).getUTCMonth() === month,
+  );
+
+  const monthTrips = trips.filter(
+    (trip) =>
+      trip.odometer_start != null &&
+      trip.odometer_end != null &&
+      trip.trip_date &&
+      new Date(trip.trip_date).getUTCFullYear() === year &&
+      new Date(trip.trip_date).getUTCMonth() === month,
+  );
+
+  const loadWindow = monthLoads.reduce(
+    (sum, load) =>
+      sum + (Number(load.odometer_end) - Number(load.odometer_start)),
+    0,
+  );
+  const tripWindow = monthTrips.reduce(
+    (sum, trip) =>
+      sum + (Number(trip.odometer_end) - Number(trip.odometer_start)),
+    0,
+  );
+  const totalMiles = loadWindow + tripWindow;
+
+  const loadedMiles = monthLoads.reduce(
+    (sum, load) => sum + Number(load.loaded_miles),
+    0,
+  );
+
+  if (totalMiles === 0) return null;
+
+  return (totalMiles - loadedMiles) / totalMiles;
+};
+
+// This month's deadhead % and last month's, for the KPI comparison.
+export const getMonthlyDeadhead = (
+  loads: Load[],
+  trips: Trip[],
+): MonthlyDeadhead => {
+  const now = new Date(Date.now());
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+
+  // First-of-previous-month in UTC — handles the Jan → Dec year rollover.
+  const prev = new Date(Date.UTC(year, month - 1, 1));
+
+  return {
+    thisMonth: deadheadForMonth(loads, trips, year, month),
+    lastMonth: deadheadForMonth(
+      loads,
+      trips,
+      prev.getUTCFullYear(),
+      prev.getUTCMonth(),
+    ),
+  };
 };
 
 // ---- MONTH KEY HELPER ---- (UTC, "YYYY-MM")

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,11 +1,12 @@
 import { useLoads } from "@/hooks/useLoads";
+import { useTrips } from "@/hooks/useTrips";
 import { KpiCard } from "@/components/KpiCard";
 import { BREAK_EVEN_RPM, DEADHEAD_TARGET } from "@/lib/constants/targets";
 import {
   getRevenueMTD,
   getRevenueLastMonth,
   getRevenueYTD,
-  getDeadheadPercent,
+  getMonthlyDeadhead,
 } from "@/lib/metrics/dashboard";
 import { getAverageRPM } from "@/lib/metrics/agent";
 import { useState } from "react";
@@ -39,7 +40,19 @@ const computeDelta = (current: number | null, previous: number | null) => {
 
 const DashboardPage = () => {
   const [refreshKey] = useState(0);
-  const { loads, isLoading, error } = useLoads(refreshKey);
+  const {
+    loads,
+    isLoading: loadsLoading,
+    error: loadsError,
+  } = useLoads(refreshKey);
+  const {
+    trips,
+    isLoading: tripsLoading,
+    error: tripsError,
+  } = useTrips(refreshKey);
+
+  const isLoading = loadsLoading || tripsLoading;
+  const error = loadsError || tripsError;
 
   if (isLoading)
     return (
@@ -60,7 +73,7 @@ const DashboardPage = () => {
   const revenueLastMonth = getRevenueLastMonth(loads);
   const revenueYTD = getRevenueYTD(loads);
   const avgRpm = getAverageRPM(loads);
-  const deadhead = getDeadheadPercent(loads);
+  const deadhead = getMonthlyDeadhead(loads, trips);
 
   const mtdDelta = computeDelta(revenueMTD, revenueLastMonth);
   const monthlyRevenue = getMonthlyRevenue(loads);
@@ -71,9 +84,9 @@ const DashboardPage = () => {
   const rpmStatus =
     avgRpm === null ? "neutral" : avgRpm >= BREAK_EVEN_RPM ? "good" : "bad";
   const deadheadStatus =
-    deadhead === null
+    deadhead.thisMonth === null
       ? "neutral"
-      : deadhead <= DEADHEAD_TARGET
+      : deadhead.thisMonth <= DEADHEAD_TARGET
         ? "good"
         : "bad"; // inverted: low is good
 
@@ -100,10 +113,10 @@ const DashboardPage = () => {
           }
         />
         <KpiCard
-          label="Deadhead"
-          value={formatPercent(deadhead)}
+          label="Deadhead · MTD"
+          value={formatPercent(deadhead.thisMonth)}
           status={deadheadStatus}
-          subtext={`target ${(DEADHEAD_TARGET * 100).toFixed(0)}%`}
+          subtext={`Last month: ${formatPercent(deadhead.lastMonth)}`}
         />
       </div>
 


### PR DESCRIPTION
Closes #157.

## Summary
Wires trips into the deadhead metric and switches it to a **this-month-vs-last-month** view.

## What changed
- New pure fn `getMonthlyDeadhead(loads, trips)` → `{ thisMonth, lastMonth }`. Per month: delivered loads (both odometers, `delivery_date` in month) + **all** trips (both odometers, `trip_date` in month). `total = Σ load+trip odometer windows`, `loaded = Σ load.loaded_miles`, `deadhead% = (total − loaded)/total` (null if no miles).
- Dashboard **Deadhead · MTD** KPI shows this month's % with last month's % underneath. Now fetches trips via `useTrips`.
- 6 new unit tests (frozen clock): math, null, trips-only=100%, cancelled/tonu excluded, delivered-but-unpaid included, Jan→Dec rollover. 13/13 pass; strict build green.

## Notes
- Payment status is irrelevant to the calc (a delivered-but-unpaid load still drove the miles). `cancelled`/`tonu` excluded.
- Old all-time `getDeadheadPercent` is now unused by the app (still exported + tested) — prune candidate.
- Version bumped to 1.24.0. Second commit updates agent `CLAUDE.md`/`MEMORY.md`.