### PR TITLE
feat: maintenance page — schedule + services, due engine, dashboard alerts

### DIFF
--- a/backend/db/migrations/026_maintenance.sql
+++ b/backend/db/migrations/026_maintenance.sql
@@ -1,0 +1,51 @@
+-- Maintenance tracking: a forward-looking SCHEDULE (what's due) and a SERVICES
+-- log (what was done). Units: 'tractor' (odometer, carries the engine items) and
+-- 'trailer' (hubodometer). Each schedule item can be mileage-based, time-based,
+-- or both (due = whichever comes first). Costs here are for VENDOR PRICING only
+-- — they are NOT rolled into the P&L (QuickBooks already books maintenance).
+
+CREATE TABLE IF NOT EXISTS maintenance_items (
+    item_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    unit VARCHAR(20) NOT NULL CHECK (unit IN ('tractor', 'trailer')),
+    name VARCHAR(120) NOT NULL,
+    category VARCHAR(40) NOT NULL DEFAULT 'other',
+    interval_miles INTEGER,        -- null = not mileage-based
+    interval_months INTEGER,       -- null = not time-based
+    interval_hours INTEGER,        -- null = not engine-hours-based
+    last_done_miles INTEGER,       -- odometer/hub at last completion
+    last_done_date DATE,           -- date of last completion
+    active BOOLEAN NOT NULL DEFAULT true,
+    notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS maintenance_services (
+    service_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    unit VARCHAR(20) NOT NULL CHECK (unit IN ('tractor', 'trailer')),
+    service_date DATE NOT NULL,
+    odometer INTEGER,              -- tractor odometer or trailer hubodometer
+    vendor VARCHAR(120),
+    location VARCHAR(120),
+    description TEXT NOT NULL,
+    cost NUMERIC(12, 2),           -- vendor pricing only, NOT a P&L figure
+    invoice_number VARCHAR(60),
+    receipt_ref VARCHAR(255),      -- filename or link (real upload is phase 2)
+    notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Which schedule items a service completed. Lets one PM visit reset several
+-- items, and gives each item its service history.
+CREATE TABLE IF NOT EXISTS maintenance_service_items (
+    service_id UUID NOT NULL REFERENCES maintenance_services(service_id) ON DELETE CASCADE,
+    item_id UUID NOT NULL REFERENCES maintenance_items(item_id) ON DELETE CASCADE,
+    PRIMARY KEY (service_id, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_maintenance_items_user ON maintenance_items(user_id);
+CREATE INDEX IF NOT EXISTS idx_maintenance_services_user ON maintenance_services(user_id);
+CREATE INDEX IF NOT EXISTS idx_maintenance_service_items_item ON maintenance_service_items(item_id);

--- a/backend/db/migrations/027_maintenance_warn_lead.sql
+++ b/backend/db/migrations/027_maintenance_warn_lead.sql
@@ -1,0 +1,7 @@
+-- Per-item warning lead time: how many days before an item comes due to start
+-- flagging it "due soon". A single global window (30 days) can't fit every
+-- item — a truck wash done every 30 days can't have a 30-day notice. Overdue
+-- is always critical; this only controls the warning lead. Backfills existing
+-- rows at 14. (Compliance's second, pre-due "critical" threshold comes later.)
+ALTER TABLE maintenance_items
+  ADD COLUMN IF NOT EXISTS warn_lead_days INTEGER NOT NULL DEFAULT 14;

--- a/backend/src/routes/maintenanceRoutes.js
+++ b/backend/src/routes/maintenanceRoutes.js
@@ -1,0 +1,122 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import {
+  getMaintenanceItems,
+  createMaintenanceItem,
+  patchMaintenanceItem,
+  deleteMaintenanceItem,
+  seedMaintenanceItems,
+  getMaintenanceServices,
+  createMaintenanceService,
+  patchMaintenanceService,
+  deleteMaintenanceService,
+} from "../services/maintenanceServices.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+const handleError = (res, err) => {
+  if (err.type === "validation")
+    return res.status(err.statusCode).json({ error: err.message });
+  if (err.type === "not_found")
+    return res.status(err.statusCode).json({ error: err.message });
+  return res
+    .status(500)
+    .json({ error: "Internal Server Error", message: err.message });
+};
+
+// ---- schedule items ----
+router.get("/items", async (req, res) => {
+  try {
+    const items = await getMaintenanceItems(req.user.user_id);
+    return res.status(200).json({ items });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.post("/items", async (req, res) => {
+  try {
+    const item = await createMaintenanceItem(req.user.user_id, req.body);
+    return res.status(201).json({ item });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.post("/items/seed", async (req, res) => {
+  try {
+    const items = await seedMaintenanceItems(req.user.user_id);
+    return res.status(201).json({ items });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.patch("/items/:id", async (req, res) => {
+  try {
+    const item = await patchMaintenanceItem(
+      req.user.user_id,
+      req.params.id,
+      req.body,
+    );
+    return res.status(200).json({ item });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.delete("/items/:id", async (req, res) => {
+  try {
+    const deleted = await deleteMaintenanceItem(req.user.user_id, req.params.id);
+    return res.status(200).json({ deleted });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+// ---- services log ----
+router.get("/services", async (req, res) => {
+  try {
+    const services = await getMaintenanceServices(req.user.user_id);
+    return res.status(200).json({ services });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.post("/services", async (req, res) => {
+  try {
+    const service = await createMaintenanceService(req.user.user_id, req.body);
+    return res.status(201).json({ service });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.patch("/services/:id", async (req, res) => {
+  try {
+    const service = await patchMaintenanceService(
+      req.user.user_id,
+      req.params.id,
+      req.body,
+    );
+    return res.status(200).json({ service });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.delete("/services/:id", async (req, res) => {
+  try {
+    const deleted = await deleteMaintenanceService(
+      req.user.user_id,
+      req.params.id,
+    );
+    return res.status(200).json({ deleted });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -19,6 +19,7 @@ import marketRouter from "./routes/marketRoutes.js";
 import agentNoteRoutes from "./routes/agentNoteRoutes.js";
 import expenseRouter from "./routes/expenseRoutes.js";
 import obligationRouter from "./routes/obligationRoutes.js";
+import maintenanceRouter from "./routes/maintenanceRoutes.js";
 
 const app = express();
 
@@ -45,6 +46,7 @@ app.use("/markets", marketRouter);
 app.use("/agents/:agent_id/notes", agentNoteRoutes);
 app.use("/expenses", expenseRouter);
 app.use("/obligations", obligationRouter);
+app.use("/maintenance", maintenanceRouter);
 
 app.get("/", (req, res) => {
   res.send("Home Page");

--- a/backend/src/services/maintenanceServices.js
+++ b/backend/src/services/maintenanceServices.js
@@ -1,0 +1,314 @@
+import { db } from "../../db/pool.js";
+import { ValidationError, NotFoundError } from "../utils/error.js";
+
+const UNITS = ["tractor", "trailer"];
+const isUnit = (u) => UNITS.includes(u);
+
+// ---- SCHEDULE ITEMS ----
+
+export async function getMaintenanceItems(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const result = await db.query(
+    `SELECT item_id, unit, name, category, interval_miles, interval_months,
+            interval_hours, last_done_miles, last_done_date, active, notes, warn_lead_days
+     FROM maintenance_items
+     WHERE user_id = $1
+     ORDER BY category, name`,
+    [user_id],
+  );
+  return result.rows;
+}
+
+const ITEM_FIELDS = [
+  "unit",
+  "name",
+  "category",
+  "interval_miles",
+  "interval_months",
+  "interval_hours",
+  "last_done_miles",
+  "last_done_date",
+  "active",
+  "notes",
+  "warn_lead_days",
+];
+
+export async function createMaintenanceItem(user_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!data.name) throw new ValidationError("name is required");
+  if (!isUnit(data.unit)) throw new ValidationError("unit must be tractor or trailer");
+
+  const result = await db.query(
+    `INSERT INTO maintenance_items
+       (user_id, unit, name, category, interval_miles, interval_months,
+        interval_hours, last_done_miles, last_done_date, notes, warn_lead_days)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+     RETURNING item_id, unit, name, category, interval_miles, interval_months,
+               interval_hours, last_done_miles, last_done_date, active, notes, warn_lead_days`,
+    [
+      user_id,
+      data.unit,
+      data.name,
+      data.category ?? "other",
+      data.interval_miles ?? null,
+      data.interval_months ?? null,
+      data.interval_hours ?? null,
+      data.last_done_miles ?? null,
+      data.last_done_date ?? null,
+      data.notes ?? null,
+      data.warn_lead_days ?? 14,
+    ],
+  );
+  return result.rows[0];
+}
+
+export async function patchMaintenanceItem(user_id, item_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!item_id) throw new ValidationError("Missing item_id");
+  if (data.unit !== undefined && !isUnit(data.unit))
+    throw new ValidationError("unit must be tractor or trailer");
+
+  const updates = [];
+  const values = [];
+  let i = 1;
+  for (const field of ITEM_FIELDS) {
+    if (data[field] !== undefined) {
+      updates.push(`${field} = $${i}`);
+      values.push(data[field]);
+      i++;
+    }
+  }
+  if (updates.length === 0) throw new ValidationError("No valid fields to update");
+
+  updates.push(`updated_at = NOW()`);
+  values.push(item_id, user_id);
+
+  const result = await db.query(
+    `UPDATE maintenance_items SET ${updates.join(", ")}
+     WHERE item_id = $${i} AND user_id = $${i + 1}
+     RETURNING item_id, unit, name, category, interval_miles, interval_months,
+               interval_hours, last_done_miles, last_done_date, active, notes, warn_lead_days`,
+    values,
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Maintenance item not found");
+  return result.rows[0];
+}
+
+export async function deleteMaintenanceItem(user_id, item_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!item_id) throw new ValidationError("Missing item_id");
+  const result = await db.query(
+    `DELETE FROM maintenance_items WHERE item_id = $1 AND user_id = $2
+     RETURNING item_id`,
+    [item_id, user_id],
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Maintenance item not found");
+  return result.rows[0];
+}
+
+// ---- SERVICES LOG ----
+
+export async function getMaintenanceServices(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const result = await db.query(
+    `SELECT s.service_id, s.unit, s.service_date, s.odometer, s.vendor,
+            s.location, s.description, s.cost, s.invoice_number, s.receipt_ref,
+            s.notes,
+            COALESCE(
+              array_agg(si.item_id) FILTER (WHERE si.item_id IS NOT NULL), '{}'
+            ) AS item_ids
+     FROM maintenance_services s
+     LEFT JOIN maintenance_service_items si ON si.service_id = s.service_id
+     WHERE s.user_id = $1
+     GROUP BY s.service_id
+     ORDER BY s.service_date DESC, s.created_at DESC`,
+    [user_id],
+  );
+  return result.rows;
+}
+
+// Create a service and, if it's linked to schedule items, reset those items'
+// "last done" to this service (unless they already have a newer completion).
+export async function createMaintenanceService(user_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!data.service_date) throw new ValidationError("service_date is required");
+  if (!data.description) throw new ValidationError("description is required");
+  if (!isUnit(data.unit)) throw new ValidationError("unit must be tractor or trailer");
+
+  const itemIds = Array.isArray(data.item_ids) ? data.item_ids : [];
+
+  const client = await db.pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const svc = await client.query(
+      `INSERT INTO maintenance_services
+         (user_id, unit, service_date, odometer, vendor, location, description,
+          cost, invoice_number, receipt_ref, notes)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       RETURNING service_id, unit, service_date, odometer, vendor, location,
+                 description, cost, invoice_number, receipt_ref, notes`,
+      [
+        user_id,
+        data.unit,
+        data.service_date,
+        data.odometer ?? null,
+        data.vendor ?? null,
+        data.location ?? null,
+        data.description,
+        data.cost ?? null,
+        data.invoice_number ?? null,
+        data.receipt_ref ?? null,
+        data.notes ?? null,
+      ],
+    );
+    const service_id = svc.rows[0].service_id;
+
+    for (const item_id of itemIds) {
+      // Only reset items that belong to this user; skip unknown ids.
+      const link = await client.query(
+        `INSERT INTO maintenance_service_items (service_id, item_id)
+         SELECT $1, item_id FROM maintenance_items
+         WHERE item_id = $2 AND user_id = $3
+         RETURNING item_id`,
+        [service_id, item_id, user_id],
+      );
+      if (link.rowCount === 0) continue;
+      // Don't let a back-dated entry clobber a newer completion.
+      await client.query(
+        `UPDATE maintenance_items
+           SET last_done_miles = $1, last_done_date = $2, updated_at = NOW()
+         WHERE item_id = $3 AND user_id = $4
+           AND (last_done_date IS NULL OR last_done_date <= $2)`,
+        [data.odometer ?? null, data.service_date, item_id, user_id],
+      );
+    }
+
+    await client.query("COMMIT");
+    return { ...svc.rows[0], item_ids: itemIds };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+const SERVICE_FIELDS = [
+  "unit",
+  "service_date",
+  "odometer",
+  "vendor",
+  "location",
+  "description",
+  "cost",
+  "invoice_number",
+  "receipt_ref",
+  "notes",
+];
+
+// Edits scalar fields only. Re-linking items / re-resetting is not handled here
+// (delete + re-add if the item links change).
+export async function patchMaintenanceService(user_id, service_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!service_id) throw new ValidationError("Missing service_id");
+  if (data.unit !== undefined && !isUnit(data.unit))
+    throw new ValidationError("unit must be tractor or trailer");
+
+  const updates = [];
+  const values = [];
+  let i = 1;
+  for (const field of SERVICE_FIELDS) {
+    if (data[field] !== undefined) {
+      updates.push(`${field} = $${i}`);
+      values.push(data[field]);
+      i++;
+    }
+  }
+  if (updates.length === 0) throw new ValidationError("No valid fields to update");
+
+  updates.push(`updated_at = NOW()`);
+  values.push(service_id, user_id);
+
+  const result = await db.query(
+    `UPDATE maintenance_services SET ${updates.join(", ")}
+     WHERE service_id = $${i} AND user_id = $${i + 1}
+     RETURNING service_id, unit, service_date, odometer, vendor, location,
+               description, cost, invoice_number, receipt_ref, notes`,
+    values,
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Service not found");
+  return result.rows[0];
+}
+
+export async function deleteMaintenanceService(user_id, service_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!service_id) throw new ValidationError("Missing service_id");
+  const result = await db.query(
+    `DELETE FROM maintenance_services WHERE service_id = $1 AND user_id = $2
+     RETURNING service_id`,
+    [service_id, user_id],
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Service not found");
+  return result.rows[0];
+}
+
+// ---- STARTER SCHEDULE ---- (severe-duty LT625 + X15 + Eaton Fuller; user edits)
+// Inserted only when the user has no items yet. Compliance/DOT lives on its own
+// page, so it's intentionally NOT seeded here. Sections come from category:
+// transmission → Transmission, trailer unit → Trailer, else → Truck.
+// [unit, name, category, interval_miles, interval_months, interval_hours, warn_lead_days]
+const STARTER_ITEMS = [
+  // Engine — Cummins X15
+  ["tractor", "Engine oil + filter", "engine", 25000, 6, null, 14],
+  ["tractor", "Fuel filter + water separator", "engine", 25000, null, null, 14],
+  ["tractor", "Coolant filter / SCA check", "engine", 50000, 12, null, 21],
+  ["tractor", "Crankcase breather filter", "engine", 150000, null, null, 21],
+  ["tractor", "DEF / aftertreatment filter", "engine", 300000, null, null, 30],
+  ["tractor", "DPF ash cleaning", "engine", 300000, null, null, 30],
+  ["tractor", "Valve lash / overhead adjustment", "engine", 500000, 60, null, 30],
+  // Chassis — International LT625
+  ["tractor", "Chassis lube (grease all points)", "chassis", 25000, null, null, 14],
+  ["tractor", "Drive axle / differential fluid", "chassis", 250000, 36, null, 30],
+  ["tractor", "Air dryer desiccant cartridge", "chassis", 150000, 36, null, 30],
+  ["tractor", "Wheel seals / hub oil (inspect)", "chassis", 25000, null, null, 14],
+  ["tractor", "Alignment", "chassis", null, 12, null, 21],
+  ["tractor", "Cabin / HVAC filter", "chassis", null, 12, null, 14],
+  ["tractor", "Brake inspection (linings, chambers, slack)", "brakes", 25000, null, null, 14],
+  // Transmission — Eaton Fuller (synthetic PS-386)
+  ["tractor", "Transmission fluid change (Eaton Fuller · synthetic)", "transmission", 500000, null, null, 30],
+  ["tractor", "Transmission level + magnetic plug check", "transmission", 25000, null, null, 14],
+  // Trailer
+  ["trailer", "Trailer lube / grease", "trailer", 25000, null, null, 14],
+  ["trailer", "Trailer brakes / ABS / lights / tape", "trailer", 25000, null, null, 14],
+];
+
+export async function seedMaintenanceItems(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const existing = await db.query(
+    `SELECT 1 FROM maintenance_items WHERE user_id = $1 LIMIT 1`,
+    [user_id],
+  );
+  if (existing.rowCount > 0)
+    throw new ValidationError("You already have maintenance items");
+
+  const client = await db.pool.connect();
+  try {
+    await client.query("BEGIN");
+    for (const [unit, name, category, miles, months, hours, warn] of STARTER_ITEMS) {
+      await client.query(
+        `INSERT INTO maintenance_items
+           (user_id, unit, name, category, interval_miles, interval_months, interval_hours, warn_lead_days)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [user_id, unit, name, category, miles, months, hours, warn],
+      );
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+  return getMaintenanceItems(user_id);
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.30.2",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.30.2",
+      "version": "1.31.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.30.2",
+  "version": "1.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import DashboardPage from "@/pages/DashboardPage";
 import LoadsPage from "@/pages/LoadsPage";
 import TripsPage from "@/pages/TripsPage";
 import ExpensesPage from "@/pages/ExpensesPage";
+import MaintenancePage from "@/pages/MaintenancePage";
 import AgentsPage from "@/pages/AgentsPage";
 import AgentDetailPage from "./pages/AgentDetailPage";
 import FuelEntriesPage from "@/pages/FuelEntriesPage";
@@ -50,6 +51,7 @@ const App = () => {
             }
           />
           <Route path="/expenses" element={<ExpensesPage />} />
+          <Route path="/maintenance" element={<MaintenancePage />} />
           <Route path="/agents" element={<AgentsPage />} />
           <Route path="/agents/:agent_id" element={<AgentDetailPage />} />
           <Route path="/fuel-entries" element={<FuelEntriesPage />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -17,6 +17,7 @@ const navItems = [
   { to: "/trips", label: "Trips" },
   { to: "/lanes", label: "Lanes" },
   { to: "/expenses", label: "Expenses" },
+  { to: "/maintenance", label: "Maintenance" },
   { to: "/agents", label: "Agents" },
   { to: "/fuel-entries", label: "Fuel Entries" },
   // { to: "/trucks", label: "Trucks" },

--- a/frontend/src/components/dashboard/AlertBanners.tsx
+++ b/frontend/src/components/dashboard/AlertBanners.tsx
@@ -1,3 +1,5 @@
+import { Wrench, ShieldAlert } from "lucide-react";
+import { Link } from "react-router-dom";
 import type { Alert } from "@/types/alert";
 
 interface Props {
@@ -9,11 +11,15 @@ const styleFor = (severity: Alert["severity"]): string =>
     ? "bg-status-negative-bg text-status-negative-text"
     : "bg-status-aware-bg text-status-aware-text";
 
-const iconFor = (kind: Alert["kind"]): string =>
-  kind === "maintenance" ? "ti-tool" : "ti-alert-circle";
+const IconFor = ({ kind }: { kind: Alert["kind"] }) =>
+  kind === "maintenance" ? (
+    <Wrench size={16} className="shrink-0" aria-hidden="true" />
+  ) : (
+    <ShieldAlert size={16} className="shrink-0" aria-hidden="true" />
+  );
 
 // Reserved dashboard region. Renders nothing when there are no alerts, so it
-// costs no space until the future alert engine feeds it.
+// costs no space until something (maintenance, compliance) feeds it.
 export const AlertBanners = ({ alerts }: Props) => {
   if (alerts.length === 0) return null;
 
@@ -24,12 +30,12 @@ export const AlertBanners = ({ alerts }: Props) => {
           key={alert.id}
           className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm ${styleFor(alert.severity)}`}
         >
-          <i className={`ti ${iconFor(alert.kind)}`} aria-hidden="true" />
+          <IconFor kind={alert.kind} />
           <span className="flex-1">{alert.message}</span>
           {alert.actionHref && (
-            <a href={alert.actionHref} className="underline whitespace-nowrap">
+            <Link to={alert.actionHref} className="underline whitespace-nowrap">
               View
-            </a>
+            </Link>
           )}
         </div>
       ))}

--- a/frontend/src/components/maintenance/MaintenanceItemForm.tsx
+++ b/frontend/src/components/maintenance/MaintenanceItemForm.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { Check, X } from "lucide-react";
+import type { MaintenanceItem, MaintenanceUnit } from "@/types/maintenance";
+import type { ItemInput } from "@/services/maintenanceService";
+
+const CATEGORIES = ["engine", "chassis", "brakes", "compliance", "trailer", "other"];
+
+const field = "bg-steel rounded px-2 py-1 text-sm w-full";
+const lbl = "text-xs text-muted-text mb-1 block";
+
+export const MaintenanceItemForm = ({
+  initial,
+  onSave,
+  onCancel,
+  busy,
+}: {
+  initial: MaintenanceItem | null;
+  onSave: (data: ItemInput) => void;
+  onCancel: () => void;
+  busy: boolean;
+}) => {
+  const [unit, setUnit] = useState<MaintenanceUnit>(initial?.unit ?? "tractor");
+  const [name, setName] = useState(initial?.name ?? "");
+  const [category, setCategory] = useState(initial?.category ?? "engine");
+  const [miles, setMiles] = useState(initial?.interval_miles?.toString() ?? "");
+  const [months, setMonths] = useState(initial?.interval_months?.toString() ?? "");
+  const [lastMiles, setLastMiles] = useState(
+    initial?.last_done_miles?.toString() ?? "",
+  );
+  const [lastDate, setLastDate] = useState(initial?.last_done_date ?? "");
+  const [warn, setWarn] = useState(initial?.warn_lead_days?.toString() ?? "14");
+  const [notes, setNotes] = useState(initial?.notes ?? "");
+
+  const intOrNull = (s: string) => (s.trim() === "" ? null : parseInt(s, 10));
+
+  const submit = () => {
+    if (!name.trim()) return;
+    onSave({
+      unit,
+      name: name.trim(),
+      category,
+      interval_miles: intOrNull(miles),
+      interval_months: intOrNull(months),
+      last_done_miles: intOrNull(lastMiles),
+      last_done_date: lastDate || null,
+      warn_lead_days: intOrNull(warn) ?? 14,
+      notes: notes.trim() || null,
+    });
+  };
+
+  return (
+    <div className="bg-plate rounded-lg p-4 mb-4">
+      <p className="text-sm font-medium mb-3">
+        {initial ? "Edit item" : "New maintenance item"}
+      </p>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <div className="col-span-2 md:col-span-1">
+          <label className={lbl}>Name</label>
+          <input
+            className={field}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Engine oil + filter"
+          />
+        </div>
+        <div>
+          <label className={lbl}>Unit</label>
+          <select
+            className={field}
+            value={unit}
+            onChange={(e) => setUnit(e.target.value as MaintenanceUnit)}
+          >
+            <option value="tractor">Tractor</option>
+            <option value="trailer">Trailer</option>
+          </select>
+        </div>
+        <div>
+          <label className={lbl}>Category</label>
+          <select
+            className={field}
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            {CATEGORIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={lbl}>Every (miles)</label>
+          <input
+            className={field}
+            value={miles}
+            onChange={(e) => setMiles(e.target.value)}
+            placeholder="25000"
+            inputMode="numeric"
+          />
+        </div>
+        <div>
+          <label className={lbl}>Every (months)</label>
+          <input
+            className={field}
+            value={months}
+            onChange={(e) => setMonths(e.target.value)}
+            placeholder="12"
+            inputMode="numeric"
+          />
+        </div>
+        <div>
+          <label className={lbl}>Last done · odometer</label>
+          <input
+            className={field}
+            value={lastMiles}
+            onChange={(e) => setLastMiles(e.target.value)}
+            placeholder="560905"
+            inputMode="numeric"
+          />
+        </div>
+        <div>
+          <label className={lbl}>Last done · date</label>
+          <input
+            type="date"
+            className={field}
+            value={lastDate ?? ""}
+            onChange={(e) => setLastDate(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={lbl}>Warn me (days before)</label>
+          <input
+            className={field}
+            value={warn}
+            onChange={(e) => setWarn(e.target.value)}
+            placeholder="14"
+            inputMode="numeric"
+          />
+        </div>
+        <div className="col-span-2 md:col-span-3">
+          <label className={lbl}>Notes</label>
+          <input
+            className={field}
+            value={notes ?? ""}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="optional"
+          />
+        </div>
+      </div>
+      <p className="text-[11px] text-muted-text mt-2">
+        Set at least a mileage or a month interval. Fill "last done" to start the
+        clock — or just log a service that completes it.
+      </p>
+      <div className="flex gap-2 mt-3">
+        <button
+          className="bg-amber text-steel px-3 py-1 rounded text-sm font-semibold flex items-center gap-1 disabled:opacity-50"
+          onClick={submit}
+          disabled={busy || !name.trim()}
+        >
+          <Check size={15} /> Save
+        </button>
+        <button
+          className="bg-steel text-light px-3 py-1 rounded text-sm flex items-center gap-1"
+          onClick={onCancel}
+        >
+          <X size={15} /> Cancel
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/maintenance/ScheduleTab.tsx
+++ b/frontend/src/components/maintenance/ScheduleTab.tsx
@@ -1,0 +1,310 @@
+import { useState } from "react";
+import { Pencil, Trash2, Plus, LayoutList, Table as TableIcon } from "lucide-react";
+import type { MaintenanceItem, MaintenanceUnit } from "@/types/maintenance";
+import {
+  createMaintenanceItem,
+  patchMaintenanceItem,
+  deleteMaintenanceItem,
+  seedMaintenanceItems,
+  type ItemInput,
+} from "@/services/maintenanceService";
+import { computeDue, type Due, type DueLevel } from "@/lib/metrics/maintenance";
+import { MaintenanceItemForm } from "./MaintenanceItemForm";
+
+interface Props {
+  items: MaintenanceItem[];
+  currentMiles: Record<MaintenanceUnit, number | null>;
+  milesPerMonth: number | null;
+  onChange: () => void;
+}
+
+const META: Record<DueLevel, { label: string; color: string }> = {
+  overdue: { label: "Overdue", color: "#e24b4a" },
+  soon: { label: "Due soon", color: "#e8940a" },
+  ok: { label: "OK", color: "#1d9e75" },
+  unknown: { label: "No baseline yet", color: "#9daabb" },
+};
+
+// Top-level sections. Transmission is physically on the tractor but gets its
+// own section; everything else on the tractor is "Truck".
+const SECTIONS = ["Truck", "Transmission", "Trailer"] as const;
+const sectionOf = (i: MaintenanceItem): string =>
+  i.category === "transmission"
+    ? "Transmission"
+    : i.unit === "trailer"
+      ? "Trailer"
+      : "Truck";
+
+const num = (n: number) => Math.round(n).toLocaleString("en-US");
+const fmtDate = (iso: string) =>
+  new Date(iso + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "2-digit",
+    timeZone: "UTC",
+  });
+
+const intervalLabel = (i: MaintenanceItem): string => {
+  const p: string[] = [];
+  if (i.interval_miles) p.push(`${Math.round(i.interval_miles / 1000)}k mi`);
+  if (i.interval_months) p.push(`${i.interval_months} mo`);
+  return p.join(" / ") || "as needed";
+};
+
+const lastDoneLabel = (i: MaintenanceItem): string => {
+  const p: string[] = [];
+  if (i.last_done_miles != null) p.push(`${num(i.last_done_miles)} mi`);
+  if (i.last_done_date) p.push(fmtDate(i.last_done_date));
+  return p.join(" · ") || "—";
+};
+
+const dueLabel = (d: Due): string => {
+  const p: string[] = [];
+  if (d.milesRemaining != null)
+    p.push(
+      d.milesRemaining < 0
+        ? `${num(-d.milesRemaining)} mi over`
+        : `${num(d.milesRemaining)} mi left`,
+    );
+  if (d.dueDate && d.daysRemaining != null)
+    p.push(
+      d.daysRemaining < 0
+        ? `${Math.round(-d.daysRemaining)} days over`
+        : `due ${fmtDate(d.dueDate)}`,
+    );
+  else if (d.etaDate) p.push(`~${fmtDate(d.etaDate)}`);
+  return p.join(" · ") || "—";
+};
+
+export const ScheduleTab = ({
+  items,
+  currentMiles,
+  milesPerMonth,
+  onChange,
+}: Props) => {
+  const [view, setView] = useState<"board" | "table">("board");
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState<MaintenanceItem | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const now = new Date();
+  const rows = items.map((item) => ({
+    item,
+    due: computeDue(item, currentMiles[item.unit], now, milesPerMonth),
+  }));
+
+  const counts = { overdue: 0, soon: 0, ok: 0, unknown: 0 };
+  for (const r of rows) counts[r.due.level]++;
+
+  const run = async (fn: () => Promise<void>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await fn();
+      onChange();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const save = (data: ItemInput) =>
+    run(async () => {
+      if (editing) await patchMaintenanceItem(editing.item_id, data);
+      else await createMaintenanceItem(data);
+      setShowForm(false);
+      setEditing(null);
+    });
+
+  const chip = (label: string, n: number, color: string) => (
+    <span
+      className="text-xs px-2.5 py-1 rounded"
+      style={{ background: "#1c2333", color }}
+    >
+      {n} {label}
+    </span>
+  );
+
+  if (items.length === 0 && !showForm) {
+    return (
+      <div className="bg-plate rounded-lg p-6 text-center">
+        <p className="text-muted-text mb-4">
+          No maintenance schedule yet. Load the starter schedule for your LT625 +
+          X15 (severe-duty intervals you can tune), or add items yourself.
+        </p>
+        {error && <p className="text-destructive text-sm mb-3">{error}</p>}
+        <div className="flex gap-2 justify-center">
+          <button
+            className="bg-amber text-steel px-3 py-1.5 rounded text-sm font-semibold disabled:opacity-50"
+            disabled={busy}
+            onClick={() => run(async () => void (await seedMaintenanceItems()))}
+          >
+            Load starter schedule
+          </button>
+          <button
+            className="bg-steel text-light px-3 py-1.5 rounded text-sm"
+            onClick={() => {
+              setEditing(null);
+              setShowForm(true);
+            }}
+          >
+            Add item
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const ItemRow = ({ item, due }: { item: MaintenanceItem; due: Due }) => (
+    <div className="flex items-center gap-3 py-2 border-t border-steel">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm truncate">
+          {item.name}{" "}
+          <span className="text-xs text-muted-text">· {item.unit}</span>
+        </p>
+        <div className="h-1.5 bg-steel rounded mt-1.5 overflow-hidden">
+          <div
+            className="h-1.5 rounded"
+            style={{
+              width: `${Math.min(1, due.progress ?? 0) * 100}%`,
+              background: META[due.level].color,
+            }}
+          />
+        </div>
+      </div>
+      <div className="text-right w-40 shrink-0">
+        <p className="text-xs" style={{ color: META[due.level].color }}>
+          {dueLabel(due)}
+        </p>
+        <p className="text-[11px] text-muted-text">every {intervalLabel(item)}</p>
+      </div>
+      <div className="flex gap-2 text-muted-text shrink-0">
+        <Pencil
+          size={15}
+          className="cursor-pointer hover:text-light"
+          aria-label="Edit"
+          onClick={() => {
+            setEditing(item);
+            setShowForm(true);
+          }}
+        />
+        <Trash2
+          size={15}
+          className="cursor-pointer hover:text-destructive"
+          aria-label="Delete"
+          onClick={() =>
+            !busy && run(() => deleteMaintenanceItem(item.item_id))
+          }
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2 items-center mb-4">
+        {chip("overdue", counts.overdue, META.overdue.color)}
+        {chip("due soon", counts.soon, META.soon.color)}
+        {chip("ok", counts.ok, META.ok.color)}
+        {counts.unknown > 0 &&
+          chip("no baseline", counts.unknown, META.unknown.color)}
+        <div className="ml-auto flex gap-2">
+          <button
+            className="bg-steel text-light px-2 py-1 rounded text-xs flex items-center gap-1"
+            onClick={() => setView(view === "board" ? "table" : "board")}
+          >
+            {view === "board" ? (
+              <>
+                <TableIcon size={14} /> Table
+              </>
+            ) : (
+              <>
+                <LayoutList size={14} /> Board
+              </>
+            )}
+          </button>
+          <button
+            className="bg-amber text-steel px-2 py-1 rounded text-xs font-semibold flex items-center gap-1"
+            onClick={() => {
+              setEditing(null);
+              setShowForm(true);
+            }}
+          >
+            <Plus size={14} /> Add item
+          </button>
+        </div>
+      </div>
+
+      {error && <p className="text-destructive text-sm mb-3">{error}</p>}
+
+      {showForm && (
+        <MaintenanceItemForm
+          initial={editing}
+          onSave={save}
+          onCancel={() => {
+            setShowForm(false);
+            setEditing(null);
+          }}
+          busy={busy}
+        />
+      )}
+
+      {view === "board" ? (
+        SECTIONS.map((section) => {
+          const group = rows.filter((r) => sectionOf(r.item) === section);
+          if (group.length === 0) return null;
+          group.sort((a, b) => (b.due.progress ?? 0) - (a.due.progress ?? 0));
+          return (
+            <div key={section} className="bg-plate rounded-lg p-4 mb-4">
+              <p className="text-sm font-medium mb-1">
+                {section}{" "}
+                <span className="text-xs text-muted-text">· {group.length}</span>
+              </p>
+              {group.map(({ item, due }) => (
+                <ItemRow key={item.item_id} item={item} due={due} />
+              ))}
+            </div>
+          );
+        })
+      ) : (
+        <div className="bg-plate rounded-lg p-4 overflow-x-auto">
+          <table className="w-full text-sm min-w-[560px] [&_th]:pr-4 [&_td]:pr-4 [&_th:last-child]:pr-0 [&_td:last-child]:pr-0">
+            <thead>
+              <tr className="text-xs text-muted-text text-left">
+                <th className="font-normal pb-2">Item</th>
+                <th className="font-normal pb-2">System</th>
+                <th className="font-normal pb-2">Every</th>
+                <th className="font-normal pb-2">Last done</th>
+                <th className="font-normal pb-2">Next due</th>
+                <th className="font-normal pb-2 text-right">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...rows]
+                .sort((a, b) => {
+                  const s =
+                    SECTIONS.indexOf(sectionOf(a.item) as (typeof SECTIONS)[number]) -
+                    SECTIONS.indexOf(sectionOf(b.item) as (typeof SECTIONS)[number]);
+                  return s !== 0 ? s : (b.due.progress ?? 0) - (a.due.progress ?? 0);
+                })
+                .map(({ item, due }) => (
+                  <tr key={item.item_id} className="border-t border-steel">
+                    <td className="py-2">{item.name}</td>
+                    <td className="py-2 text-muted-text">{sectionOf(item)}</td>
+                    <td className="py-2 text-muted-text">{intervalLabel(item)}</td>
+                    <td className="py-2 text-muted-text">{lastDoneLabel(item)}</td>
+                    <td className="py-2">{dueLabel(due)}</td>
+                    <td className="py-2 text-right" style={{ color: META[due.level].color }}>
+                      {META[due.level].label}
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/maintenance/ServiceForm.tsx
+++ b/frontend/src/components/maintenance/ServiceForm.tsx
@@ -1,0 +1,193 @@
+import { useState } from "react";
+import { Check, X } from "lucide-react";
+import type { MaintenanceItem, MaintenanceUnit } from "@/types/maintenance";
+import type { ServiceInput } from "@/services/maintenanceService";
+
+const field = "bg-steel rounded px-2 py-1 text-sm w-full";
+const lbl = "text-xs text-muted-text mb-1 block";
+
+export const ServiceForm = ({
+  items,
+  onSave,
+  onCancel,
+  busy,
+}: {
+  items: MaintenanceItem[];
+  onSave: (data: ServiceInput) => void;
+  onCancel: () => void;
+  busy: boolean;
+}) => {
+  const [unit, setUnit] = useState<MaintenanceUnit>("tractor");
+  const [date, setDate] = useState("");
+  const [odometer, setOdometer] = useState("");
+  const [vendor, setVendor] = useState("");
+  const [location, setLocation] = useState("");
+  const [description, setDescription] = useState("");
+  const [cost, setCost] = useState("");
+  const [invoice, setInvoice] = useState("");
+  const [notes, setNotes] = useState("");
+  const [completed, setCompleted] = useState<Set<string>>(new Set());
+
+  const toggle = (id: string) =>
+    setCompleted((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const submit = () => {
+    if (!date || !description.trim()) return;
+    onSave({
+      unit,
+      service_date: date,
+      odometer: odometer.trim() === "" ? null : parseInt(odometer, 10),
+      vendor: vendor.trim() || null,
+      location: location.trim() || null,
+      description: description.trim(),
+      cost: cost.trim() === "" ? null : parseFloat(cost),
+      invoice_number: invoice.trim() || null,
+      notes: notes.trim() || null,
+      item_ids: [...completed],
+    });
+  };
+
+  const unitItems = items.filter((i) => i.unit === unit && i.active);
+
+  return (
+    <div className="bg-plate rounded-lg p-4 mb-4">
+      <p className="text-sm font-medium mb-3">Log service</p>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div>
+          <label className={lbl}>Unit</label>
+          <select
+            className={field}
+            value={unit}
+            onChange={(e) => {
+              setUnit(e.target.value as MaintenanceUnit);
+              setCompleted(new Set());
+            }}
+          >
+            <option value="tractor">Tractor</option>
+            <option value="trailer">Trailer</option>
+          </select>
+        </div>
+        <div>
+          <label className={lbl}>Date</label>
+          <input
+            type="date"
+            className={field}
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={lbl}>{unit === "trailer" ? "Hubodometer" : "Odometer"}</label>
+          <input
+            className={field}
+            value={odometer}
+            onChange={(e) => setOdometer(e.target.value)}
+            placeholder="568737"
+            inputMode="numeric"
+          />
+        </div>
+        <div>
+          <label className={lbl}>Cost</label>
+          <input
+            className={field}
+            value={cost}
+            onChange={(e) => setCost(e.target.value)}
+            placeholder="433.64"
+            inputMode="decimal"
+          />
+        </div>
+        <div>
+          <label className={lbl}>Vendor</label>
+          <input
+            className={field}
+            value={vendor}
+            onChange={(e) => setVendor(e.target.value)}
+            placeholder="TA Petro"
+          />
+        </div>
+        <div>
+          <label className={lbl}>Location</label>
+          <input
+            className={field}
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            placeholder="Mebane, NC"
+          />
+        </div>
+        <div>
+          <label className={lbl}>Invoice #</label>
+          <input
+            className={field}
+            value={invoice}
+            onChange={(e) => setInvoice(e.target.value)}
+          />
+        </div>
+        <div className="col-span-2 md:col-span-4">
+          <label className={lbl}>Service performed</label>
+          <input
+            className={field}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Landstar Ultimate PM: oil, fuel filter, separator, grease all points"
+          />
+        </div>
+        <div className="col-span-2 md:col-span-4">
+          <label className={lbl}>Notes</label>
+          <input
+            className={field}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="optional"
+          />
+        </div>
+      </div>
+
+      {unitItems.length > 0 && (
+        <div className="mt-3">
+          <p className={lbl}>
+            Completes which scheduled items? (resets their clock)
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {unitItems.map((i) => {
+              const on = completed.has(i.item_id);
+              return (
+                <button
+                  key={i.item_id}
+                  onClick={() => toggle(i.item_id)}
+                  className={`text-xs px-2 py-1 rounded border ${
+                    on
+                      ? "bg-amber text-steel border-amber font-semibold"
+                      : "bg-steel text-muted-text border-steel"
+                  }`}
+                >
+                  {i.name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className="flex gap-2 mt-4">
+        <button
+          className="bg-amber text-steel px-3 py-1 rounded text-sm font-semibold flex items-center gap-1 disabled:opacity-50"
+          onClick={submit}
+          disabled={busy || !date || !description.trim()}
+        >
+          <Check size={15} /> Save
+        </button>
+        <button
+          className="bg-steel text-light px-3 py-1 rounded text-sm flex items-center gap-1"
+          onClick={onCancel}
+        >
+          <X size={15} /> Cancel
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/maintenance/ServicesTab.tsx
+++ b/frontend/src/components/maintenance/ServicesTab.tsx
@@ -1,0 +1,319 @@
+import { useState, useMemo } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import type { MaintenanceItem, MaintenanceService } from "@/types/maintenance";
+import {
+  createMaintenanceService,
+  deleteMaintenanceService,
+  type ServiceInput,
+} from "@/services/maintenanceService";
+import { ServiceForm } from "./ServiceForm";
+
+interface Props {
+  services: MaintenanceService[];
+  items: MaintenanceItem[];
+  onChange: () => void;
+}
+
+const money = (n: number | null): string =>
+  n == null
+    ? "—"
+    : `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const fmtDate = (iso: string) =>
+  new Date(iso + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+// 'YYYY-MM' for a month offset from the current UTC month.
+const monthKey = (offset: number): string => {
+  const d = new Date();
+  const m = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + offset, 1));
+  return `${m.getUTCFullYear()}-${String(m.getUTCMonth() + 1).padStart(2, "0")}`;
+};
+
+const fmtMonth = (ym: string) =>
+  new Date(ym + "-01T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+type RangeMode = "3m" | "6m" | "12m" | "ytd" | "all" | "custom";
+const PRESETS: [RangeMode, string][] = [
+  ["3m", "3 months"],
+  ["6m", "6 months"],
+  ["12m", "12 months"],
+  ["ytd", "This year"],
+  ["all", "All time"],
+  ["custom", "Custom"],
+];
+
+export const ServicesTab = ({ services, items, onChange }: Props) => {
+  const [showForm, setShowForm] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Month range for pulling a window of services (e.g. to re-enter into
+  // Landstar's app). Presets cover the common cases; "Custom" reveals dropdowns.
+  const [mode, setMode] = useState<RangeMode>("3m");
+  const [customFrom, setCustomFrom] = useState(() => monthKey(-2));
+  const [customTo, setCustomTo] = useState(() => monthKey(0));
+
+  const { from, to } = useMemo(() => {
+    if (mode === "custom") return { from: customFrom, to: customTo };
+    if (mode === "all") return { from: "", to: "" };
+    if (mode === "ytd")
+      return { from: `${new Date().getUTCFullYear()}-01`, to: monthKey(0) };
+    const back = mode === "3m" ? -2 : mode === "6m" ? -5 : -11;
+    return { from: monthKey(back), to: monthKey(0) };
+  }, [mode, customFrom, customTo]);
+
+  // Months that actually have services (newest first) for the custom dropdowns.
+  // Capped at ~36 months back so one stray/typo'd date can't balloon the list
+  // into hundreds of options (that was the click lag).
+  const monthOptions = useMemo(() => {
+    const floor = monthKey(-35);
+    const months = services.map((s) => s.service_date.slice(0, 7));
+    const earliestSvc = months.length
+      ? months.reduce((a, b) => (a < b ? a : b))
+      : monthKey(-11);
+    const earliest = earliestSvc < floor ? floor : earliestSvc;
+    const [ey, em] = earliest.split("-").map(Number);
+    const out: string[] = [];
+    const d = new Date();
+    let y = d.getUTCFullYear();
+    let m = d.getUTCMonth() + 1;
+    while (y > ey || (y === ey && m >= em)) {
+      out.push(`${y}-${String(m).padStart(2, "0")}`);
+      if (--m === 0) {
+        m = 12;
+        y--;
+      }
+    }
+    return out;
+  }, [services]);
+
+  const nameById = new Map(items.map((i) => [i.item_id, i.name]));
+
+  const filtered = services.filter((s) => {
+    const m = s.service_date.slice(0, 7);
+    return (!from || m >= from) && (!to || m <= to);
+  });
+  const rangeTotal = filtered.reduce((sum, s) => sum + (s.cost ?? 0), 0);
+
+  // Vendor pricing (over the selected range): what each shop has cost you.
+  const byVendor = new Map<string, { count: number; total: number; priced: number }>();
+  for (const s of filtered) {
+    if (!s.vendor) continue;
+    const v = byVendor.get(s.vendor) ?? { count: 0, total: 0, priced: 0 };
+    v.count++;
+    if (s.cost != null) {
+      v.total += s.cost;
+      v.priced++;
+    }
+    byVendor.set(s.vendor, v);
+  }
+  const vendors = [...byVendor.entries()].sort((a, b) => b[1].total - a[1].total);
+
+  const run = async (fn: () => Promise<void>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await fn();
+      onChange();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const save = (data: ServiceInput) =>
+    run(async () => {
+      await createMaintenanceService(data);
+      setShowForm(false);
+    });
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-4">
+        <p className="text-xs text-muted-text">
+          Every service, chronological — cost here tracks vendor pricing, not your
+          P&amp;L.
+        </p>
+        {!showForm && (
+          <button
+            className="bg-amber text-steel px-2 py-1 rounded text-xs font-semibold flex items-center gap-1"
+            onClick={() => setShowForm(true)}
+          >
+            <Plus size={14} /> Log service
+          </button>
+        )}
+      </div>
+
+      {error && <p className="text-destructive text-sm mb-3">{error}</p>}
+
+      {showForm && (
+        <ServiceForm
+          items={items}
+          onSave={save}
+          onCancel={() => setShowForm(false)}
+          busy={busy}
+        />
+      )}
+
+      <div className="bg-plate rounded-lg p-3 mb-4">
+        <div className="flex flex-wrap items-center gap-2">
+          {PRESETS.map(([key, label]) => (
+            <button
+              key={key}
+              onClick={() => setMode(key)}
+              className={`text-xs px-2.5 py-1 rounded ${
+                mode === key
+                  ? "bg-amber text-steel font-semibold"
+                  : "bg-steel text-muted-text"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+          <span className="text-xs text-muted-text ml-auto">
+            {filtered.length} service{filtered.length !== 1 ? "s" : ""} ·{" "}
+            {money(rangeTotal)}
+          </span>
+        </div>
+        {mode === "custom" && (
+          <div className="flex items-end gap-3 mt-3">
+            <div>
+              <label className="text-xs text-muted-text block mb-1">From</label>
+              <select
+                className="bg-steel rounded px-2 py-1 text-sm"
+                value={customFrom}
+                onChange={(e) => setCustomFrom(e.target.value)}
+              >
+                {monthOptions.map((m) => (
+                  <option key={m} value={m}>
+                    {fmtMonth(m)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="text-xs text-muted-text block mb-1">To</label>
+              <select
+                className="bg-steel rounded px-2 py-1 text-sm"
+                value={customTo}
+                onChange={(e) => setCustomTo(e.target.value)}
+              >
+                {monthOptions.map((m) => (
+                  <option key={m} value={m}>
+                    {fmtMonth(m)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {vendors.length > 0 && (
+        <div className="bg-plate rounded-lg p-4 mb-4">
+          <p className="text-xs text-muted-text mb-2">Vendor pricing</p>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-xs text-muted-text text-left">
+                <th className="font-normal pb-1">Vendor</th>
+                <th className="font-normal pb-1 text-right">Visits</th>
+                <th className="font-normal pb-1 text-right">Total</th>
+                <th className="font-normal pb-1 text-right">Avg</th>
+              </tr>
+            </thead>
+            <tbody>
+              {vendors.map(([vendor, v]) => (
+                <tr key={vendor} className="border-t border-steel">
+                  <td className="py-1.5">{vendor}</td>
+                  <td className="py-1.5 text-right text-muted-text">{v.count}</td>
+                  <td className="py-1.5 text-right">{money(v.total)}</td>
+                  <td className="py-1.5 text-right text-muted-text">
+                    {v.priced ? money(v.total / v.priced) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {filtered.length === 0 ? (
+        <p className="text-muted-text text-sm">
+          {services.length === 0
+            ? "No services logged yet."
+            : "No services in this month range."}
+        </p>
+      ) : (
+        <div className="bg-plate rounded-lg p-4 overflow-x-auto">
+          <table className="w-full text-sm min-w-[720px] [&_th]:pr-5 [&_td]:pr-5 [&_th:last-child]:pr-0 [&_td:last-child]:pr-0">
+            <thead>
+              <tr className="text-xs text-muted-text text-left">
+                <th className="font-normal pb-2">Date</th>
+                <th className="font-normal pb-2">Unit</th>
+                <th className="font-normal pb-2">Vendor</th>
+                <th className="font-normal pb-2 text-right">Odo</th>
+                <th className="font-normal pb-2">Service</th>
+                <th className="font-normal pb-2 text-right">Cost</th>
+                <th className="font-normal pb-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((s) => (
+                <tr key={s.service_id} className="border-t border-steel align-top">
+                  <td className="py-2 whitespace-nowrap">{fmtDate(s.service_date)}</td>
+                  <td className="py-2 text-muted-text">{s.unit}</td>
+                  <td className="py-2">
+                    {s.vendor ?? "—"}
+                    {s.location && (
+                      <span className="text-xs text-muted-text block">
+                        {s.location}
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-2 text-right text-muted-text whitespace-nowrap">
+                    {s.odometer != null ? s.odometer.toLocaleString("en-US") : "—"}
+                  </td>
+                  <td className="py-2">
+                    {s.description}
+                    {s.item_ids.length > 0 && (
+                      <span className="flex flex-wrap gap-1 mt-1">
+                        {s.item_ids.map((id) => (
+                          <span
+                            key={id}
+                            className="text-[11px] bg-steel text-muted-text px-1.5 rounded"
+                          >
+                            ✓ {nameById.get(id) ?? "item"}
+                          </span>
+                        ))}
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-2 text-right whitespace-nowrap">{money(s.cost)}</td>
+                  <td className="py-2 text-right">
+                    <Trash2
+                      size={15}
+                      className="cursor-pointer text-muted-text hover:text-destructive"
+                      aria-label="Delete"
+                      onClick={() =>
+                        !busy && run(() => deleteMaintenanceService(s.service_id))
+                      }
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useMaintenanceAlerts.ts
+++ b/frontend/src/hooks/useMaintenanceAlerts.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect, useMemo } from "react";
+import type { Load } from "@/types/load";
+import type { Alert } from "@/types/alert";
+import type {
+  MaintenanceItem,
+  MaintenanceService,
+  MaintenanceUnit,
+} from "@/types/maintenance";
+import {
+  getMaintenanceItems,
+  getMaintenanceServices,
+} from "@/services/maintenanceService";
+import {
+  maintenanceAlerts,
+  currentTractorMiles,
+  avgMilesPerMonth,
+  maxOdometer,
+} from "@/lib/metrics/maintenance";
+
+// Overdue / due-soon maintenance items as dashboard alerts. Empty (renders no
+// banners) until items exist and something is actually due.
+export const useMaintenanceAlerts = (loads: Load[]): Alert[] => {
+  const [items, setItems] = useState<MaintenanceItem[]>([]);
+  const [services, setServices] = useState<MaintenanceService[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    Promise.all([getMaintenanceItems(), getMaintenanceServices()])
+      .then(([its, svcs]) => {
+        if (!active) return;
+        setItems(its);
+        setServices(svcs);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return useMemo(() => {
+    const now = new Date();
+    const svcOdo = (unit: MaintenanceUnit): number | null =>
+      services
+        .filter((s) => s.unit === unit && s.odometer != null)
+        .reduce<number | null>(
+          (m, s) => (m == null || s.odometer! > m ? s.odometer! : m),
+          null,
+        );
+    const currentMiles: Record<MaintenanceUnit, number | null> = {
+      tractor: maxOdometer(currentTractorMiles(loads), svcOdo("tractor")),
+      trailer: maxOdometer(svcOdo("trailer")),
+    };
+    return maintenanceAlerts(items, currentMiles, now, avgMilesPerMonth(loads, now));
+  }, [items, services, loads]);
+};

--- a/frontend/src/lib/metrics/maintenance.test.ts
+++ b/frontend/src/lib/metrics/maintenance.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from "vitest";
+import type { MaintenanceItem } from "@/types/maintenance";
+import type { Load } from "@/types/load";
+import {
+  computeDue,
+  addMonths,
+  currentTractorMiles,
+  avgMilesPerMonth,
+  maxOdometer,
+  maintenanceAlerts,
+} from "./maintenance";
+
+const item = (over: Partial<MaintenanceItem>): MaintenanceItem => ({
+  item_id: "i",
+  unit: "tractor",
+  name: "x",
+  category: "engine",
+  interval_miles: null,
+  interval_months: null,
+  interval_hours: null,
+  last_done_miles: null,
+  last_done_date: null,
+  warn_lead_days: 30,
+  active: true,
+  notes: null,
+  ...over,
+});
+
+const load = (over: Partial<Load>): Load =>
+  ({
+    load_id: "l",
+    load_status: "delivered",
+    delivery_date: "2026-06-15",
+    odometer_start: 0,
+    odometer_end: 0,
+    ...over,
+  }) as Load;
+
+const now = new Date("2026-07-09T00:00:00Z");
+
+describe("addMonths", () => {
+  it("adds months UTC-safe", () => {
+    expect(addMonths("2026-04-17", 12)).toBe("2027-04-17");
+    expect(addMonths("2025-11-08", 12)).toBe("2026-11-08");
+  });
+});
+
+describe("computeDue — mileage", () => {
+  it("ok when well within the interval", () => {
+    const d = computeDue(
+      item({ interval_miles: 25000, last_done_miles: 560000 }),
+      565000,
+      now,
+      8000,
+    );
+    expect(d.dueMiles).toBe(585000);
+    expect(d.milesRemaining).toBe(20000);
+    expect(d.level).toBe("ok");
+    expect(d.progress).toBeCloseTo(0.2, 5);
+  });
+
+  it("soon at ≥85% elapsed", () => {
+    const d = computeDue(
+      item({ interval_miles: 25000, last_done_miles: 560000 }),
+      582000,
+      now,
+      8000,
+    );
+    expect(d.level).toBe("soon"); // 22000/25000 = 0.88
+  });
+
+  it("overdue past the due mileage", () => {
+    const d = computeDue(
+      item({ interval_miles: 25000, last_done_miles: 560000 }),
+      590000,
+      now,
+      8000,
+    );
+    expect(d.milesRemaining).toBe(-5000);
+    expect(d.level).toBe("overdue");
+  });
+
+  it("projects a due date from miles remaining and pace", () => {
+    // 20000 miles left at 10000/mo ≈ 2 months out
+    const d = computeDue(
+      item({ interval_miles: 25000, last_done_miles: 560000 }),
+      565000,
+      now,
+      10000,
+    );
+    expect(d.etaDate).not.toBeNull();
+    const months =
+      (new Date(d.etaDate as string).getTime() - now.getTime()) /
+      (30.44 * 86_400_000);
+    expect(months).toBeCloseTo(2, 0);
+  });
+
+  it("unknown without a baseline", () => {
+    const d = computeDue(item({ interval_miles: 25000 }), 565000, now, 8000);
+    expect(d.level).toBe("unknown");
+    expect(d.progress).toBeNull();
+  });
+});
+
+describe("computeDue — time", () => {
+  it("uses months since last done; overdue when past", () => {
+    // annual, last done 14 months ago → overdue
+    const d = computeDue(
+      item({ interval_months: 12, last_done_date: "2025-05-01" }),
+      null,
+      now,
+      null,
+    );
+    expect(d.dueDate).toBe("2026-05-01");
+    expect(d.level).toBe("overdue");
+    expect(d.daysRemaining).toBeLessThan(0);
+  });
+
+  it("soon when within the last ~15% of the interval", () => {
+    // 12-month interval, last done ~11 months ago
+    const d = computeDue(
+      item({ interval_months: 12, last_done_date: "2025-08-05" }),
+      null,
+      now,
+      null,
+    );
+    expect(d.level).toBe("soon");
+  });
+});
+
+describe("computeDue — 'soon' is lead-time based, not percentage", () => {
+  const longItem = { interval_miles: 500000, last_done_miles: 0 };
+
+  it("NOT soon far out even at high % elapsed (the old bug)", () => {
+    // 450k of 500k = 90% elapsed, but 50k mi left ≈ 190 days at 8k/mo → ok
+    const d = computeDue(item(longItem), 450000, now, 8000);
+    expect(d.progress).toBeCloseTo(0.9, 5);
+    expect(d.level).toBe("ok");
+  });
+
+  it("soon once the projection lands within the lead window", () => {
+    // 5k mi left ≈ 19 days at 8k/mo → soon
+    const d = computeDue(item(longItem), 495000, now, 8000);
+    expect(d.level).toBe("soon");
+  });
+
+  it("respects each item's own warning lead", () => {
+    // ~14 days out at 8k/mo (3,700 mi left of a 25k interval)
+    const base = { interval_miles: 25000, last_done_miles: 560000 };
+    const short = computeDue(item({ ...base, warn_lead_days: 7 }), 581300, now, 8000);
+    expect(short.level).toBe("ok"); // 14 days out > 7-day lead
+    const long = computeDue(item({ ...base, warn_lead_days: 30 }), 581300, now, 8000);
+    expect(long.level).toBe("soon"); // 14 days out <= 30-day lead
+  });
+
+  it("falls back to % elapsed when there's no pace projection", () => {
+    const d = computeDue(
+      item({ interval_miles: 25000, last_done_miles: 560000 }),
+      582000, // 88% elapsed
+      now,
+      null, // no pace → no mileage ETA
+    );
+    expect(d.level).toBe("soon");
+  });
+});
+
+describe("maintenanceAlerts", () => {
+  it("emits overdue (critical) first, then soon (warning); skips ok/inactive", () => {
+    const items = [
+      item({ item_id: "ok", interval_miles: 25000, last_done_miles: 560000 }), // 20k left → ok
+      item({
+        item_id: "overdue",
+        name: "Oil",
+        interval_miles: 25000,
+        last_done_miles: 540000,
+      }), // 27k over → overdue
+      item({
+        item_id: "soon",
+        name: "Lube",
+        interval_miles: 25000,
+        last_done_miles: 545000,
+      }), // ~2k left → soon
+      item({ item_id: "off", interval_miles: 25000, last_done_miles: 540000, active: false }),
+    ];
+    const alerts = maintenanceAlerts(items, { tractor: 567000 }, now, 8000);
+    expect(alerts).toHaveLength(2);
+    expect(alerts[0].severity).toBe("critical");
+    expect(alerts[0].message).toContain("Oil");
+    expect(alerts[1].severity).toBe("warning");
+    expect(alerts[1].actionHref).toBe("/maintenance");
+  });
+});
+
+describe("computeDue — both lenses, worst wins", () => {
+  it("time overdue outranks mileage ok", () => {
+    const d = computeDue(
+      item({
+        interval_miles: 25000,
+        last_done_miles: 560000,
+        interval_months: 12,
+        last_done_date: "2025-05-01",
+      }),
+      565000, // mileage only 20% elapsed
+      now,
+      8000,
+    );
+    expect(d.level).toBe("overdue"); // time lens dominates
+  });
+});
+
+describe("currentTractorMiles / avgMilesPerMonth", () => {
+  it("takes the highest odometer reading", () => {
+    const loads = [
+      load({ odometer_end: 560000 }),
+      load({ odometer_end: 568737 }),
+      load({ odometer_end: 565000 }),
+    ];
+    expect(currentTractorMiles(loads)).toBe(568737);
+  });
+
+  it("averages last-90-day delivered miles into a monthly pace", () => {
+    const loads = [
+      load({ delivery_date: "2026-06-20", odometer_start: 0, odometer_end: 9000 }),
+      load({ delivery_date: "2026-07-01", odometer_start: 0, odometer_end: 9000 }),
+      load({ delivery_date: "2026-01-01", odometer_start: 0, odometer_end: 9999 }), // outside 90d
+    ];
+    expect(avgMilesPerMonth(loads, now)).toBeCloseTo(6000, 5); // 18000 / 3
+  });
+
+  it("null pace when there are no recent miles", () => {
+    expect(avgMilesPerMonth([], now)).toBeNull();
+  });
+});
+
+describe("maxOdometer", () => {
+  it("takes the highest across sources, ignoring null/undefined", () => {
+    expect(maxOdometer(314697, 568387, null)).toBe(568387); // fuel-style fresh read wins
+    expect(maxOdometer(null, undefined)).toBeNull();
+    expect(maxOdometer(560000)).toBe(560000);
+  });
+});

--- a/frontend/src/lib/metrics/maintenance.ts
+++ b/frontend/src/lib/metrics/maintenance.ts
@@ -1,0 +1,168 @@
+import type { MaintenanceItem } from "@/types/maintenance";
+import type { Load } from "@/types/load";
+import type { Alert } from "@/types/alert";
+
+const MS_DAY = 86_400_000;
+const DAYS_PER_MONTH = 30.44;
+// "Due soon" = projected to come due within this many days at the current pace.
+export const SOON_WITHIN_DAYS = 30;
+// Fallback only, for items with no projected date (mileage item, no pace data).
+const SOON_FRACTION = 0.85;
+
+export type DueLevel = "overdue" | "soon" | "ok" | "unknown";
+
+export interface Due {
+  level: DueLevel;
+  dueMiles: number | null;
+  milesRemaining: number | null;
+  dueDate: string | null; // from the time interval ('YYYY-MM-DD')
+  daysRemaining: number | null;
+  progress: number | null; // max of mileage/time fraction elapsed (0..1+)
+  etaDate: string | null; // effective predicted due date (earliest of the two lenses)
+}
+
+// Add whole months to a 'YYYY-MM-DD' date, UTC-safe.
+export const addMonths = (iso: string, months: number): string => {
+  const d = new Date(iso);
+  const r = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + months, d.getUTCDate()),
+  );
+  return r.toISOString().slice(0, 10);
+};
+
+// When is this item due, and how close? Handles mileage-based, time-based, or
+// both (the more-elapsed lens wins). etaDate blends the time interval with a
+// mileage projection (miles remaining ÷ your recent miles/month).
+export const computeDue = (
+  item: MaintenanceItem,
+  currentMiles: number | null,
+  now: Date,
+  milesPerMonth: number | null,
+  soonWithinDays: number = SOON_WITHIN_DAYS,
+): Due => {
+  let mileFrac: number | null = null;
+  let dueMiles: number | null = null;
+  let milesRemaining: number | null = null;
+  if (item.interval_miles && item.last_done_miles != null && currentMiles != null) {
+    dueMiles = item.last_done_miles + item.interval_miles;
+    milesRemaining = dueMiles - currentMiles;
+    mileFrac = (currentMiles - item.last_done_miles) / item.interval_miles;
+  }
+
+  let timeFrac: number | null = null;
+  let dueDate: string | null = null;
+  let daysRemaining: number | null = null;
+  if (item.interval_months && item.last_done_date) {
+    dueDate = addMonths(item.last_done_date, item.interval_months);
+    const total = item.interval_months * DAYS_PER_MONTH;
+    const elapsed =
+      (now.getTime() - new Date(item.last_done_date).getTime()) / MS_DAY;
+    timeFrac = elapsed / total;
+    daysRemaining = (new Date(dueDate).getTime() - now.getTime()) / MS_DAY;
+  }
+
+  // Effective due date = whichever lens comes first (time interval, or the
+  // mileage projection from recent pace).
+  const candidates: string[] = [];
+  if (dueDate) candidates.push(dueDate);
+  if (milesRemaining != null && milesPerMonth && milesPerMonth > 0) {
+    const daysOut = (milesRemaining / milesPerMonth) * DAYS_PER_MONTH;
+    candidates.push(new Date(now.getTime() + daysOut * MS_DAY).toISOString().slice(0, 10));
+  }
+  const etaDate = candidates.length ? candidates.sort()[0] : null;
+  const daysToEta =
+    etaDate != null ? (new Date(etaDate).getTime() - now.getTime()) / MS_DAY : null;
+
+  const fracs = [mileFrac, timeFrac].filter((f): f is number => f != null);
+  const progress = fracs.length ? Math.max(...fracs) : null;
+
+  // Overdue if past either threshold. Otherwise "soon" when the projected date
+  // is within the item's own warning lead (falls back to % elapsed with no
+  // projection). Per-item lead lets a truck wash warn at 2 weeks while a DOT
+  // inspection warns at 30 days.
+  const lead = item.warn_lead_days ?? soonWithinDays;
+  let level: DueLevel = "unknown";
+  if (progress != null) {
+    const past =
+      (milesRemaining != null && milesRemaining < 0) ||
+      (daysRemaining != null && daysRemaining < 0) ||
+      progress >= 1;
+    const soon = daysToEta != null ? daysToEta <= lead : progress >= SOON_FRACTION;
+    level = past ? "overdue" : soon ? "soon" : "ok";
+  }
+
+  return { level, dueMiles, milesRemaining, dueDate, daysRemaining, progress, etaDate };
+};
+
+// Highest odometer across any sources that carry one — loads, services, and
+// (later) fuel entries. Fuel readings will usually be the freshest.
+export const maxOdometer = (
+  ...values: (number | null | undefined)[]
+): number | null => {
+  let max: number | null = null;
+  for (const v of values) if (v != null && (max == null || v > max)) max = v;
+  return max;
+};
+
+// Current tractor odometer = the highest odometer reading across loads.
+export const currentTractorMiles = (loads: Load[]): number | null => {
+  let max: number | null = null;
+  for (const l of loads) {
+    if (l.odometer_end != null) {
+      const v = Number(l.odometer_end);
+      if (max == null || v > max) max = v;
+    }
+  }
+  return max;
+};
+
+// Recent driving pace (miles/month) from delivered loads in the last 90 days —
+// drives the mileage→date projection.
+export const avgMilesPerMonth = (loads: Load[], now: Date): number | null => {
+  const cutoff = now.getTime() - 90 * MS_DAY;
+  let miles = 0;
+  for (const l of loads) {
+    if (l.load_status !== "delivered" || !l.delivery_date) continue;
+    if (new Date(l.delivery_date).getTime() < cutoff) continue;
+    if (l.odometer_end != null && l.odometer_start != null)
+      miles += Number(l.odometer_end) - Number(l.odometer_start);
+  }
+  return miles > 0 ? miles / 3 : null;
+};
+
+// Overdue / due-soon items → dashboard alerts (overdue = critical, first).
+export const maintenanceAlerts = (
+  items: MaintenanceItem[],
+  currentMiles: Record<string, number | null>,
+  now: Date,
+  milesPerMonth: number | null,
+): Alert[] => {
+  const ranked: { alert: Alert; rank: number }[] = [];
+  for (const it of items) {
+    if (!it.active) continue;
+    const due = computeDue(it, currentMiles[it.unit] ?? null, now, milesPerMonth);
+    if (due.level !== "overdue" && due.level !== "soon") continue;
+
+    let suffix = "";
+    if (due.milesRemaining != null && due.milesRemaining < 0)
+      suffix = `${Math.round(-due.milesRemaining).toLocaleString("en-US")} mi over`;
+    else if (due.daysRemaining != null && due.daysRemaining < 0)
+      suffix = `${Math.round(-due.daysRemaining)} days over`;
+    else if (due.milesRemaining != null && due.milesRemaining >= 0)
+      suffix = `${Math.round(due.milesRemaining).toLocaleString("en-US")} mi left`;
+    else if (due.etaDate)
+      suffix = `in ${Math.max(0, Math.round((new Date(due.etaDate).getTime() - now.getTime()) / MS_DAY))} days`;
+
+    ranked.push({
+      rank: due.level === "overdue" ? 0 : 1,
+      alert: {
+        id: `maint-${it.item_id}`,
+        kind: "maintenance",
+        severity: due.level === "overdue" ? "critical" : "warning",
+        message: `${it.name} ${due.level === "overdue" ? "overdue" : "due soon"}${suffix ? ` · ${suffix}` : ""}`,
+        actionHref: "/maintenance",
+      },
+    });
+  }
+  return ranked.sort((a, b) => a.rank - b.rank).map((r) => r.alert);
+};

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -17,6 +17,7 @@ import {
   getRecentDeliveredLoads,
 } from "@/lib/metrics/dashboard";
 import { useRateTargets } from "@/hooks/useRateTargets";
+import { useMaintenanceAlerts } from "@/hooks/useMaintenanceAlerts";
 import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
 import { RevenueChart } from "@/components/RevenueChart";
 import { RpmChart } from "@/components/RpmChart";
@@ -25,7 +26,6 @@ import { AlertBanners } from "@/components/dashboard/AlertBanners";
 import { TopAgents } from "@/components/dashboard/TopAgents";
 import { WhatsNext } from "@/components/dashboard/WhatsNext";
 import { RecentLoads } from "@/components/dashboard/RecentLoads";
-import type { Alert } from "@/types/alert";
 
 // helpers
 const formatCurrency = (n: number | null): string =>
@@ -61,6 +61,7 @@ const DashboardPage = () => {
     error: tripsError,
   } = useTrips(refreshKey);
   const targets = useRateTargets(loads);
+  const alerts = useMaintenanceAlerts(loads);
 
   const isLoading = loadsLoading || tripsLoading;
   const error = loadsError || tripsError;
@@ -95,9 +96,6 @@ const DashboardPage = () => {
   const topAgents = getTopAgentsByRevenue(loads);
   const upcoming = getUpcomingLoads(loads);
   const recentLoads = getRecentDeliveredLoads(loads);
-
-  // Reserved for the future alert engine (maintenance / compliance).
-  const alerts: Alert[] = [];
 
   // ---- threshold-based status ----
   // Live break-even (true cost ÷ loaded miles, last 3 complete months); falls

--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -1,0 +1,107 @@
+import { useState, useEffect, useMemo } from "react";
+import { useLoads } from "@/hooks/useLoads";
+import type { MaintenanceItem, MaintenanceService, MaintenanceUnit } from "@/types/maintenance";
+import {
+  getMaintenanceItems,
+  getMaintenanceServices,
+} from "@/services/maintenanceService";
+import {
+  currentTractorMiles,
+  avgMilesPerMonth,
+  maxOdometer,
+} from "@/lib/metrics/maintenance";
+import { ScheduleTab } from "@/components/maintenance/ScheduleTab";
+import { ServicesTab } from "@/components/maintenance/ServicesTab";
+
+const MaintenancePage = () => {
+  const { loads } = useLoads(0);
+  const [items, setItems] = useState<MaintenanceItem[]>([]);
+  const [services, setServices] = useState<MaintenanceService[]>([]);
+  const [tab, setTab] = useState<"schedule" | "services">("schedule");
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    Promise.all([getMaintenanceItems(), getMaintenanceServices()])
+      .then(([its, svcs]) => {
+        if (!active) return;
+        setItems(its);
+        setServices(svcs);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [refreshKey]);
+
+  const refresh = () => setRefreshKey((k) => k + 1);
+
+  // Current mileage = the highest reading we've seen, from either loads or the
+  // service log (services often carry a fresher odometer than entered loads).
+  const currentMiles: Record<MaintenanceUnit, number | null> = useMemo(() => {
+    const maxServiceOdo = (unit: MaintenanceUnit): number | null =>
+      services
+        .filter((s) => s.unit === unit && s.odometer != null)
+        .reduce<number | null>(
+          (max, s) => (max == null || s.odometer! > max ? s.odometer! : max),
+          null,
+        );
+    // When the fuel page carries odometer, add its latest reading here — it'll
+    // usually be the freshest.
+    return {
+      tractor: maxOdometer(currentTractorMiles(loads), maxServiceOdo("tractor")),
+      trailer: maxOdometer(maxServiceOdo("trailer")),
+    };
+  }, [loads, services]);
+
+  const milesPerMonth = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
+
+  const tabBtn = (key: "schedule" | "services", label: string) => (
+    <button
+      onClick={() => setTab(key)}
+      className={`px-3 py-2 text-sm border-b-2 ${
+        tab === key
+          ? "border-amber text-light font-medium"
+          : "border-transparent text-muted-text"
+      }`}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <h1 className="text-3xl font-condensed mb-1">Maintenance</h1>
+      <p className="text-xs text-muted-text mb-4">
+        Tractor 580991 · International LT625 / Cummins X15 · Trailer 780991
+        {currentMiles.tractor != null &&
+          ` · ${currentMiles.tractor.toLocaleString("en-US")} mi`}
+      </p>
+
+      <div className="flex gap-1 border-b border-steel mb-5">
+        {tabBtn("schedule", "Schedule")}
+        {tabBtn("services", "Services")}
+      </div>
+
+      {loading ? (
+        <p className="text-muted-text">Loading...</p>
+      ) : tab === "schedule" ? (
+        <ScheduleTab
+          items={items}
+          currentMiles={currentMiles}
+          milesPerMonth={milesPerMonth}
+          onChange={refresh}
+        />
+      ) : (
+        <ServicesTab items={items} services={services} onChange={refresh} />
+      )}
+    </div>
+  );
+};
+
+export default MaintenancePage;

--- a/frontend/src/services/maintenanceService.ts
+++ b/frontend/src/services/maintenanceService.ts
@@ -1,0 +1,107 @@
+import api from "./api";
+import type { MaintenanceItem, MaintenanceService } from "@/types/maintenance";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const numOrNull = (v: any): number | null =>
+  v == null || v === "" ? null : Number(v);
+const dateOrNull = (v: any): string | null =>
+  v == null ? null : String(v).slice(0, 10);
+
+const coerceItem = (i: any): MaintenanceItem => ({
+  item_id: i.item_id,
+  unit: i.unit,
+  name: i.name,
+  category: i.category,
+  interval_miles: numOrNull(i.interval_miles),
+  interval_months: numOrNull(i.interval_months),
+  interval_hours: numOrNull(i.interval_hours),
+  last_done_miles: numOrNull(i.last_done_miles),
+  last_done_date: dateOrNull(i.last_done_date),
+  warn_lead_days: numOrNull(i.warn_lead_days) ?? 14,
+  active: i.active,
+  notes: i.notes ?? null,
+});
+
+const coerceService = (s: any): MaintenanceService => ({
+  service_id: s.service_id,
+  unit: s.unit,
+  service_date: dateOrNull(s.service_date) as string,
+  odometer: numOrNull(s.odometer),
+  vendor: s.vendor ?? null,
+  location: s.location ?? null,
+  description: s.description,
+  cost: numOrNull(s.cost),
+  invoice_number: s.invoice_number ?? null,
+  notes: s.notes ?? null,
+  item_ids: Array.isArray(s.item_ids) ? s.item_ids : [],
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// ---- schedule items ----
+export const getMaintenanceItems = async (): Promise<MaintenanceItem[]> => {
+  const res = await api.get("/maintenance/items");
+  return res.data.items.map(coerceItem);
+};
+
+export const seedMaintenanceItems = async (): Promise<MaintenanceItem[]> => {
+  const res = await api.post("/maintenance/items/seed");
+  return res.data.items.map(coerceItem);
+};
+
+export type ItemInput = Partial<Omit<MaintenanceItem, "item_id">>;
+
+export const createMaintenanceItem = async (
+  data: ItemInput,
+): Promise<MaintenanceItem> => {
+  const res = await api.post("/maintenance/items", data);
+  return coerceItem(res.data.item);
+};
+
+export const patchMaintenanceItem = async (
+  id: string,
+  data: ItemInput,
+): Promise<MaintenanceItem> => {
+  const res = await api.patch(`/maintenance/items/${id}`, data);
+  return coerceItem(res.data.item);
+};
+
+export const deleteMaintenanceItem = async (id: string): Promise<void> => {
+  await api.delete(`/maintenance/items/${id}`);
+};
+
+// ---- services log ----
+export const getMaintenanceServices = async (): Promise<MaintenanceService[]> => {
+  const res = await api.get("/maintenance/services");
+  return res.data.services.map(coerceService);
+};
+
+export interface ServiceInput {
+  unit: string;
+  service_date: string;
+  odometer?: number | null;
+  vendor?: string | null;
+  location?: string | null;
+  description: string;
+  cost?: number | null;
+  invoice_number?: string | null;
+  notes?: string | null;
+  item_ids?: string[];
+}
+
+export const createMaintenanceService = async (
+  data: ServiceInput,
+): Promise<MaintenanceService> => {
+  const res = await api.post("/maintenance/services", data);
+  return coerceService(res.data.service);
+};
+
+export const patchMaintenanceService = async (
+  id: string,
+  data: Partial<ServiceInput>,
+): Promise<void> => {
+  await api.patch(`/maintenance/services/${id}`, data);
+};
+
+export const deleteMaintenanceService = async (id: string): Promise<void> => {
+  await api.delete(`/maintenance/services/${id}`);
+};

--- a/frontend/src/types/maintenance.ts
+++ b/frontend/src/types/maintenance.ts
@@ -1,0 +1,32 @@
+export type MaintenanceUnit = "tractor" | "trailer";
+
+export interface MaintenanceItem {
+  item_id: string;
+  unit: MaintenanceUnit;
+  name: string;
+  category: string;
+  interval_miles: number | null;
+  interval_months: number | null;
+  interval_hours: number | null;
+  last_done_miles: number | null;
+  last_done_date: string | null; // 'YYYY-MM-DD'
+  warn_lead_days: number; // start flagging "due soon" this many days before due
+  active: boolean;
+  notes: string | null;
+}
+
+// Costs are for vendor pricing only — never rolled into the P&L. Receipts live
+// in QuickBooks, so there's no receipt field here.
+export interface MaintenanceService {
+  service_id: string;
+  unit: MaintenanceUnit;
+  service_date: string; // 'YYYY-MM-DD'
+  odometer: number | null;
+  vendor: string | null;
+  location: string | null;
+  description: string;
+  cost: number | null;
+  invoice_number: string | null;
+  notes: string | null;
+  item_ids: string[]; // schedule items this service completed
+}


### PR DESCRIPTION
A maintenance tracker for the LT625 + Cummins X15 + Eaton Fuller and the trailer. Two tabs, grouped by system (Truck / Transmission / Trailer).

## Schedule tab
- Status board (overdue / due-soon triage chips) with a table toggle
- **Due engine**: mileage- or time-based (whichever comes first). "Due soon" is **lead-time based** — projected within each item's own `warn_lead_days` — so a 500k valve job doesn't flag "soon" 75k miles out; overdue = past due
- Projected due dates from recent miles/month; current odometer = max across loads and the service log (fuel-ready via `maxOdometer`)
- "Load starter schedule" seeds severe-duty OEM intervals (all editable)

## Services tab
- Chronological log (vendor, location, odometer, cost, invoice); logging a service can complete scheduled items and reset their clocks
- Cost is **vendor-pricing only — never rolled into the P&L** (QuickBooks already books maintenance); rollup shows spend/avg per shop
- Month-range filter (preset pills + custom dropdowns) to pull any window

## Dashboard
- Overdue (**critical**) / due-soon (**warning**) items post as alert banners via a reusable `maintenanceAlerts` generator + `useMaintenanceAlerts` hook — the same engine the future Compliance page will use
- Fixed AlertBanners' dead Tabler icons (→ lucide) + router links

## Backend
- Migrations **026** (items / services / link tables) + **027** (per-item `warn_lead_days`) — already run on dev and prod
- `maintenanceServices` + routes at `/maintenance`

90 tests, strict build green. Receipts intentionally omitted (kept in QuickBooks); compliance items excluded (own page later).