### PR TITLE
feat: editable fleet entities, app-derived odometer, date-only display

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.32.0",
+  "version": "1.33.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/fleet/EntityForm.tsx
+++ b/frontend/src/components/fleet/EntityForm.tsx
@@ -17,13 +17,22 @@ interface Props {
   onCancel: () => void;
   busy: boolean;
   error: string | null;
+  initial?: Record<string, string>; // prefill for editing
 }
 
 const field = "bg-steel rounded px-2 py-1 text-sm w-full";
 const lbl = "text-xs text-muted-text mb-1 block";
 
-export const EntityForm = ({ title, fields, onSave, onCancel, busy, error }: Props) => {
-  const [values, setValues] = useState<Record<string, string>>({});
+export const EntityForm = ({
+  title,
+  fields,
+  onSave,
+  onCancel,
+  busy,
+  error,
+  initial,
+}: Props) => {
+  const [values, setValues] = useState<Record<string, string>>(initial ?? {});
   const set = (name: string, v: string) =>
     setValues((p) => ({ ...p, [name]: v }));
 

--- a/frontend/src/lib/fleetFields.ts
+++ b/frontend/src/lib/fleetFields.ts
@@ -1,0 +1,73 @@
+import type { FormField } from "@/components/fleet/EntityForm";
+
+// Turn an entity into the string map the form prefills from (dates → date-only).
+export const toFormValues = (
+  obj: Record<string, unknown>,
+  fields: FormField[],
+): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const f of fields) {
+    const v = obj[f.name];
+    if (v === null || v === undefined) continue;
+    out[f.name] = f.type === "date" ? String(v).slice(0, 10) : String(v);
+  }
+  return out;
+};
+
+// Shared field definitions so the create form (list page) and the edit form
+// (detail page) stay in sync.
+
+export const TRUCK_FIELDS: FormField[] = [
+  { name: "unit_number", label: "Unit #", required: true, placeholder: "580991" },
+  { name: "make", label: "Make", placeholder: "International" },
+  { name: "model", label: "Model", placeholder: "LT625" },
+  { name: "year", label: "Year", type: "number", placeholder: "2019" },
+  { name: "vin", label: "VIN (17 chars)", placeholder: "3HSDZAPR…" },
+  { name: "plate_number", label: "Plate", placeholder: "DTS625" },
+  { name: "plate_state", label: "State", placeholder: "AL" },
+  { name: "current_odometer", label: "Odometer", type: "number", placeholder: "568737" },
+  {
+    name: "status",
+    label: "Status",
+    type: "select",
+    options: ["active", "maintenance", "out_of_service", "inactive"],
+  },
+  { name: "in_service_date", label: "In service", type: "date" },
+];
+
+export const DRIVER_FIELDS: FormField[] = [
+  { name: "first_name", label: "First name", required: true },
+  { name: "last_name", label: "Last name", required: true },
+  { name: "phone", label: "Phone" },
+  { name: "email", label: "Email" },
+  { name: "cdl_number", label: "CDL #" },
+  { name: "cdl_state", label: "CDL state", placeholder: "AL" },
+  { name: "cdl_expiration", label: "CDL expires", type: "date" },
+  { name: "endorsements", label: "Endorsements", placeholder: "H, N, T" },
+  { name: "hire_date", label: "Hire date", type: "date" },
+];
+
+export const TRAILER_FIELDS: FormField[] = [
+  { name: "unit_number", label: "Unit #", required: true, placeholder: "780991" },
+  {
+    name: "trailer_type",
+    label: "Type",
+    type: "select",
+    options: ["flatbed", "step deck", "RGN", "lowboy", "double drop", "conestoga"],
+  },
+  { name: "length_ft", label: "Length (ft)", type: "number", placeholder: "48" },
+  { name: "make", label: "Make", placeholder: "Utility" },
+  { name: "model", label: "Model" },
+  { name: "year", label: "Year", type: "number", placeholder: "2019" },
+  { name: "vin", label: "VIN" },
+  { name: "plate_number", label: "Plate", placeholder: "DTS780" },
+  { name: "plate_state", label: "State", placeholder: "AL" },
+  { name: "current_hub", label: "Hubodometer", type: "number", placeholder: "456123" },
+  {
+    name: "status",
+    label: "Status",
+    type: "select",
+    options: ["active", "maintenance", "out_of_service", "inactive"],
+  },
+  { name: "in_service_date", label: "In service", type: "date" },
+];

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,12 @@
+// Format a DATE value (which the API returns as an ISO string) to just the
+// date, UTC-safe — no time, no timezone.
+export const formatDate = (v: string | null | undefined): string | null => {
+  if (!v) return null;
+  const d = String(v).slice(0, 10); // 'YYYY-MM-DD'
+  return new Date(d + "T00:00:00Z").toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+};

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import { Pencil } from "lucide-react";
 import type { Driver } from "@/types/driver";
 import type { Load } from "@/types/load";
-import { getDriver } from "@/services/driversService";
+import { getDriver, patchDriver } from "@/services/driversService";
 import { useLoads } from "@/hooks/useLoads";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
+import { EntityForm } from "@/components/fleet/EntityForm";
+import { DRIVER_FIELDS, toFormValues } from "@/lib/fleetFields";
+import { formatDate } from "@/lib/format";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const loadRev = (l: Load) =>
@@ -27,6 +31,9 @@ const DriverDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const { loads } = useLoads(0);
   const [driver, setDriver] = useState<Driver | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!id) return;
@@ -37,6 +44,24 @@ const DriverDetailPage = () => {
     () => loads.filter((l) => l.driver_id === id),
     [loads, id],
   );
+
+  const saveEdit = async (data: Record<string, unknown>) => {
+    if (!driver) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await patchDriver(driver.driver_id, data);
+      setDriver(updated);
+      setEditing(false);
+    } catch (e) {
+      setError(
+        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+          "Could not save",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
 
   if (!driver)
     return (
@@ -63,23 +88,48 @@ const DriverDetailPage = () => {
           onUpdated={(u) => setDriver({ ...driver, avatar_url: u })}
         />
         <div className="flex-1">
-          <h1 className="text-3xl font-condensed">
-            {driver.first_name} {driver.last_name}
-          </h1>
-          <p className="text-muted-text text-sm mb-4">
-            {driver.active ? "Active driver" : "Inactive"}
-          </p>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <Spec label="Phone" value={driver.phone} />
-            <Spec label="Email" value={driver.email} />
-            <Spec
-              label="CDL"
-              value={driver.cdl_number ? `${driver.cdl_number} ${driver.cdl_state || ""}` : null}
-            />
-            <Spec label="CDL expires" value={driver.cdl_expiration} />
-            <Spec label="Endorsements" value={driver.endorsements} />
-            <Spec label="Hired" value={driver.hire_date} />
+          <div className="flex justify-between items-start">
+            <div>
+              <h1 className="text-3xl font-condensed">
+                {driver.first_name} {driver.last_name}
+              </h1>
+              <p className="text-muted-text text-sm mb-4">
+                {driver.active ? "Active driver" : "Inactive"}
+              </p>
+            </div>
+            {!editing && (
+              <button
+                onClick={() => setEditing(true)}
+                className="bg-steel text-light px-2 py-1 rounded text-xs flex items-center gap-1"
+              >
+                <Pencil size={13} /> Edit
+              </button>
+            )}
           </div>
+
+          {editing ? (
+            <EntityForm
+              title="Edit driver"
+              fields={DRIVER_FIELDS}
+              initial={toFormValues(driver as unknown as Record<string, unknown>, DRIVER_FIELDS)}
+              onSave={saveEdit}
+              onCancel={() => setEditing(false)}
+              busy={busy}
+              error={error}
+            />
+          ) : (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Spec label="Phone" value={driver.phone} />
+              <Spec label="Email" value={driver.email} />
+              <Spec
+                label="CDL"
+                value={driver.cdl_number ? `${driver.cdl_number} ${driver.cdl_state || ""}` : null}
+              />
+              <Spec label="CDL expires" value={formatDate(driver.cdl_expiration)} />
+              <Spec label="Endorsements" value={driver.endorsements} />
+              <Spec label="Hired" value={formatDate(driver.hire_date)} />
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import { Pencil } from "lucide-react";
 import type { Trailer } from "@/types/trailer";
-import type { MaintenanceItem } from "@/types/maintenance";
-import { getTrailer } from "@/services/trailersService";
-import { getMaintenanceItems } from "@/services/maintenanceService";
+import type { MaintenanceItem, MaintenanceService } from "@/types/maintenance";
+import { getTrailer, patchTrailer } from "@/services/trailersService";
+import {
+  getMaintenanceItems,
+  getMaintenanceServices,
+} from "@/services/maintenanceService";
 import { useLoads } from "@/hooks/useLoads";
-import { computeDue, avgMilesPerMonth } from "@/lib/metrics/maintenance";
+import { computeDue, avgMilesPerMonth, maxOdometer } from "@/lib/metrics/maintenance";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
+import { EntityForm } from "@/components/fleet/EntityForm";
+import { TRAILER_FIELDS, toFormValues } from "@/lib/fleetFields";
+import { formatDate } from "@/lib/format";
 
 const Spec = ({
   label,
@@ -26,26 +33,54 @@ const TrailerDetailPage = () => {
   const { loads } = useLoads(0);
   const [trailer, setTrailer] = useState<Trailer | null>(null);
   const [items, setItems] = useState<MaintenanceItem[]>([]);
+  const [services, setServices] = useState<MaintenanceService[]>([]);
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!id) return;
     getTrailer(id).then(setTrailer).catch(() => {});
     getMaintenanceItems().then(setItems).catch(() => {});
+    getMaintenanceServices().then(setServices).catch(() => {});
   }, [id]);
+
+  // Latest hub reading, derived from the app: stored + newest trailer service.
+  const hub = useMemo(() => {
+    if (!trailer) return 0;
+    const svcOdos = services.filter((s) => s.unit === "trailer").map((s) => s.odometer);
+    return maxOdometer(trailer.current_hub, ...svcOdos) ?? trailer.current_hub;
+  }, [trailer, services]);
 
   const mpm = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
   const due = useMemo(() => {
     let overdue = 0;
     let soon = 0;
-    if (trailer) {
-      for (const it of items.filter((i) => i.trailer_id === id)) {
-        const d = computeDue(it, trailer.current_hub, new Date(), mpm);
-        if (d.level === "overdue") overdue++;
-        else if (d.level === "soon") soon++;
-      }
+    for (const it of items.filter((i) => i.trailer_id === id)) {
+      const d = computeDue(it, hub, new Date(), mpm);
+      if (d.level === "overdue") overdue++;
+      else if (d.level === "soon") soon++;
     }
     return { overdue, soon };
-  }, [items, trailer, id, mpm]);
+  }, [items, id, hub, mpm]);
+
+  const saveEdit = async (data: Record<string, unknown>) => {
+    if (!trailer) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await patchTrailer(trailer.trailer_id, data);
+      setTrailer(updated);
+      setEditing(false);
+    } catch (e) {
+      setError(
+        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+          "Could not save",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
 
   if (!trailer)
     return (
@@ -69,21 +104,46 @@ const TrailerDetailPage = () => {
           onUpdated={(u) => setTrailer({ ...trailer, avatar_url: u })}
         />
         <div className="flex-1">
-          <h1 className="text-3xl font-condensed">Unit {trailer.unit_number}</h1>
-          <p className="text-muted-text text-sm mb-4 capitalize">
-            {trailer.trailer_type}
-            {trailer.length_ft ? ` · ${trailer.length_ft}'` : ""} · {trailer.status}
-          </p>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <Spec label="Hubodometer" value={`${trailer.current_hub.toLocaleString("en-US")} mi`} />
-            <Spec label="VIN" value={trailer.vin} />
-            <Spec
-              label="Plate"
-              value={trailer.plate_number ? `${trailer.plate_number} ${trailer.plate_state || ""}` : null}
-            />
-            <Spec label="Make" value={[trailer.year, trailer.make, trailer.model].filter(Boolean).join(" ")} />
-            <Spec label="In service" value={trailer.in_service_date} />
+          <div className="flex justify-between items-start">
+            <div>
+              <h1 className="text-3xl font-condensed">Unit {trailer.unit_number}</h1>
+              <p className="text-muted-text text-sm mb-4 capitalize">
+                {trailer.trailer_type}
+                {trailer.length_ft ? ` · ${trailer.length_ft}'` : ""} · {trailer.status}
+              </p>
+            </div>
+            {!editing && (
+              <button
+                onClick={() => setEditing(true)}
+                className="bg-steel text-light px-2 py-1 rounded text-xs flex items-center gap-1"
+              >
+                <Pencil size={13} /> Edit
+              </button>
+            )}
           </div>
+
+          {editing ? (
+            <EntityForm
+              title="Edit trailer"
+              fields={TRAILER_FIELDS}
+              initial={toFormValues(trailer as unknown as Record<string, unknown>, TRAILER_FIELDS)}
+              onSave={saveEdit}
+              onCancel={() => setEditing(false)}
+              busy={busy}
+              error={error}
+            />
+          ) : (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Spec label="Hubodometer · latest" value={`${hub.toLocaleString("en-US")} mi`} />
+              <Spec label="VIN" value={trailer.vin} />
+              <Spec
+                label="Plate"
+                value={trailer.plate_number ? `${trailer.plate_number} ${trailer.plate_state || ""}` : null}
+              />
+              <Spec label="Make" value={[trailer.year, trailer.make, trailer.model].filter(Boolean).join(" ")} />
+              <Spec label="In service" value={formatDate(trailer.in_service_date)} />
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -1,13 +1,20 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import { Pencil } from "lucide-react";
 import type { Truck } from "@/types/truck";
 import type { Load } from "@/types/load";
-import type { MaintenanceItem } from "@/types/maintenance";
-import { getTruck } from "@/services/trucksService";
-import { getMaintenanceItems } from "@/services/maintenanceService";
+import type { MaintenanceItem, MaintenanceService } from "@/types/maintenance";
+import { getTruck, patchTruck } from "@/services/trucksService";
+import {
+  getMaintenanceItems,
+  getMaintenanceServices,
+} from "@/services/maintenanceService";
 import { useLoads } from "@/hooks/useLoads";
-import { computeDue, avgMilesPerMonth } from "@/lib/metrics/maintenance";
+import { computeDue, avgMilesPerMonth, maxOdometer } from "@/lib/metrics/maintenance";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
+import { EntityForm } from "@/components/fleet/EntityForm";
+import { TRUCK_FIELDS, toFormValues } from "@/lib/fleetFields";
+import { formatDate } from "@/lib/format";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const loadRev = (l: Load) =>
@@ -31,30 +38,64 @@ const TruckDetailPage = () => {
   const { loads } = useLoads(0);
   const [truck, setTruck] = useState<Truck | null>(null);
   const [items, setItems] = useState<MaintenanceItem[]>([]);
+  const [services, setServices] = useState<MaintenanceService[]>([]);
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!id) return;
     getTruck(id).then(setTruck).catch(() => {});
     getMaintenanceItems().then(setItems).catch(() => {});
+    getMaintenanceServices().then(setServices).catch(() => {});
   }, [id]);
 
   const truckLoads = useMemo(
     () => loads.filter((l) => l.truck_id === id),
     [loads, id],
   );
+
+  // Latest odometer, derived from the app: stored value + newest load + newest
+  // service reading (fuel will fold in once it carries an odometer).
+  const odometer = useMemo(() => {
+    if (!truck) return 0;
+    const loadOdos = truckLoads.map((l) => l.odometer_end ?? null);
+    const svcOdos = services.filter((s) => s.unit === "tractor").map((s) => s.odometer);
+    return (
+      maxOdometer(truck.current_odometer, ...loadOdos, ...svcOdos) ??
+      truck.current_odometer
+    );
+  }, [truck, truckLoads, services]);
+
   const mpm = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
   const due = useMemo(() => {
     let overdue = 0;
     let soon = 0;
-    if (truck) {
-      for (const it of items.filter((i) => i.truck_id === id)) {
-        const d = computeDue(it, truck.current_odometer, new Date(), mpm);
-        if (d.level === "overdue") overdue++;
-        else if (d.level === "soon") soon++;
-      }
+    for (const it of items.filter((i) => i.truck_id === id)) {
+      const d = computeDue(it, odometer, new Date(), mpm);
+      if (d.level === "overdue") overdue++;
+      else if (d.level === "soon") soon++;
     }
     return { overdue, soon };
-  }, [items, truck, id, mpm]);
+  }, [items, id, odometer, mpm]);
+
+  const saveEdit = async (data: Record<string, unknown>) => {
+    if (!truck) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await patchTruck(truck.truck_id, data);
+      setTruck(updated);
+      setEditing(false);
+    } catch (e) {
+      setError(
+        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+          "Could not save",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
 
   if (!truck)
     return (
@@ -80,21 +121,46 @@ const TruckDetailPage = () => {
           onUpdated={(u) => setTruck({ ...truck, avatar_url: u })}
         />
         <div className="flex-1">
-          <h1 className="text-3xl font-condensed">Unit {truck.unit_number}</h1>
-          <p className="text-muted-text text-sm mb-4">
-            {[truck.year, truck.make, truck.model].filter(Boolean).join(" ")} ·{" "}
-            {truck.status}
-          </p>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <Spec label="Unit #" value={truck.unit_number} />
-            <Spec label="Odometer" value={`${truck.current_odometer.toLocaleString("en-US")} mi`} />
-            <Spec label="VIN" value={truck.vin} />
-            <Spec
-              label="Plate"
-              value={truck.plate_number ? `${truck.plate_number} ${truck.plate_state || ""}` : null}
-            />
-            <Spec label="In service" value={truck.in_service_date} />
+          <div className="flex justify-between items-start">
+            <div>
+              <h1 className="text-3xl font-condensed">Unit {truck.unit_number}</h1>
+              <p className="text-muted-text text-sm mb-4">
+                {[truck.year, truck.make, truck.model].filter(Boolean).join(" ")} ·{" "}
+                {truck.status}
+              </p>
+            </div>
+            {!editing && (
+              <button
+                onClick={() => setEditing(true)}
+                className="bg-steel text-light px-2 py-1 rounded text-xs flex items-center gap-1"
+              >
+                <Pencil size={13} /> Edit
+              </button>
+            )}
           </div>
+
+          {editing ? (
+            <EntityForm
+              title="Edit truck"
+              fields={TRUCK_FIELDS}
+              initial={toFormValues(truck as unknown as Record<string, unknown>, TRUCK_FIELDS)}
+              onSave={saveEdit}
+              onCancel={() => setEditing(false)}
+              busy={busy}
+              error={error}
+            />
+          ) : (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Spec label="Unit #" value={truck.unit_number} />
+              <Spec label="Odometer · latest" value={`${odometer.toLocaleString("en-US")} mi`} />
+              <Spec label="VIN" value={truck.vin} />
+              <Spec
+                label="Plate"
+                value={truck.plate_number ? `${truck.plate_number} ${truck.plate_state || ""}` : null}
+              />
+              <Spec label="In service" value={formatDate(truck.in_service_date)} />
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/services/driversService.ts
+++ b/frontend/src/services/driversService.ts
@@ -17,3 +17,11 @@ export const createDriver = async (
   const res = await api.post("/drivers", data);
   return res.data.driver;
 };
+
+export const patchDriver = async (
+  id: string,
+  data: Record<string, unknown>,
+): Promise<Driver> => {
+  const res = await api.patch(`/drivers/${id}`, data);
+  return res.data.driver;
+};

--- a/frontend/src/services/trailersService.ts
+++ b/frontend/src/services/trailersService.ts
@@ -17,3 +17,11 @@ export const createTrailer = async (
   const res = await api.post("/trailers/me", data);
   return res.data.trailer;
 };
+
+export const patchTrailer = async (
+  id: string,
+  data: Record<string, unknown>,
+): Promise<Trailer> => {
+  const res = await api.patch(`/trailers/me/${id}`, data);
+  return res.data.trailer;
+};

--- a/frontend/src/services/trucksService.ts
+++ b/frontend/src/services/trucksService.ts
@@ -17,3 +17,11 @@ export const createTruck = async (
   const res = await api.post("/trucks/me", data);
   return res.data.truck;
 };
+
+export const patchTruck = async (
+  id: string,
+  data: Record<string, unknown>,
+): Promise<Truck> => {
+  const res = await api.patch(`/trucks/me/${id}`, data);
+  return res.data.truck;
+};


### PR DESCRIPTION
Follow-ups on the fleet detail pages, from dev feedback.

- **Editable** — Edit button on each Truck/Driver/Trailer detail page opens a prefilled form (`EntityForm` gains an `initial` prop) and saves via PATCH. Field definitions centralized in `lib/fleetFields` so create + edit stay in sync.
- **App-derived odometer** — the truck's "Odometer · latest" is the max of its stored value, its newest load reading, and its newest service reading; the trailer's hub does the same from its services. Fuel folds in automatically once the fuel page carries an odometer (MPG will come from there too).
- **Date-only display** — `in service`, `CDL expires`, `hired` now render just the date, UTC-safe (`lib/format`) — no time/timezone.

Frontend-only, no migration. 90 tests, strict build green.