### PR TITLE
fix: service item-completion crashed with column "unit" does not exist

### DIFF
--- a/backend/src/services/maintenanceServices.js
+++ b/backend/src/services/maintenanceServices.js
@@ -215,17 +215,22 @@ export async function createMaintenanceService(user_id, data) {
     const service_id = svc.rows[0].service_id;
 
     for (const item_id of itemIds) {
-      // Only reset items that belong to this user; skip unknown ids.
-      const linked = await client.query(
-        `INSERT INTO maintenance_service_items (service_id, item_id)
-         SELECT $1, item_id FROM maintenance_items
-         WHERE item_id = $2 AND user_id = $3
-         RETURNING item_id, unit`,
-        [service_id, item_id, user_id],
+      // Only reset items that belong to this user; skip unknown ids. The item's
+      // unit decides which reading resets it (trailer items use the hub). The
+      // join table has no `unit`, so read it from maintenance_items directly.
+      const owned = await client.query(
+        `SELECT unit FROM maintenance_items WHERE item_id = $1 AND user_id = $2`,
+        [item_id, user_id],
       );
-      if (linked.rowCount === 0) continue;
-      // Reset with the reading for the item's unit (trailer items use the hub).
-      const reading = linked.rows[0].unit === "trailer" ? trailerHub : truckOdo;
+      if (owned.rowCount === 0) continue;
+
+      await client.query(
+        `INSERT INTO maintenance_service_items (service_id, item_id)
+         VALUES ($1, $2)`,
+        [service_id, item_id],
+      );
+
+      const reading = owned.rows[0].unit === "trailer" ? trailerHub : truckOdo;
       // Don't let a back-dated entry clobber a newer completion.
       await client.query(
         `UPDATE maintenance_items

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.35.0",
+  "version": "1.35.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Bug

Logging a service that completes any scheduled item returned `500 — column "unit" does not exist`.

`createMaintenanceService`'s reset loop used:

```sql
INSERT INTO maintenance_service_items (service_id, item_id)
SELECT $1, item_id FROM maintenance_items WHERE item_id = $2 AND user_id = $3
RETURNING item_id, unit
```

`RETURNING` only references the **target** table's columns, and the join table `maintenance_service_items` has only `(service_id, item_id)` — no `unit`. So the statement failed to plan for every service with completed items (not just `both`). Introduced in #176.

## Fix

Look the item's `unit` up from `maintenance_items` first (which also serves as the per-user ownership check), then insert the link row without the bad `RETURNING`, and reset each item against the reading for its own unit.

## Verification

Exercised the real statement shapes against dev inside a `DO` block that `RAISE`s to roll back — service insert (`unit='both'` + `trailer_hub`), join insert, and per-unit reset all executed with no missing-column error and left no data behind. Unit tests (90) still green; backend syntax-checked.

Backend-only; version bumped to 1.35.1. Prod needs a **backend redeploy** (no migration).