### PR TITLE
feat: maintenance services can cover both truck and trailer

### DIFF
--- a/backend/db/migrations/029_service_both.sql
+++ b/backend/db/migrations/029_service_both.sql
@@ -1,0 +1,17 @@
+-- A maintenance service (shop visit / invoice) can cover the truck, the
+-- trailer, or BOTH. The truck odometer and trailer hubodometer are different
+-- readings, so add a second reading (`trailer_hub`) and allow unit = 'both'.
+-- `odometer` now always means the truck reading; `trailer_hub` the trailer
+-- reading. Existing trailer-only services move their reading across.
+
+ALTER TABLE maintenance_services ADD COLUMN IF NOT EXISTS trailer_hub INTEGER;
+
+UPDATE maintenance_services
+  SET trailer_hub = odometer, odometer = NULL
+  WHERE unit = 'trailer' AND trailer_hub IS NULL;
+
+ALTER TABLE maintenance_services
+  DROP CONSTRAINT IF EXISTS maintenance_services_unit_check;
+ALTER TABLE maintenance_services
+  ADD CONSTRAINT maintenance_services_unit_check
+  CHECK (unit IN ('tractor', 'trailer', 'both'));

--- a/backend/src/services/maintenanceServices.js
+++ b/backend/src/services/maintenanceServices.js
@@ -3,6 +3,9 @@ import { ValidationError, NotFoundError } from "../utils/error.js";
 
 const UNITS = ["tractor", "trailer"];
 const isUnit = (u) => UNITS.includes(u);
+// A schedule item belongs to one unit; a service (shop visit) can cover both.
+const SERVICE_UNITS = ["tractor", "trailer", "both"];
+const isServiceUnit = (u) => SERVICE_UNITS.includes(u);
 
 // Resolve the user's single active truck/trailer so maintenance auto-links to
 // the right entity when there's only one — no picker needed. Returns null when
@@ -22,8 +25,14 @@ async function resolveFleet(runner, user_id) {
   };
 }
 const linkFor = (unit, ids, data) => ({
-  truck_id: unit === "tractor" ? (data.truck_id ?? ids.truckId) : null,
-  trailer_id: unit === "trailer" ? (data.trailer_id ?? ids.trailerId) : null,
+  truck_id:
+    unit === "tractor" || unit === "both"
+      ? (data.truck_id ?? ids.truckId)
+      : null,
+  trailer_id:
+    unit === "trailer" || unit === "both"
+      ? (data.trailer_id ?? ids.trailerId)
+      : null,
 });
 
 // ---- SCHEDULE ITEMS ----
@@ -140,9 +149,9 @@ export async function deleteMaintenanceItem(user_id, item_id) {
 export async function getMaintenanceServices(user_id) {
   if (!user_id) throw new ValidationError("Missing user_id");
   const result = await db.query(
-    `SELECT s.service_id, s.unit, s.service_date, s.odometer, s.vendor,
-            s.location, s.description, s.cost, s.invoice_number, s.receipt_ref,
-            s.notes,
+    `SELECT s.service_id, s.unit, s.service_date, s.odometer, s.trailer_hub,
+            s.vendor, s.location, s.description, s.cost, s.invoice_number,
+            s.receipt_ref, s.notes,
             COALESCE(
               array_agg(si.item_id) FILTER (WHERE si.item_id IS NOT NULL), '{}'
             ) AS item_ids
@@ -162,9 +171,15 @@ export async function createMaintenanceService(user_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
   if (!data.service_date) throw new ValidationError("service_date is required");
   if (!data.description) throw new ValidationError("description is required");
-  if (!isUnit(data.unit)) throw new ValidationError("unit must be tractor or trailer");
+  if (!isServiceUnit(data.unit))
+    throw new ValidationError("unit must be tractor, trailer, or both");
 
   const itemIds = Array.isArray(data.item_ids) ? data.item_ids : [];
+  // `odometer` is the truck reading, `trailer_hub` the trailer reading. A
+  // combined ("both") service carries both; each completed item is reset with
+  // the reading for its own unit.
+  const truckOdo = data.odometer ?? null;
+  const trailerHub = data.trailer_hub ?? null;
 
   const client = await db.pool.connect();
   try {
@@ -174,16 +189,18 @@ export async function createMaintenanceService(user_id, data) {
 
     const svc = await client.query(
       `INSERT INTO maintenance_services
-         (user_id, unit, service_date, odometer, vendor, location, description,
-          cost, invoice_number, receipt_ref, notes, truck_id, trailer_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-       RETURNING service_id, unit, service_date, odometer, vendor, location,
-                 description, cost, invoice_number, receipt_ref, notes`,
+         (user_id, unit, service_date, odometer, trailer_hub, vendor, location,
+          description, cost, invoice_number, receipt_ref, notes, truck_id,
+          trailer_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+       RETURNING service_id, unit, service_date, odometer, trailer_hub, vendor,
+                 location, description, cost, invoice_number, receipt_ref, notes`,
       [
         user_id,
         data.unit,
         data.service_date,
-        data.odometer ?? null,
+        truckOdo,
+        trailerHub,
         data.vendor ?? null,
         data.location ?? null,
         data.description,
@@ -199,21 +216,23 @@ export async function createMaintenanceService(user_id, data) {
 
     for (const item_id of itemIds) {
       // Only reset items that belong to this user; skip unknown ids.
-      const link = await client.query(
+      const linked = await client.query(
         `INSERT INTO maintenance_service_items (service_id, item_id)
          SELECT $1, item_id FROM maintenance_items
          WHERE item_id = $2 AND user_id = $3
-         RETURNING item_id`,
+         RETURNING item_id, unit`,
         [service_id, item_id, user_id],
       );
-      if (link.rowCount === 0) continue;
+      if (linked.rowCount === 0) continue;
+      // Reset with the reading for the item's unit (trailer items use the hub).
+      const reading = linked.rows[0].unit === "trailer" ? trailerHub : truckOdo;
       // Don't let a back-dated entry clobber a newer completion.
       await client.query(
         `UPDATE maintenance_items
            SET last_done_miles = $1, last_done_date = $2, updated_at = NOW()
          WHERE item_id = $3 AND user_id = $4
            AND (last_done_date IS NULL OR last_done_date <= $2)`,
-        [data.odometer ?? null, data.service_date, item_id, user_id],
+        [reading, data.service_date, item_id, user_id],
       );
     }
 
@@ -231,6 +250,7 @@ const SERVICE_FIELDS = [
   "unit",
   "service_date",
   "odometer",
+  "trailer_hub",
   "vendor",
   "location",
   "description",
@@ -245,8 +265,8 @@ const SERVICE_FIELDS = [
 export async function patchMaintenanceService(user_id, service_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
   if (!service_id) throw new ValidationError("Missing service_id");
-  if (data.unit !== undefined && !isUnit(data.unit))
-    throw new ValidationError("unit must be tractor or trailer");
+  if (data.unit !== undefined && !isServiceUnit(data.unit))
+    throw new ValidationError("unit must be tractor, trailer, or both");
 
   const updates = [];
   const values = [];
@@ -266,8 +286,8 @@ export async function patchMaintenanceService(user_id, service_id, data) {
   const result = await db.query(
     `UPDATE maintenance_services SET ${updates.join(", ")}
      WHERE service_id = $${i} AND user_id = $${i + 1}
-     RETURNING service_id, unit, service_date, odometer, vendor, location,
-               description, cost, invoice_number, receipt_ref, notes`,
+     RETURNING service_id, unit, service_date, odometer, trailer_hub, vendor,
+               location, description, cost, invoice_number, receipt_ref, notes`,
     values,
   );
   if (result.rowCount === 0) throw new NotFoundError("Service not found");

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.34.0",
+  "version": "1.35.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/maintenance/ServiceForm.tsx
+++ b/frontend/src/components/maintenance/ServiceForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Check, X } from "lucide-react";
-import type { MaintenanceItem, MaintenanceUnit } from "@/types/maintenance";
+import type { MaintenanceItem, ServiceUnit } from "@/types/maintenance";
 import type { ServiceInput } from "@/services/maintenanceService";
 
 const field = "bg-steel rounded px-2 py-1 text-sm w-full";
@@ -17,9 +17,10 @@ export const ServiceForm = ({
   onCancel: () => void;
   busy: boolean;
 }) => {
-  const [unit, setUnit] = useState<MaintenanceUnit>("tractor");
+  const [unit, setUnit] = useState<ServiceUnit>("tractor");
   const [date, setDate] = useState("");
-  const [odometer, setOdometer] = useState("");
+  const [odometer, setOdometer] = useState(""); // truck reading
+  const [trailerHub, setTrailerHub] = useState(""); // trailer reading
   const [vendor, setVendor] = useState("");
   const [location, setLocation] = useState("");
   const [description, setDescription] = useState("");
@@ -36,12 +37,17 @@ export const ServiceForm = ({
       return next;
     });
 
+  const toInt = (v: string) => (v.trim() === "" ? null : parseInt(v, 10));
+
   const submit = () => {
     if (!date || !description.trim()) return;
     onSave({
       unit,
       service_date: date,
-      odometer: odometer.trim() === "" ? null : parseInt(odometer, 10),
+      // odometer = truck reading, trailer_hub = trailer reading; a service only
+      // sends the reading(s) for the unit(s) it covers.
+      odometer: unit === "trailer" ? null : toInt(odometer),
+      trailer_hub: unit === "tractor" ? null : toInt(trailerHub),
       vendor: vendor.trim() || null,
       location: location.trim() || null,
       description: description.trim(),
@@ -52,7 +58,10 @@ export const ServiceForm = ({
     });
   };
 
-  const unitItems = items.filter((i) => i.unit === unit && i.active);
+  // "both" services can complete items on either unit.
+  const unitItems = items.filter(
+    (i) => i.active && (unit === "both" || i.unit === unit),
+  );
 
   return (
     <div className="bg-plate rounded-lg p-4 mb-4">
@@ -64,12 +73,13 @@ export const ServiceForm = ({
             className={field}
             value={unit}
             onChange={(e) => {
-              setUnit(e.target.value as MaintenanceUnit);
+              setUnit(e.target.value as ServiceUnit);
               setCompleted(new Set());
             }}
           >
             <option value="tractor">Tractor</option>
             <option value="trailer">Trailer</option>
+            <option value="both">Both (truck + trailer)</option>
           </select>
         </div>
         <div>
@@ -81,16 +91,34 @@ export const ServiceForm = ({
             onChange={(e) => setDate(e.target.value)}
           />
         </div>
-        <div>
-          <label className={lbl}>{unit === "trailer" ? "Hubodometer" : "Odometer"}</label>
-          <input
-            className={field}
-            value={odometer}
-            onChange={(e) => setOdometer(e.target.value)}
-            placeholder="568737"
-            inputMode="numeric"
-          />
-        </div>
+        {unit !== "trailer" && (
+          <div>
+            <label className={lbl}>
+              {unit === "both" ? "Truck odometer" : "Odometer"}
+            </label>
+            <input
+              className={field}
+              value={odometer}
+              onChange={(e) => setOdometer(e.target.value)}
+              placeholder="568737"
+              inputMode="numeric"
+            />
+          </div>
+        )}
+        {unit !== "tractor" && (
+          <div>
+            <label className={lbl}>
+              {unit === "both" ? "Trailer hub" : "Hubodometer"}
+            </label>
+            <input
+              className={field}
+              value={trailerHub}
+              onChange={(e) => setTrailerHub(e.target.value)}
+              placeholder="445000"
+              inputMode="numeric"
+            />
+          </div>
+        )}
         <div>
           <label className={lbl}>Cost</label>
           <input

--- a/frontend/src/components/maintenance/ServicesTab.tsx
+++ b/frontend/src/components/maintenance/ServicesTab.tsx
@@ -19,6 +19,23 @@ const money = (n: number | null): string =>
     ? "—"
     : `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
+const num = (n: number | null) => (n == null ? "—" : n.toLocaleString("en-US"));
+
+// The reading cell: truck odometer, trailer hub, or both stacked for a
+// combined service.
+const reading = (s: MaintenanceService) => {
+  if (s.unit === "both")
+    return (
+      <>
+        {num(s.odometer)}
+        {s.trailer_hub != null && (
+          <span className="text-xs block">{num(s.trailer_hub)} hub</span>
+        )}
+      </>
+    );
+  return num(s.unit === "trailer" ? s.trailer_hub : s.odometer);
+};
+
 const fmtDate = (iso: string) =>
   new Date(iso + "T00:00:00Z").toLocaleDateString("en-US", {
     month: "short",
@@ -280,7 +297,7 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
                     )}
                   </td>
                   <td className="py-2 text-right text-muted-text whitespace-nowrap">
-                    {s.odometer != null ? s.odometer.toLocaleString("en-US") : "—"}
+                    {reading(s)}
                   </td>
                   <td className="py-2">
                     {s.description}

--- a/frontend/src/hooks/useMaintenanceAlerts.ts
+++ b/frontend/src/hooks/useMaintenanceAlerts.ts
@@ -39,13 +39,18 @@ export const useMaintenanceAlerts = (loads: Load[]): Alert[] => {
 
   return useMemo(() => {
     const now = new Date();
-    const svcOdo = (unit: MaintenanceUnit): number | null =>
-      services
-        .filter((s) => s.unit === unit && s.odometer != null)
-        .reduce<number | null>(
-          (m, s) => (m == null || s.odometer! > m ? s.odometer! : m),
-          null,
-        );
+    // A "both" service covers this unit too; the trailer reads its hub, the
+    // truck its odometer.
+    const svcOdo = (unit: MaintenanceUnit): number | null => {
+      const read = (s: (typeof services)[number]) =>
+        unit === "trailer" ? s.trailer_hub : s.odometer;
+      return services
+        .filter((s) => (s.unit === unit || s.unit === "both") && read(s) != null)
+        .reduce<number | null>((m, s) => {
+          const v = read(s)!;
+          return m == null || v > m ? v : m;
+        }, null);
+    };
     const currentMiles: Record<MaintenanceUnit, number | null> = {
       tractor: maxOdometer(currentTractorMiles(loads), svcOdo("tractor")),
       trailer: maxOdometer(svcOdo("trailer")),

--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -44,13 +44,18 @@ const MaintenancePage = () => {
   // Current mileage = the highest reading we've seen, from either loads or the
   // service log (services often carry a fresher odometer than entered loads).
   const currentMiles: Record<MaintenanceUnit, number | null> = useMemo(() => {
-    const maxServiceOdo = (unit: MaintenanceUnit): number | null =>
-      services
-        .filter((s) => s.unit === unit && s.odometer != null)
-        .reduce<number | null>(
-          (max, s) => (max == null || s.odometer! > max ? s.odometer! : max),
-          null,
-        );
+    // A "both" service covers this unit too; the trailer reads its hub, the
+    // truck its odometer.
+    const maxServiceOdo = (unit: MaintenanceUnit): number | null => {
+      const read = (s: (typeof services)[number]) =>
+        unit === "trailer" ? s.trailer_hub : s.odometer;
+      return services
+        .filter((s) => (s.unit === unit || s.unit === "both") && read(s) != null)
+        .reduce<number | null>((max, s) => {
+          const v = read(s)!;
+          return max == null || v > max ? v : max;
+        }, null);
+    };
     // When the fuel page carries odometer, add its latest reading here — it'll
     // usually be the freshest.
     return {

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -48,8 +48,10 @@ const TrailerDetailPage = () => {
   // Latest hub reading, derived from the app: stored + newest trailer service.
   const hub = useMemo(() => {
     if (!trailer) return 0;
-    const svcOdos = services.filter((s) => s.unit === "trailer").map((s) => s.odometer);
-    return maxOdometer(trailer.current_hub, ...svcOdos) ?? trailer.current_hub;
+    const svcHubs = services
+      .filter((s) => s.unit === "trailer" || s.unit === "both")
+      .map((s) => s.trailer_hub);
+    return maxOdometer(trailer.current_hub, ...svcHubs) ?? trailer.current_hub;
   }, [trailer, services]);
 
   const mpm = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -60,7 +60,9 @@ const TruckDetailPage = () => {
   const odometer = useMemo(() => {
     if (!truck) return 0;
     const loadOdos = truckLoads.map((l) => l.odometer_end ?? null);
-    const svcOdos = services.filter((s) => s.unit === "tractor").map((s) => s.odometer);
+    const svcOdos = services
+      .filter((s) => s.unit === "tractor" || s.unit === "both")
+      .map((s) => s.odometer);
     return (
       maxOdometer(truck.current_odometer, ...loadOdos, ...svcOdos) ??
       truck.current_odometer

--- a/frontend/src/services/maintenanceService.ts
+++ b/frontend/src/services/maintenanceService.ts
@@ -29,6 +29,7 @@ const coerceService = (s: any): MaintenanceService => ({
   unit: s.unit,
   service_date: dateOrNull(s.service_date) as string,
   odometer: numOrNull(s.odometer),
+  trailer_hub: numOrNull(s.trailer_hub),
   vendor: s.vendor ?? null,
   location: s.location ?? null,
   description: s.description,
@@ -80,7 +81,8 @@ export const getMaintenanceServices = async (): Promise<MaintenanceService[]> =>
 export interface ServiceInput {
   unit: string;
   service_date: string;
-  odometer?: number | null;
+  odometer?: number | null; // truck reading (tractor / both)
+  trailer_hub?: number | null; // trailer reading (trailer / both)
   vendor?: string | null;
   location?: string | null;
   description: string;

--- a/frontend/src/types/maintenance.ts
+++ b/frontend/src/types/maintenance.ts
@@ -1,4 +1,6 @@
 export type MaintenanceUnit = "tractor" | "trailer";
+// A schedule item belongs to one unit; a service (shop visit) can cover both.
+export type ServiceUnit = "tractor" | "trailer" | "both";
 
 export interface MaintenanceItem {
   item_id: string;
@@ -21,9 +23,10 @@ export interface MaintenanceItem {
 // in QuickBooks, so there's no receipt field here.
 export interface MaintenanceService {
   service_id: string;
-  unit: MaintenanceUnit;
+  unit: ServiceUnit;
   service_date: string; // 'YYYY-MM-DD'
-  odometer: number | null;
+  odometer: number | null; // truck reading (tractor / both)
+  trailer_hub: number | null; // trailer reading (trailer / both)
   vendor: string | null;
   location: string | null;
   description: string;


### PR DESCRIPTION
## What

A shop visit / invoice often covers the **tractor and the trailer together** (a combined Landstar Ultimate PM, for example), but a service could only be logged against one unit. This adds a **Both** option so a single service links to both entities with one cost — no more splitting a combined invoice into two rows.

## How

- **Schema (migration 029):** `maintenance_services` gains a `trailer_hub` column and `unit` now allows `both`. `odometer` is strictly the *truck* reading; `trailer_hub` the *trailer* reading. Existing trailer-only services have their reading moved from `odometer` into `trailer_hub`.
- **Backend:** a service can be `tractor` / `trailer` / `both`. A `both` service links to both the truck and trailer, carries both readings, and one cost. When it completes scheduled items, each item resets against the reading for **its own** unit (truck items → odometer, trailer items → hub) — so a trailer lube never gets stamped with a truck odometer.
- **Frontend:** the Log-service form has a **Both (truck + trailer)** option that reveals two reading fields and shows completable items from both units. The services log's odometer column and the Truck/Trailer detail "latest reading" pull the correct column, and the maintenance alert engine includes `both` services per unit.

## Verification

- Frontend production build (`tsc -b && vite build`) clean; 90/90 tests pass.
- Migration 029 applied on **dev** and verified: 4 tractor services kept their odometer; both trailer services correctly moved their reading (445,000 / 456,123) into `trailer_hub`, no data lost.

## Deploy note

Order matters on prod: **run migration 029 + redeploy the backend before the frontend**, so the new form doesn't send `both` / `trailer_hub` to a backend that doesn't understand them yet.