### PR TITLE
feat: fold obligations into headline expense metrics + chart

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.28.0",
+  "version": "1.29.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/expenses/ExpenseYtdChart.tsx
+++ b/frontend/src/components/expenses/ExpenseYtdChart.tsx
@@ -53,10 +53,18 @@ const ChartTooltip = ({
   );
 };
 
-export const ExpenseYtdChart = ({ periods }: { periods: ExpensePeriod[] }) => {
+export const ExpenseYtdChart = ({
+  periods,
+  obligationsTotal = 0,
+}: {
+  periods: ExpensePeriod[];
+  obligationsTotal?: number;
+}) => {
+  // Obligations are a single current figure (not stored per month), so we add
+  // the same monthly total to every month — the cost line is "true cash out."
   const data: Datum[] = [...periods].reverse().map((p) => {
     const income = p.income_total ?? 0;
-    const cost = (p.cogs_total ?? 0) + (p.expense_total ?? 0);
+    const cost = (p.cogs_total ?? 0) + (p.expense_total ?? 0) + obligationsTotal;
     return {
       month: p.period_label ?? p.period_month,
       income,
@@ -69,7 +77,9 @@ export const ExpenseYtdChart = ({ periods }: { periods: ExpensePeriod[] }) => {
 
   return (
     <div className="bg-plate rounded-lg p-4" style={{ height: 280 }}>
-      <p className="text-xs text-muted-text mb-2">Revenue vs cost · year to date</p>
+      <p className="text-xs text-muted-text mb-2">
+        Revenue vs {obligationsTotal > 0 ? "true cost" : "cost"} · year to date
+      </p>
       <ResponsiveContainer width="100%" height="88%">
         <LineChart data={data} margin={{ top: 8, right: 12, bottom: 0, left: 8 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#2a3347" vertical={false} />

--- a/frontend/src/components/expenses/ObligationsCard.tsx
+++ b/frontend/src/components/expenses/ObligationsCard.tsx
@@ -1,25 +1,25 @@
-import { useEffect, useState } from "react";
-import { Pencil, Trash2, Check, X, Plus } from "lucide-react";
+import { useState } from "react";
+import { Pencil, Trash2, Check, X, Plus, Eye, EyeOff } from "lucide-react";
 import type { Obligation } from "@/types/obligation";
 import {
-  getObligations,
   createObligation,
   patchObligation,
   deleteObligation,
 } from "@/services/obligationsService";
-import { getCashMetrics } from "@/lib/metrics/expenses";
 
 interface Props {
-  operatingCost: number;
-  totalMiles: number;
-  loadedMiles: number;
+  items: Obligation[];
+  onChange: () => void; // refetch at the page level after a mutation
 }
 
 const money = (n: number): string =>
   `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
 
-export const ObligationsCard = ({ operatingCost, totalMiles, loadedMiles }: Props) => {
-  const [items, setItems] = useState<Obligation[]>([]);
+// Manages the obligations list. Their dollar/break-even impact now shows in the
+// page's headline KPIs (obligations are folded into true cost); this card is
+// where the list is edited, with a running monthly total. Toggle an obligation
+// inactive (the eye) to drop it from the numbers without deleting it.
+export const ObligationsCard = ({ items, onChange }: Props) => {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [editing, setEditing] = useState<string | null>(null);
@@ -29,17 +29,12 @@ export const ObligationsCard = ({ operatingCost, totalMiles, loadedMiles }: Prop
   const [newLabel, setNewLabel] = useState("");
   const [newAmt, setNewAmt] = useState("");
 
-  const load = () => getObligations().then(setItems).catch(() => {});
-  useEffect(() => {
-    load();
-  }, []);
-
   const run = async (fn: () => Promise<void>) => {
     setBusy(true);
     setError(null);
     try {
       await fn();
-      await load();
+      onChange();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Something went wrong");
     } finally {
@@ -50,38 +45,24 @@ export const ObligationsCard = ({ operatingCost, totalMiles, loadedMiles }: Prop
   const activeTotal = items
     .filter((o) => o.active)
     .reduce((s, o) => s + o.amount, 0);
-  const cash = getCashMetrics(operatingCost, activeTotal, totalMiles, loadedMiles);
 
   return (
     <div className="bg-plate rounded-lg p-4 mb-6">
-      <p className="text-xs text-muted-text mb-1">
-        Monthly obligations · cash out that's not on your P&amp;L
-      </p>
+      <div className="flex justify-between items-start mb-1">
+        <p className="text-xs text-muted-text">
+          Monthly obligations · cash out that's not on your P&amp;L
+        </p>
+        <p className="text-sm">
+          <span className="text-muted-text">Obligations / mo </span>
+          <span className="font-condensed">{money(activeTotal)}</span>
+        </p>
+      </div>
       <p className="text-[11px] text-muted-text mb-3">
         Loan <span className="text-light">principal only</span> (not the full
         payment — interest is already counted on your P&amp;L), plus owner draws.
+        These fold into the true cost in the KPIs above; toggle one inactive to
+        see the numbers without it.
       </p>
-
-      <div className="grid grid-cols-3 gap-4 mb-4">
-        <div>
-          <p className="text-xs text-muted-text">Obligations / mo</p>
-          <p className="text-xl font-condensed mt-1">{money(activeTotal)}</p>
-        </div>
-        <div>
-          <p className="text-xs text-muted-text">True cash out / mo</p>
-          <p className="text-xl font-condensed mt-1">
-            {money(cash.trueMonthlyCost)}
-          </p>
-        </div>
-        <div>
-          <p className="text-xs text-muted-text">True break-even RPM</p>
-          <p className="text-xl font-condensed mt-1 text-amber">
-            {cash.trueBreakEvenRpm == null
-              ? "—"
-              : `$${cash.trueBreakEvenRpm.toFixed(2)}`}
-          </p>
-        </div>
-      </div>
 
       <table className="w-full text-sm">
         <tbody>
@@ -108,10 +89,12 @@ export const ObligationsCard = ({ operatingCost, totalMiles, loadedMiles }: Prop
                     onChange={(e) => setEditAmt(e.target.value)}
                   />
                 ) : (
-                  money(o.amount)
+                  <span className={o.active ? "" : "opacity-40"}>
+                    {money(o.amount)}
+                  </span>
                 )}
               </td>
-              <td className="py-2 text-right w-20">
+              <td className="py-2 text-right w-28">
                 <div className="flex gap-3 justify-end text-muted-text">
                   {editing === o.obligation_id ? (
                     <Check
@@ -129,16 +112,43 @@ export const ObligationsCard = ({ operatingCost, totalMiles, loadedMiles }: Prop
                       }
                     />
                   ) : (
-                    <Pencil
-                      size={16}
-                      className="cursor-pointer hover:text-light"
-                      aria-label="Edit"
-                      onClick={() => {
-                        setEditing(o.obligation_id);
-                        setEditLabel(o.label);
-                        setEditAmt(String(o.amount));
-                      }}
-                    />
+                    <>
+                      {o.active ? (
+                        <Eye
+                          size={16}
+                          className="cursor-pointer hover:text-light"
+                          aria-label="Counted — click to exclude"
+                          onClick={() =>
+                            !busy &&
+                            run(() =>
+                              patchObligation(o.obligation_id, { active: false }),
+                            )
+                          }
+                        />
+                      ) : (
+                        <EyeOff
+                          size={16}
+                          className="cursor-pointer hover:text-light opacity-50"
+                          aria-label="Excluded — click to count"
+                          onClick={() =>
+                            !busy &&
+                            run(() =>
+                              patchObligation(o.obligation_id, { active: true }),
+                            )
+                          }
+                        />
+                      )}
+                      <Pencil
+                        size={16}
+                        className="cursor-pointer hover:text-light"
+                        aria-label="Edit"
+                        onClick={() => {
+                          setEditing(o.obligation_id);
+                          setEditLabel(o.label);
+                          setEditAmt(String(o.amount));
+                        }}
+                      />
+                    </>
                   )}
                   <Trash2
                     size={16}
@@ -156,7 +166,7 @@ export const ObligationsCard = ({ operatingCost, totalMiles, loadedMiles }: Prop
             <tr className="border-t border-steel">
               <td className="py-2">
                 <input
-                  placeholder="e.g. Truck lease"
+                  placeholder="e.g. Truck loan principal"
                   className="bg-steel rounded px-2 py-1 w-full"
                   value={newLabel}
                   onChange={(e) => setNewLabel(e.target.value)}

--- a/frontend/src/lib/metrics/expenses.test.ts
+++ b/frontend/src/lib/metrics/expenses.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import type { ExpensePeriod, ExpenseLine } from "@/types/expense";
-import { getExpenseMetrics, pctOfRevenue, getCashMetrics } from "./expenses";
+import {
+  getExpenseMetrics,
+  pctOfRevenue,
+  getCashMetrics,
+  getTrueMonthly,
+} from "./expenses";
 
 const line = (over: Partial<ExpenseLine>): ExpenseLine => ({
   line_id: "x",
@@ -83,5 +88,21 @@ describe("getCashMetrics", () => {
     expect(m.trueMonthlyCost).toBe(8000);
     expect(m.trueCpm).toBeNull();
     expect(m.trueBreakEvenRpm).toBeNull();
+  });
+});
+
+describe("getTrueMonthly", () => {
+  it("folds obligations into the month's cost, weekly, and margin", () => {
+    // operating 8000 + obligations 2000 = 10000 true; income 15000
+    const t = getTrueMonthly(8000, 2000, 15000);
+    expect(t.trueMonthlyCost).toBe(10000);
+    expect(t.trueWeeklyCost).toBeCloseTo(10000 / (52 / 12), 5);
+    expect(t.trueNetMargin).toBeCloseTo((15000 - 10000) / 15000, 5); // ≈0.333
+  });
+
+  it("no obligations = operating cost; null margin when income is missing", () => {
+    const t = getTrueMonthly(8000, 0, 0);
+    expect(t.trueMonthlyCost).toBe(8000);
+    expect(t.trueNetMargin).toBeNull();
   });
 });

--- a/frontend/src/lib/metrics/expenses.ts
+++ b/frontend/src/lib/metrics/expenses.ts
@@ -74,3 +74,26 @@ export const getCashMetrics = (
     trueBreakEvenRpm: loadedMiles > 0 ? trueMonthlyCost / loadedMiles : null,
   };
 };
+
+// This-month dollar figures on a TRUE-cost basis (operating + obligations).
+// Per-mile figures use the trailing blend (getCashMetrics); these dollar/margin
+// figures use this month so they reconcile with the month's P&L.
+export interface TrueMonthly {
+  trueMonthlyCost: number; // operating + obligations
+  trueWeeklyCost: number;
+  trueNetMargin: number | null; // (income − true cost) / income
+}
+
+export const getTrueMonthly = (
+  operatingMonthlyCost: number,
+  obligationsTotal: number,
+  income: number | null,
+): TrueMonthly => {
+  const trueMonthlyCost = operatingMonthlyCost + obligationsTotal;
+  const inc = income ?? 0;
+  return {
+    trueMonthlyCost,
+    trueWeeklyCost: trueMonthlyCost / WEEKS_PER_MONTH,
+    trueNetMargin: inc > 0 ? (inc - trueMonthlyCost) / inc : null,
+  };
+};

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -2,11 +2,17 @@ import { useState, useEffect, useMemo } from "react";
 import { useLoads } from "@/hooks/useLoads";
 import type { Load } from "@/types/load";
 import type { ExpensePeriod } from "@/types/expense";
+import type { Obligation } from "@/types/obligation";
 import {
   getExpensePeriods,
   getExpensePeriod,
 } from "@/services/expensesService";
-import { getExpenseMetrics } from "@/lib/metrics/expenses";
+import { getObligations } from "@/services/obligationsService";
+import {
+  getExpenseMetrics,
+  getCashMetrics,
+  getTrueMonthly,
+} from "@/lib/metrics/expenses";
 import { ExpenseUpload } from "@/components/expenses/ExpenseUpload";
 import { ExpenseLedger } from "@/components/expenses/ExpenseLedger";
 import { ExpenseYtdChart } from "@/components/expenses/ExpenseYtdChart";
@@ -54,6 +60,15 @@ const ExpensesPage = () => {
   const [selected, setSelected] = useState<ExpensePeriod | null>(null);
   const [showUpload, setShowUpload] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [obligations, setObligations] = useState<Obligation[]>([]);
+
+  // Obligations live at the page level so the headline KPIs + chart can fold
+  // them into true cost; the card just edits the list and calls this back.
+  const reloadObligations = () =>
+    getObligations().then(setObligations).catch(() => {});
+  useEffect(() => {
+    reloadObligations();
+  }, []);
 
   // Load the period list; keep the current selection if it still exists.
   useEffect(() => {
@@ -108,10 +123,9 @@ const ExpensesPage = () => {
     ? getExpenseMetrics(selected, miles.totalMiles, miles.loadedMiles)
     : null;
 
-  // Blended trailing window: sum cost + miles over the selected month and up to
-  // 2 prior, so cost/mile + break-even aren't whipped around by one noisy month.
-  // Numerator and denominator cover the same window (variable cost moves with
-  // miles, so they must). Also expose per-month averages for the cash view.
+  // Blended trailing window: average cost + miles over the selected month and
+  // up to 2 prior, so the per-mile figures aren't whipped around by one noisy
+  // month. Exposes per-month averages that the cash view divides.
   const trailing = useMemo(() => {
     const idx = periods.findIndex((p) => p.period_id === selectedId);
     const windowPeriods = idx >= 0 ? periods.slice(idx, idx + 3) : [];
@@ -127,13 +141,29 @@ const ExpensesPage = () => {
     }
     return {
       months: n || 1,
-      cpm: total > 0 ? cost / total : null,
-      breakEvenRpm: loaded > 0 ? cost / loaded : null,
       avgCost: n > 0 ? cost / n : 0,
       avgTotalMiles: n > 0 ? total / n : 0,
       avgLoadedMiles: n > 0 ? loaded / n : 0,
     };
   }, [periods, selectedId, loads]);
+
+  // Obligations folded into every headline number. Dollar figures use this
+  // month (reconcile with the month's P&L); per-mile figures use the trailing
+  // blend. obligationsTotal = 0 → these equal the operating-only numbers.
+  const obligationsTotal = useMemo(
+    () => obligations.filter((o) => o.active).reduce((s, o) => s + o.amount, 0),
+    [obligations],
+  );
+  const trueMonthly =
+    metrics && selected
+      ? getTrueMonthly(metrics.monthlyCost, obligationsTotal, selected.income_total)
+      : null;
+  const cash = getCashMetrics(
+    trailing.avgCost,
+    obligationsTotal,
+    trailing.avgTotalMiles,
+    trailing.avgLoadedMiles,
+  );
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -168,7 +198,7 @@ const ExpensesPage = () => {
         <p className="text-muted-text">
           No P&amp;L uploaded yet. Upload one to get started.
         </p>
-      ) : selected && metrics ? (
+      ) : selected && metrics && trueMonthly ? (
         <>
           {periods.length > 1 && (
             <div className="flex gap-1 mb-4 flex-wrap">
@@ -189,35 +219,44 @@ const ExpensesPage = () => {
           )}
 
           <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
-            <Kpi label="Monthly cost" value={money(metrics.monthlyCost)} />
-            <Kpi label="Weekly cost" value={money(metrics.weeklyCost)} />
+            <Kpi label="Monthly cost" value={money(trueMonthly.trueMonthlyCost)} />
+            <Kpi label="Weekly cost" value={money(trueMonthly.trueWeeklyCost)} />
             <Kpi
               label={`Cost / mile · ${trailing.months}mo`}
-              value={trailing.cpm == null ? "—" : `$${trailing.cpm.toFixed(2)}`}
+              value={cash.trueCpm == null ? "—" : `$${cash.trueCpm.toFixed(2)}`}
             />
             <Kpi
               label={`Break-even RPM · ${trailing.months}mo`}
               value={
-                trailing.breakEvenRpm == null
+                cash.trueBreakEvenRpm == null
                   ? "—"
-                  : `$${trailing.breakEvenRpm.toFixed(2)}`
+                  : `$${cash.trueBreakEvenRpm.toFixed(2)}`
               }
             />
             <Kpi
               label="Net margin"
               value={
-                metrics.netMargin == null
+                trueMonthly.trueNetMargin == null
                   ? "—"
-                  : `${(metrics.netMargin * 100).toFixed(1)}%`
+                  : `${(trueMonthly.trueNetMargin * 100).toFixed(1)}%`
               }
             />
           </div>
+          {obligationsTotal > 0 && (
+            <p className="text-[11px] text-muted-text -mt-4 mb-6">
+              Includes {money(obligationsTotal)}/mo of obligations (loan principal
+              + draws). Dollar figures are this month; per-mile figures blend the
+              last {trailing.months} month{trailing.months > 1 ? "s" : ""}.
+            </p>
+          )}
 
-          {periods.length > 1 && <ExpenseYtdChart periods={periods} />}
+          {periods.length > 1 && (
+            <ExpenseYtdChart periods={periods} obligationsTotal={obligationsTotal} />
+          )}
 
           <div className="bg-plate rounded-lg p-4 mb-6 mt-6">
             <p className="text-xs text-muted-text mb-2">
-              Fixed vs variable · {money(metrics.monthlyCost)}
+              Fixed vs variable · P&amp;L operating · {money(metrics.monthlyCost)}
             </p>
             <div className="flex h-3 rounded overflow-hidden mb-2">
               <div
@@ -238,13 +277,19 @@ const ExpensesPage = () => {
                 {money(metrics.variableTotal)}
               </span>
             </div>
+            {obligationsTotal > 0 && (
+              <p className="text-[11px] text-muted-text mt-2">
+                Operating {money(metrics.monthlyCost)} + obligations{" "}
+                {money(obligationsTotal)} ={" "}
+                <span className="text-light">
+                  {money(trueMonthly.trueMonthlyCost)}
+                </span>{" "}
+                true monthly cost
+              </p>
+            )}
           </div>
 
-          <ObligationsCard
-            operatingCost={trailing.avgCost}
-            totalMiles={trailing.avgTotalMiles}
-            loadedMiles={trailing.avgLoadedMiles}
-          />
+          <ObligationsCard items={obligations} onChange={reloadObligations} />
 
           <div className="bg-plate rounded-lg p-4 mb-6">
             <p className="text-xs text-muted-text mb-2">


### PR DESCRIPTION
Follow-up to the obligations feature (#165) from post-deploy feedback.

**Problem:** obligations only moved the "Monthly obligations" card — the headline KPIs and the revenue-vs-cost chart still showed P&L-only numbers, so adding an obligation looked like it did nothing. Jason wants **one set of numbers**: true cost = P&L operating + active obligations, everywhere.

**Change:**
- `getTrueMonthly(operating, obligations, income)` → this-month true monthly cost, weekly cost, and net margin (dollar figures stay this-month so they reconcile with the month's P&L)
- Every headline KPI now reflects true cost — Monthly/Weekly cost + Net margin via `getTrueMonthly`; Cost/mile + Break-even RPM via `getCashMetrics` over the trailing blend
- YTD chart cost line becomes **true cost** (obligations added to each month; gap = true profit)
- Reconciliation line under the fixed/variable bar: `operating + obligations = true monthly cost`
- `ObligationsCard` slimmed to a list manager (the true-cash numbers moved to the headline) + gained a real **active toggle** (eye icon) so an obligation can be excluded without deleting it
- `obligations = 0` → numbers identical to before (no regression)

**Test:** 56 frontend tests green; strict prod build green. Verified on dev.

Frontend-only — **no migration**.