### PR TITLE
fix: Avg RPM KPI = rolling 3mo, ladder marker = current week

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.30.0",
+      "version": "1.30.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.30.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -68,7 +68,9 @@ export const RateTargetsCard = ({
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-[1.6fr_1fr_1fr] gap-6">
           <div>
-            <p className="text-xs text-muted-text mb-3">Rate per loaded mile</p>
+            <p className="text-xs text-muted-text mb-3">
+              Rate per loaded mile · marker = this week
+            </p>
             <RateLadder ladder={ladder} rpm={markerRpm} />
           </div>
 

--- a/frontend/src/hooks/useRateTargets.ts
+++ b/frontend/src/hooks/useRateTargets.ts
@@ -10,6 +10,8 @@ import {
   getGrossTargets,
   payWeekRange,
   getWeekBookedGross,
+  getWeekRpm,
+  getWindowRpm,
 } from "@/lib/metrics/rateTargets";
 import {
   RATE_TIERS,
@@ -55,11 +57,15 @@ export const useRateTargets = (loads: Load[]) => {
     );
     const { start, end } = payWeekRange(now, PAY_WEEK_START_DOW);
     const weekBooked = getWeekBookedGross(loads, start, end);
+    const weekRpm = getWeekRpm(loads, start, end);
+    const rollingRpm = getWindowRpm(loads, now);
     return {
       basis,
       ladder,
       gross,
       weekBooked,
+      weekRpm, // this week's blended rate — the ladder marker
+      rollingRpm, // rolling 3-complete-month RPM — the Avg RPM KPI
       weekStart: start,
       weekEnd: end,
       ready: basis.breakEvenRpm != null,

--- a/frontend/src/lib/metrics/rateTargets.test.ts
+++ b/frontend/src/lib/metrics/rateTargets.test.ts
@@ -8,6 +8,8 @@ import {
   getGrossTargets,
   payWeekRange,
   getWeekBookedGross,
+  getWeekRpm,
+  getWindowRpm,
 } from "./rateTargets";
 
 const load = (over: Partial<Load>): Load =>
@@ -166,5 +168,41 @@ describe("getWeekBookedGross", () => {
       load({ delivery_date: "2026-07-01", load_status: "delivered", linehaul: "9999" }), // before range
     ];
     expect(getWeekBookedGross(loads, start, end)).toBeCloseTo(6000, 5);
+  });
+});
+
+describe("getWeekRpm", () => {
+  const start = new Date("2026-07-08T00:00:00Z");
+  const end = new Date("2026-07-15T00:00:00Z");
+
+  it("blends this week's revenue over this week's loaded miles", () => {
+    const loads = [
+      load({ delivery_date: "2026-07-09", load_status: "booked", linehaul: "4000", loaded_miles: 1000 }),
+      load({ delivery_date: "2026-07-11", load_status: "delivered", linehaul: "6000", loaded_miles: 1000 }),
+      load({ delivery_date: "2026-07-20", load_status: "delivered", linehaul: "9999", loaded_miles: 1000 }), // out of range
+    ];
+    expect(getWeekRpm(loads, start, end)).toBeCloseTo(5.0, 5); // 10000 / 2000
+  });
+
+  it("null when there are no loaded miles this week", () => {
+    expect(getWeekRpm([], start, end)).toBeNull();
+  });
+});
+
+describe("getWindowRpm", () => {
+  const now = new Date("2026-07-09T00:00:00Z");
+
+  it("blends revenue over loaded miles for the last 3 complete months, loads only", () => {
+    const loads = [
+      load({ delivery_date: "2026-04-15", linehaul: "8000", loaded_miles: 2000 }),
+      load({ delivery_date: "2026-05-15", linehaul: "8000", loaded_miles: 2000 }),
+      load({ delivery_date: "2026-06-15", linehaul: "8000", loaded_miles: 2000 }),
+      load({ delivery_date: "2026-07-15", linehaul: "9999", loaded_miles: 2000 }), // current month excluded
+    ];
+    expect(getWindowRpm(loads, now)).toBeCloseTo(4.0, 5); // 24000 / 6000
+  });
+
+  it("null when there are no loaded miles in the window", () => {
+    expect(getWindowRpm([], now)).toBeNull();
   });
 });

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -174,21 +174,49 @@ export const payWeekRange = (
   return { start, end };
 };
 
-// Gross of every non-cancelled load delivering in [start, end) — booked,
-// in-transit, and delivered all count, so mid-week shows committed + earned.
-export const getWeekBookedGross = (
-  loads: Load[],
-  start: Date,
-  end: Date,
-): number => {
-  let sum = 0;
-  for (const l of loads) {
-    if (l.load_status === "cancelled" || !l.delivery_date) continue;
+// Non-cancelled loads delivering in [start, end) — booked, in-transit, and
+// delivered all count, so mid-week reflects committed + earned freight.
+const loadsInWeek = (loads: Load[], start: Date, end: Date): Load[] =>
+  loads.filter((l) => {
+    if (l.load_status === "cancelled" || !l.delivery_date) return false;
     const dd = new Date(l.delivery_date);
     const day = new Date(
       Date.UTC(dd.getUTCFullYear(), dd.getUTCMonth(), dd.getUTCDate()),
     );
-    if (day >= start && day < end) sum += loadRevenue(l);
+    return day >= start && day < end;
+  });
+
+export const getWeekBookedGross = (
+  loads: Load[],
+  start: Date,
+  end: Date,
+): number => loadsInWeek(loads, start, end).reduce((s, l) => s + loadRevenue(l), 0);
+
+// This week's blended rate per loaded mile — where you're landing right now.
+export const getWeekRpm = (
+  loads: Load[],
+  start: Date,
+  end: Date,
+): number | null => {
+  const wk = loadsInWeek(loads, start, end);
+  const revenue = wk.reduce((s, l) => s + loadRevenue(l), 0);
+  const loaded = wk.reduce((s, l) => s + Number(l.loaded_miles || 0), 0);
+  return loaded > 0 ? revenue / loaded : null;
+};
+
+// Rolling blended RPM over the last `monthsBack` complete months — loads only,
+// so it stands on its own (doesn't need a P&L like the break-even does).
+export const getWindowRpm = (
+  loads: Load[],
+  now: Date,
+  monthsBack = 3,
+): number | null => {
+  let revenue = 0;
+  let loaded = 0;
+  for (const { year, month } of completeMonthsBefore(now, monthsBack)) {
+    const m = monthMiles(loads, year, month);
+    revenue += m.revenue;
+    loaded += m.loaded;
   }
-  return sum;
+  return loaded > 0 ? revenue / loaded : null;
 };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -16,7 +16,6 @@ import {
   getUpcomingLoads,
   getRecentDeliveredLoads,
 } from "@/lib/metrics/dashboard";
-import { getAverageRPM } from "@/lib/metrics/agent";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
 import { RevenueChart } from "@/components/RevenueChart";
@@ -84,7 +83,7 @@ const DashboardPage = () => {
   const revenueMTD = getRevenueMTD(loads);
   const revenueLastMonth = getRevenueLastMonth(loads);
   const revenueYTD = getRevenueYTD(loads);
-  const avgRpm = getAverageRPM(loads);
+  const avgRpm = targets.rollingRpm; // rolling 3-complete-month blended RPM
   const deadhead = getMonthlyDeadhead(loads, trips);
   const loadsMonthly = getLoadsMonthly(loads);
 
@@ -128,7 +127,7 @@ const DashboardPage = () => {
         />
         <KpiCard label="Revenue · YTD" value={formatCurrency(revenueYTD)} />
         <KpiCard
-          label="Avg RPM"
+          label="Avg RPM · 3mo"
           value={formatRpm(avgRpm)}
           status={rpmStatus}
           subtext={
@@ -152,7 +151,7 @@ const DashboardPage = () => {
 
       {/* Rate & pace targets */}
       <div className="mt-6">
-        <RateTargetsCard targets={targets} rpm={avgRpm} />
+        <RateTargetsCard targets={targets} rpm={targets.weekRpm} />
       </div>
 
       {/* Revenue chart + top agents */}


### PR DESCRIPTION
Refines the "your rate" numbers on the dashboard into the two distinct lenses they should be.

- **Avg RPM KPI** → rolling blended RPM over the last 3 complete months (`getWindowRpm`, loads only), relabeled "Avg RPM · 3mo". Same window as the break-even it's compared against, so the above/below-break-even read is apples-to-apples. Replaces the all-time `getAverageRPM`.
- **Ladder marker** (dashboard card) → the current pay week's blended rate (`getWeekRpm`), so you can see where the week is landing mid-stream. Captioned "marker = this week".
- Expenses ladder marker stays on the 3-month window (that page is about recent economics, not the live week).

4 new tests (72 total); strict build green. Verified on dev. Frontend-only — no migration.