### PR TITLE
feat: fleet entities — truck / driver / trailer with AI avatars

### DIFF
--- a/backend/db/migrations/028_fleet_entities.sql
+++ b/backend/db/migrations/028_fleet_entities.sql
@@ -1,0 +1,59 @@
+-- Fleet entities: make truck / driver / trailer first-class and tie loads +
+-- maintenance to them. Adds a trailers table, enriches drivers, adds avatar_url
+-- (generated or uploaded) to each entity, and nullable FKs on loads +
+-- maintenance. FKs are nullable so existing rows stay valid; a data backfill
+-- assigns the single rig. Multi-truck UI comes later.
+
+-- ---- avatars on trucks ----
+ALTER TABLE trucks ADD COLUMN IF NOT EXISTS avatar_url VARCHAR(500);
+
+-- ---- enrich drivers ----
+ALTER TABLE drivers
+  ADD COLUMN IF NOT EXISTS phone VARCHAR(30),
+  ADD COLUMN IF NOT EXISTS email VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS cdl_number VARCHAR(50),
+  ADD COLUMN IF NOT EXISTS cdl_state VARCHAR(2),
+  ADD COLUMN IF NOT EXISTS cdl_expiration DATE,
+  ADD COLUMN IF NOT EXISTS endorsements VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS hire_date DATE,
+  ADD COLUMN IF NOT EXISTS avatar_url VARCHAR(500),
+  ADD COLUMN IF NOT EXISTS notes TEXT;
+
+-- ---- trailers (mirrors trucks; reuses the truck_status enum) ----
+CREATE TABLE IF NOT EXISTS trailers (
+  trailer_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  unit_number VARCHAR(50) NOT NULL,
+  vin VARCHAR(50),
+  plate_number VARCHAR(20),
+  plate_state VARCHAR(2),
+  trailer_type VARCHAR(40) NOT NULL DEFAULT 'flatbed',
+  length_ft INTEGER,
+  make VARCHAR(60),
+  model VARCHAR(60),
+  year INTEGER,
+  current_hub INTEGER NOT NULL DEFAULT 0,
+  status truck_status NOT NULL DEFAULT 'active',
+  avatar_url VARCHAR(500),
+  in_service_date DATE,
+  notes TEXT,
+  is_deleted BOOLEAN NOT NULL DEFAULT false,
+  deleted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_trailers_user ON trailers(user_id);
+
+-- ---- tie loads to truck / driver / trailer ----
+ALTER TABLE loads
+  ADD COLUMN IF NOT EXISTS truck_id UUID REFERENCES trucks(truck_id),
+  ADD COLUMN IF NOT EXISTS driver_id UUID REFERENCES drivers(driver_id),
+  ADD COLUMN IF NOT EXISTS trailer_id UUID REFERENCES trailers(trailer_id);
+
+-- ---- tie maintenance to truck / trailer (unit string stays for now) ----
+ALTER TABLE maintenance_items
+  ADD COLUMN IF NOT EXISTS truck_id UUID REFERENCES trucks(truck_id),
+  ADD COLUMN IF NOT EXISTS trailer_id UUID REFERENCES trailers(trailer_id);
+ALTER TABLE maintenance_services
+  ADD COLUMN IF NOT EXISTS truck_id UUID REFERENCES trucks(truck_id),
+  ADD COLUMN IF NOT EXISTS trailer_id UUID REFERENCES trailers(trailer_id);

--- a/backend/src/routes/avatarRoutes.js
+++ b/backend/src/routes/avatarRoutes.js
@@ -1,0 +1,60 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import { generateAvatar, uploadAvatar } from "../services/avatarService.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+const handleError = (res, err) => {
+  if (err.type === "validation")
+    return res.status(err.statusCode).json({ error: err.message });
+  if (err.type === "not_found")
+    return res.status(err.statusCode).json({ error: err.message });
+  return res
+    .status(500)
+    .json({ error: "Internal Server Error", message: err.message });
+};
+
+// Generate a themed avatar for a truck/driver/trailer. Body: { variant } for
+// driver gender ('male' | 'female').
+router.post("/:kind/:id/generate", async (req, res) => {
+  try {
+    const result = await generateAvatar(
+      req.user.user_id,
+      req.params.kind,
+      req.params.id,
+      req.body?.variant,
+    );
+    return res.status(200).json(result);
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+// Upload a photo to override the avatar. Send the raw image as the body with an
+// image/* Content-Type.
+router.post(
+  "/:kind/:id/upload",
+  express.raw({
+    type: ["image/jpeg", "image/png", "image/webp"],
+    limit: "5mb",
+  }),
+  async (req, res) => {
+    try {
+      if (!req.body || !req.body.length)
+        return res.status(400).json({ error: "No image in request body" });
+      const result = await uploadAvatar(
+        req.user.user_id,
+        req.params.kind,
+        req.params.id,
+        req.body,
+        req.headers["content-type"],
+      );
+      return res.status(200).json(result);
+    } catch (err) {
+      return handleError(res, err);
+    }
+  },
+);
+
+export default router;

--- a/backend/src/routes/trailerRoutes.js
+++ b/backend/src/routes/trailerRoutes.js
@@ -1,0 +1,69 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import {
+  getTrailers,
+  getTrailer,
+  createTrailer,
+  patchTrailer,
+  deleteTrailer,
+} from "../services/trailerServices.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+const handleError = (res, err) => {
+  if (err.type === "validation")
+    return res.status(err.statusCode).json({ error: err.message });
+  if (err.type === "not_found")
+    return res.status(err.statusCode).json({ error: err.message });
+  return res
+    .status(500)
+    .json({ error: "Internal Server Error", message: err.message });
+};
+
+router.get("/me", async (req, res) => {
+  try {
+    const trailers = await getTrailers(req.user.user_id);
+    return res.status(200).json({ trailers });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.get("/me/:id", async (req, res) => {
+  try {
+    const trailer = await getTrailer(req.user.user_id, req.params.id);
+    return res.status(200).json({ trailer });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.post("/me", async (req, res) => {
+  try {
+    const trailer = await createTrailer(req.user.user_id, req.body);
+    return res.status(201).json({ trailer });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.patch("/me/:id", async (req, res) => {
+  try {
+    const trailer = await patchTrailer(req.user.user_id, req.params.id, req.body);
+    return res.status(200).json({ trailer });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.delete("/me/:id", async (req, res) => {
+  try {
+    const deleted = await deleteTrailer(req.user.user_id, req.params.id);
+    return res.status(200).json({ deleted });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -20,6 +20,8 @@ import agentNoteRoutes from "./routes/agentNoteRoutes.js";
 import expenseRouter from "./routes/expenseRoutes.js";
 import obligationRouter from "./routes/obligationRoutes.js";
 import maintenanceRouter from "./routes/maintenanceRoutes.js";
+import trailerRouter from "./routes/trailerRoutes.js";
+import avatarRouter from "./routes/avatarRoutes.js";
 
 const app = express();
 
@@ -47,6 +49,8 @@ app.use("/agents/:agent_id/notes", agentNoteRoutes);
 app.use("/expenses", expenseRouter);
 app.use("/obligations", obligationRouter);
 app.use("/maintenance", maintenanceRouter);
+app.use("/trailers", trailerRouter);
+app.use("/avatars", avatarRouter);
 
 app.get("/", (req, res) => {
   res.send("Home Page");

--- a/backend/src/services/avatarService.js
+++ b/backend/src/services/avatarService.js
@@ -1,0 +1,132 @@
+import { db } from "../../db/pool.js";
+import { ValidationError, NotFoundError } from "../utils/error.js";
+
+const FAL_API_KEY = process.env.FAL_API_KEY;
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const BUCKET = "avatars";
+const FAL_MODEL = "fal-ai/flux/schnell";
+
+// Which table + id column each avatar kind writes to. Fixed map (not user
+// input), so interpolating the names into SQL is safe.
+const ENTITY = {
+  truck: { table: "trucks", idCol: "truck_id" },
+  driver: { table: "drivers", idCol: "driver_id" },
+  trailer: { table: "trailers", idCol: "trailer_id" },
+};
+
+// Locked house style: comic-illustration, steel-blue + amber, dark depot,
+// clean front 3/4 (the truck-0 / driver-0 look Jason signed off on).
+const STYLE =
+  "comic book digital illustration, cel shaded, bold clean line art, " +
+  "dark steel-blue and amber color palette, dark industrial background, " +
+  "cinematic rim lighting";
+
+const buildPrompt = (kind, row, variant) => {
+  if (kind === "truck") {
+    const desc = [row.year, row.make, row.model].filter(Boolean).join(" ");
+    return (
+      `${STYLE}. A ${desc || "modern"} semi truck day cab tractor, ` +
+      "clean front three-quarter view, chrome grille angled at 45 degrees, " +
+      "glowing amber marker lights, dynamic vehicle character portrait."
+    );
+  }
+  if (kind === "driver") {
+    const g = variant === "female" ? "female" : "male";
+    return (
+      `${STYLE}. Head and shoulders avatar portrait of a rugged ${g} American ` +
+      "truck driver, baseball cap, work shirt, confident calm expression."
+    );
+  }
+  // trailer — reflect the actual type, and force a STANDALONE trailer (flux
+  // otherwise draws a flatbed body truck).
+  const len = row.length_ft ? `${row.length_ft} foot ` : "";
+  const type = row.trailer_type || "flatbed";
+  return (
+    `${STYLE}. A single detached ${len}${type} semi-trailer parked alone on its ` +
+    "landing gear, NO truck, NO cab, NO tractor attached, empty deck, side " +
+    "three-quarter view, isolated product shot."
+  );
+};
+
+const falGenerate = async (prompt) => {
+  if (!FAL_API_KEY) throw new ValidationError("FAL_API_KEY is not configured");
+  const res = await fetch(`https://fal.run/${FAL_MODEL}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Key ${FAL_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ prompt, image_size: "square_hd", num_images: 1 }),
+  });
+  if (!res.ok)
+    throw new Error(`Image generation failed (${res.status})`);
+  const data = await res.json();
+  const url = data?.images?.[0]?.url;
+  if (!url) throw new Error("Image generation returned no image");
+  return url;
+};
+
+const uploadToStorage = async (path, buffer, contentType) => {
+  if (!SUPABASE_URL || !SERVICE_KEY)
+    throw new ValidationError(
+      "Avatar storage is not configured (set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY)",
+    );
+  const res = await fetch(
+    `${SUPABASE_URL}/storage/v1/object/${BUCKET}/${path}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${SERVICE_KEY}`,
+        "Content-Type": contentType,
+        "x-upsert": "true",
+      },
+      body: buffer,
+    },
+  );
+  if (!res.ok)
+    throw new Error(`Storage upload failed (${res.status})`);
+  return `${SUPABASE_URL}/storage/v1/object/public/${BUCKET}/${path}`;
+};
+
+const setAvatarUrl = async (kind, user_id, id, url) => {
+  const { table, idCol } = ENTITY[kind];
+  await db.query(
+    `UPDATE ${table} SET avatar_url = $1, updated_at = NOW()
+     WHERE ${idCol} = $2 AND user_id = $3`,
+    [url, id, user_id],
+  );
+};
+
+const getEntity = async (kind, user_id, id) => {
+  const { table, idCol } = ENTITY[kind];
+  const r = await db.query(
+    `SELECT * FROM ${table} WHERE ${idCol} = $1 AND user_id = $2`,
+    [id, user_id],
+  );
+  if (r.rowCount === 0) throw new NotFoundError(`${kind} not found`);
+  return r.rows[0];
+};
+
+// Generate a themed avatar, store it, and set the entity's avatar_url.
+export const generateAvatar = async (user_id, kind, id, variant) => {
+  if (!ENTITY[kind]) throw new ValidationError("Invalid avatar kind");
+  const row = await getEntity(kind, user_id, id);
+  const imageUrl = await falGenerate(buildPrompt(kind, row, variant));
+  const buffer = Buffer.from(await (await fetch(imageUrl)).arrayBuffer());
+  const path = `${kind}/${id}.jpg`;
+  const publicUrl = await uploadToStorage(path, buffer, "image/jpeg");
+  await setAvatarUrl(kind, user_id, id, publicUrl);
+  return { avatar_url: publicUrl };
+};
+
+// Store a user-uploaded image (buffer) and set the entity's avatar_url.
+export const uploadAvatar = async (user_id, kind, id, buffer, contentType) => {
+  if (!ENTITY[kind]) throw new ValidationError("Invalid avatar kind");
+  await getEntity(kind, user_id, id); // ownership check
+  const ext = contentType === "image/png" ? "png" : contentType === "image/webp" ? "webp" : "jpg";
+  const path = `${kind}/${id}-upload.${ext}`;
+  const publicUrl = await uploadToStorage(path, buffer, contentType);
+  await setAvatarUrl(kind, user_id, id, publicUrl);
+  return { avatar_url: publicUrl };
+};

--- a/backend/src/services/driverServices.js
+++ b/backend/src/services/driverServices.js
@@ -12,7 +12,20 @@ export async function createDriver(user_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
 
   // Reject unknown fields
-  const allowedFields = ["first_name", "last_name", "active"];
+  const allowedFields = [
+    "first_name",
+    "last_name",
+    "phone",
+    "email",
+    "cdl_number",
+    "cdl_state",
+    "cdl_expiration",
+    "endorsements",
+    "hire_date",
+    "avatar_url",
+    "notes",
+    "active",
+  ];
 
   for (const field in data) {
     if (!allowedFields.includes(field)) {
@@ -64,6 +77,15 @@ export async function getDrivers(user_id) {
         driver_id,
         first_name,
         last_name,
+        phone,
+        email,
+        cdl_number,
+        cdl_state,
+        cdl_expiration,
+        endorsements,
+        hire_date,
+        avatar_url,
+        notes,
         active,
         created_at,
         updated_at
@@ -90,6 +112,15 @@ export async function getDriver(user_id, driver_id) {
         driver_id,
         first_name,
         last_name,
+        phone,
+        email,
+        cdl_number,
+        cdl_state,
+        cdl_expiration,
+        endorsements,
+        hire_date,
+        avatar_url,
+        notes,
         active,
         created_at,
         updated_at
@@ -110,7 +141,20 @@ export async function patchDriver(user_id, driver_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
   if (!driver_id) throw new ValidationError("Missing driver_id");
 
-  const allowedFields = ["first_name", "last_name", "active"];
+  const allowedFields = [
+    "first_name",
+    "last_name",
+    "phone",
+    "email",
+    "cdl_number",
+    "cdl_state",
+    "cdl_expiration",
+    "endorsements",
+    "hire_date",
+    "avatar_url",
+    "notes",
+    "active",
+  ];
 
   // Throw error if data contains invalid field(s)
   for (const field in data) {

--- a/backend/src/services/loadServices.js
+++ b/backend/src/services/loadServices.js
@@ -42,6 +42,9 @@ export async function getLoads(user_id) {
             odometer_start,
             odometer_end,
             payment_status,
+            loads.truck_id,
+            loads.driver_id,
+            loads.trailer_id,
             loads.created_at AS created_at,
             loads.updated_at AS updated_at
         FROM loads

--- a/backend/src/services/maintenanceServices.js
+++ b/backend/src/services/maintenanceServices.js
@@ -10,7 +10,8 @@ export async function getMaintenanceItems(user_id) {
   if (!user_id) throw new ValidationError("Missing user_id");
   const result = await db.query(
     `SELECT item_id, unit, name, category, interval_miles, interval_months,
-            interval_hours, last_done_miles, last_done_date, active, notes, warn_lead_days
+            interval_hours, last_done_miles, last_done_date, active, notes,
+            warn_lead_days, truck_id, trailer_id
      FROM maintenance_items
      WHERE user_id = $1
      ORDER BY category, name`,

--- a/backend/src/services/trailerServices.js
+++ b/backend/src/services/trailerServices.js
@@ -1,0 +1,122 @@
+import { db } from "../../db/pool.js";
+import { ValidationError, NotFoundError } from "../utils/error.js";
+
+const SELECT_COLS = `
+  trailer_id, unit_number, vin, plate_number, plate_state, trailer_type,
+  length_ft, make, model, year, current_hub, status, avatar_url,
+  in_service_date, notes, created_at, updated_at`;
+
+const ALLOWED = [
+  "unit_number",
+  "vin",
+  "plate_number",
+  "plate_state",
+  "trailer_type",
+  "length_ft",
+  "make",
+  "model",
+  "year",
+  "current_hub",
+  "status",
+  "avatar_url",
+  "in_service_date",
+  "notes",
+];
+
+// ---- GET ALL TRAILERS ----
+export async function getTrailers(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const result = await db.query(
+    `SELECT ${SELECT_COLS} FROM trailers
+     WHERE user_id = $1 AND is_deleted = false
+     ORDER BY created_at DESC`,
+    [user_id],
+  );
+  return result.rows;
+}
+
+// ---- GET TRAILER BY ID ----
+export async function getTrailer(user_id, trailer_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!trailer_id) throw new ValidationError("Missing trailer_id");
+  const result = await db.query(
+    `SELECT ${SELECT_COLS} FROM trailers
+     WHERE user_id = $1 AND trailer_id = $2 AND is_deleted = false`,
+    [user_id, trailer_id],
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Trailer not found");
+  return result.rows[0];
+}
+
+// ---- CREATE TRAILER ----
+export async function createTrailer(user_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!data.unit_number) throw new ValidationError("unit_number is required");
+
+  const fields = ["user_id"];
+  const values = [user_id];
+  const placeholders = ["$1"];
+  let i = 2;
+  for (const field of ALLOWED) {
+    if (data[field] !== undefined) {
+      fields.push(field);
+      values.push(data[field]);
+      placeholders.push(`$${i}`);
+      i++;
+    }
+  }
+
+  const result = await db.query(
+    `INSERT INTO trailers (${fields.join(", ")})
+     VALUES (${placeholders.join(", ")})
+     RETURNING ${SELECT_COLS}`,
+    values,
+  );
+  return result.rows[0];
+}
+
+// ---- PATCH TRAILER ----
+export async function patchTrailer(user_id, trailer_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!trailer_id) throw new ValidationError("Missing trailer_id");
+
+  const updates = [];
+  const values = [];
+  let i = 1;
+  for (const field of ALLOWED) {
+    if (data[field] !== undefined) {
+      updates.push(`${field} = $${i}`);
+      values.push(data[field]);
+      i++;
+    }
+  }
+  if (updates.length === 0)
+    throw new ValidationError("No valid fields to update");
+
+  updates.push(`updated_at = NOW()`);
+  values.push(trailer_id, user_id);
+
+  const result = await db.query(
+    `UPDATE trailers SET ${updates.join(", ")}
+     WHERE trailer_id = $${i} AND user_id = $${i + 1} AND is_deleted = false
+     RETURNING ${SELECT_COLS}`,
+    values,
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Trailer not found");
+  return result.rows[0];
+}
+
+// ---- DELETE TRAILER (soft) ----
+export async function deleteTrailer(user_id, trailer_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!trailer_id) throw new ValidationError("Missing trailer_id");
+  const result = await db.query(
+    `UPDATE trailers
+       SET is_deleted = true, deleted_at = NOW(), updated_at = NOW()
+     WHERE trailer_id = $1 AND user_id = $2 AND is_deleted = false
+     RETURNING trailer_id`,
+    [trailer_id, user_id],
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Trailer not found");
+  return result.rows[0];
+}

--- a/backend/src/services/truckServices.js
+++ b/backend/src/services/truckServices.js
@@ -17,7 +17,6 @@ export async function getTrucks(user_id) {
     SELECT
       truck_id,
       unit_number,
-      truck_name,
       vin,
       plate_number,
       plate_state,
@@ -27,6 +26,7 @@ export async function getTrucks(user_id) {
       current_odometer,
       status,
       in_service_date,
+      avatar_url,
       is_deleted,
       created_at,
       updated_at,
@@ -58,7 +58,6 @@ export async function getTruck(user_id, truck_id) {
     `
     SELECT
       truck_id,
-      truck_name,
       unit_number,
       vin,
       plate_number,
@@ -69,6 +68,7 @@ export async function getTruck(user_id, truck_id) {
       current_odometer,
       status,
       in_service_date,
+      avatar_url,
       is_deleted,
       created_at,
       updated_at,
@@ -102,7 +102,7 @@ export async function createTruck(user_id, data) {
     "current_odometer",
     "status",
     "in_service_date",
-    "truck_name",
+    "avatar_url",
   ];
 
   // Filter for allowed fields only
@@ -163,7 +163,7 @@ export async function patchTruck(user_id, truck_id, data) {
     "current_odometer",
     "status",
     "in_service_date",
-    "truck_name",
+    "avatar_url",
   ];
 
   const updates = [];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.31.0",
+  "version": "1.32.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,11 @@ import AgentsPage from "@/pages/AgentsPage";
 import AgentDetailPage from "./pages/AgentDetailPage";
 import FuelEntriesPage from "@/pages/FuelEntriesPage";
 import TrucksPage from "@/pages/TrucksPage";
+import TruckDetailPage from "@/pages/TruckDetailPage";
 import DriversPage from "@/pages/DriversPage";
+import DriverDetailPage from "@/pages/DriverDetailPage";
+import TrailersPage from "@/pages/TrailersPage";
+import TrailerDetailPage from "@/pages/TrailerDetailPage";
 import { LoadDetailPage } from "@/pages/LoadDetailPage";
 import { SwatchesPage } from "@/pages/SwatchesPage";
 import SignupPage from "@/pages/SignupPage";
@@ -56,7 +60,11 @@ const App = () => {
           <Route path="/agents/:agent_id" element={<AgentDetailPage />} />
           <Route path="/fuel-entries" element={<FuelEntriesPage />} />
           <Route path="/trucks" element={<TrucksPage />} />
+          <Route path="/trucks/:id" element={<TruckDetailPage />} />
           <Route path="/drivers" element={<DriversPage />} />
+          <Route path="/drivers/:id" element={<DriverDetailPage />} />
+          <Route path="/trailers" element={<TrailersPage />} />
+          <Route path="/trailers/:id" element={<TrailerDetailPage />} />
         </Route>
       </Route>
 

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -18,10 +18,11 @@ const navItems = [
   { to: "/lanes", label: "Lanes" },
   { to: "/expenses", label: "Expenses" },
   { to: "/maintenance", label: "Maintenance" },
+  { to: "/trucks", label: "Trucks" },
+  { to: "/trailers", label: "Trailers" },
+  { to: "/drivers", label: "Drivers" },
   { to: "/agents", label: "Agents" },
   { to: "/fuel-entries", label: "Fuel Entries" },
-  // { to: "/trucks", label: "Trucks" },
-  // { to: "/drivers", label: "Drivers" },
 ];
 
 const AppSidebar = () => {

--- a/frontend/src/components/fleet/AvatarFallback.tsx
+++ b/frontend/src/components/fleet/AvatarFallback.tsx
@@ -1,0 +1,53 @@
+import type { AvatarKind } from "@/services/avatarsService";
+
+// Flat, on-brand default avatars shown until a generated/uploaded image exists.
+export const AvatarFallback = ({ kind }: { kind: AvatarKind }) => {
+  if (kind === "truck") {
+    return (
+      <svg viewBox="0 0 200 200" width="100%" height="100%" role="img" aria-label="Truck">
+        <rect width="200" height="200" fill="#12161f" />
+        <ellipse cx="100" cy="168" rx="66" ry="9" fill="#000" opacity="0.35" />
+        <rect x="56" y="40" width="6" height="58" rx="3" fill="#5a6478" />
+        <rect x="138" y="40" width="6" height="58" rx="3" fill="#5a6478" />
+        <polygon points="144,66 170,82 170,150 144,150" fill="#232c3f" />
+        <rect x="52" y="58" width="92" height="98" rx="12" fill="#33425b" />
+        <rect x="64" y="68" width="68" height="30" rx="7" fill="#0d1117" />
+        <rect x="64" y="102" width="68" height="4" rx="2" fill="#e8940a" />
+        <rect x="72" y="110" width="52" height="34" rx="4" fill="#1c2333" stroke="#e8940a" strokeWidth="1.5" />
+        <line x1="82" y1="112" x2="82" y2="142" stroke="#4a5468" strokeWidth="2" />
+        <line x1="92" y1="112" x2="92" y2="142" stroke="#4a5468" strokeWidth="2" />
+        <line x1="102" y1="112" x2="102" y2="142" stroke="#4a5468" strokeWidth="2" />
+        <line x1="112" y1="112" x2="112" y2="142" stroke="#4a5468" strokeWidth="2" />
+        <rect x="54" y="112" width="14" height="16" rx="4" fill="#e8940a" />
+        <rect x="128" y="112" width="14" height="16" rx="4" fill="#e8940a" />
+        <rect x="52" y="146" width="96" height="12" rx="3" fill="#3a4152" />
+        <circle cx="72" cy="160" r="11" fill="#0d1117" /><circle cx="72" cy="160" r="4" fill="#5a6478" />
+        <circle cx="128" cy="160" r="11" fill="#0d1117" /><circle cx="128" cy="160" r="4" fill="#5a6478" />
+      </svg>
+    );
+  }
+  if (kind === "trailer") {
+    return (
+      <svg viewBox="0 0 200 200" width="100%" height="100%" role="img" aria-label="Trailer">
+        <rect width="200" height="200" fill="#12161f" />
+        <ellipse cx="100" cy="150" rx="74" ry="9" fill="#000" opacity="0.35" />
+        <polygon points="26,110 174,110 182,120 18,120" fill="#33425b" />
+        <rect x="18" y="118" width="164" height="10" fill="#232c3f" />
+        <rect x="150" y="86" width="8" height="26" rx="2" fill="#5a6478" />
+        <rect x="150" y="104" width="10" height="10" rx="2" fill="#e8940a" />
+        <rect x="24" y="110" width="150" height="3" fill="#e8940a" opacity="0.8" />
+        <circle cx="60" cy="134" r="11" fill="#0d1117" /><circle cx="60" cy="134" r="4" fill="#5a6478" />
+        <circle cx="82" cy="134" r="11" fill="#0d1117" /><circle cx="82" cy="134" r="4" fill="#5a6478" />
+        <circle cx="150" cy="134" r="11" fill="#0d1117" /><circle cx="150" cy="134" r="4" fill="#5a6478" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 200 200" width="100%" height="100%" role="img" aria-label="Driver">
+      <rect width="200" height="200" fill="#1c2333" />
+      <path d="M45,180 C45,132 66,116 100,116 C134,116 155,132 155,180 Z" fill="#5a6478" />
+      <circle cx="100" cy="80" r="34" fill="#5a6478" />
+      <path d="M66,74 C66,52 82,44 100,44 C118,44 134,52 134,74 C124,64 76,64 66,74 Z" fill="#47506a" />
+    </svg>
+  );
+};

--- a/frontend/src/components/fleet/EntityAvatar.tsx
+++ b/frontend/src/components/fleet/EntityAvatar.tsx
@@ -1,0 +1,128 @@
+import { useRef, useState } from "react";
+import { Sparkles, Upload } from "lucide-react";
+import {
+  generateAvatar,
+  uploadAvatar,
+  type AvatarKind,
+} from "@/services/avatarsService";
+import { AvatarFallback } from "./AvatarFallback";
+
+interface Props {
+  kind: AvatarKind;
+  id: string;
+  avatarUrl: string | null;
+  size?: number;
+  allowVariant?: boolean; // driver male/female toggle
+  onUpdated?: (url: string) => void;
+}
+
+export const EntityAvatar = ({
+  kind,
+  id,
+  avatarUrl,
+  size = 160,
+  allowVariant,
+  onUpdated,
+}: Props) => {
+  const [url, setUrl] = useState<string | null>(avatarUrl);
+  const [busy, setBusy] = useState<null | "gen" | "up">(null);
+  const [variant, setVariant] = useState("male");
+  const [err, setErr] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  // Storage path is fixed per entity, so a fresh image reuses the URL — bust
+  // the browser cache so the new one shows.
+  const bust = (u: string) => `${u}?t=${Date.now()}`;
+
+  const gen = async () => {
+    setBusy("gen");
+    setErr(null);
+    try {
+      const u = await generateAvatar(kind, id, allowVariant ? variant : undefined);
+      setUrl(bust(u));
+      onUpdated?.(u);
+    } catch {
+      setErr("Generation failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    e.target.value = "";
+    if (!f) return;
+    setBusy("up");
+    setErr(null);
+    try {
+      const u = await uploadAvatar(kind, id, f);
+      setUrl(bust(u));
+      onUpdated?.(u);
+    } catch {
+      setErr("Upload failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className="rounded-xl overflow-hidden bg-plate relative shrink-0"
+        style={{ width: size, height: size }}
+      >
+        {url ? (
+          <img src={url} alt="" className="w-full h-full object-cover" />
+        ) : (
+          <AvatarFallback kind={kind} />
+        )}
+        {busy && (
+          <div className="absolute inset-0 bg-black/55 flex items-center justify-center text-xs text-light">
+            {busy === "gen" ? "Generating…" : "Uploading…"}
+          </div>
+        )}
+      </div>
+
+      {allowVariant && (
+        <div className="flex gap-1 text-xs">
+          {["male", "female"].map((v) => (
+            <button
+              key={v}
+              onClick={() => setVariant(v)}
+              className={`px-2 py-0.5 rounded capitalize ${
+                variant === v ? "bg-amber text-steel" : "bg-steel text-muted-text"
+              }`}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          onClick={gen}
+          disabled={!!busy}
+          className="bg-amber text-steel px-2 py-1 rounded text-xs font-semibold flex items-center gap-1 disabled:opacity-50"
+        >
+          <Sparkles size={13} /> Generate
+        </button>
+        <button
+          onClick={() => fileRef.current?.click()}
+          disabled={!!busy}
+          className="bg-steel text-light px-2 py-1 rounded text-xs flex items-center gap-1 disabled:opacity-50"
+        >
+          <Upload size={13} /> Upload
+        </button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          className="hidden"
+          onChange={onFile}
+        />
+      </div>
+      {err && <p className="text-destructive text-xs">{err}</p>}
+    </div>
+  );
+};

--- a/frontend/src/components/fleet/EntityForm.tsx
+++ b/frontend/src/components/fleet/EntityForm.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { Check, X } from "lucide-react";
+
+export interface FormField {
+  name: string;
+  label: string;
+  type?: "text" | "number" | "date" | "select";
+  options?: string[];
+  required?: boolean;
+  placeholder?: string;
+}
+
+interface Props {
+  title: string;
+  fields: FormField[];
+  onSave: (data: Record<string, unknown>) => void;
+  onCancel: () => void;
+  busy: boolean;
+  error: string | null;
+}
+
+const field = "bg-steel rounded px-2 py-1 text-sm w-full";
+const lbl = "text-xs text-muted-text mb-1 block";
+
+export const EntityForm = ({ title, fields, onSave, onCancel, busy, error }: Props) => {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const set = (name: string, v: string) =>
+    setValues((p) => ({ ...p, [name]: v }));
+
+  const missing = fields.some((f) => f.required && !(values[f.name] || "").trim());
+
+  const submit = () => {
+    const data: Record<string, unknown> = {};
+    for (const f of fields) {
+      const v = (values[f.name] ?? "").trim();
+      if (v === "") continue;
+      data[f.name] = f.type === "number" ? Number(v) : v;
+    }
+    onSave(data);
+  };
+
+  return (
+    <div className="bg-plate rounded-lg p-4 mb-4">
+      <p className="text-sm font-medium mb-3">{title}</p>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        {fields.map((f) => (
+          <div key={f.name}>
+            <label className={lbl}>
+              {f.label}
+              {f.required ? " *" : ""}
+            </label>
+            {f.type === "select" ? (
+              <select
+                className={field}
+                value={values[f.name] ?? ""}
+                onChange={(e) => set(f.name, e.target.value)}
+              >
+                <option value="">—</option>
+                {f.options?.map((o) => (
+                  <option key={o} value={o}>
+                    {o}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                className={field}
+                type={f.type === "date" ? "date" : "text"}
+                inputMode={f.type === "number" ? "numeric" : undefined}
+                value={values[f.name] ?? ""}
+                onChange={(e) => set(f.name, e.target.value)}
+                placeholder={f.placeholder}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      {error && <p className="text-destructive text-sm mt-2">{error}</p>}
+      <div className="flex gap-2 mt-3">
+        <button
+          onClick={submit}
+          disabled={busy || missing}
+          className="bg-amber text-steel px-3 py-1 rounded text-sm font-semibold flex items-center gap-1 disabled:opacity-50"
+        >
+          <Check size={15} /> Save
+        </button>
+        <button
+          onClick={onCancel}
+          className="bg-steel text-light px-3 py-1 rounded text-sm flex items-center gap-1"
+        >
+          <X size={15} /> Cancel
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/lib/metrics/maintenance.test.ts
+++ b/frontend/src/lib/metrics/maintenance.test.ts
@@ -21,6 +21,8 @@ const item = (over: Partial<MaintenanceItem>): MaintenanceItem => ({
   last_done_miles: null,
   last_done_date: null,
   warn_lead_days: 30,
+  truck_id: null,
+  trailer_id: null,
   active: true,
   notes: null,
   ...over,

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useMemo, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import type { Driver } from "@/types/driver";
+import type { Load } from "@/types/load";
+import { getDriver } from "@/services/driversService";
+import { useLoads } from "@/hooks/useLoads";
+import { EntityAvatar } from "@/components/fleet/EntityAvatar";
+
+const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+const loadRev = (l: Load) =>
+  Number(l.linehaul) + Number(l.fuel_surcharge) + Number(l.total_accessorials);
+
+const Spec = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null | undefined;
+}) => (
+  <div>
+    <p className="text-xs text-muted-text">{label}</p>
+    <p className="text-sm">{value ? value : "—"}</p>
+  </div>
+);
+
+const DriverDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const { loads } = useLoads(0);
+  const [driver, setDriver] = useState<Driver | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    getDriver(id).then(setDriver).catch(() => {});
+  }, [id]);
+
+  const driverLoads = useMemo(
+    () => loads.filter((l) => l.driver_id === id),
+    [loads, id],
+  );
+
+  if (!driver)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <p className="text-muted-text">Loading…</p>
+      </div>
+    );
+
+  const revenue = driverLoads.reduce((s, l) => s + loadRev(l), 0);
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <Link to="/drivers" className="text-xs text-muted-text hover:text-light">
+        ← Drivers
+      </Link>
+
+      <div className="flex flex-col md:flex-row gap-6 mt-3 mb-6">
+        <EntityAvatar
+          kind="driver"
+          id={driver.driver_id}
+          avatarUrl={driver.avatar_url}
+          size={180}
+          allowVariant
+          onUpdated={(u) => setDriver({ ...driver, avatar_url: u })}
+        />
+        <div className="flex-1">
+          <h1 className="text-3xl font-condensed">
+            {driver.first_name} {driver.last_name}
+          </h1>
+          <p className="text-muted-text text-sm mb-4">
+            {driver.active ? "Active driver" : "Inactive"}
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <Spec label="Phone" value={driver.phone} />
+            <Spec label="Email" value={driver.email} />
+            <Spec
+              label="CDL"
+              value={driver.cdl_number ? `${driver.cdl_number} ${driver.cdl_state || ""}` : null}
+            />
+            <Spec label="CDL expires" value={driver.cdl_expiration} />
+            <Spec label="Endorsements" value={driver.endorsements} />
+            <Spec label="Hired" value={driver.hire_date} />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
+        <div className="bg-plate rounded-lg p-4">
+          <p className="text-xs text-muted-text mb-1">Loads hauled</p>
+          <p className="text-2xl font-condensed">{driverLoads.length}</p>
+        </div>
+        <div className="bg-plate rounded-lg p-4">
+          <p className="text-xs text-muted-text mb-1">Revenue · all time</p>
+          <p className="text-2xl font-condensed">{money(revenue)}</p>
+        </div>
+      </div>
+
+      <div className="bg-plate rounded-lg p-4">
+        <p className="text-xs text-muted-text mb-2">Recent loads</p>
+        {driverLoads.length === 0 ? (
+          <p className="text-sm text-muted-text">None for this driver yet.</p>
+        ) : (
+          <div className="text-sm divide-y divide-steel">
+            {driverLoads.slice(0, 6).map((l) => (
+              <div key={l.load_id} className="py-2 flex justify-between">
+                <span>
+                  {l.origin_market} → {l.delivery_market}
+                </span>
+                <span className="text-muted-text">{money(loadRev(l))}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DriverDetailPage;

--- a/frontend/src/pages/DriversPage.tsx
+++ b/frontend/src/pages/DriversPage.tsx
@@ -1,5 +1,114 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Plus } from "lucide-react";
+import type { Driver } from "@/types/driver";
+import { getDrivers, createDriver } from "@/services/driversService";
+import { AvatarFallback } from "@/components/fleet/AvatarFallback";
+import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
+
+const FIELDS: FormField[] = [
+  { name: "first_name", label: "First name", required: true },
+  { name: "last_name", label: "Last name", required: true },
+  { name: "phone", label: "Phone" },
+  { name: "email", label: "Email" },
+  { name: "cdl_number", label: "CDL #" },
+  { name: "cdl_state", label: "CDL state", placeholder: "AL" },
+  { name: "cdl_expiration", label: "CDL expires", type: "date" },
+  { name: "endorsements", label: "Endorsements", placeholder: "H, N, T" },
+  { name: "hire_date", label: "Hire date", type: "date" },
+];
+
 const DriversPage = () => {
-  return <div>Drivers Page (placeholder)</div>;
+  const [drivers, setDrivers] = useState<Driver[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = () =>
+    getDrivers()
+      .then(setDrivers)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const save = async (data: Record<string, unknown>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await createDriver(data);
+      setShowForm(false);
+      await load();
+    } catch (e) {
+      const msg =
+        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+        "Could not create the driver";
+      setError(msg);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-condensed">Drivers</h1>
+        {!showForm && (
+          <button
+            className="bg-amber text-steel px-3 py-1 rounded text-sm font-semibold flex items-center gap-1"
+            onClick={() => setShowForm(true)}
+          >
+            <Plus size={15} /> Add driver
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <EntityForm
+          title="New driver"
+          fields={FIELDS}
+          onSave={save}
+          onCancel={() => setShowForm(false)}
+          busy={busy}
+          error={error}
+        />
+      )}
+
+      {loading ? (
+        <p className="text-muted-text">Loading…</p>
+      ) : drivers.length === 0 ? (
+        <p className="text-muted-text">No drivers yet. Add one to get started.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {drivers.map((d) => (
+            <Link
+              key={d.driver_id}
+              to={`/drivers/${d.driver_id}`}
+              className="bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
+            >
+              <div className="w-16 h-16 rounded-full overflow-hidden bg-steel shrink-0">
+                {d.avatar_url ? (
+                  <img src={d.avatar_url} alt="" className="w-full h-full object-cover" />
+                ) : (
+                  <AvatarFallback kind="driver" />
+                )}
+              </div>
+              <div className="min-w-0">
+                <p className="font-medium truncate">
+                  {d.first_name} {d.last_name}
+                </p>
+                <p className="text-xs text-muted-text truncate">{d.phone || d.email || "—"}</p>
+                <p className="text-xs text-muted-text">{d.active ? "active" : "inactive"}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default DriversPage;

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import type { Trailer } from "@/types/trailer";
+import type { MaintenanceItem } from "@/types/maintenance";
+import { getTrailer } from "@/services/trailersService";
+import { getMaintenanceItems } from "@/services/maintenanceService";
+import { useLoads } from "@/hooks/useLoads";
+import { computeDue, avgMilesPerMonth } from "@/lib/metrics/maintenance";
+import { EntityAvatar } from "@/components/fleet/EntityAvatar";
+
+const Spec = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number | null | undefined;
+}) => (
+  <div>
+    <p className="text-xs text-muted-text">{label}</p>
+    <p className="text-sm">{value === null || value === undefined || value === "" ? "—" : value}</p>
+  </div>
+);
+
+const TrailerDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const { loads } = useLoads(0);
+  const [trailer, setTrailer] = useState<Trailer | null>(null);
+  const [items, setItems] = useState<MaintenanceItem[]>([]);
+
+  useEffect(() => {
+    if (!id) return;
+    getTrailer(id).then(setTrailer).catch(() => {});
+    getMaintenanceItems().then(setItems).catch(() => {});
+  }, [id]);
+
+  const mpm = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
+  const due = useMemo(() => {
+    let overdue = 0;
+    let soon = 0;
+    if (trailer) {
+      for (const it of items.filter((i) => i.trailer_id === id)) {
+        const d = computeDue(it, trailer.current_hub, new Date(), mpm);
+        if (d.level === "overdue") overdue++;
+        else if (d.level === "soon") soon++;
+      }
+    }
+    return { overdue, soon };
+  }, [items, trailer, id, mpm]);
+
+  if (!trailer)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <p className="text-muted-text">Loading…</p>
+      </div>
+    );
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <Link to="/trailers" className="text-xs text-muted-text hover:text-light">
+        ← Trailers
+      </Link>
+
+      <div className="flex flex-col md:flex-row gap-6 mt-3 mb-6">
+        <EntityAvatar
+          kind="trailer"
+          id={trailer.trailer_id}
+          avatarUrl={trailer.avatar_url}
+          size={180}
+          onUpdated={(u) => setTrailer({ ...trailer, avatar_url: u })}
+        />
+        <div className="flex-1">
+          <h1 className="text-3xl font-condensed">Unit {trailer.unit_number}</h1>
+          <p className="text-muted-text text-sm mb-4 capitalize">
+            {trailer.trailer_type}
+            {trailer.length_ft ? ` · ${trailer.length_ft}'` : ""} · {trailer.status}
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <Spec label="Hubodometer" value={`${trailer.current_hub.toLocaleString("en-US")} mi`} />
+            <Spec label="VIN" value={trailer.vin} />
+            <Spec
+              label="Plate"
+              value={trailer.plate_number ? `${trailer.plate_number} ${trailer.plate_state || ""}` : null}
+            />
+            <Spec label="Make" value={[trailer.year, trailer.make, trailer.model].filter(Boolean).join(" ")} />
+            <Spec label="In service" value={trailer.in_service_date} />
+          </div>
+        </div>
+      </div>
+
+      <Link
+        to="/maintenance"
+        className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors block max-w-xs"
+      >
+        <p className="text-xs text-muted-text mb-2">Maintenance</p>
+        <div className="flex gap-3 text-sm">
+          <span style={{ color: "#e24b4a" }}>{due.overdue} overdue</span>
+          <span style={{ color: "#e8940a" }}>{due.soon} due soon</span>
+        </div>
+      </Link>
+    </div>
+  );
+};
+
+export default TrailerDetailPage;

--- a/frontend/src/pages/TrailersPage.tsx
+++ b/frontend/src/pages/TrailersPage.tsx
@@ -1,20 +1,27 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Plus } from "lucide-react";
-import type { Truck } from "@/types/truck";
-import { getTrucks, createTruck } from "@/services/trucksService";
+import type { Trailer } from "@/types/trailer";
+import { getTrailers, createTrailer } from "@/services/trailersService";
 import { AvatarFallback } from "@/components/fleet/AvatarFallback";
 import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
 
 const FIELDS: FormField[] = [
-  { name: "unit_number", label: "Unit #", required: true, placeholder: "580991" },
-  { name: "make", label: "Make", placeholder: "International" },
-  { name: "model", label: "Model", placeholder: "LT625" },
+  { name: "unit_number", label: "Unit #", required: true, placeholder: "780991" },
+  {
+    name: "trailer_type",
+    label: "Type",
+    type: "select",
+    options: ["flatbed", "step deck", "RGN", "lowboy", "double drop", "conestoga"],
+  },
+  { name: "length_ft", label: "Length (ft)", type: "number", placeholder: "48" },
+  { name: "make", label: "Make", placeholder: "Utility" },
+  { name: "model", label: "Model" },
   { name: "year", label: "Year", type: "number", placeholder: "2019" },
-  { name: "vin", label: "VIN (17 chars)", placeholder: "3HSDZAPR…" },
-  { name: "plate_number", label: "Plate", placeholder: "DTS625" },
+  { name: "vin", label: "VIN" },
+  { name: "plate_number", label: "Plate", placeholder: "DTS780" },
   { name: "plate_state", label: "State", placeholder: "AL" },
-  { name: "current_odometer", label: "Odometer", type: "number", placeholder: "568737" },
+  { name: "current_hub", label: "Hubodometer", type: "number", placeholder: "456123" },
   {
     name: "status",
     label: "Status",
@@ -24,16 +31,16 @@ const FIELDS: FormField[] = [
   { name: "in_service_date", label: "In service", type: "date" },
 ];
 
-const TrucksPage = () => {
-  const [trucks, setTrucks] = useState<Truck[]>([]);
+const TrailersPage = () => {
+  const [trailers, setTrailers] = useState<Trailer[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const load = () =>
-    getTrucks()
-      .then(setTrucks)
+    getTrailers()
+      .then(setTrailers)
       .catch(() => {})
       .finally(() => setLoading(false));
 
@@ -45,13 +52,13 @@ const TrucksPage = () => {
     setBusy(true);
     setError(null);
     try {
-      await createTruck(data);
+      await createTrailer(data);
       setShowForm(false);
       await load();
     } catch (e) {
       const msg =
         (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
-        "Could not create the truck";
+        "Could not create the trailer";
       setError(msg);
     } finally {
       setBusy(false);
@@ -61,20 +68,20 @@ const TrucksPage = () => {
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-condensed">Trucks</h1>
+        <h1 className="text-3xl font-condensed">Trailers</h1>
         {!showForm && (
           <button
             className="bg-amber text-steel px-3 py-1 rounded text-sm font-semibold flex items-center gap-1"
             onClick={() => setShowForm(true)}
           >
-            <Plus size={15} /> Add truck
+            <Plus size={15} /> Add trailer
           </button>
         )}
       </div>
 
       {showForm && (
         <EntityForm
-          title="New truck"
+          title="New trailer"
           fields={FIELDS}
           onSave={save}
           onCancel={() => setShowForm(false)}
@@ -85,30 +92,31 @@ const TrucksPage = () => {
 
       {loading ? (
         <p className="text-muted-text">Loading…</p>
-      ) : trucks.length === 0 ? (
-        <p className="text-muted-text">No trucks yet. Add one to get started.</p>
+      ) : trailers.length === 0 ? (
+        <p className="text-muted-text">No trailers yet. Add one to get started.</p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {trucks.map((t) => (
+          {trailers.map((t) => (
             <Link
-              key={t.truck_id}
-              to={`/trucks/${t.truck_id}`}
+              key={t.trailer_id}
+              to={`/trailers/${t.trailer_id}`}
               className="bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
             >
               <div className="w-16 h-16 rounded-lg overflow-hidden bg-steel shrink-0">
                 {t.avatar_url ? (
                   <img src={t.avatar_url} alt="" className="w-full h-full object-cover" />
                 ) : (
-                  <AvatarFallback kind="truck" />
+                  <AvatarFallback kind="trailer" />
                 )}
               </div>
               <div className="min-w-0">
                 <p className="font-medium truncate">Unit {t.unit_number}</p>
-                <p className="text-xs text-muted-text truncate">
-                  {[t.year, t.make, t.model].filter(Boolean).join(" ") || "—"}
+                <p className="text-xs text-muted-text truncate capitalize">
+                  {t.trailer_type}
+                  {t.length_ft ? ` · ${t.length_ft}'` : ""}
                 </p>
                 <p className="text-xs text-muted-text">
-                  {t.current_odometer.toLocaleString("en-US")} mi · {t.status}
+                  {t.current_hub.toLocaleString("en-US")} mi · {t.status}
                 </p>
               </div>
             </Link>
@@ -119,4 +127,4 @@ const TrucksPage = () => {
   );
 };
 
-export default TrucksPage;
+export default TrailersPage;

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import type { Truck } from "@/types/truck";
+import type { Load } from "@/types/load";
+import type { MaintenanceItem } from "@/types/maintenance";
+import { getTruck } from "@/services/trucksService";
+import { getMaintenanceItems } from "@/services/maintenanceService";
+import { useLoads } from "@/hooks/useLoads";
+import { computeDue, avgMilesPerMonth } from "@/lib/metrics/maintenance";
+import { EntityAvatar } from "@/components/fleet/EntityAvatar";
+
+const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+const loadRev = (l: Load) =>
+  Number(l.linehaul) + Number(l.fuel_surcharge) + Number(l.total_accessorials);
+
+const Spec = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number | null | undefined;
+}) => (
+  <div>
+    <p className="text-xs text-muted-text">{label}</p>
+    <p className="text-sm">{value === null || value === undefined || value === "" ? "—" : value}</p>
+  </div>
+);
+
+const TruckDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const { loads } = useLoads(0);
+  const [truck, setTruck] = useState<Truck | null>(null);
+  const [items, setItems] = useState<MaintenanceItem[]>([]);
+
+  useEffect(() => {
+    if (!id) return;
+    getTruck(id).then(setTruck).catch(() => {});
+    getMaintenanceItems().then(setItems).catch(() => {});
+  }, [id]);
+
+  const truckLoads = useMemo(
+    () => loads.filter((l) => l.truck_id === id),
+    [loads, id],
+  );
+  const mpm = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
+  const due = useMemo(() => {
+    let overdue = 0;
+    let soon = 0;
+    if (truck) {
+      for (const it of items.filter((i) => i.truck_id === id)) {
+        const d = computeDue(it, truck.current_odometer, new Date(), mpm);
+        if (d.level === "overdue") overdue++;
+        else if (d.level === "soon") soon++;
+      }
+    }
+    return { overdue, soon };
+  }, [items, truck, id, mpm]);
+
+  if (!truck)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <p className="text-muted-text">Loading…</p>
+      </div>
+    );
+
+  const revenue = truckLoads.reduce((s, l) => s + loadRev(l), 0);
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <Link to="/trucks" className="text-xs text-muted-text hover:text-light">
+        ← Trucks
+      </Link>
+
+      <div className="flex flex-col md:flex-row gap-6 mt-3 mb-6">
+        <EntityAvatar
+          kind="truck"
+          id={truck.truck_id}
+          avatarUrl={truck.avatar_url}
+          size={180}
+          onUpdated={(u) => setTruck({ ...truck, avatar_url: u })}
+        />
+        <div className="flex-1">
+          <h1 className="text-3xl font-condensed">Unit {truck.unit_number}</h1>
+          <p className="text-muted-text text-sm mb-4">
+            {[truck.year, truck.make, truck.model].filter(Boolean).join(" ")} ·{" "}
+            {truck.status}
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <Spec label="Unit #" value={truck.unit_number} />
+            <Spec label="Odometer" value={`${truck.current_odometer.toLocaleString("en-US")} mi`} />
+            <Spec label="VIN" value={truck.vin} />
+            <Spec
+              label="Plate"
+              value={truck.plate_number ? `${truck.plate_number} ${truck.plate_state || ""}` : null}
+            />
+            <Spec label="In service" value={truck.in_service_date} />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Link to="/maintenance" className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors">
+          <p className="text-xs text-muted-text mb-2">Maintenance</p>
+          <div className="flex gap-3 text-sm">
+            <span style={{ color: "#e24b4a" }}>{due.overdue} overdue</span>
+            <span style={{ color: "#e8940a" }}>{due.soon} due soon</span>
+          </div>
+        </Link>
+        <div className="bg-plate rounded-lg p-4">
+          <p className="text-xs text-muted-text mb-1">Loads hauled</p>
+          <p className="text-2xl font-condensed">{truckLoads.length}</p>
+        </div>
+        <div className="bg-plate rounded-lg p-4">
+          <p className="text-xs text-muted-text mb-1">Revenue · all time</p>
+          <p className="text-2xl font-condensed">{money(revenue)}</p>
+        </div>
+      </div>
+
+      <div className="bg-plate rounded-lg p-4 mt-4">
+        <p className="text-xs text-muted-text mb-2">Recent loads</p>
+        {truckLoads.length === 0 ? (
+          <p className="text-sm text-muted-text">None on this truck yet.</p>
+        ) : (
+          <div className="text-sm divide-y divide-steel">
+            {truckLoads.slice(0, 6).map((l) => (
+              <div key={l.load_id} className="py-2 flex justify-between">
+                <span>
+                  {l.origin_market} → {l.delivery_market}
+                </span>
+                <span className="text-muted-text">{money(loadRev(l))}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TruckDetailPage;

--- a/frontend/src/services/avatarsService.ts
+++ b/frontend/src/services/avatarsService.ts
@@ -1,0 +1,29 @@
+import api from "./api";
+
+export type AvatarKind = "truck" | "driver" | "trailer";
+
+// Generate a themed avatar server-side (fal → Supabase Storage). `variant` is
+// the driver gender ('male' | 'female'); ignored for truck/trailer.
+export const generateAvatar = async (
+  kind: AvatarKind,
+  id: string,
+  variant?: string,
+): Promise<string> => {
+  const res = await api.post(
+    `/avatars/${kind}/${id}/generate`,
+    variant ? { variant } : {},
+  );
+  return res.data.avatar_url as string;
+};
+
+// Upload a photo to override the avatar (raw image body).
+export const uploadAvatar = async (
+  kind: AvatarKind,
+  id: string,
+  file: File,
+): Promise<string> => {
+  const res = await api.post(`/avatars/${kind}/${id}/upload`, file, {
+    headers: { "Content-Type": file.type },
+  });
+  return res.data.avatar_url as string;
+};

--- a/frontend/src/services/driversService.ts
+++ b/frontend/src/services/driversService.ts
@@ -1,0 +1,19 @@
+import api from "./api";
+import type { Driver } from "@/types/driver";
+
+export const getDrivers = async (): Promise<Driver[]> => {
+  const res = await api.get("/drivers");
+  return res.data.drivers;
+};
+
+export const getDriver = async (id: string): Promise<Driver> => {
+  const res = await api.get(`/drivers/${id}`);
+  return res.data.driver;
+};
+
+export const createDriver = async (
+  data: Record<string, unknown>,
+): Promise<Driver> => {
+  const res = await api.post("/drivers", data);
+  return res.data.driver;
+};

--- a/frontend/src/services/maintenanceService.ts
+++ b/frontend/src/services/maintenanceService.ts
@@ -18,6 +18,8 @@ const coerceItem = (i: any): MaintenanceItem => ({
   last_done_miles: numOrNull(i.last_done_miles),
   last_done_date: dateOrNull(i.last_done_date),
   warn_lead_days: numOrNull(i.warn_lead_days) ?? 14,
+  truck_id: i.truck_id ?? null,
+  trailer_id: i.trailer_id ?? null,
   active: i.active,
   notes: i.notes ?? null,
 });

--- a/frontend/src/services/trailersService.ts
+++ b/frontend/src/services/trailersService.ts
@@ -1,0 +1,19 @@
+import api from "./api";
+import type { Trailer } from "@/types/trailer";
+
+export const getTrailers = async (): Promise<Trailer[]> => {
+  const res = await api.get("/trailers/me");
+  return res.data.trailers;
+};
+
+export const getTrailer = async (id: string): Promise<Trailer> => {
+  const res = await api.get(`/trailers/me/${id}`);
+  return res.data.trailer;
+};
+
+export const createTrailer = async (
+  data: Record<string, unknown>,
+): Promise<Trailer> => {
+  const res = await api.post("/trailers/me", data);
+  return res.data.trailer;
+};

--- a/frontend/src/services/trucksService.ts
+++ b/frontend/src/services/trucksService.ts
@@ -1,0 +1,19 @@
+import api from "./api";
+import type { Truck } from "@/types/truck";
+
+export const getTrucks = async (): Promise<Truck[]> => {
+  const res = await api.get("/trucks/me");
+  return res.data.trucks;
+};
+
+export const getTruck = async (id: string): Promise<Truck> => {
+  const res = await api.get(`/trucks/me/${id}`);
+  return res.data.truck;
+};
+
+export const createTruck = async (
+  data: Record<string, unknown>,
+): Promise<Truck> => {
+  const res = await api.post("/trucks/me", data);
+  return res.data.truck;
+};

--- a/frontend/src/types/driver.ts
+++ b/frontend/src/types/driver.ts
@@ -1,0 +1,15 @@
+export interface Driver {
+  driver_id: string;
+  first_name: string;
+  last_name: string;
+  phone: string | null;
+  email: string | null;
+  cdl_number: string | null;
+  cdl_state: string | null;
+  cdl_expiration: string | null;
+  endorsements: string | null;
+  hire_date: string | null;
+  avatar_url: string | null;
+  notes: string | null;
+  active: boolean;
+}

--- a/frontend/src/types/load.ts
+++ b/frontend/src/types/load.ts
@@ -31,6 +31,9 @@ export interface Load {
   odometer_start?: number | null;
   odometer_end?: number | null;
   payment_status: string;
+  truck_id?: string | null;
+  driver_id?: string | null;
+  trailer_id?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/types/maintenance.ts
+++ b/frontend/src/types/maintenance.ts
@@ -11,6 +11,8 @@ export interface MaintenanceItem {
   last_done_miles: number | null;
   last_done_date: string | null; // 'YYYY-MM-DD'
   warn_lead_days: number; // start flagging "due soon" this many days before due
+  truck_id: string | null;
+  trailer_id: string | null;
   active: boolean;
   notes: string | null;
 }

--- a/frontend/src/types/trailer.ts
+++ b/frontend/src/types/trailer.ts
@@ -1,0 +1,17 @@
+export interface Trailer {
+  trailer_id: string;
+  unit_number: string;
+  vin: string | null;
+  plate_number: string | null;
+  plate_state: string | null;
+  trailer_type: string;
+  length_ft: number | null;
+  make: string | null;
+  model: string | null;
+  year: number | null;
+  current_hub: number;
+  status: string;
+  avatar_url: string | null;
+  in_service_date: string | null;
+  notes: string | null;
+}

--- a/frontend/src/types/truck.ts
+++ b/frontend/src/types/truck.ts
@@ -1,0 +1,14 @@
+export interface Truck {
+  truck_id: string;
+  unit_number: string;
+  vin: string | null;
+  plate_number: string | null;
+  plate_state: string | null;
+  make: string | null;
+  model: string | null;
+  year: number | null;
+  current_odometer: number;
+  status: string; // active | maintenance | out_of_service | inactive
+  in_service_date: string | null;
+  avatar_url: string | null;
+}


### PR DESCRIPTION
Makes truck, driver, and trailer first-class, ties loads + maintenance to them, and gives each a detail-page hub with a generated avatar.

## Schema (migration 028)
- New `trailers` table; `drivers` enriched (contact, CDL, hire date); `avatar_url` on all three entities
- Nullable `truck_id`/`driver_id`/`trailer_id` on `loads`, `truck_id`/`trailer_id` on maintenance — existing data backfilled to the single rig

## Backend
- Trailer CRUD + routes; truck/driver services expose the new fields
- Loads + maintenance reads carry the entity links
- **Avatar service** — fal (flux) → Supabase Storage → `avatar_url`, plus a photo-upload route. Trailer prompt is type-driven and forced to a standalone trailer.

## Frontend
- **Truck / Driver / Trailer** list + detail pages. Each detail page is a hub: avatar, specs, its maintenance status (overdue/soon), and its loads/revenue.
- **Create forms** on each list page
- **`EntityAvatar`** — generate/upload with an SVG fallback and a driver male/female variant toggle
- Nav un-hidden (Trucks, Trailers, Drivers)

## Deploy
- ⚠️ Run migration **`028`** on prod, and create the **`avatars` Storage bucket** on the prod project. Prod already has its Supabase + fal keys.

90 tests, strict build green. Deferred to follow-ups: inline spec editing, fuel/MPG on the truck page, load/maintenance assignment selectors.