### PR TITLE
feat: group the sidebar into collapsible Freight / Fleet sections

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.33.0",
+  "version": "1.33.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1,3 +1,5 @@
+import { useState, useEffect } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
@@ -7,71 +9,128 @@ import {
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuButton,
+  SidebarMenuSub,
+  SidebarMenuSubItem,
+  SidebarMenuSubButton,
 } from "@/components/ui/sidebar";
-
 import { Link, useLocation } from "react-router-dom";
 
-const navItems = [
+type Leaf = { to: string; label: string };
+type Group = { label: string; children: Leaf[] };
+type Entry = Leaf | Group;
+const isGroup = (e: Entry): e is Group => "children" in e;
+
+const nav: Entry[] = [
   { to: "/dashboard", label: "Dashboard" },
-  { to: "/loads", label: "Loads" },
-  { to: "/trips", label: "Trips" },
-  { to: "/lanes", label: "Lanes" },
+  {
+    label: "Freight",
+    children: [
+      { to: "/loads", label: "Loads" },
+      { to: "/trips", label: "Trips" },
+      { to: "/lanes", label: "Lanes" },
+      { to: "/agents", label: "Agents" },
+    ],
+  },
+  {
+    label: "Fleet",
+    children: [
+      { to: "/trucks", label: "Trucks" },
+      { to: "/trailers", label: "Trailers" },
+      { to: "/drivers", label: "Drivers" },
+      { to: "/maintenance", label: "Maintenance" },
+      { to: "/fuel-entries", label: "Fuel" },
+    ],
+  },
   { to: "/expenses", label: "Expenses" },
-  { to: "/maintenance", label: "Maintenance" },
-  { to: "/trucks", label: "Trucks" },
-  { to: "/trailers", label: "Trailers" },
-  { to: "/drivers", label: "Drivers" },
-  { to: "/agents", label: "Agents" },
-  { to: "/fuel-entries", label: "Fuel Entries" },
 ];
 
 const AppSidebar = () => {
-  const location = useLocation();
+  const { pathname } = useLocation();
+  const active = (to: string) =>
+    pathname === to || pathname.startsWith(to + "/");
+
+  // A group starts open if it holds the current route; navigating into a group
+  // opens it, but manual toggles of the others are preserved.
+  const [open, setOpen] = useState<Record<string, boolean>>(() => {
+    const init: Record<string, boolean> = {};
+    for (const e of nav)
+      if (isGroup(e)) init[e.label] = e.children.some((c) => active(c.to));
+    return init;
+  });
+
+  useEffect(() => {
+    for (const e of nav)
+      if (isGroup(e) && e.children.some((c) => active(c.to)))
+        setOpen((o) => ({ ...o, [e.label]: true }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  const linkCls = (to: string) =>
+    active(to)
+      ? "!text-sidebar-primary font-semibold"
+      : "!text-sidebar-foreground";
 
   return (
     <Sidebar>
       <SidebarHeader>
-        <div className="p-4 font-bold text-sidebar-foreground text-xl">
-          Dash
-        </div>
+        <div className="p-4 font-bold text-sidebar-foreground text-xl">Dash</div>
       </SidebarHeader>
 
       <SidebarContent>
         <SidebarGroup>
           <SidebarMenu>
-            {navItems.map((item) => {
-              const isActive =
-                location.pathname === item.to ||
-                location.pathname.startsWith(item.to + "/");
-
-              return (
-                <SidebarMenuItem key={item.to}>
+            {nav.map((e) =>
+              isGroup(e) ? (
+                <SidebarMenuItem key={e.label}>
+                  <SidebarMenuButton
+                    onClick={() =>
+                      setOpen((o) => ({ ...o, [e.label]: !o[e.label] }))
+                    }
+                    className="!bg-transparent hover:!bg-transparent justify-between !text-sidebar-foreground"
+                  >
+                    <span>{e.label}</span>
+                    {open[e.label] ? (
+                      <ChevronDown size={16} />
+                    ) : (
+                      <ChevronRight size={16} />
+                    )}
+                  </SidebarMenuButton>
+                  {open[e.label] && (
+                    <SidebarMenuSub>
+                      {e.children.map((c) => (
+                        <SidebarMenuSubItem key={c.to}>
+                          <SidebarMenuSubButton
+                            asChild
+                            className="!bg-transparent hover:!bg-transparent"
+                          >
+                            <Link to={c.to} className={linkCls(c.to)}>
+                              {c.label}
+                            </Link>
+                          </SidebarMenuSubButton>
+                        </SidebarMenuSubItem>
+                      ))}
+                    </SidebarMenuSub>
+                  )}
+                </SidebarMenuItem>
+              ) : (
+                <SidebarMenuItem key={e.to}>
                   <SidebarMenuButton
                     asChild
                     className="!bg-transparent hover:!bg-transparent"
                   >
-                    <Link
-                      to={item.to}
-                      className={
-                        isActive
-                          ? "!text-sidebar-primary font-semibold"
-                          : "!text-sidebar-foreground"
-                      }
-                    >
-                      {item.label}
+                    <Link to={e.to} className={linkCls(e.to)}>
+                      {e.label}
                     </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
-              );
-            })}
+              ),
+            )}
           </SidebarMenu>
         </SidebarGroup>
       </SidebarContent>
 
       <SidebarFooter>
-        <div className="p-4 text-sm text-muted-foreground">
-          v{__APP_VERSION__}
-        </div>
+        <div className="p-4 text-sm text-muted-foreground">v{__APP_VERSION__}</div>
       </SidebarFooter>
     </Sidebar>
   );


### PR DESCRIPTION
Sidebar was getting busy (11 flat items). Regrouped into 4 top-level entries:

- **Dashboard** (top)
- **Freight** ▸ — Loads · Trips · Lanes · Agents
- **Fleet** ▸ — Trucks · Trailers · Drivers · Maintenance · Fuel
- **Expenses** (top)

Freight/Fleet are collapsible; the group holding the current route auto-opens, and manual toggles on the others persist. No new dependency (local state + existing shadcn `SidebarMenuSub*`). Frontend-only, build green.