### PR TITLE
feat: live rate & pace targets — retire hardcoded break-even

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.29.0",
+  "version": "1.30.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/RateLadder.tsx
+++ b/frontend/src/components/dashboard/RateLadder.tsx
@@ -1,0 +1,78 @@
+import type { RateLadder as Ladder } from "@/lib/metrics/rateTargets";
+
+interface Props {
+  ladder: Ladder;
+  rpm: number | null; // your current rate — the marker
+}
+
+const RED = "#e24b4a";
+const AMBER = "#e8940a";
+const GREEN = "#1d9e75";
+const TRACK = "#232c3f";
+
+const rate = (n: number | null): string => (n == null ? "—" : `$${n.toFixed(2)}`);
+
+// Horizontal ladder from walk-away → strong, split at the target tier. A marker
+// shows where the current rate lands: red at/below walk-away (losing money),
+// amber below target, green at/above target.
+export const RateLadder = ({ ladder, rpm }: Props) => {
+  const { walkAway, target, strong } = ladder;
+  if (walkAway == null || target == null || strong == null) return null;
+
+  const span = strong - walkAway;
+  const targetPos = span > 0 ? ((target - walkAway) / span) * 100 : 58;
+  const markerPos =
+    rpm == null || span <= 0
+      ? null
+      : Math.max(0, Math.min(1, (rpm - walkAway) / span)) * 100;
+  const markerColor =
+    rpm == null ? AMBER : rpm >= target ? GREEN : rpm <= walkAway ? RED : AMBER;
+
+  return (
+    <div>
+      {markerPos != null && (
+        <div className="relative h-4 mb-1 text-xs">
+          <div
+            className="absolute whitespace-nowrap font-condensed"
+            style={{
+              left: `${markerPos}%`,
+              transform: "translateX(-50%)",
+              color: markerColor,
+            }}
+          >
+            you {rate(rpm)} ▼
+          </div>
+        </div>
+      )}
+
+      <div
+        className="flex h-3 rounded overflow-hidden"
+        style={{ background: TRACK }}
+      >
+        <div style={{ width: `${targetPos}%`, background: AMBER, opacity: 0.55 }} />
+        <div style={{ flex: 1, background: GREEN, opacity: 0.55 }} />
+      </div>
+
+      <div className="relative h-8 mt-1 text-xs text-muted-text">
+        <span className="absolute left-0">
+          walk-away
+          <br />
+          <span className="text-light">{rate(walkAway)}</span>
+        </span>
+        <span
+          className="absolute text-center"
+          style={{ left: `${targetPos}%`, transform: "translateX(-50%)" }}
+        >
+          target
+          <br />
+          <span className="text-light">{rate(target)}</span>
+        </span>
+        <span className="absolute right-0 text-right">
+          strong
+          <br />
+          <span className="text-light">{rate(strong)}</span>
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -1,0 +1,102 @@
+import type { useRateTargets } from "@/hooks/useRateTargets";
+import { RateLadder } from "./RateLadder";
+
+type Targets = ReturnType<typeof useRateTargets>;
+
+const RED = "#e24b4a";
+const AMBER = "#e8940a";
+const GREEN = "#1d9e75";
+const TRACK = "#232c3f";
+
+const money = (n: number | null): string =>
+  n == null ? "—" : `$${Math.round(n).toLocaleString("en-US")}`;
+
+// This week's booked gross against its floor (break-even) and target ticks.
+const PaceBar = ({
+  booked,
+  floor,
+  target,
+}: {
+  booked: number;
+  floor: number;
+  target: number;
+}) => {
+  const fill = target > 0 ? Math.max(0, Math.min(1, booked / target)) : 0;
+  const floorPos = target > 0 ? Math.min(1, floor / target) : 0;
+  const color = booked >= target ? GREEN : booked >= floor ? AMBER : RED;
+  return (
+    <div className="relative h-2 rounded mt-2 mb-1" style={{ background: TRACK }}>
+      <div
+        className="absolute left-0 top-0 h-2 rounded"
+        style={{ width: `${fill * 100}%`, background: color }}
+      />
+      <div
+        className="absolute top-0 h-2"
+        style={{ left: `${floorPos * 100}%`, width: 2, background: "#ebedf5" }}
+        title="break-even floor"
+      />
+    </div>
+  );
+};
+
+export const RateTargetsCard = ({
+  targets,
+  rpm,
+}: {
+  targets: Targets;
+  rpm?: number | null; // "your rate" marker; defaults to the recent-window rate
+}) => {
+  const { ladder, gross, weekBooked, basis, ready } = targets;
+  const markerRpm = rpm !== undefined ? rpm : basis.windowRpm;
+
+  return (
+    <div className="bg-plate rounded-lg p-4">
+      <div className="flex justify-between items-baseline mb-3">
+        <p className="text-sm font-medium text-light">Rate &amp; pace targets</p>
+        <p className="text-xs text-muted-text">
+          {ready
+            ? `live · last ${basis.months} complete month${basis.months > 1 ? "s" : ""}`
+            : "needs P&L history"}
+        </p>
+      </div>
+
+      {!ready ? (
+        <p className="text-sm text-muted-text py-4">
+          Upload a few months of P&amp;L on the Expenses page to unlock your live
+          rate targets.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-[1.6fr_1fr_1fr] gap-6">
+          <div>
+            <p className="text-xs text-muted-text mb-3">Rate per loaded mile</p>
+            <RateLadder ladder={ladder} rpm={markerRpm} />
+          </div>
+
+          <div>
+            <p className="text-xs text-muted-text">This week · booked</p>
+            <p className="text-xl font-condensed mt-1">{money(weekBooked)}</p>
+            <PaceBar
+              booked={weekBooked}
+              floor={gross.weeklyBreakEven ?? 0}
+              target={gross.weeklyTarget ?? 0}
+            />
+            <p className="text-xs text-muted-text">
+              floor {money(gross.weeklyBreakEven)} · target{" "}
+              {money(gross.weeklyTarget)}
+            </p>
+          </div>
+
+          <div>
+            <p className="text-xs text-muted-text">Daily rate target</p>
+            <p className="text-xl font-condensed mt-1" style={{ color: GREEN }}>
+              {money(gross.dailyTarget)}
+            </p>
+            <p className="text-xs text-muted-text mt-1">
+              break-even {money(gross.dailyBreakEven)}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useRateTargets.ts
+++ b/frontend/src/hooks/useRateTargets.ts
@@ -1,0 +1,68 @@
+import { useState, useEffect, useMemo } from "react";
+import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+import type { Obligation } from "@/types/obligation";
+import { getExpensePeriods } from "@/services/expensesService";
+import { getObligations } from "@/services/obligationsService";
+import {
+  getCostBasis,
+  getRateLadder,
+  getGrossTargets,
+  payWeekRange,
+  getWeekBookedGross,
+} from "@/lib/metrics/rateTargets";
+import {
+  RATE_TIERS,
+  WORKING_DAYS_PER_MONTH,
+  PAY_WEEK_START_DOW,
+} from "@/lib/constants/targets";
+
+// Assembles the rate ladder + weekly/daily pace targets from the P&L,
+// obligations, and loads. Break-even is blended over the last 3 complete
+// months (see getCostBasis); everything hangs off that true cost.
+export const useRateTargets = (loads: Load[]) => {
+  const [periods, setPeriods] = useState<ExpensePeriod[]>([]);
+  const [obligations, setObligations] = useState<Obligation[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    Promise.all([
+      getExpensePeriods().catch(() => [] as ExpensePeriod[]),
+      getObligations().catch(() => [] as Obligation[]),
+    ]).then(([ps, obs]) => {
+      if (!active) return;
+      setPeriods(ps);
+      setObligations(obs);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const obligationsMonthly = useMemo(
+    () => obligations.filter((o) => o.active).reduce((s, o) => s + o.amount, 0),
+    [obligations],
+  );
+
+  return useMemo(() => {
+    const now = new Date();
+    const basis = getCostBasis(periods, obligationsMonthly, loads, now);
+    const ladder = getRateLadder(basis.breakEvenRpm, RATE_TIERS);
+    const gross = getGrossTargets(
+      basis.trueMonthlyCost,
+      RATE_TIERS.target,
+      WORKING_DAYS_PER_MONTH,
+    );
+    const { start, end } = payWeekRange(now, PAY_WEEK_START_DOW);
+    const weekBooked = getWeekBookedGross(loads, start, end);
+    return {
+      basis,
+      ladder,
+      gross,
+      weekBooked,
+      weekStart: start,
+      weekEnd: end,
+      ready: basis.breakEvenRpm != null,
+    };
+  }, [periods, obligationsMonthly, loads]);
+};

--- a/frontend/src/lib/constants/targets.ts
+++ b/frontend/src/lib/constants/targets.ts
@@ -1,7 +1,20 @@
 // Operational targets / thresholds for dashboard profitability lenses.
-// IMPORTANT: BREAK_EVEN_RPM must be your all-in COST per mile (from CPM analysis),
-// NOT a revenue figure. RPM above this = profitable; below = losing money.
-export const BREAK_EVEN_RPM = 2.96; // TODO: confirm this is cost-per-mile, not revenue RPM
+// BREAK_EVEN_RPM is now derived live (true cost ÷ loaded miles over the last 3
+// complete months — see lib/metrics/rateTargets). This constant is only a
+// fallback for when there's not enough P&L history to compute it yet.
+export const BREAK_EVEN_RPM = 2.96;
 
 // Deadhead target: fraction of miles that are empty. Lower is better.
 export const DEADHEAD_TARGET = 0.2; // 20%
+
+// Rate tiers = markup OVER the break-even (walk-away) rate — a load at the
+// break-even rate makes $0; each tier adds margin on top. Matches Jason's ops
+// sheet (walk-away × 1.15 / 1.35 / 1.60).
+export const RATE_TIERS = { minimum: 0.15, target: 0.35, strong: 0.6 } as const;
+
+// Gross-pace targets: working days per month for the daily rate.
+export const WORKING_DAYS_PER_MONTH = 22;
+
+// Pay week runs Wednesday → Tuesday. Day-of-week index, 0=Sun … 6=Sat.
+// TODO: move to a per-user settings page (planned) so this isn't hard-coded.
+export const PAY_WEEK_START_DOW = 3; // Wednesday

--- a/frontend/src/lib/metrics/rateTargets.test.ts
+++ b/frontend/src/lib/metrics/rateTargets.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+import {
+  completeMonthsBefore,
+  getCostBasis,
+  getRateLadder,
+  getGrossTargets,
+  payWeekRange,
+  getWeekBookedGross,
+} from "./rateTargets";
+
+const load = (over: Partial<Load>): Load =>
+  ({
+    load_id: "l",
+    load_number: "1",
+    load_status: "delivered",
+    delivery_date: "2026-05-15",
+    loaded_miles: 1000,
+    odometer_start: 0,
+    odometer_end: 1200,
+    linehaul: "2000",
+    fuel_surcharge: "0",
+    total_accessorials: "0",
+    ...over,
+  }) as Load;
+
+const period = (month: string, cogs: number, expense: number): ExpensePeriod => ({
+  period_id: month,
+  period_month: month,
+  period_label: month,
+  income_total: null,
+  cogs_total: cogs,
+  expense_total: expense,
+});
+
+describe("completeMonthsBefore", () => {
+  it("excludes the current month and returns the 3 prior", () => {
+    const months = completeMonthsBefore(new Date("2026-07-09T00:00:00Z"), 3);
+    expect(months).toEqual([
+      { year: 2026, month: 3 }, // Apr
+      { year: 2026, month: 4 }, // May
+      { year: 2026, month: 5 }, // Jun
+    ]);
+  });
+
+  it("rolls over the year boundary", () => {
+    const months = completeMonthsBefore(new Date("2026-02-10T00:00:00Z"), 3);
+    expect(months).toEqual([
+      { year: 2025, month: 10 }, // Nov
+      { year: 2025, month: 11 }, // Dec
+      { year: 2026, month: 0 }, // Jan
+    ]);
+  });
+});
+
+describe("getCostBasis", () => {
+  const now = new Date("2026-07-09T00:00:00Z");
+
+  it("blends true cost + miles over the 3 complete prior months", () => {
+    const periods = [
+      period("2026-04-01", 5000, 5000), // 10k operating
+      period("2026-05-01", 5000, 5000),
+      period("2026-06-01", 5000, 5000),
+    ];
+    const loads = [
+      load({ delivery_date: "2026-04-15", loaded_miles: 2000, odometer_start: 0, odometer_end: 2500, linehaul: "8000" }),
+      load({ delivery_date: "2026-05-15", loaded_miles: 2000, odometer_start: 0, odometer_end: 2500, linehaul: "8000" }),
+      load({ delivery_date: "2026-06-15", loaded_miles: 2000, odometer_start: 0, odometer_end: 2500, linehaul: "8000" }),
+      // current + future month loads must be ignored
+      load({ delivery_date: "2026-07-15", loaded_miles: 9999, linehaul: "99999" }),
+    ];
+    // obligations 2000/mo → true monthly = 10k + 2k = 12k
+    const b = getCostBasis(periods, 2000, loads, now);
+    expect(b.months).toBe(3);
+    expect(b.trueMonthlyCost).toBeCloseTo(12000, 5);
+    expect(b.loadedMiles).toBe(6000); // 3 × 2000
+    expect(b.totalMiles).toBe(7500); // 3 × 2500
+    // walk-away = total true cost (36k) / loaded (6000) = 6.00
+    expect(b.breakEvenRpm).toBeCloseTo(6.0, 5);
+    // your rate = revenue (24k) / loaded (6000) = 4.00
+    expect(b.windowRpm).toBeCloseTo(4.0, 5);
+  });
+
+  it("skips months with no P&L, keeping cost and miles aligned", () => {
+    const periods = [period("2026-05-01", 5000, 5000)]; // only May
+    const loads = [
+      load({ delivery_date: "2026-04-15", loaded_miles: 5000 }), // Apr miles ignored (no P&L)
+      load({ delivery_date: "2026-05-15", loaded_miles: 2000, linehaul: "8000" }),
+    ];
+    const b = getCostBasis(periods, 0, loads, now);
+    expect(b.months).toBe(1);
+    expect(b.loadedMiles).toBe(2000); // only May
+    expect(b.breakEvenRpm).toBeCloseTo(10000 / 2000, 5); // 5.00
+  });
+
+  it("null break-even when there's no P&L history", () => {
+    const b = getCostBasis([], 0, [], now);
+    expect(b.months).toBe(0);
+    expect(b.trueMonthlyCost).toBeNull();
+    expect(b.breakEvenRpm).toBeNull();
+  });
+});
+
+describe("getRateLadder", () => {
+  it("marks up the walk-away by each tier", () => {
+    const l = getRateLadder(4, { minimum: 0.15, target: 0.35, strong: 0.6 });
+    expect(l.walkAway).toBe(4);
+    expect(l.minimum).toBeCloseTo(4.6, 5);
+    expect(l.target).toBeCloseTo(5.4, 5);
+    expect(l.strong).toBeCloseTo(6.4, 5);
+  });
+
+  it("all null when break-even is unknown", () => {
+    const l = getRateLadder(null, { minimum: 0.15, target: 0.35, strong: 0.6 });
+    expect(l.walkAway).toBeNull();
+    expect(l.target).toBeNull();
+  });
+});
+
+describe("getGrossTargets", () => {
+  it("weekly + daily floors and target-markup", () => {
+    const g = getGrossTargets(26000, 0.35, 22);
+    expect(g.weeklyBreakEven).toBeCloseTo(26000 / (52 / 12), 5); // 6000
+    expect(g.weeklyTarget).toBeCloseTo((26000 / (52 / 12)) * 1.35, 5);
+    expect(g.dailyBreakEven).toBeCloseTo(26000 / 22, 5);
+    expect(g.dailyTarget).toBeCloseTo((26000 / 22) * 1.35, 5);
+  });
+
+  it("null when there's no cost basis", () => {
+    const g = getGrossTargets(null, 0.35, 22);
+    expect(g.weeklyBreakEven).toBeNull();
+    expect(g.dailyTarget).toBeNull();
+  });
+});
+
+describe("payWeekRange", () => {
+  it("runs Wednesday → the next Wednesday (Wed–Tue inclusive)", () => {
+    // 2026-07-09 is a Thursday → pay week started Wed 2026-07-08
+    const { start, end } = payWeekRange(new Date("2026-07-09T12:00:00Z"), 3);
+    expect(start.getUTCDay()).toBe(3); // Wednesday
+    expect(start.toISOString().slice(0, 10)).toBe("2026-07-08");
+    expect(end.toISOString().slice(0, 10)).toBe("2026-07-15");
+    const days = (end.getTime() - start.getTime()) / 86_400_000;
+    expect(days).toBe(7);
+  });
+
+  it("on the start day itself, the week starts today", () => {
+    // 2026-07-08 is a Wednesday
+    const { start } = payWeekRange(new Date("2026-07-08T00:00:00Z"), 3);
+    expect(start.toISOString().slice(0, 10)).toBe("2026-07-08");
+  });
+});
+
+describe("getWeekBookedGross", () => {
+  const start = new Date("2026-07-08T00:00:00Z");
+  const end = new Date("2026-07-15T00:00:00Z");
+
+  it("sums booked + in-transit + delivered in range, excludes cancelled and out-of-range", () => {
+    const loads = [
+      load({ delivery_date: "2026-07-08", load_status: "delivered", linehaul: "1000" }),
+      load({ delivery_date: "2026-07-10", load_status: "booked", linehaul: "2000" }),
+      load({ delivery_date: "2026-07-14", load_status: "in_transit", linehaul: "3000" }),
+      load({ delivery_date: "2026-07-15", load_status: "booked", linehaul: "9999" }), // end is exclusive
+      load({ delivery_date: "2026-07-10", load_status: "cancelled", linehaul: "9999" }),
+      load({ delivery_date: "2026-07-01", load_status: "delivered", linehaul: "9999" }), // before range
+    ];
+    expect(getWeekBookedGross(loads, start, end)).toBeCloseTo(6000, 5);
+  });
+});

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -1,0 +1,194 @@
+import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+
+// Rate & pace targets, all derived live from the P&L + loads. Pure functions
+// take `now` explicitly so they're testable without touching the clock.
+
+// Load gross revenue = linehaul + fuel surcharge + accessorials (NUMERIC strings).
+export const loadRevenue = (l: Load): number =>
+  Number(l.linehaul) + Number(l.fuel_surcharge) + Number(l.total_accessorials);
+
+// The `count` COMPLETE calendar months before now's month (excludes the
+// in-progress current month — its miles lag its cost and would inflate $/mile).
+// now = 2026-07-xx, count = 3 → [Apr, May, Jun] 2026.
+export const completeMonthsBefore = (
+  now: Date,
+  count: number,
+): { year: number; month: number }[] => {
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth();
+  const out: { year: number; month: number }[] = [];
+  for (let i = count; i >= 1; i--) {
+    const d = new Date(Date.UTC(y, m - i, 1));
+    out.push({ year: d.getUTCFullYear(), month: d.getUTCMonth() });
+  }
+  return out;
+};
+
+// Delivered-load miles for one UTC month: total = odometer window, loaded =
+// loaded_miles. Mirrors the Expenses page's month-miles logic.
+const monthMiles = (loads: Load[], year: number, month: number) => {
+  const inMonth = loads.filter(
+    (l) =>
+      l.load_status === "delivered" &&
+      l.delivery_date &&
+      new Date(l.delivery_date).getUTCFullYear() === year &&
+      new Date(l.delivery_date).getUTCMonth() === month,
+  );
+  const total = inMonth.reduce(
+    (s, l) =>
+      s +
+      (l.odometer_end != null && l.odometer_start != null
+        ? Number(l.odometer_end) - Number(l.odometer_start)
+        : 0),
+    0,
+  );
+  const loaded = inMonth.reduce((s, l) => s + Number(l.loaded_miles || 0), 0);
+  const revenue = inMonth.reduce((s, l) => s + loadRevenue(l), 0);
+  return { total, loaded, revenue };
+};
+
+export interface CostBasis {
+  trueMonthlyCost: number | null; // avg monthly true cost over included months
+  loadedMiles: number; // summed over included months
+  totalMiles: number;
+  breakEvenRpm: number | null; // true cost ÷ loaded miles = the walk-away rate
+  windowRpm: number | null; // revenue ÷ loaded miles over the window (your rate)
+  months: number; // months with a P&L that were actually included
+}
+
+// Blend true cost + miles over the last `monthsBack` COMPLETE months. Only
+// months that have a P&L are counted, and their miles are summed over the SAME
+// months, so numerator and denominator always cover the same window.
+export const getCostBasis = (
+  periods: ExpensePeriod[],
+  obligationsMonthly: number,
+  loads: Load[],
+  now: Date,
+  monthsBack = 3,
+): CostBasis => {
+  const byKey = new Map<string, ExpensePeriod>();
+  for (const p of periods) {
+    const d = new Date(p.period_month);
+    byKey.set(`${d.getUTCFullYear()}-${d.getUTCMonth()}`, p);
+  }
+
+  let cost = 0;
+  let loaded = 0;
+  let total = 0;
+  let revenue = 0;
+  let n = 0;
+  for (const { year, month } of completeMonthsBefore(now, monthsBack)) {
+    const p = byKey.get(`${year}-${month}`);
+    if (!p) continue; // no P&L for this month → skip cost AND miles (stay aligned)
+    n++;
+    cost += (p.cogs_total ?? 0) + (p.expense_total ?? 0) + obligationsMonthly;
+    const m = monthMiles(loads, year, month);
+    loaded += m.loaded;
+    total += m.total;
+    revenue += m.revenue;
+  }
+
+  return {
+    trueMonthlyCost: n > 0 ? cost / n : null,
+    loadedMiles: loaded,
+    totalMiles: total,
+    breakEvenRpm: loaded > 0 ? cost / loaded : null,
+    windowRpm: loaded > 0 ? revenue / loaded : null,
+    months: n,
+  };
+};
+
+export interface RateTiers {
+  minimum: number;
+  target: number;
+  strong: number;
+}
+
+export interface RateLadder {
+  walkAway: number | null; // break-even per loaded mile — below this you lose money
+  minimum: number | null;
+  target: number | null;
+  strong: number | null;
+}
+
+// Tiers are markups over the walk-away (break-even) rate.
+export const getRateLadder = (
+  breakEvenRpm: number | null,
+  tiers: RateTiers,
+): RateLadder => {
+  if (breakEvenRpm == null)
+    return { walkAway: null, minimum: null, target: null, strong: null };
+  return {
+    walkAway: breakEvenRpm,
+    minimum: breakEvenRpm * (1 + tiers.minimum),
+    target: breakEvenRpm * (1 + tiers.target),
+    strong: breakEvenRpm * (1 + tiers.strong),
+  };
+};
+
+const WEEKS_PER_MONTH = 52 / 12;
+
+export interface GrossTargets {
+  weeklyBreakEven: number | null; // gross needed to cover true cost
+  weeklyTarget: number | null; // + target-tier markup
+  dailyBreakEven: number | null;
+  dailyTarget: number | null;
+}
+
+export const getGrossTargets = (
+  trueMonthlyCost: number | null,
+  targetTier: number,
+  workingDaysPerMonth: number,
+): GrossTargets => {
+  if (trueMonthlyCost == null || trueMonthlyCost <= 0)
+    return {
+      weeklyBreakEven: null,
+      weeklyTarget: null,
+      dailyBreakEven: null,
+      dailyTarget: null,
+    };
+  const weekly = trueMonthlyCost / WEEKS_PER_MONTH;
+  const daily = trueMonthlyCost / workingDaysPerMonth;
+  return {
+    weeklyBreakEven: weekly,
+    weeklyTarget: weekly * (1 + targetTier),
+    dailyBreakEven: daily,
+    dailyTarget: daily * (1 + targetTier),
+  };
+};
+
+// [start, end) UTC for the pay week containing `now`. startDow: 0=Sun … 6=Sat.
+export const payWeekRange = (
+  now: Date,
+  startDow: number,
+): { start: Date; end: Date } => {
+  const d = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const diff = (d.getUTCDay() - startDow + 7) % 7;
+  const start = new Date(d);
+  start.setUTCDate(d.getUTCDate() - diff);
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 7);
+  return { start, end };
+};
+
+// Gross of every non-cancelled load delivering in [start, end) — booked,
+// in-transit, and delivered all count, so mid-week shows committed + earned.
+export const getWeekBookedGross = (
+  loads: Load[],
+  start: Date,
+  end: Date,
+): number => {
+  let sum = 0;
+  for (const l of loads) {
+    if (l.load_status === "cancelled" || !l.delivery_date) continue;
+    const dd = new Date(l.delivery_date);
+    const day = new Date(
+      Date.UTC(dd.getUTCFullYear(), dd.getUTCMonth(), dd.getUTCDate()),
+    );
+    if (day >= start && day < end) sum += loadRevenue(l);
+  }
+  return sum;
+};

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -17,6 +17,8 @@ import {
   getRecentDeliveredLoads,
 } from "@/lib/metrics/dashboard";
 import { getAverageRPM } from "@/lib/metrics/agent";
+import { useRateTargets } from "@/hooks/useRateTargets";
+import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
 import { RevenueChart } from "@/components/RevenueChart";
 import { RpmChart } from "@/components/RpmChart";
 import { OutstandingLoadsList } from "@/components/OutstandingLoadsList";
@@ -59,6 +61,7 @@ const DashboardPage = () => {
     isLoading: tripsLoading,
     error: tripsError,
   } = useTrips(refreshKey);
+  const targets = useRateTargets(loads);
 
   const isLoading = loadsLoading || tripsLoading;
   const error = loadsError || tripsError;
@@ -98,8 +101,11 @@ const DashboardPage = () => {
   const alerts: Alert[] = [];
 
   // ---- threshold-based status ----
+  // Live break-even (true cost ÷ loaded miles, last 3 complete months); falls
+  // back to the constant until there's enough P&L history.
+  const liveBreakEven = targets.ladder.walkAway ?? BREAK_EVEN_RPM;
   const rpmStatus =
-    avgRpm === null ? "neutral" : avgRpm >= BREAK_EVEN_RPM ? "good" : "bad";
+    avgRpm === null ? "neutral" : avgRpm >= liveBreakEven ? "good" : "bad";
   const deadheadStatus =
     deadhead.thisMonth === null
       ? "neutral"
@@ -128,7 +134,7 @@ const DashboardPage = () => {
           subtext={
             avgRpm === null
               ? undefined
-              : `${avgRpm >= BREAK_EVEN_RPM ? "above" : "below"} $${BREAK_EVEN_RPM.toFixed(2)} break-even`
+              : `${avgRpm >= liveBreakEven ? "above" : "below"} $${liveBreakEven.toFixed(2)} break-even`
           }
         />
         <KpiCard
@@ -142,6 +148,11 @@ const DashboardPage = () => {
           value={String(loadsMonthly.thisMonth)}
           delta={loadsDelta}
         />
+      </div>
+
+      {/* Rate & pace targets */}
+      <div className="mt-6">
+        <RateTargetsCard targets={targets} rpm={avgRpm} />
       </div>
 
       {/* Revenue chart + top agents */}
@@ -160,7 +171,7 @@ const DashboardPage = () => {
       {/* RPM chart + what's next */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-6">
         <div className="lg:col-span-2">
-          <RpmChart data={monthlyRpm} breakEven={BREAK_EVEN_RPM} />
+          <RpmChart data={monthlyRpm} breakEven={liveBreakEven} />
         </div>
         <div className="bg-plate rounded-lg p-4">
           <p className="text-xs text-muted-text mb-2">What's next · booked</p>

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -13,6 +13,9 @@ import {
   getCashMetrics,
   getTrueMonthly,
 } from "@/lib/metrics/expenses";
+import { getCostBasis, getRateLadder } from "@/lib/metrics/rateTargets";
+import { RATE_TIERS } from "@/lib/constants/targets";
+import { RateLadder } from "@/components/dashboard/RateLadder";
 import { ExpenseUpload } from "@/components/expenses/ExpenseUpload";
 import { ExpenseLedger } from "@/components/expenses/ExpenseLedger";
 import { ExpenseYtdChart } from "@/components/expenses/ExpenseYtdChart";
@@ -165,6 +168,14 @@ const ExpensesPage = () => {
     trailing.avgLoadedMiles,
   );
 
+  // Rate targets anchored to today (last 3 complete months, NOT the selected
+  // month) — forward pricing guidance, same basis as the dashboard card.
+  const rateBasis = useMemo(
+    () => getCostBasis(periods, obligationsTotal, loads, new Date()),
+    [periods, obligationsTotal, loads],
+  );
+  const rateLadder = getRateLadder(rateBasis.breakEvenRpm, RATE_TIERS);
+
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
       <div className="flex justify-between items-center mb-6">
@@ -248,6 +259,16 @@ const ExpensesPage = () => {
               + draws). Dollar figures are this month; per-mile figures blend the
               last {trailing.months} month{trailing.months > 1 ? "s" : ""}.
             </p>
+          )}
+
+          {rateLadder.walkAway != null && (
+            <div className="bg-plate rounded-lg p-4 mb-6">
+              <p className="text-xs text-muted-text mb-3">
+                Rate targets · per loaded mile · last {rateBasis.months} complete
+                month{rateBasis.months > 1 ? "s" : ""}
+              </p>
+              <RateLadder ladder={rateLadder} rpm={rateBasis.windowRpm} />
+            </div>
           )}
 
           {periods.length > 1 && (


### PR DESCRIPTION
Turns Jason's ops-sheet rate targets into live, self-updating dashboard metrics and retires the hardcoded `$2.96` break-even.

## Engine (`lib/metrics/rateTargets.ts`, pure, `now`-injected)
- `getCostBasis` — break-even = true cost (operating + active obligations) ÷ loaded miles, blended over the **last 3 complete months** (excludes the in-progress month; only months with a P&L are counted so cost and miles stay aligned)
- `getRateLadder` — walk-away / minimum / target / strong = break-even × 1.15 / 1.35 / 1.60
- `getGrossTargets` — weekly (÷ 4.333) + daily (÷ 22) break-even floors and 35% target markups
- `payWeekRange` — **Wed → Tue** via `PAY_WEEK_START_DOW` (one constant, ready to move to a settings page)
- `getWeekBookedGross` — Σ rate of non-cancelled loads delivering this pay week (booked + in-transit + delivered), so mid-week shows committed + earned

## UI
- **Dashboard** — new "Rate & pace targets" card under the KPI strip: rate ladder with a "your rate" marker, this-week booked pace bar with break-even + target ticks, daily target. Avg RPM card + RPM chart now compare against the **live** break-even.
- **Fixes an apples-to-oranges bug** — the dashboard was comparing Avg RPM (revenue per *loaded* mile) against `$2.96` (cost per *total* mile), flattering profitability. Now it's vs the ~$4+ walk-away.
- **Expenses** — same rate-ladder strip, anchored to today.
- `BREAK_EVEN_RPM` stays only as a fallback until 3 months of P&L exist.

## Test
12 new engine tests (68 total); strict prod build green. Verified on dev.

Frontend-only — **no migration**.