### PR TITLE
feat: monthly obligations + blended trailing per-mile metrics

### DIFF
--- a/backend/db/migrations/025_obligations.sql
+++ b/backend/db/migrations/025_obligations.sql
@@ -1,0 +1,13 @@
+-- Monthly obligations: recurring cash outflows NOT on the P&L (loan principal,
+-- owner draws) so the Expenses page can show a TRUE cash break-even alongside
+-- the accounting one. User-level + recurring (same each month) — v1 applies
+-- them uniformly to every month (not effective-dated).
+CREATE TABLE IF NOT EXISTS obligations (
+    obligation_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    label VARCHAR(100) NOT NULL,
+    amount NUMERIC(12, 2) NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/backend/src/routes/obligationRoutes.js
+++ b/backend/src/routes/obligationRoutes.js
@@ -1,0 +1,63 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import {
+  getObligations,
+  createObligation,
+  patchObligation,
+  deleteObligation,
+} from "../services/obligationServices.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+const handleError = (res, err) => {
+  if (err.type === "validation")
+    return res.status(err.statusCode).json({ error: err.message });
+  if (err.type === "not_found")
+    return res.status(err.statusCode).json({ error: err.message });
+  return res
+    .status(500)
+    .json({ error: "Internal Server Error", message: err.message });
+};
+
+router.get("/", async (req, res) => {
+  try {
+    const obligations = await getObligations(req.user.user_id);
+    return res.status(200).json({ obligations });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.post("/", async (req, res) => {
+  try {
+    const obligation = await createObligation(req.user.user_id, req.body);
+    return res.status(201).json({ obligation });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.patch("/:id", async (req, res) => {
+  try {
+    const obligation = await patchObligation(
+      req.user.user_id,
+      req.params.id,
+      req.body,
+    );
+    return res.status(200).json({ obligation });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.delete("/:id", async (req, res) => {
+  try {
+    const deleted = await deleteObligation(req.user.user_id, req.params.id);
+    return res.status(200).json({ deleted });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -18,6 +18,7 @@ import agentRouter from "./routes/agentRoutes.js";
 import marketRouter from "./routes/marketRoutes.js";
 import agentNoteRoutes from "./routes/agentNoteRoutes.js";
 import expenseRouter from "./routes/expenseRoutes.js";
+import obligationRouter from "./routes/obligationRoutes.js";
 
 const app = express();
 
@@ -43,6 +44,7 @@ app.use("/agents", agentRouter);
 app.use("/markets", marketRouter);
 app.use("/agents/:agent_id/notes", agentNoteRoutes);
 app.use("/expenses", expenseRouter);
+app.use("/obligations", obligationRouter);
 
 app.get("/", (req, res) => {
   res.send("Home Page");

--- a/backend/src/services/obligationServices.js
+++ b/backend/src/services/obligationServices.js
@@ -1,0 +1,79 @@
+import { db } from "../../db/pool.js";
+import { ValidationError, NotFoundError } from "../utils/error.js";
+
+// ---- LIST ----
+export async function getObligations(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const result = await db.query(
+    `SELECT obligation_id, label, amount, active
+     FROM obligations
+     WHERE user_id = $1
+     ORDER BY created_at`,
+    [user_id],
+  );
+  return result.rows;
+}
+
+// ---- CREATE ----
+export async function createObligation(user_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const { label, amount } = data;
+  if (!label || amount == null)
+    throw new ValidationError("label and amount are required");
+
+  const result = await db.query(
+    `INSERT INTO obligations (user_id, label, amount)
+     VALUES ($1, $2, $3)
+     RETURNING obligation_id, label, amount, active`,
+    [user_id, label, amount],
+  );
+  return result.rows[0];
+}
+
+// ---- PATCH ---- (edit label / amount / active)
+export async function patchObligation(user_id, obligation_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!obligation_id) throw new ValidationError("Missing obligation_id");
+
+  const allowedFields = ["label", "amount", "active"];
+  const updates = [];
+  const values = [];
+  let index = 1;
+  for (const field of allowedFields) {
+    if (data[field] !== undefined) {
+      updates.push(`${field} = $${index}`);
+      values.push(data[field]);
+      index++;
+    }
+  }
+  if (updates.length === 0)
+    throw new ValidationError("No valid fields to update");
+
+  updates.push(`updated_at = NOW()`);
+  values.push(obligation_id, user_id);
+
+  const result = await db.query(
+    `UPDATE obligations
+       SET ${updates.join(", ")}
+     WHERE obligation_id = $${index} AND user_id = $${index + 1}
+     RETURNING obligation_id, label, amount, active`,
+    values,
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Obligation not found");
+  return result.rows[0];
+}
+
+// ---- DELETE ----
+export async function deleteObligation(user_id, obligation_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!obligation_id) throw new ValidationError("Missing obligation_id");
+
+  const result = await db.query(
+    `DELETE FROM obligations
+     WHERE obligation_id = $1 AND user_id = $2
+     RETURNING obligation_id`,
+    [obligation_id, user_id],
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Obligation not found");
+  return result.rows[0];
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.27.0",
+  "version": "1.28.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/expenses/ObligationsCard.tsx
+++ b/frontend/src/components/expenses/ObligationsCard.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useState } from "react";
+import { Pencil, Trash2, Check, X, Plus } from "lucide-react";
+import type { Obligation } from "@/types/obligation";
+import {
+  getObligations,
+  createObligation,
+  patchObligation,
+  deleteObligation,
+} from "@/services/obligationsService";
+import { getCashMetrics } from "@/lib/metrics/expenses";
+
+interface Props {
+  operatingCost: number;
+  totalMiles: number;
+  loadedMiles: number;
+}
+
+const money = (n: number): string =>
+  `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+
+export const ObligationsCard = ({ operatingCost, totalMiles, loadedMiles }: Props) => {
+  const [items, setItems] = useState<Obligation[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [editLabel, setEditLabel] = useState("");
+  const [editAmt, setEditAmt] = useState("");
+  const [showAdd, setShowAdd] = useState(false);
+  const [newLabel, setNewLabel] = useState("");
+  const [newAmt, setNewAmt] = useState("");
+
+  const load = () => getObligations().then(setItems).catch(() => {});
+  useEffect(() => {
+    load();
+  }, []);
+
+  const run = async (fn: () => Promise<void>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await fn();
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const activeTotal = items
+    .filter((o) => o.active)
+    .reduce((s, o) => s + o.amount, 0);
+  const cash = getCashMetrics(operatingCost, activeTotal, totalMiles, loadedMiles);
+
+  return (
+    <div className="bg-plate rounded-lg p-4 mb-6">
+      <p className="text-xs text-muted-text mb-1">
+        Monthly obligations · cash out that's not on your P&amp;L
+      </p>
+      <p className="text-[11px] text-muted-text mb-3">
+        Loan <span className="text-light">principal only</span> (not the full
+        payment — interest is already counted on your P&amp;L), plus owner draws.
+      </p>
+
+      <div className="grid grid-cols-3 gap-4 mb-4">
+        <div>
+          <p className="text-xs text-muted-text">Obligations / mo</p>
+          <p className="text-xl font-condensed mt-1">{money(activeTotal)}</p>
+        </div>
+        <div>
+          <p className="text-xs text-muted-text">True cash out / mo</p>
+          <p className="text-xl font-condensed mt-1">
+            {money(cash.trueMonthlyCost)}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-muted-text">True break-even RPM</p>
+          <p className="text-xl font-condensed mt-1 text-amber">
+            {cash.trueBreakEvenRpm == null
+              ? "—"
+              : `$${cash.trueBreakEvenRpm.toFixed(2)}`}
+          </p>
+        </div>
+      </div>
+
+      <table className="w-full text-sm">
+        <tbody>
+          {items.map((o) => (
+            <tr key={o.obligation_id} className="border-t border-steel">
+              <td className="py-2">
+                {editing === o.obligation_id ? (
+                  <input
+                    className="bg-steel rounded px-2 py-1 w-full"
+                    value={editLabel}
+                    onChange={(e) => setEditLabel(e.target.value)}
+                  />
+                ) : (
+                  <span className={o.active ? "" : "opacity-40 line-through"}>
+                    {o.label}
+                  </span>
+                )}
+              </td>
+              <td className="py-2 text-right w-28">
+                {editing === o.obligation_id ? (
+                  <input
+                    className="bg-steel rounded px-2 py-1 w-24 text-right"
+                    value={editAmt}
+                    onChange={(e) => setEditAmt(e.target.value)}
+                  />
+                ) : (
+                  money(o.amount)
+                )}
+              </td>
+              <td className="py-2 text-right w-20">
+                <div className="flex gap-3 justify-end text-muted-text">
+                  {editing === o.obligation_id ? (
+                    <Check
+                      size={16}
+                      className="cursor-pointer hover:text-light"
+                      aria-label="Save"
+                      onClick={() =>
+                        run(async () => {
+                          await patchObligation(o.obligation_id, {
+                            label: editLabel,
+                            amount: Number(editAmt),
+                          });
+                          setEditing(null);
+                        })
+                      }
+                    />
+                  ) : (
+                    <Pencil
+                      size={16}
+                      className="cursor-pointer hover:text-light"
+                      aria-label="Edit"
+                      onClick={() => {
+                        setEditing(o.obligation_id);
+                        setEditLabel(o.label);
+                        setEditAmt(String(o.amount));
+                      }}
+                    />
+                  )}
+                  <Trash2
+                    size={16}
+                    className="cursor-pointer hover:text-destructive"
+                    aria-label="Delete"
+                    onClick={() =>
+                      !busy && run(() => deleteObligation(o.obligation_id))
+                    }
+                  />
+                </div>
+              </td>
+            </tr>
+          ))}
+          {showAdd ? (
+            <tr className="border-t border-steel">
+              <td className="py-2">
+                <input
+                  placeholder="e.g. Truck lease"
+                  className="bg-steel rounded px-2 py-1 w-full"
+                  value={newLabel}
+                  onChange={(e) => setNewLabel(e.target.value)}
+                />
+              </td>
+              <td className="py-2 text-right">
+                <input
+                  placeholder="0"
+                  className="bg-steel rounded px-2 py-1 w-24 text-right"
+                  value={newAmt}
+                  onChange={(e) => setNewAmt(e.target.value)}
+                />
+              </td>
+              <td className="py-2 text-right">
+                <div className="flex gap-3 justify-end text-muted-text">
+                  <Check
+                    size={16}
+                    className="cursor-pointer hover:text-light"
+                    aria-label="Add"
+                    onClick={() =>
+                      newLabel &&
+                      run(async () => {
+                        await createObligation({
+                          label: newLabel,
+                          amount: Number(newAmt),
+                        });
+                        setNewLabel("");
+                        setNewAmt("");
+                        setShowAdd(false);
+                      })
+                    }
+                  />
+                  <X
+                    size={16}
+                    className="cursor-pointer hover:text-light"
+                    aria-label="Cancel"
+                    onClick={() => setShowAdd(false)}
+                  />
+                </div>
+              </td>
+            </tr>
+          ) : (
+            <tr>
+              <td colSpan={3} className="py-2">
+                <button
+                  className="flex items-center gap-1 text-status-info-text"
+                  onClick={() => setShowAdd(true)}
+                >
+                  <Plus size={16} /> Add obligation
+                </button>
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      {error && <p className="text-destructive text-sm mt-2">{error}</p>}
+    </div>
+  );
+};

--- a/frontend/src/lib/metrics/expenses.test.ts
+++ b/frontend/src/lib/metrics/expenses.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { ExpensePeriod, ExpenseLine } from "@/types/expense";
-import { getExpenseMetrics, pctOfRevenue } from "./expenses";
+import { getExpenseMetrics, pctOfRevenue, getCashMetrics } from "./expenses";
 
 const line = (over: Partial<ExpenseLine>): ExpenseLine => ({
   line_id: "x",
@@ -65,5 +65,23 @@ describe("pctOfRevenue", () => {
     expect(pctOfRevenue(2500, 10000)).toBeCloseTo(0.25, 5);
     expect(pctOfRevenue(2500, 0)).toBeNull();
     expect(pctOfRevenue(2500, null)).toBeNull();
+  });
+});
+
+describe("getCashMetrics", () => {
+  it("adds obligations to operating cost for the true cash break-even", () => {
+    // operating cost 8000, obligations 2000 → true cash cost 10000
+    const m = getCashMetrics(8000, 2000, 10000, 8000);
+    expect(m.obligationsTotal).toBe(2000);
+    expect(m.trueMonthlyCost).toBe(10000);
+    expect(m.trueCpm).toBeCloseTo(1.0, 5); // 10000 / 10000 total miles
+    expect(m.trueBreakEvenRpm).toBeCloseTo(1.25, 5); // 10000 / 8000 loaded
+  });
+
+  it("null ratios when miles are zero; no obligations = operating cost", () => {
+    const m = getCashMetrics(8000, 0, 0, 0);
+    expect(m.trueMonthlyCost).toBe(8000);
+    expect(m.trueCpm).toBeNull();
+    expect(m.trueBreakEvenRpm).toBeNull();
   });
 });

--- a/frontend/src/lib/metrics/expenses.ts
+++ b/frontend/src/lib/metrics/expenses.ts
@@ -49,3 +49,28 @@ export const pctOfRevenue = (
   amount: number,
   income: number | null,
 ): number | null => (income && income > 0 ? amount / income : null);
+
+// Cash view: operating cost (from the P&L) PLUS recurring obligations the P&L
+// doesn't show (loan principal, owner draws). This is what he must actually
+// gross to cover, so break-even here uses true cash-out over loaded miles.
+export interface CashMetrics {
+  obligationsTotal: number;
+  trueMonthlyCost: number; // operating cost + obligations
+  trueCpm: number | null; // trueMonthlyCost / total miles
+  trueBreakEvenRpm: number | null; // trueMonthlyCost / loaded miles
+}
+
+export const getCashMetrics = (
+  operatingMonthlyCost: number,
+  obligationsTotal: number,
+  totalMiles: number,
+  loadedMiles: number,
+): CashMetrics => {
+  const trueMonthlyCost = operatingMonthlyCost + obligationsTotal;
+  return {
+    obligationsTotal,
+    trueMonthlyCost,
+    trueCpm: totalMiles > 0 ? trueMonthlyCost / totalMiles : null,
+    trueBreakEvenRpm: loadedMiles > 0 ? trueMonthlyCost / loadedMiles : null,
+  };
+};

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -10,6 +10,7 @@ import { getExpenseMetrics } from "@/lib/metrics/expenses";
 import { ExpenseUpload } from "@/components/expenses/ExpenseUpload";
 import { ExpenseLedger } from "@/components/expenses/ExpenseLedger";
 import { ExpenseYtdChart } from "@/components/expenses/ExpenseYtdChart";
+import { ObligationsCard } from "@/components/expenses/ObligationsCard";
 
 const money = (n: number): string =>
   `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
@@ -107,6 +108,33 @@ const ExpensesPage = () => {
     ? getExpenseMetrics(selected, miles.totalMiles, miles.loadedMiles)
     : null;
 
+  // Blended trailing window: sum cost + miles over the selected month and up to
+  // 2 prior, so cost/mile + break-even aren't whipped around by one noisy month.
+  // Numerator and denominator cover the same window (variable cost moves with
+  // miles, so they must). Also expose per-month averages for the cash view.
+  const trailing = useMemo(() => {
+    const idx = periods.findIndex((p) => p.period_id === selectedId);
+    const windowPeriods = idx >= 0 ? periods.slice(idx, idx + 3) : [];
+    const n = windowPeriods.length;
+    let cost = 0;
+    let total = 0;
+    let loaded = 0;
+    for (const p of windowPeriods) {
+      cost += (p.cogs_total ?? 0) + (p.expense_total ?? 0);
+      const m = monthMiles(loads, p.period_month);
+      total += m.totalMiles;
+      loaded += m.loadedMiles;
+    }
+    return {
+      months: n || 1,
+      cpm: total > 0 ? cost / total : null,
+      breakEvenRpm: loaded > 0 ? cost / loaded : null,
+      avgCost: n > 0 ? cost / n : 0,
+      avgTotalMiles: n > 0 ? total / n : 0,
+      avgLoadedMiles: n > 0 ? loaded / n : 0,
+    };
+  }, [periods, selectedId, loads]);
+
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
       <div className="flex justify-between items-center mb-6">
@@ -144,7 +172,7 @@ const ExpensesPage = () => {
         <>
           {periods.length > 1 && (
             <div className="flex gap-1 mb-4 flex-wrap">
-              {periods.map((p) => (
+              {[...periods].reverse().map((p) => (
                 <button
                   key={p.period_id}
                   onClick={() => setSelectedId(p.period_id)}
@@ -164,15 +192,15 @@ const ExpensesPage = () => {
             <Kpi label="Monthly cost" value={money(metrics.monthlyCost)} />
             <Kpi label="Weekly cost" value={money(metrics.weeklyCost)} />
             <Kpi
-              label="Cost / mile"
-              value={metrics.cpm == null ? "—" : `$${metrics.cpm.toFixed(2)}`}
+              label={`Cost / mile · ${trailing.months}mo`}
+              value={trailing.cpm == null ? "—" : `$${trailing.cpm.toFixed(2)}`}
             />
             <Kpi
-              label="Break-even RPM"
+              label={`Break-even RPM · ${trailing.months}mo`}
               value={
-                metrics.breakEvenRpm == null
+                trailing.breakEvenRpm == null
                   ? "—"
-                  : `$${metrics.breakEvenRpm.toFixed(2)}`
+                  : `$${trailing.breakEvenRpm.toFixed(2)}`
               }
             />
             <Kpi
@@ -211,6 +239,12 @@ const ExpensesPage = () => {
               </span>
             </div>
           </div>
+
+          <ObligationsCard
+            operatingCost={trailing.avgCost}
+            totalMiles={trailing.avgTotalMiles}
+            loadedMiles={trailing.avgLoadedMiles}
+          />
 
           <div className="bg-plate rounded-lg p-4 mb-6">
             <p className="text-xs text-muted-text mb-2">

--- a/frontend/src/services/obligationsService.ts
+++ b/frontend/src/services/obligationsService.ts
@@ -1,0 +1,51 @@
+import api from "./api";
+import type { Obligation } from "@/types/obligation";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const coerce = (o: any): Obligation => ({
+  obligation_id: o.obligation_id,
+  label: o.label,
+  amount: Number(o.amount),
+  active: o.active,
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export const getObligations = async (): Promise<Obligation[]> => {
+  try {
+    const res = await api.get("/obligations");
+    return res.data.obligations.map(coerce);
+  } catch {
+    throw new Error("Unable to fetch obligations");
+  }
+};
+
+export const createObligation = async (data: {
+  label: string;
+  amount: number;
+}): Promise<Obligation> => {
+  try {
+    const res = await api.post("/obligations", data);
+    return coerce(res.data.obligation);
+  } catch {
+    throw new Error("Unable to add the obligation");
+  }
+};
+
+export const patchObligation = async (
+  id: string,
+  data: Partial<{ label: string; amount: number; active: boolean }>,
+): Promise<void> => {
+  try {
+    await api.patch(`/obligations/${id}`, data);
+  } catch {
+    throw new Error("Unable to update the obligation");
+  }
+};
+
+export const deleteObligation = async (id: string): Promise<void> => {
+  try {
+    await api.delete(`/obligations/${id}`);
+  } catch {
+    throw new Error("Unable to delete the obligation");
+  }
+};

--- a/frontend/src/types/obligation.ts
+++ b/frontend/src/types/obligation.ts
@@ -1,0 +1,6 @@
+export interface Obligation {
+  obligation_id: string;
+  label: string;
+  amount: number;
+  active: boolean;
+}


### PR DESCRIPTION
Closes #165.

## Monthly obligations
Captures recurring cash outflows that never appear on the P&L — loan **principal** and owner **draws** — to compute a *true cash break-even*.

- `obligations` table (migration `025`), CRUD service + routes at `/obligations` (auth-gated, scoped to `req.user.user_id`)
- `ObligationsCard`: add / edit / delete / toggle; shows **Obligations/mo**, **True cash out/mo**, **True break-even RPM**
- Card hint spells out **principal only** — interest is already on the P&L, so adding the full loan payment would double-count it
- `getCashMetrics`: operating cost + active obligations → true break-even

## Per-mile refinements (dev feedback)
- **Cost/mile, break-even RPM, and true break-even** now blend over a **trailing 3-month window** (Σ cost ÷ Σ miles over the same window) so one noisy month can't whip them around — labeled `· Nmo`
- **Month-selector chips** now read chronologically (oldest → newest)

## Deploy
- ⚠️ **Run migration `025_obligations.sql` on prod** before/at deploy
- Deploy backend + frontend

## Test
- 54 frontend tests green; strict prod build green