### PR TITLE
feat: loads list + detail redesign, fleet on loads, per-load fuel estimate

### DIFF
--- a/backend/src/services/loadServices.js
+++ b/backend/src/services/loadServices.js
@@ -107,6 +107,12 @@ export async function getLoad(user_id, load_id) {
             odometer_start,
             odometer_end,
             payment_status,
+            l.truck_id,
+            l.driver_id,
+            l.trailer_id,
+            trk.unit_number AS truck_unit,
+            drv.first_name || ' ' || drv.last_name AS driver_name,
+            trl.unit_number AS trailer_unit,
             l.created_at AS created_at,
             l.updated_at AS updated_at
         FROM loads AS l
@@ -118,6 +124,12 @@ export async function getLoad(user_id, load_id) {
         ON l.origin_market_id = origin_market.market_id
         JOIN markets AS destination_market
         ON l.destination_market_id = destination_market.market_id
+        LEFT JOIN trucks AS trk
+        ON l.truck_id = trk.truck_id
+        LEFT JOIN drivers AS drv
+        ON l.driver_id = drv.driver_id
+        LEFT JOIN trailers AS trl
+        ON l.trailer_id = trl.trailer_id
         WHERE l.user_id = $1
         AND load_id = $2;
     `;
@@ -161,6 +173,9 @@ export async function createLoad(user_id, data) {
     "deadhead_miles",
     "odometer_start",
     "odometer_end",
+    "truck_id",
+    "driver_id",
+    "trailer_id",
   ];
 
   for (const field in data) {
@@ -233,6 +248,9 @@ export async function patchLoad(user_id, load_id, data) {
     "deadhead_miles",
     "odometer_start",
     "odometer_end",
+    "truck_id",
+    "driver_id",
+    "trailer_id",
   ];
 
   // Throw error if data contains invalid field(s)

--- a/backend/src/utils/validation/loadValidation.js
+++ b/backend/src/utils/validation/loadValidation.js
@@ -301,6 +301,20 @@ const rules = {
       errors.push("odometer_end must be greater than 0");
     }
   },
+  // Fleet links are optional; null/absent means unassigned. When present they
+  // must be a UUID.
+  truck_id: (value, errors) => {
+    if (value === null || value === undefined) return;
+    if (!isValidUUID(value)) errors.push("truck_id must be a valid UUID");
+  },
+  driver_id: (value, errors) => {
+    if (value === null || value === undefined) return;
+    if (!isValidUUID(value)) errors.push("driver_id must be a valid UUID");
+  },
+  trailer_id: (value, errors) => {
+    if (value === null || value === undefined) return;
+    if (!isValidUUID(value)) errors.push("trailer_id must be a valid UUID");
+  },
 };
 
 // ---- CREATE LOAD VALIDATION ----

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.35.1",
+  "version": "1.36.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/Kpi.tsx
+++ b/frontend/src/components/Kpi.tsx
@@ -1,0 +1,18 @@
+// Shared KPI card in the coherent theme (bg-plate, muted label, condensed value).
+export const Kpi = ({
+  label,
+  value,
+  sub,
+  valueClass = "text-light",
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  valueClass?: string;
+}) => (
+  <div className="bg-plate rounded-lg p-4">
+    <p className="text-xs text-muted-text">{label}</p>
+    <p className={`text-2xl font-condensed mt-1 ${valueClass}`}>{value}</p>
+    {sub && <p className="text-xs text-muted-text mt-1">{sub}</p>}
+  </div>
+);

--- a/frontend/src/components/LoadForm.tsx
+++ b/frontend/src/components/LoadForm.tsx
@@ -1,8 +1,14 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { Broker } from "@/types/broker";
 import type { Agent } from "@/types/agent";
 import type { Market } from "@/types/market";
 import type { LoadInput } from "@/types/LoadInput";
+import type { Truck } from "@/types/truck";
+import type { Driver } from "@/types/driver";
+import type { Trailer } from "@/types/trailer";
+import { getTrucks } from "@/services/trucksService";
+import { getDrivers } from "@/services/driversService";
+import { getTrailers } from "@/services/trailersService";
 import { QuickAddBroker } from "./QuickAddBroker";
 import { QuickAddAgent } from "./QuickAddAgent";
 import { QuickAddMarket } from "./QuickAddMarket";
@@ -86,6 +92,9 @@ const LoadForm = ({
           odometer_start: initialData.odometer_start ?? null,
           odometer_end: initialData.odometer_end ?? null,
           payment_status: initialData.payment_status,
+          truck_id: initialData.truck_id ?? null,
+          driver_id: initialData.driver_id ?? null,
+          trailer_id: initialData.trailer_id ?? null,
         }
       : {
           load_number: "",
@@ -111,7 +120,11 @@ const LoadForm = ({
           deadhead_miles: null,
           loaded_miles: null,
           odometer_start: null,
+          odometer_end: null,
           payment_status: "unpaid",
+          truck_id: null,
+          driver_id: null,
+          trailer_id: null,
         },
   );
 
@@ -119,7 +132,35 @@ const LoadForm = ({
   const [agentList, setAgentList] = useState<Agent[]>(agents);
   const [marketList, setMarketList] = useState<Market[]>(markets);
 
+  const [trucks, setTrucks] = useState<Truck[]>([]);
+  const [drivers, setDrivers] = useState<Driver[]>([]);
+  const [trailers, setTrailers] = useState<Trailer[]>([]);
+
   const [error, setError] = useState<string | null>(null);
+
+  // Load the fleet and auto-assign the sole rig when there's only one — no
+  // picker needed. Anything already chosen (edit mode) is left untouched.
+  useEffect(() => {
+    let active = true;
+    Promise.all([getTrucks(), getDrivers(), getTrailers()])
+      .then(([t, d, tr]) => {
+        if (!active) return;
+        setTrucks(t);
+        setDrivers(d);
+        setTrailers(tr);
+        setFormData((prev) => ({
+          ...prev,
+          truck_id: prev.truck_id || (t.length === 1 ? t[0].truck_id : null),
+          driver_id: prev.driver_id || (d.length === 1 ? d[0].driver_id : null),
+          trailer_id:
+            prev.trailer_id || (tr.length === 1 ? tr[0].trailer_id : null),
+        }));
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
 
   // Form controll states for brokers, agents, and markets
   const [showBrokerForm, setShowBrokerForm] = useState(false);
@@ -179,7 +220,6 @@ const LoadForm = ({
 
   const handleCreateAgent = async () => {
     try {
-      console.log(newAgent);
       const created = await createAgent(newAgent);
       handleAgentCreated(created);
       setShowAgentForm(false);
@@ -232,6 +272,54 @@ const LoadForm = ({
     }
   };
 
+  const truckOptions = trucks.map((t) => ({
+    id: t.truck_id,
+    name: `Unit ${t.unit_number}`,
+  }));
+  const driverOptions = drivers.map((d) => ({
+    id: d.driver_id,
+    name: `${d.first_name} ${d.last_name}`,
+  }));
+  const trailerOptions = trailers.map((t) => ({
+    id: t.trailer_id,
+    name: `Unit ${t.unit_number}`,
+  }));
+
+  // Single rig → read-only auto-assigned line; multiple → a picker; none → hint.
+  const fleetField = (
+    label: string,
+    value: string | null,
+    options: { id: string; name: string }[],
+    onChange: (id: string) => void,
+  ) => (
+    <div>
+      <Label>{label}</Label>
+      {options.length === 0 ? (
+        <p className="text-sm text-muted-text mt-2">None added yet</p>
+      ) : options.length === 1 ? (
+        <p className="text-sm mt-2">
+          {options[0].name}
+          <span className="text-muted-text text-xs"> · auto-assigned</span>
+        </p>
+      ) : (
+        <Select value={value ?? ""} onValueChange={onChange}>
+          <SelectTrigger>
+            <SelectValue placeholder={`Select a ${label.toLowerCase()}`} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {options.map((o) => (
+                <SelectItem key={o.id} value={o.id}>
+                  {o.name}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      )}
+    </div>
+  );
+
   // ---- JSX ----
   return (
     <div>
@@ -239,7 +327,11 @@ const LoadForm = ({
         <h2 className="text-xl font-semibold">
           {mode === "create" ? "Create Load" : "Edit Load"}
         </h2>
-        <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+        <button
+          onClick={onClose}
+          className="text-muted-text hover:text-light"
+          aria-label="Close"
+        >
           ✕
         </button>
       </div>
@@ -417,7 +509,7 @@ const LoadForm = ({
                 </div>
               </div>
               {brokerFormError && (
-                <p className="text-red-500 text-sm mt-2">{brokerFormError}</p>
+                <p className="text-destructive text-sm mt-2">{brokerFormError}</p>
               )}
               <div className="flex gap-2 mt-3">
                 <Button onClick={handleCreateBroker}>Create Broker</Button>
@@ -547,7 +639,7 @@ const LoadForm = ({
                 </div>
               </div>
               {agentFormError && (
-                <p className="text-red-500 text-sm mt-2">{agentFormError}</p>
+                <p className="text-destructive text-sm mt-2">{agentFormError}</p>
               )}
               <div className="flex gap-2 mt-3">
                 <Button onClick={handleCreateAgent}>Create Agent</Button>
@@ -738,7 +830,7 @@ const LoadForm = ({
                 </div>
               </div>
               {marketFormError && (
-                <p className="text-red-500 text-sm mt-2">{marketFormError}</p>
+                <p className="text-destructive text-sm mt-2">{marketFormError}</p>
               )}
               <div className="flex gap-2 mt-3">
                 <Button onClick={handleCreateMarket}>Create Market</Button>
@@ -901,8 +993,32 @@ const LoadForm = ({
             </div>
           </div>
         </div>
-        {error && <p>{error}</p>}
-        <Button onClick={handleSubmit}>
+        {/* ---- FLEET ---- */}
+        <div className="mt-4">
+          <h3 className="text-sm font-semibold mb-2">Fleet</h3>
+          <div className="grid grid-cols-3 gap-3">
+            {fleetField(
+              "Truck",
+              formData.truck_id ?? null,
+              truckOptions,
+              (id) => setFormData({ ...formData, truck_id: id }),
+            )}
+            {fleetField(
+              "Driver",
+              formData.driver_id ?? null,
+              driverOptions,
+              (id) => setFormData({ ...formData, driver_id: id }),
+            )}
+            {fleetField(
+              "Trailer",
+              formData.trailer_id ?? null,
+              trailerOptions,
+              (id) => setFormData({ ...formData, trailer_id: id }),
+            )}
+          </div>
+        </div>
+        {error && <p className="text-destructive text-sm mt-3">{error}</p>}
+        <Button className="mt-4" onClick={handleSubmit}>
           {mode === "create" ? "Create Load" : "Save Changes"}
         </Button>
       </div>

--- a/frontend/src/lib/metrics/fuel.test.ts
+++ b/frontend/src/lib/metrics/fuel.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { estimateLoadFuel, ASSUMED_MPG, ASSUMED_FUEL_PRICE } from "./fuel";
+
+describe("estimateLoadFuel", () => {
+  it("estimates from loaded + deadhead miles when odometer is missing", () => {
+    const f = estimateLoadFuel({ loaded_miles: 1000, deadhead_miles: 100 });
+    expect(f?.basis).toBe("estimated");
+    expect(f?.miles).toBe(1100);
+    expect(f?.gallons).toBeCloseTo(1100 / ASSUMED_MPG);
+    expect(f?.cost).toBeCloseTo((1100 / ASSUMED_MPG) * ASSUMED_FUEL_PRICE);
+  });
+
+  it("estimates from loaded miles alone when there's no deadhead", () => {
+    const f = estimateLoadFuel({ loaded_miles: 800, deadhead_miles: null });
+    expect(f?.basis).toBe("estimated");
+    expect(f?.miles).toBe(800);
+  });
+
+  it("uses actual odometer miles once both readings are present", () => {
+    const f = estimateLoadFuel({
+      loaded_miles: 1000,
+      deadhead_miles: 100,
+      odometer_start: 568000,
+      odometer_end: 569200,
+    });
+    expect(f?.basis).toBe("actual");
+    expect(f?.miles).toBe(1200);
+  });
+
+  it("falls back to estimate when odometer_end is not greater than start", () => {
+    const f = estimateLoadFuel({
+      loaded_miles: 500,
+      deadhead_miles: 0,
+      odometer_start: 569000,
+      odometer_end: 569000,
+    });
+    expect(f?.basis).toBe("estimated");
+    expect(f?.miles).toBe(500);
+  });
+
+  it("returns null when there are no miles to work with", () => {
+    expect(estimateLoadFuel({ loaded_miles: 0, deadhead_miles: 0 })).toBeNull();
+    expect(estimateLoadFuel({ loaded_miles: null, deadhead_miles: null })).toBeNull();
+  });
+});

--- a/frontend/src/lib/metrics/fuel.ts
+++ b/frontend/src/lib/metrics/fuel.ts
@@ -1,0 +1,44 @@
+// Per-load fuel estimate. Until the fuel page feeds real numbers, MPG and price
+// are explicit assumptions (Jason's working figures). The mileage basis is what
+// changes: before a load is closed out we estimate from loaded + deadhead miles;
+// once both odometer readings are entered we use the actual miles driven.
+export const ASSUMED_MPG = 6.5;
+export const ASSUMED_FUEL_PRICE = 5.5; // dollars per gallon
+
+export interface FuelEstimate {
+  miles: number;
+  gallons: number;
+  cost: number;
+  basis: "estimated" | "actual";
+}
+
+interface FuelInput {
+  loaded_miles: number | null;
+  deadhead_miles: number | null;
+  odometer_start?: number | null;
+  odometer_end?: number | null;
+}
+
+export const estimateLoadFuel = (
+  load: FuelInput,
+  mpg: number = ASSUMED_MPG,
+  price: number = ASSUMED_FUEL_PRICE,
+): FuelEstimate | null => {
+  const { odometer_start: start, odometer_end: end } = load;
+
+  let miles: number;
+  let basis: FuelEstimate["basis"];
+  if (start != null && end != null && end > start) {
+    miles = end - start;
+    basis = "actual";
+  } else {
+    // Estimate: loaded miles, plus deadhead when we have it.
+    miles = (Number(load.loaded_miles) || 0) + (Number(load.deadhead_miles) || 0);
+    basis = "estimated";
+  }
+
+  if (miles <= 0 || mpg <= 0) return null;
+
+  const gallons = miles / mpg;
+  return { miles, gallons, cost: gallons * price, basis };
+};

--- a/frontend/src/lib/metrics/loads.test.ts
+++ b/frontend/src/lib/metrics/loads.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
   getBookedCount,
+  getInTransitCount,
   getOutstandingTotal,
+  outstandingLoads,
   deliveredThisMonth,
+  loadRevenue,
+  loadsKpis,
 } from "./loads";
 
 describe("getBookedCount", () => {
@@ -75,5 +79,89 @@ describe("deliveredThisMonth", () => {
     const result = deliveredThisMonth(loads as any, now);
 
     expect(result.length).toBe(2);
+  });
+});
+
+describe("loadRevenue", () => {
+  it("sums linehaul, fuel surcharge, and accessorials (string-safe)", () => {
+    const load = { linehaul: "1000", fuel_surcharge: "250.5", total_accessorials: "100" };
+    expect(loadRevenue(load as any)).toBe(1350.5);
+  });
+});
+
+describe("getInTransitCount", () => {
+  it("counts only in_transit loads", () => {
+    const loads = [
+      { load_status: "in_transit" },
+      { load_status: "booked" },
+      { load_status: "in_transit" },
+    ];
+    expect(getInTransitCount(loads as any)).toBe(2);
+  });
+});
+
+describe("outstandingLoads", () => {
+  it("includes delivered+unpaid and any invoiced, excludes paid/booked", () => {
+    const loads = [
+      { load_status: "delivered", payment_status: "unpaid" }, // ✓
+      { load_status: "in_transit", payment_status: "invoiced" }, // ✓ (invoiced regardless of status)
+      { load_status: "delivered", payment_status: "paid" }, // ✗
+      { load_status: "booked", payment_status: "unpaid" }, // ✗ (not delivered, not invoiced)
+    ];
+    expect(outstandingLoads(loads as any).length).toBe(2);
+  });
+});
+
+describe("loadsKpis", () => {
+  const now = new Date("2026-06-15T00:00:00.000Z");
+
+  it("aggregates delivered gross, RPM, AR, and pipeline", () => {
+    const loads = [
+      {
+        load_status: "delivered",
+        delivery_date: "2026-06-05T04:00:00.000Z",
+        payment_status: "paid",
+        linehaul: "2000",
+        fuel_surcharge: "0",
+        total_accessorials: "0",
+        loaded_miles: 1000,
+      },
+      {
+        load_status: "delivered",
+        delivery_date: "2026-06-20T04:00:00.000Z",
+        payment_status: "unpaid",
+        linehaul: "1000",
+        fuel_surcharge: "0",
+        total_accessorials: "0",
+        loaded_miles: 500,
+      },
+      { load_status: "booked", payment_status: "unpaid" },
+      { load_status: "in_transit", payment_status: "unpaid" },
+    ];
+
+    const k = loadsKpis(loads as any, now);
+    expect(k.deliveredCount).toBe(2);
+    expect(k.deliveredGross).toBe(3000);
+    expect(k.loadedMiles).toBe(1500);
+    expect(k.rpm).toBeCloseTo(2); // 3000 / 1500
+    expect(k.arTotal).toBe(1000); // the delivered+unpaid one
+    expect(k.arCount).toBe(1);
+    expect(k.bookedCount).toBe(1);
+    expect(k.inTransitCount).toBe(1);
+  });
+
+  it("returns null RPM when there are no loaded miles", () => {
+    const loads = [
+      {
+        load_status: "delivered",
+        delivery_date: "2026-06-05T04:00:00.000Z",
+        payment_status: "paid",
+        linehaul: "2000",
+        fuel_surcharge: "0",
+        total_accessorials: "0",
+        loaded_miles: 0,
+      },
+    ];
+    expect(loadsKpis(loads as any, now).rpm).toBeNull();
   });
 });

--- a/frontend/src/lib/metrics/loads.ts
+++ b/frontend/src/lib/metrics/loads.ts
@@ -1,43 +1,88 @@
 import type { Load } from "@/types/load";
 
-export const getBookedCount = (loads: Array<Load>) => {
-  return loads.filter((load) => load.load_status === "booked").length;
-};
+// Total revenue for a load = linehaul + fuel surcharge + accessorials.
+// Postgres numerics arrive as strings, so coerce before adding.
+export const loadRevenue = (load: Load): number =>
+  Number(load.linehaul) +
+  Number(load.fuel_surcharge) +
+  Number(load.total_accessorials);
 
-export const getOutstandingTotal = (loads: Array<Load>) => {
-  const outstandingLoads = loads.filter(
+export const getBookedCount = (loads: Array<Load>): number =>
+  loads.filter((load) => load.load_status === "booked").length;
+
+export const getInTransitCount = (loads: Array<Load>): number =>
+  loads.filter((load) => load.load_status === "in_transit").length;
+
+// Money still owed to us: delivered-but-unpaid, or anything invoiced.
+export const outstandingLoads = (loads: Array<Load>): Array<Load> =>
+  loads.filter(
     (load) =>
       (load.load_status === "delivered" && load.payment_status === "unpaid") ||
       load.payment_status === "invoiced",
   );
 
-  const outstandingLoadsTotal = outstandingLoads.reduce((total, load) => {
-    return (
-      total +
-      Number(load.linehaul) +
-      Number(load.fuel_surcharge) +
-      Number(load.total_accessorials)
-    );
-  }, 0);
+export const getOutstandingTotal = (loads: Array<Load>): number =>
+  outstandingLoads(loads).reduce((total, load) => total + loadRevenue(load), 0);
 
-  return outstandingLoadsTotal;
+// Rate per (loaded) mile for a single load; null when there are no loaded miles.
+export const loadRpm = (load: Load): number | null => {
+  const miles = Number(load.loaded_miles) || 0;
+  return miles > 0 ? loadRevenue(load) / miles : null;
 };
 
-export const deliveredThisMonth = (loads: Array<Load>, now: Date) => {
-  // Filter by 'delivered' status
-  const deliveredLoads = loads.filter(
-    (load) => load.load_status === "delivered",
-  );
+// Deadhead share of total miles (0–1); null when the load has no miles at all.
+export const deadheadShare = (load: Load): number | null => {
+  const loaded = Number(load.loaded_miles) || 0;
+  const deadhead = Number(load.deadhead_miles) || 0;
+  const total = loaded + deadhead;
+  return total > 0 ? deadhead / total : null;
+};
 
-  const currentYear = now.getUTCFullYear();
-  const currentMonth = now.getUTCMonth();
-
-  return deliveredLoads.filter((load) => {
-    if (!load.delivery_date) return false;
-    const loadDate = new Date(load.delivery_date);
-    const loadYear = loadDate.getUTCFullYear();
-    const loadMonth = loadDate.getUTCMonth();
-
-    return loadYear === currentYear && loadMonth === currentMonth;
+// Loads delivered in the current (UTC) month. Returns the array so callers can
+// count them or sum their revenue. A delivered load with no delivery_date is
+// excluded (we can't place it in a month).
+export const deliveredThisMonth = (
+  loads: Array<Load>,
+  now: Date,
+): Array<Load> => {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  return loads.filter((load) => {
+    if (load.load_status !== "delivered" || !load.delivery_date) return false;
+    const d = new Date(load.delivery_date);
+    return d.getUTCFullYear() === year && d.getUTCMonth() === month;
   });
+};
+
+export interface LoadsKpis {
+  deliveredCount: number;
+  deliveredGross: number;
+  rpm: number | null; // revenue per loaded mile this month; null when no miles
+  loadedMiles: number;
+  arTotal: number;
+  arCount: number;
+  bookedCount: number;
+  inTransitCount: number;
+}
+
+// The four loads-page KPIs in one pass: this month's earnings + efficiency,
+// what's owed, and what's in the pipeline.
+export const loadsKpis = (loads: Array<Load>, now: Date): LoadsKpis => {
+  const delivered = deliveredThisMonth(loads, now);
+  const deliveredGross = delivered.reduce((s, l) => s + loadRevenue(l), 0);
+  const loadedMiles = delivered.reduce(
+    (s, l) => s + (Number(l.loaded_miles) || 0),
+    0,
+  );
+  const ar = outstandingLoads(loads);
+  return {
+    deliveredCount: delivered.length,
+    deliveredGross,
+    rpm: loadedMiles > 0 ? deliveredGross / loadedMiles : null,
+    loadedMiles,
+    arTotal: ar.reduce((s, l) => s + loadRevenue(l), 0),
+    arCount: ar.length,
+    bookedCount: getBookedCount(loads),
+    inTransitCount: getInTransitCount(loads),
+  };
 };

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -1,49 +1,23 @@
-import { useState } from "react";
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
+import type { ReactNode } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Pencil, Trash2, Truck, User, Container } from "lucide-react";
+
 import { useLoad } from "@/hooks/useLoad";
 import { useAccessorials } from "@/hooks/useAccessorials";
-import { useNavigate } from "react-router-dom";
-
-// Types
-import type { Badge } from "@/types/badge";
-
-// Hooks
 import { useBrokers } from "@/hooks/useBrokers";
 import { useAgents } from "@/hooks/useAgents";
 import { useMarkets } from "@/hooks/useMarkets";
 
-// Services
 import { patchLoad } from "@/services/patchLoadService";
 import { createAccessorial } from "@/services/createAccessorialService";
 import { deleteAccessorial } from "@/services/deleteAccessorialService";
 import { patchAccessorial } from "@/services/patchAccessorialService";
 import { deleteLoad } from "@/services/deleteLoadService";
 
-// Components
 import LoadForm from "@/components/LoadForm";
-
-// UI Components
-import { PageHeader } from "@/components/PageHeader";
-import { MetricStrip } from "@/components/MetricStrip";
-import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { StatusBadge } from "@/components/StatusBadge";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { Kpi } from "@/components/Kpi";
 import {
   Dialog,
   DialogContent,
@@ -52,191 +26,179 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+import { loadRevenue, loadRpm, deadheadShare } from "@/lib/metrics/loads";
+import {
+  estimateLoadFuel,
+  ASSUMED_MPG,
+  ASSUMED_FUEL_PRICE,
+} from "@/lib/metrics/fuel";
+import { fmtRpm, rpmTextClass } from "@/components/lanes/rpmStyle";
+
+const money0 = (n: number) =>
+  n.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+const money2 = (n: number) =>
+  n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+
+const fmtDate = (d?: string | null) =>
+  d
+    ? new Date(String(d).slice(0, 10) + "T00:00:00Z").toLocaleDateString(
+        "en-US",
+        { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" },
+      )
+    : "Not set";
+
+const cardLbl = "text-xs text-muted-text uppercase tracking-wider mb-2";
+
+const Row = ({ label, value }: { label: ReactNode; value: ReactNode }) => (
+  <div className="flex justify-between gap-3 py-0.5 text-sm">
+    <span className="text-muted-text">{label}</span>
+    <span className="text-right">{value}</span>
+  </div>
+);
+
+const LOAD_STATUSES = ["booked", "in_transit", "delivered", "cancelled", "tonu"];
+const PAYMENT_STATUSES = ["unpaid", "invoiced", "paid", "cancelled"];
 
 export const LoadDetailPage = () => {
   const [refreshKey, setRefreshKey] = useState(0);
-  const [accessorialsRefreshKey, setAccessorialsRefreshKey] = useState(0);
+  const [accRefreshKey, setAccRefreshKey] = useState(0);
   const { load, isLoading, error } = useLoad(refreshKey);
-  const { accessorials } = useAccessorials(accessorialsRefreshKey);
-  const [newAccessorialType, setNewAccessorialType] = useState("");
-  const [newAccessorialAmount, setNewAccessorialAmount] = useState("");
-  const [isSaving, setIsSaving] = useState(false);
-  const [selectedLoadStatus, setSelectedLoadStatus] = useState("");
-  const [selectedPaymentStatus, setSelectedPaymentStatus] = useState("");
+  const { accessorials } = useAccessorials(accRefreshKey);
 
-  // Edit Accessorial States
-  const [editingId, setEditingId] = useState<string>("");
-  const [editingType, setEditingType] = useState<string>("");
+  const [newType, setNewType] = useState("");
+  const [newAmount, setNewAmount] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [statusSel, setStatusSel] = useState("");
+  const [paymentSel, setPaymentSel] = useState("");
+
+  const [editingId, setEditingId] = useState("");
+  const [editingType, setEditingType] = useState("");
   const [editingAmount, setEditingAmount] = useState<number>(0);
 
-  // Edit Load Button state
   const [showEditForm, setShowEditForm] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { brokers } = useBrokers(0);
   const { agents } = useAgents(0);
   const { markets } = useMarkets(0);
-
-  // Delete state
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const navigate = useNavigate();
 
   useEffect(() => {
     if (load) {
-      setSelectedLoadStatus(load.load_status);
-      setSelectedPaymentStatus(load.payment_status);
+      setStatusSel(load.load_status);
+      setPaymentSel(load.payment_status);
     }
   }, [load]);
 
-  // Date format options
-  const dateOptions: Intl.DateTimeFormatOptions = {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    timeZone: "UTC",
-  };
-
-  let totalAccessorialCharges = 0;
-  accessorials.forEach((accessorial) => {
-    totalAccessorialCharges += Number(accessorial.amount);
-  });
-  if (isLoading) {
+  if (isLoading)
     return (
-      <div>
-        <p>Loading</p>
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <p className="text-muted-text">Loading…</p>
       </div>
     );
-  }
-
-  if (error) {
+  if (error)
     return (
-      <div>
-        <p>{error}</p>
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <p className="text-destructive">{error}</p>
       </div>
     );
-  }
+  if (!load) return null;
 
-  if (!load) {
-    return null;
-  }
+  const capitalize = (str: string) =>
+    str
+      .split(" ")
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(" ");
 
-  const capitalize = (str: string): string => {
-    const words = str.split(" ");
-    const capitalized = words.map(
-      (word) => word.charAt(0).toUpperCase() + word.slice(1),
-    );
-    return capitalized.join(" ");
-  };
+  const revenue = loadRevenue(load);
+  const rpm = loadRpm(load);
+  const dh = deadheadShare(load);
+  const fuel = estimateLoadFuel(load);
+  const accTotal = accessorials.reduce((s, a) => s + Number(a.amount), 0);
 
-  // HANDLERS
   const handleSaveChanges = async () => {
-    const data = {
-      load_status: selectedLoadStatus,
-      payment_status: selectedPaymentStatus,
-    };
-
-    // Check if the state for the selects have changed
-    if (
-      data.load_status !== load.load_status ||
-      data.payment_status !== load.payment_status
-    ) {
-      try {
-        setIsSaving(true);
-        await patchLoad(load.load_id, data);
-        setRefreshKey((prev) => prev + 1);
-      } catch {
-        throw new Error("Unable to update status");
-      } finally {
-        setIsSaving(false);
-      }
+    if (statusSel === load.load_status && paymentSel === load.payment_status)
+      return;
+    try {
+      setIsSaving(true);
+      await patchLoad(load.load_id, {
+        load_status: statusSel,
+        payment_status: paymentSel,
+      });
+      setRefreshKey((p) => p + 1);
+    } catch {
+      // surfaced by the row's own state; nothing to do here
+    } finally {
+      setIsSaving(false);
     }
   };
 
   const handleAddAccessorial = async () => {
-    const data = {
-      accessorial_type: capitalize(newAccessorialType),
-      amount: Number(newAccessorialAmount),
-    };
-
-    if (data.accessorial_type !== "" && data.amount !== null) {
-      try {
-        await createAccessorial(load.load_id, data);
-        setAccessorialsRefreshKey((prev) => prev + 1);
-        setRefreshKey((prev) => prev + 1);
-      } catch {
-        throw new Error("Unable to create new accessorial");
-      } finally {
-        setNewAccessorialType("");
-        setNewAccessorialAmount("");
-      }
-    }
-  };
-
-  const handleDeleteAccessorial = async (accessorial_id: string) => {
+    if (!newType.trim() || newAmount.trim() === "") return;
     try {
-      await deleteAccessorial(accessorial_id);
-      setAccessorialsRefreshKey((prev) => prev + 1);
-      setRefreshKey((prev) => prev + 1);
-    } catch {
-      throw new Error("Unable to delete accessorial");
+      await createAccessorial(load.load_id, {
+        accessorial_type: capitalize(newType.trim()),
+        amount: Number(newAmount),
+      });
+      setAccRefreshKey((p) => p + 1);
+      setRefreshKey((p) => p + 1);
+    } finally {
+      setNewType("");
+      setNewAmount("");
     }
   };
 
-  const handleEditAccessorial = (
-    accessorial_id: string,
-    accessorial_type: string,
-    amount: number,
-  ) => {
-    setEditingId(accessorial_id);
-    setEditingType(accessorial_type);
+  const handleDeleteAccessorial = async (id: string) => {
+    await deleteAccessorial(id);
+    setAccRefreshKey((p) => p + 1);
+    setRefreshKey((p) => p + 1);
+  };
+
+  const startEdit = (id: string, type: string, amount: number) => {
+    setEditingId(id);
+    setEditingType(type);
     setEditingAmount(amount);
   };
 
-  const handleSaveEditAccessorial = async () => {
-    const data = {
-      accessorial_type: editingType,
-      amount: editingAmount,
-    };
+  const handleSaveEdit = async () => {
     try {
-      await patchAccessorial(editingId, data);
-      setAccessorialsRefreshKey((prev) => prev + 1);
-      setRefreshKey((prev) => prev + 1);
-    } catch {
-      throw new Error("Unable to patch accessorial");
+      await patchAccessorial(editingId, {
+        accessorial_type: editingType,
+        amount: editingAmount,
+      });
+      setAccRefreshKey((p) => p + 1);
+      setRefreshKey((p) => p + 1);
     } finally {
       setEditingId("");
-      setEditingType("");
-      setEditingAmount(0);
     }
   };
 
-  const handleCancelEditAccessorial = () => {
-    setEditingId("");
-  };
-
   const handleDeleteLoad = async () => {
-    const loadToDelete = load.load_id;
     try {
-      await deleteLoad(loadToDelete);
+      await deleteLoad(load.load_id);
       navigate("/loads");
-    } catch {
-      throw new Error("Unable to delete load");
     } finally {
       setShowDeleteModal(false);
     }
   };
 
+  const fleetChip = (n?: string | null) => (n ? n : "—");
+
   return (
-    // CONTAINER
-    <div className="m-2 font-body">
-      {showEditForm && load && (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      {showEditForm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div
             className="absolute inset-0 bg-black/50"
             onClick={() => setShowEditForm(false)}
           />
-          <div className="relative w-[750px] max-h-[90vh] bg-card text-foreground overflow-y-auto shadow-xl rounded-lg p-6">
+          <div className="relative w-[750px] max-h-[90vh] bg-iron text-light overflow-y-auto shadow-xl rounded-lg p-6 border border-plate">
             <LoadForm
               mode="edit"
               initialData={{
@@ -263,7 +225,11 @@ export const LoadDetailPage = () => {
                 deadhead_miles: load.deadhead_miles,
                 loaded_miles: load.loaded_miles,
                 odometer_start: load.odometer_start ?? null,
+                odometer_end: load.odometer_end ?? null,
                 payment_status: load.payment_status,
+                truck_id: load.truck_id ?? null,
+                driver_id: load.driver_id ?? null,
+                trailer_id: load.trailer_id ?? null,
               }}
               brokers={brokers}
               agents={agents}
@@ -271,7 +237,7 @@ export const LoadDetailPage = () => {
               onSubmit={async (data) => {
                 await patchLoad(load.load_id, data);
               }}
-              onSuccess={() => setRefreshKey((prev) => prev + 1)}
+              onSuccess={() => setRefreshKey((p) => p + 1)}
               onBrokerCreated={() => {}}
               onAgentCreated={() => {}}
               onMarketCreated={() => {}}
@@ -280,540 +246,436 @@ export const LoadDetailPage = () => {
           </div>
         </div>
       )}
+
       <Dialog open={showDeleteModal} onOpenChange={setShowDeleteModal}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete Load</DialogTitle>
+            <DialogTitle>Delete load</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete {load.load_number}? This action
-              cannot be undone.
+              Are you sure you want to delete {load.load_number}? This can't be
+              undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowDeleteModal(false)}>
               Cancel
             </Button>
-            <Button onClick={handleDeleteLoad}>Delete</Button>
+            <Button variant="destructive" onClick={handleDeleteLoad}>
+              Delete
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <PageHeader
-        title={load.load_number}
-        subtitle={`${load.broker} · ${load.agent} · ${capitalize(load.load_type)}`}
-        badges={[
-          { value: load.load_status as Badge["value"] },
-          { value: load.payment_status as Badge["value"] },
-        ]}
-        actions={
-          <>
-            <Button
-              className="bg-amber-dark mr-2"
-              onClick={() => setShowEditForm(true)}
-            >
-              Edit
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={() => setShowDeleteModal(true)}
-            >
-              Delete
-            </Button>
-          </>
-        }
-        metrics={
-          <MetricStrip
-            cards={[
-              {
-                label: "Total Revenue",
-                value: Number(load.linehaul) + Number(load.fuel_surcharge),
-                format: "currency",
-              },
-              {
-                label: "Linehaul",
-                value: load.linehaul,
-                format: "currency",
-              },
-              {
-                label: "FSC",
-                value: load.fuel_surcharge,
-                format: "currency",
-              },
-              {
-                label: "RPM",
-                value:
-                  (Number(load.linehaul) + Number(load.fuel_surcharge)) /
-                  load.loaded_miles,
-                format: "currency",
-              },
-              {
-                label: "Loaded Miles",
-                value: load.loaded_miles,
-                format: "number",
-              },
-            ]}
-          />
-        }
-      />
-      <div className="grid grid-cols-4">
-        {/* MAIN CONTENT */}
-        <div className="p-2 col-span-3 bg-plate text-foreground">
-          <Tabs defaultValue="details">
-            <TabsList
-              variant="line"
-              className="w-full justify-start border-b border-iron"
-            >
-              <TabsTrigger
-                value="details"
-                className="text-muted-text hover:text-foreground data-[state=active]:text-amber [&_after]:bg-amber"
-              >
-                Details
-              </TabsTrigger>
-              <TabsTrigger
-                value="accessorials"
-                className="text-muted-text hover:text-foreground data-[state=active]:text-amber [&_after]:bg-amber"
-              >
-                Accessorials
-              </TabsTrigger>
-            </TabsList>
-            {/* DETAILS CONTENT */}
-            <TabsContent value="details">
-              <div className="grid grid-cols-2 pl-4 mt-4 mb-8 gap-y-8">
-                {/* ROUTE CONTENT */}
-                <div className="border-b-2 border-iron pb-4">
-                  <div>
-                    <p className="text-xs uppercase tracking-wider text-muted-text mb-3">
-                      Route
-                    </p>
-                  </div>
-                  <div className="flex content-center">
-                    <div className="w-[10px] self-center mr-6">
-                      <div
-                        id="circle"
-                        className="w-[8px] h-[8px] bg-steel rounded-full"
-                      ></div>
-                    </div>
-                    <div className="ml-6 text-sm text-foreground font-bold">
-                      <p>
-                        {load.origin_city}, {load.origin_state}
-                      </p>
-                      <p className="text-xs text-foreground">
-                        {load.origin_market}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="border-l-2 border-iron h-[15px] ml-[3px]"></div>
-                  <div className="flex content-center">
-                    <div className="w-[10px] self-center mr-6">
-                      <div
-                        id="circle"
-                        className="w-[8px] h-[8px] bg-steel rounded-full"
-                      ></div>
-                    </div>
-                    <div className="ml-6 text-sm text-foreground font-bold">
-                      <p>
-                        {load.destination_city}, {load.destination_state}
-                      </p>
-                      <p className="text-xs text-foreground">
-                        {load.delivery_market}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                {/* CARGO CONTENT */}
-                <div className="border-b-2 border-iron">
-                  <p className="text-xs uppercase tracking-wider text-muted-text mb-3">
-                    Cargo
-                  </p>
-                  <div className="flex gap-6">
-                    <div className="text-sm text-foreground">
-                      <p className="mb-1 font-bold">Commodity</p>
-                      <p className="mb-1 font-bold">Weight</p>
-                      <p className="mb-1 font-bold">Dimensions</p>
-                    </div>
-                    <div className="text-sm text-foreground">
-                      <p className="mb-1">{load.commodity}</p>
-                      <p className="mb-1">{load.weight}</p>
-                      <p className="mb-1">
-                        {!load.dimensions ? "Legal" : load.dimensions}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                {/* DATES CONTENT */}
-                <div>
-                  <div>
-                    <p className="text-xs uppercase tracking-wider text-muted-text mb-3">
-                      Dates
-                    </p>
-                    <div className="grid grid-cols-2">
-                      <div>
-                        <p className="text-muted-text mb-2 text-sm">Pickup</p>
-                        <p className="text-muted-text text-sm">Delivery</p>
-                      </div>
-                      <div>
-                        <p className="text-foreground mb-2 text-sm">
-                          {new Date(load.pickup_date).toLocaleDateString(
-                            "en-US",
-                            dateOptions,
-                          )}
-                        </p>
-                        <p className="text-foreground text-sm">
-                          {load.delivery_date
-                            ? new Date(load.delivery_date).toLocaleDateString(
-                                "en-US",
-                                dateOptions,
-                              )
-                            : "Not set"}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                {/* MILEAGE CONTENT */}
-                <div>
-                  <div>
-                    <p className="text-xs uppercase tracking-wider text-muted-text mb-3">
-                      Mileage
-                    </p>
-                  </div>
-                  <div className="grid grid-cols-2">
-                    <div>
-                      <p className="text-sm text-muted-text mb-2">Loaded</p>
-                      <p className="text-sm text-muted-text mb-2">Deadhead</p>
-                      <p className="text-sm text-muted-text mb-2">
-                        Odometer Start
-                      </p>
-                      <p className="text-sm text-muted-text">Odometer End</p>
-                    </div>
-                    <div>
-                      <p className="text-sm text-foreground mb-2">
-                        {load.loaded_miles} mi
-                      </p>
-                      <p className="text-sm text-foreground mb-2">
-                        {load.deadhead_miles} mi
-                      </p>
-                      <p className="text-sm text-foreground mb-2">
-                        {load.odometer_start?.toLocaleString()}
-                      </p>
-                      <p className="text-sm text-foreground">
-                        {load.odometer_end?.toLocaleString()}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                {/* SHIPPER & RECEIVER CONTENT */}
-                <div>
-                  <div>
-                    <p className="text-xs uppercase tracking-wider text-muted-text mb-3">
-                      Shipper & Receiver
-                    </p>
-                    <div className="grid grid-cols-2">
-                      <div>
-                        <p className="text-muted-text mb-2 text-sm">Shipper</p>
-                        <p className="text-muted-text text-sm">Receiver</p>
-                      </div>
-                      <div>
-                        <p className="text-foreground mb-2 text-sm">
-                          {load.shipper_name}
-                        </p>
-                        <p className="text-foreground text-sm">
-                          {load.receiver_name}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                {/* FUEL CONTENT */}
-                <div>
-                  <div>
-                    <p className="text-xs uppercase tracking-wider text-muted-text mb-3">
-                      Fuel <StatusBadge value="est" />
-                    </p>
-                    <div className="grid grid-cols-2">
-                      <div>
-                        <p className="text-muted-text mb-2 text-sm">
-                          Est. Cost
-                        </p>
-                        <p className="text-muted-text mb-2 text-sm">Avg MPG</p>
-                        <p className="text-muted-text text-sm">Fuel Price</p>
-                      </div>
-                      <div>
-                        <p className="text-foreground mb-2 text-sm">
-                          {(
-                            ((load.loaded_miles + load.deadhead_miles) / 6.5) *
-                            5.5
-                          ).toLocaleString("en-US", {
-                            style: "currency",
-                            currency: "USD",
-                          })}
-                        </p>
-                        <p className="text-foreground text-sm mb-2">6.5</p>
-                        <p className="text-foreground text-sm mb-2">
-                          $5.50/gal
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </TabsContent>
-            {/* ACCESSORIALS CONTENT */}
-            <TabsContent value="accessorials">
-              {accessorials.length === 0 ? (
-                <p>No accessorials for current load</p>
-              ) : (
-                <div>
-                  <p className="text-xs uppercase tracking-wider text-muted-text mb-3 mt-4 pl-4">
-                    Charges
-                  </p>
-                  <Table>
-                    <TableHeader>
-                      <TableRow className="border-b-2 border-iron">
-                        <TableHead className="text-muted-text text-sm pl-4">
-                          Type
-                        </TableHead>
-                        <TableHead className="text-muted-text text-sm">
-                          Amount
-                        </TableHead>
-                        <TableHead className="text-muted-text text-sm text-center">
-                          Actions
-                        </TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {accessorials.map((accessorial) => (
-                        <TableRow
-                          key={accessorial.accessorial_id}
-                          className="border-b-2 border-iron"
-                        >
-                          <TableCell className="text-sm text-foreground pl-4">
-                            {editingId === accessorial.accessorial_id ? (
-                              <input
-                                id="edit-accessorial-type"
-                                name="edit-accessorial-type"
-                                value={editingType}
-                                onChange={(e) => setEditingType(e.target.value)}
-                              />
-                            ) : (
-                              <span>{accessorial.accessorial_type}</span>
-                            )}
-                          </TableCell>
-                          <TableCell>
-                            {editingId === accessorial.accessorial_id ? (
-                              <input
-                                id="edit-accessorial-amount"
-                                name="edit-accessorial-amount"
-                                value={editingAmount}
-                                onChange={(e) =>
-                                  setEditingAmount(Number(e.target.value))
-                                }
-                              />
-                            ) : (
-                              <span>
-                                {Number(accessorial.amount).toLocaleString(
-                                  "en-US",
-                                  {
-                                    style: "currency",
-                                    currency: "USD",
-                                  },
-                                )}
-                              </span>
-                            )}
-                          </TableCell>
-                          <TableCell>
-                            <div className="flex items-center justify-center gap-2">
-                              {editingId === accessorial.accessorial_id ? (
-                                <Button onClick={handleSaveEditAccessorial}>
-                                  Save
-                                </Button>
-                              ) : (
-                                <Pencil
-                                  size={14}
-                                  className="text-muted-text hover:text-foreground cursor-pointer"
-                                  onClick={() =>
-                                    handleEditAccessorial(
-                                      accessorial.accessorial_id,
-                                      accessorial.accessorial_type,
-                                      accessorial.amount,
-                                    )
-                                  }
-                                />
-                              )}
-                              {editingId === accessorial.accessorial_id ? (
-                                <Button onClick={handleCancelEditAccessorial}>
-                                  Cancel
-                                </Button>
-                              ) : (
-                                <Trash2
-                                  size={14}
-                                  className="text-red-400 hover:text-destructive cursor-pointer"
-                                  onClick={() =>
-                                    handleDeleteAccessorial(
-                                      accessorial.accessorial_id,
-                                    )
-                                  }
-                                />
-                              )}
-                            </div>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                  <div className="grid grid-cols-3 border-t-2 border-iron">
-                    <p className="text-sm text-foreground pl-4 pt-2">
-                      Total Accessorials
-                    </p>
-                    <p className="text-sm text-foreground pt-2">
-                      {totalAccessorialCharges.toLocaleString("en-US", {
-                        style: "currency",
-                        currency: "USD",
-                      })}
-                    </p>
-                  </div>
-                </div>
-              )}
-              <div className="flex justify-center mt-8">
-                <div className="bg-iron p-6 w-3/4 self-center rounded-md">
-                  <div className="grid grid-cols-3 gap-x-6 gap-y-2">
-                    <p className="text-xs text-muted-text">Type</p>
-                    <p className="text-xs text-muted-text">Amount</p>
-                    <div></div>
-                    <input
-                      id="new-accessorial-type"
-                      name="new-accessorial-type"
-                      placeholder="e.g. Layover"
-                      className="p-2 bg-plate rounded-md"
-                      value={newAccessorialType}
-                      onChange={(e) => setNewAccessorialType(e.target.value)}
-                    />
-                    <input
-                      id="new-accessorial-amount"
-                      name="new-accessorial-amount"
-                      placeholder="0.00"
-                      className="p-2 bg-plate rounded-md"
-                      value={newAccessorialAmount}
-                      onChange={(e) => setNewAccessorialAmount(e.target.value)}
-                    />
-                    <Button
-                      className="bg-primary border-1 border-iron"
-                      onClick={handleAddAccessorial}
-                    >
-                      Add
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </TabsContent>
-          </Tabs>
+
+      <Link to="/loads" className="text-xs text-muted-text hover:text-light">
+        ← Loads
+      </Link>
+
+      <div className="flex justify-between items-start mt-3 mb-6">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-3xl font-condensed">{load.load_number}</h1>
+            <StatusBadge value={load.load_status} />
+            <StatusBadge value={load.payment_status} />
+          </div>
+          <p className="text-muted-text text-sm mt-1">
+            {load.broker} · {load.agent} · {capitalize(load.load_type)}
+          </p>
         </div>
-        {/* SIDEBAR */}
-        <div className="p-2 bg-plate border-l-1 border-iron text-foreground">
-          <div className="border-b-1 border-iron pl-2 pr-2 pb-4">
-            <p className="text-xs text-muted-text mt-2 mb-2 uppercase tracking-wider">
-              Broker & Agent
-            </p>
-            <p className="text-sm text-foreground">{load.broker}</p>
-            <p className="text-sm text-muted-text">{load.agent}</p>
-            <p className="text-sm text-muted-text">{load.agent_email}</p>
-          </div>
-          <div className="border-b-1 border-iron pl-2 pr-2">
-            <p className="text-xs text-muted-text mt-2 mb-2 uppercase tracking-wider">
-              Load Status
-            </p>
-            <Select
-              value={selectedLoadStatus}
-              onValueChange={(value) => setSelectedLoadStatus(value)}
-            >
-              <SelectTrigger className="mb-4">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectItem value="booked">Booked</SelectItem>
-                  <SelectItem value="in_transit">In Transit</SelectItem>
-                  <SelectItem value="delivered">Delivered</SelectItem>
-                  <SelectItem value="cancelled">Cancelled</SelectItem>
-                  <SelectItem value="tonu">Tonu</SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-            <p className="text-xs text-muted-text mt-2 mb-2 uppercase tracking-wider">
-              Payment Status
-            </p>
-            <Select
-              value={selectedPaymentStatus}
-              onValueChange={(value) => setSelectedPaymentStatus(value)}
-            >
-              <SelectTrigger className="mb-4">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectItem value="unpaid">Unpaid</SelectItem>
-                  <SelectItem value="invoiced">Invoiced</SelectItem>
-                  <SelectItem value="paid">Paid</SelectItem>
-                  <SelectItem value="cancelled">Cancelled</SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="border-b-1 border-iron pl-2 pr-2 pb-4">
-            <p className="text-xs text-muted-text mt-2 mb-2 uppercase tracking-wider">
-              Revenue
-            </p>
-            <div className="grid grid-cols-2">
-              <div>
-                <p className="text-sm text-muted-text">Linehaul</p>
-                <p className="text-sm text-muted-text">FSC</p>
-                <p className="text-sm text-muted-text">Accessorials</p>
-              </div>
-              <div>
-                <p className="text-sm text-foreground">
-                  {Number(load.linehaul).toLocaleString("en-US", {
-                    style: "currency",
-                    currency: "USD",
-                  })}
-                </p>
-                <p className="text-sm text-foreground">
-                  {Number(load.fuel_surcharge).toLocaleString("en-US", {
-                    style: "currency",
-                    currency: "USD",
-                  })}
-                </p>
-                <p className="text-sm text-foreground">
-                  {Number(load.total_accessorials).toLocaleString("en-US", {
-                    style: "currency",
-                    currency: "USD",
-                  })}
-                </p>
-              </div>
-            </div>
-          </div>
-          <div className="pt-2 pl-2 pr-2 pb-4 grid grid-cols-2">
-            <div>
-              <p className="text-sm text-foreground">Total</p>
-            </div>
-            <div>
-              <p className="text-foreground">
-                {(
-                  Number(load.total_accessorials) +
-                  Number(load.linehaul) +
-                  Number(load.fuel_surcharge)
-                ).toLocaleString("en-US", {
-                  style: "currency",
-                  currency: "USD",
-                })}
-              </p>
-            </div>
-          </div>
-          <Button
-            disabled={isSaving}
-            className="border-2 border-amber bg-primary text-steel hover:cursor-pointer hover:scale-105"
-            onClick={handleSaveChanges}
+        <div className="flex gap-2">
+          <button
+            onClick={() => setShowEditForm(true)}
+            className="bg-steel text-light px-3 py-1.5 rounded text-sm flex items-center gap-1"
           >
-            {isSaving ? "...Saving" : "Save Changes"}
-          </Button>
+            <Pencil size={14} /> Edit
+          </button>
+          <button
+            onClick={() => setShowDeleteModal(true)}
+            className="bg-steel text-destructive px-3 py-1.5 rounded text-sm flex items-center gap-1"
+          >
+            <Trash2 size={14} /> Delete
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Kpi label="Total revenue" value={money0(revenue)} />
+        <Kpi
+          label="Rate / mile"
+          value={fmtRpm(rpm)}
+          valueClass={rpmTextClass(rpm)}
+          sub={`${(Number(load.loaded_miles) || 0).toLocaleString("en-US")} loaded mi`}
+        />
+        <Kpi
+          label="Loaded miles"
+          value={(Number(load.loaded_miles) || 0).toLocaleString("en-US")}
+        />
+        <Kpi
+          label="Deadhead"
+          value={dh == null ? "—" : `${Math.round(dh * 100)}%`}
+          sub={`${(Number(load.deadhead_miles) || 0).toLocaleString("en-US")} mi`}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+        <div className="bg-plate rounded-lg p-4">
+          <p className={cardLbl}>Route</p>
+          <div className="flex gap-3">
+            <div className="flex flex-col items-center pt-1.5">
+              <div className="w-2 h-2 rounded-full bg-muted-text" />
+              <div className="w-px flex-1 bg-steel min-h-[24px] my-1" />
+              <div className="w-2 h-2 rounded-full bg-amber" />
+            </div>
+            <div className="text-sm flex-1">
+              <p className="font-medium">
+                {load.origin_city}, {load.origin_state}
+              </p>
+              <p className="text-xs text-muted-text mb-3">
+                {load.origin_market}
+              </p>
+              <p className="font-medium">
+                {load.destination_city}, {load.destination_state}
+              </p>
+              <p className="text-xs text-muted-text">{load.delivery_market}</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-plate rounded-lg p-4 border border-amber">
+          <p className={`${cardLbl} text-amber-light`}>Fleet</p>
+          <Row
+            label={
+              <span className="flex items-center gap-1.5">
+                <Truck size={15} /> Truck
+              </span>
+            }
+            value={
+              load.truck_id ? (
+                <Link
+                  to={`/trucks/${load.truck_id}`}
+                  className="text-amber-light hover:underline"
+                >
+                  Unit {fleetChip(load.truck_unit)}
+                </Link>
+              ) : (
+                "—"
+              )
+            }
+          />
+          <Row
+            label={
+              <span className="flex items-center gap-1.5">
+                <User size={15} /> Driver
+              </span>
+            }
+            value={
+              load.driver_id ? (
+                <Link
+                  to={`/drivers/${load.driver_id}`}
+                  className="text-amber-light hover:underline"
+                >
+                  {fleetChip(load.driver_name)}
+                </Link>
+              ) : (
+                "—"
+              )
+            }
+          />
+          <Row
+            label={
+              <span className="flex items-center gap-1.5">
+                <Container size={15} /> Trailer
+              </span>
+            }
+            value={
+              load.trailer_id ? (
+                <Link
+                  to={`/trailers/${load.trailer_id}`}
+                  className="text-amber-light hover:underline"
+                >
+                  Unit {fleetChip(load.trailer_unit)}
+                </Link>
+              ) : (
+                "—"
+              )
+            }
+          />
+        </div>
+
+        <div className="bg-plate rounded-lg p-4">
+          <p className={cardLbl}>Revenue</p>
+          <Row label="Linehaul" value={money2(Number(load.linehaul))} />
+          <Row
+            label="Fuel surcharge"
+            value={money2(Number(load.fuel_surcharge))}
+          />
+          <Row
+            label="Accessorials"
+            value={money2(Number(load.total_accessorials))}
+          />
+          <div className="flex justify-between border-t border-steel mt-1.5 pt-1.5 text-sm">
+            <span>Total</span>
+            <span className="font-condensed text-base">{money2(revenue)}</span>
+          </div>
+        </div>
+
+        <div className="bg-plate rounded-lg p-4">
+          <p className={cardLbl}>Mileage</p>
+          <Row
+            label="Loaded"
+            value={`${(Number(load.loaded_miles) || 0).toLocaleString("en-US")} mi`}
+          />
+          <Row
+            label="Deadhead"
+            value={`${(Number(load.deadhead_miles) || 0).toLocaleString("en-US")} mi`}
+          />
+          <Row
+            label="Odometer"
+            value={
+              load.odometer_start && load.odometer_end
+                ? `${load.odometer_start.toLocaleString("en-US")} → ${load.odometer_end.toLocaleString("en-US")}`
+                : "Not recorded"
+            }
+          />
+        </div>
+
+        <div className="bg-plate rounded-lg p-4">
+          <p className={cardLbl}>Cargo</p>
+          <Row label="Commodity" value={load.commodity || "—"} />
+          <Row
+            label="Weight"
+            value={load.weight ? `${load.weight.toLocaleString("en-US")} lb` : "—"}
+          />
+          <Row label="Dimensions" value={load.dimensions || "Legal"} />
+        </div>
+
+        <div className="bg-plate rounded-lg p-4">
+          <p className={cardLbl}>Dates</p>
+          <Row label="Pickup" value={fmtDate(load.pickup_date)} />
+          <Row label="Delivery" value={fmtDate(load.delivery_date)} />
+          <Row
+            label="Shipper → receiver"
+            value={`${load.shipper_name || "—"} → ${load.receiver_name || "—"}`}
+          />
+        </div>
+
+        <div className="bg-plate rounded-lg p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <p className={`${cardLbl} mb-0`}>Fuel</p>
+            <span
+              className="text-[11px] px-2 py-0.5 rounded"
+              style={{
+                backgroundColor:
+                  fuel?.basis === "actual"
+                    ? "var(--color-status-positive-bg)"
+                    : "var(--color-status-aware-bg)",
+                color:
+                  fuel?.basis === "actual"
+                    ? "var(--color-status-positive-text)"
+                    : "var(--color-status-aware-text)",
+              }}
+            >
+              {fuel?.basis === "actual" ? "actual" : "est."}
+            </span>
+          </div>
+          {fuel ? (
+            <>
+              <Row label="Fuel cost" value={money2(fuel.cost)} />
+              <Row
+                label="Miles"
+                value={`${fuel.miles.toLocaleString("en-US")} mi`}
+              />
+              <Row
+                label="Gallons"
+                value={`${Math.round(fuel.gallons).toLocaleString("en-US")} gal`}
+              />
+              <Row
+                label="Assumed"
+                value={`${ASSUMED_MPG} mpg · $${ASSUMED_FUEL_PRICE.toFixed(2)}/gal`}
+              />
+              <p className="text-xs text-muted-text mt-2">
+                {fuel.basis === "actual"
+                  ? "Based on the odometer readings entered for this load."
+                  : "Estimated from loaded + deadhead miles. Enter odometer start and end to reflect actual miles."}
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-muted-text">
+              Add loaded miles to estimate fuel.
+            </p>
+          )}
+        </div>
+
+        <div className="bg-plate rounded-lg p-4">
+          <p className={cardLbl}>Broker · agent</p>
+          <p className="text-sm">{load.broker}</p>
+          <p className="text-sm text-muted-text">
+            <Link
+              to={`/agents/${load.agent_id}`}
+              className="text-amber-light hover:underline"
+            >
+              {load.agent}
+            </Link>
+            {load.agent_email ? ` · ${load.agent_email}` : ""}
+          </p>
+        </div>
+
+        <div className="bg-plate rounded-lg p-4 md:col-span-2">
+          <p className={cardLbl}>Update status</p>
+          <div className="flex flex-wrap gap-2 items-center">
+            <select
+              className="bg-steel rounded px-2 py-1.5 text-sm flex-1 min-w-[140px] text-light"
+              value={statusSel}
+              onChange={(e) => setStatusSel(e.target.value)}
+            >
+              {LOAD_STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {capitalize(s.replace("_", " "))}
+                </option>
+              ))}
+            </select>
+            <select
+              className="bg-steel rounded px-2 py-1.5 text-sm flex-1 min-w-[140px] text-light"
+              value={paymentSel}
+              onChange={(e) => setPaymentSel(e.target.value)}
+            >
+              {PAYMENT_STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {capitalize(s)}
+                </option>
+              ))}
+            </select>
+            <button
+              disabled={isSaving}
+              onClick={handleSaveChanges}
+              className="bg-amber text-steel px-4 py-1.5 rounded text-sm font-semibold disabled:opacity-50"
+            >
+              {isSaving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-plate rounded-lg p-4 mt-4">
+        <div className="flex justify-between items-center mb-2">
+          <p className={`${cardLbl} mb-0`}>Accessorials</p>
+          <span className="text-xs text-muted-text">
+            Total {money2(accTotal)}
+          </span>
+        </div>
+
+        {accessorials.length === 0 ? (
+          <p className="text-sm text-muted-text">No accessorials logged.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-xs text-muted-text text-left">
+                <th className="font-normal pb-1">Type</th>
+                <th className="font-normal pb-1 text-right">Amount</th>
+                <th className="font-normal pb-1 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {accessorials.map((a) => {
+                const editing = editingId === a.accessorial_id;
+                return (
+                  <tr
+                    key={a.accessorial_id}
+                    className="border-t border-steel"
+                  >
+                    <td className="py-2">
+                      {editing ? (
+                        <input
+                          className="bg-steel rounded px-2 py-1 text-sm w-full"
+                          value={editingType}
+                          onChange={(e) => setEditingType(e.target.value)}
+                        />
+                      ) : (
+                        a.accessorial_type
+                      )}
+                    </td>
+                    <td className="py-2 text-right whitespace-nowrap">
+                      {editing ? (
+                        <input
+                          className="bg-steel rounded px-2 py-1 text-sm w-24 text-right"
+                          value={editingAmount}
+                          inputMode="decimal"
+                          onChange={(e) =>
+                            setEditingAmount(Number(e.target.value))
+                          }
+                        />
+                      ) : (
+                        money2(Number(a.amount))
+                      )}
+                    </td>
+                    <td className="py-2">
+                      <div className="flex items-center justify-end gap-3">
+                        {editing ? (
+                          <>
+                            <button
+                              onClick={handleSaveEdit}
+                              className="text-amber text-xs font-semibold"
+                            >
+                              Save
+                            </button>
+                            <button
+                              onClick={() => setEditingId("")}
+                              className="text-muted-text text-xs"
+                            >
+                              Cancel
+                            </button>
+                          </>
+                        ) : (
+                          <>
+                            <Pencil
+                              size={14}
+                              className="text-muted-text hover:text-light cursor-pointer"
+                              onClick={() =>
+                                startEdit(
+                                  a.accessorial_id,
+                                  a.accessorial_type,
+                                  a.amount,
+                                )
+                              }
+                            />
+                            <Trash2
+                              size={14}
+                              className="text-muted-text hover:text-destructive cursor-pointer"
+                              onClick={() =>
+                                handleDeleteAccessorial(a.accessorial_id)
+                              }
+                            />
+                          </>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+
+        <div className="flex flex-wrap gap-2 mt-3">
+          <input
+            className="bg-steel rounded px-2 py-1.5 text-sm flex-1 min-w-[160px] text-light placeholder:text-muted-text"
+            placeholder="Type — e.g. Layover"
+            value={newType}
+            onChange={(e) => setNewType(e.target.value)}
+          />
+          <input
+            className="bg-steel rounded px-2 py-1.5 text-sm w-28 text-light placeholder:text-muted-text"
+            placeholder="0.00"
+            inputMode="decimal"
+            value={newAmount}
+            onChange={(e) => setNewAmount(e.target.value)}
+          />
+          <button
+            onClick={handleAddAccessorial}
+            className="bg-steel text-light px-4 py-1.5 rounded text-sm border border-plate"
+          >
+            Add
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/LoadsPage.tsx
+++ b/frontend/src/pages/LoadsPage.tsx
@@ -1,84 +1,108 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Link } from "react-router";
 
 import { useLoads } from "@/hooks/useLoads";
 import { useBrokers } from "@/hooks/useBrokers";
 import { useAgents } from "@/hooks/useAgents";
 import { useMarkets } from "@/hooks/useMarkets";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { StatusBadge } from "@/components/StatusBadge";
-import { MetricStrip } from "@/components/MetricStrip";
+import { Kpi } from "@/components/Kpi";
 import LoadForm from "../components/LoadForm";
-import { Button } from "@/components/ui/button";
 import { createLoad } from "@/services/createLoadService";
+import { loadsKpis, loadRevenue } from "@/lib/metrics/loads";
+import { fmtRpm, rpmTextClass } from "@/components/lanes/rpmStyle";
 
-import {
-  getBookedCount,
-  getOutstandingTotal,
-  deliveredThisMonth,
-} from "@/lib/metrics/loads";
+const money = (n: number) =>
+  n.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+
+// Date-only, UTC-safe (Postgres dates would otherwise shift a day in local tz).
+const fmtDate = (d: string) =>
+  new Date(String(d).slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+const STATUS_FILTERS: [string, string][] = [
+  ["all", "All"],
+  ["booked", "Booked"],
+  ["in_transit", "In transit"],
+  ["delivered", "Delivered"],
+];
+
+const plural = (n: number) => (n !== 1 ? "s" : "");
 
 const LoadsPage = () => {
   const [refreshKey, setRefreshKey] = useState(0);
   const [brokerRefreshKey, setBrokerRefreshKey] = useState(0);
   const [agentRefreshKey, setAgentRefreshKey] = useState(0);
   const [marketRefreshKey, setMarketRefreshKey] = useState(0);
-  const { brokers } = useBrokers(brokerRefreshKey);
 
+  const { brokers } = useBrokers(brokerRefreshKey);
   const { loads, isLoading, error } = useLoads(refreshKey);
   const { agents } = useAgents(agentRefreshKey);
   const { markets } = useMarkets(marketRefreshKey);
 
   const [showCreateForm, setShowCreateForm] = useState(false);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [paymentFilter, setPaymentFilter] = useState("all");
 
-  const handleLoadCreated = () => {
-    setRefreshKey((prev) => prev + 1);
-  };
+  // KPIs describe the whole business, so they ignore the table filters.
+  const kpis = useMemo(() => loadsKpis(loads ?? [], new Date()), [loads]);
 
-  const handleBrokerRefresh = () => {
-    setBrokerRefreshKey((prev) => prev + 1);
-  };
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return (loads ?? []).filter((l) => {
+      if (statusFilter !== "all" && l.load_status !== statusFilter) return false;
+      if (paymentFilter !== "all" && l.payment_status !== paymentFilter)
+        return false;
+      if (!q) return true;
+      const hay = [
+        l.load_number,
+        l.broker,
+        l.agent,
+        l.origin_city,
+        l.origin_state,
+        l.destination_city,
+        l.destination_state,
+      ]
+        .join(" ")
+        .toLowerCase();
+      return hay.includes(q);
+    });
+  }, [loads, search, statusFilter, paymentFilter]);
 
-  const handleAgentRefresh = () => {
-    setAgentRefreshKey((prev) => prev + 1);
-  };
-
-  const handleMarketRefresh = () => {
-    setMarketRefreshKey((prev) => prev + 1);
-  };
-
-  if (isLoading) {
+  if (isLoading)
     return (
-      <div>
-        <p>Loading...</p>
+      <div className="p-6 bg-iron text-light min-h-screen">
+        <p className="text-muted-text">Loading loads...</p>
       </div>
     );
-  }
 
-  if (error !== null) {
+  if (error)
     return (
-      <div>
-        <p>{error}</p>
+      <div className="p-6 bg-iron text-light min-h-screen">
+        <p className="text-destructive">{error}</p>
       </div>
     );
-  }
+
+  const pipeline = kpis.bookedCount + kpis.inTransitCount;
+
   return (
-    <div>
-      {/* Overlay */}
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
       {showCreateForm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div
             className="absolute inset-0 bg-black/50"
             onClick={() => setShowCreateForm(false)}
           />
-          <div className="relative w-[750px] max-h-[90vh] bg-card text-foreground overflow-y-auto shadow-xl rounded-lg p-6">
+          <div className="relative w-[750px] max-h-[90vh] bg-iron text-light overflow-y-auto shadow-xl rounded-lg p-6 border border-plate">
             <LoadForm
               mode="create"
               brokers={brokers}
@@ -87,98 +111,157 @@ const LoadsPage = () => {
               onSubmit={async (data) => {
                 await createLoad(data);
               }}
-              onSuccess={handleLoadCreated}
-              onBrokerCreated={handleBrokerRefresh}
-              onAgentCreated={handleAgentRefresh}
-              onMarketCreated={handleMarketRefresh}
+              onSuccess={() => setRefreshKey((p) => p + 1)}
+              onBrokerCreated={() => setBrokerRefreshKey((p) => p + 1)}
+              onAgentCreated={() => setAgentRefreshKey((p) => p + 1)}
+              onMarketCreated={() => setMarketRefreshKey((p) => p + 1)}
               onClose={() => setShowCreateForm(false)}
             />
           </div>
         </div>
       )}
-      <Button onClick={() => setShowCreateForm(true)}>Create Load</Button>
-      {/* METRIC STRIP */}
-      <MetricStrip
-        cards={[
-          {
-            label: "Delivered this month",
-            value: deliveredThisMonth(loads, new Date()).length,
-            format: "number",
-          },
-          {
-            label: "Booked",
-            value: getBookedCount(loads),
-            format: "number",
-          },
-          {
-            label: "Outstanding Revenue",
-            value: getOutstandingTotal(loads),
-            format: "currency",
-          },
-        ]}
-      />
-      <div className="bg-iron mt-4 p-6">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Load #</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Broker</TableHead>
-              <TableHead>Origin</TableHead>
-              <TableHead>Destination</TableHead>
-              <TableHead>Pickup Date</TableHead>
-              <TableHead>Gross Revenue</TableHead>
-              <TableHead>Payment Status</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {loads.map((load) => (
-              <TableRow
-                key={load.load_id}
-                className={
-                  load.load_status === "in_transit"
-                    ? "border-l-4 border-l-primary"
-                    : ""
-                }
-              >
-                <TableCell className="text-foreground hover:text-primary hover:underline cursor-pointer">
-                  <Link to={`/loads/${load.load_id}`}>{load.load_number}</Link>
-                </TableCell>
-                <TableCell>
-                  <StatusBadge value={load.load_status} />
-                </TableCell>
-                <TableCell>{load.broker}</TableCell>
-                <TableCell>
-                  {load.origin_city + ", " + load.origin_state}
-                </TableCell>
-                <TableCell>
-                  {load.destination_city + ", " + load.destination_state}
-                </TableCell>
-                <TableCell>
-                  {new Date(load.pickup_date).toLocaleDateString("en-US", {
-                    month: "short",
-                    day: "numeric",
-                    year: "numeric",
-                    timeZone: "UTC",
-                  })}
-                </TableCell>
-                <TableCell>
-                  {(
-                    Number(load.linehaul) +
-                    Number(load.fuel_surcharge) +
-                    Number(load.total_accessorials)
-                  ).toLocaleString("en-US", {
-                    style: "currency",
-                    currency: "USD",
-                  })}
-                </TableCell>
-                <TableCell>
-                  <StatusBadge value={load.payment_status} />
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-condensed text-light">Loads</h1>
+        <button
+          className="bg-amber text-steel px-3 py-2 rounded-lg text-sm font-semibold"
+          onClick={() => setShowCreateForm(true)}
+        >
+          + Create load
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Kpi
+          label="This month"
+          value={money(kpis.deliveredGross)}
+          sub={`${kpis.deliveredCount} load${plural(kpis.deliveredCount)} delivered`}
+        />
+        <Kpi
+          label="Avg rate / mile"
+          value={fmtRpm(kpis.rpm)}
+          valueClass={rpmTextClass(kpis.rpm)}
+          sub={`this month · ${kpis.loadedMiles.toLocaleString("en-US")} mi`}
+        />
+        <Kpi
+          label="Outstanding AR"
+          value={money(kpis.arTotal)}
+          sub={`${kpis.arCount} load${plural(kpis.arCount)} · unpaid + invoiced`}
+        />
+        <Kpi
+          label="Pipeline"
+          value={`${pipeline} load${plural(pipeline)}`}
+          sub={`${kpis.bookedCount} booked · ${kpis.inTransitCount} in transit`}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 bg-plate rounded-lg p-3 mt-4">
+        <input
+          className="bg-steel rounded px-3 py-1.5 text-sm flex-1 min-w-[180px] text-light placeholder:text-muted-text"
+          placeholder="Search load #, broker, city"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <div className="flex gap-1 bg-steel rounded-lg p-1">
+          {STATUS_FILTERS.map(([key, label]) => (
+            <button
+              key={key}
+              onClick={() => setStatusFilter(key)}
+              className={`px-2.5 py-1 rounded text-sm ${
+                statusFilter === key
+                  ? "bg-amber text-steel font-semibold"
+                  : "text-muted-text"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <select
+          className="bg-steel rounded px-2 py-1.5 text-sm text-light"
+          value={paymentFilter}
+          onChange={(e) => setPaymentFilter(e.target.value)}
+        >
+          <option value="all">All payments</option>
+          <option value="unpaid">Unpaid</option>
+          <option value="invoiced">Invoiced</option>
+          <option value="paid">Paid</option>
+        </select>
+      </div>
+
+      <div className="bg-plate rounded-lg p-4 mt-4 overflow-x-auto">
+        {filtered.length === 0 ? (
+          <p className="text-muted-text text-sm">
+            {loads.length === 0
+              ? "No loads yet."
+              : "No loads match these filters."}
+          </p>
+        ) : (
+          <table className="w-full text-sm min-w-[760px] [&_th]:pr-5 [&_td]:pr-5 [&_th:last-child]:pr-0 [&_td:last-child]:pr-0">
+            <thead>
+              <tr className="text-xs text-muted-text text-left">
+                <th className="font-normal pb-2">Load #</th>
+                <th className="font-normal pb-2">Status</th>
+                <th className="font-normal pb-2">Broker · agent</th>
+                <th className="font-normal pb-2">Lane</th>
+                <th className="font-normal pb-2">Pickup</th>
+                <th className="font-normal pb-2 text-right">Gross</th>
+                <th className="font-normal pb-2">Payment</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((load) => (
+                <tr
+                  key={load.load_id}
+                  className="border-t border-steel align-top"
+                >
+                  <td
+                    className={`py-2 whitespace-nowrap ${
+                      load.load_status === "in_transit"
+                        ? "border-l-2 border-l-amber pl-2"
+                        : ""
+                    }`}
+                  >
+                    <Link
+                      to={`/loads/${load.load_id}`}
+                      className="text-amber-light hover:underline font-medium"
+                    >
+                      {load.load_number}
+                    </Link>
+                  </td>
+                  <td className="py-2">
+                    <StatusBadge value={load.load_status} />
+                  </td>
+                  <td className="py-2">
+                    {load.broker}
+                    <span className="text-xs block">
+                      <Link
+                        to={`/agents/${load.agent_id}`}
+                        className="text-muted-text hover:text-amber-light hover:underline"
+                      >
+                        {load.agent}
+                      </Link>
+                    </span>
+                  </td>
+                  <td className="py-2 whitespace-nowrap">
+                    {load.origin_city}, {load.origin_state}
+                    <span className="text-muted-text"> → </span>
+                    {load.destination_city}, {load.destination_state}
+                  </td>
+                  <td className="py-2 text-muted-text whitespace-nowrap">
+                    {fmtDate(load.pickup_date)}
+                  </td>
+                  <td className="py-2 text-right whitespace-nowrap">
+                    {money(loadRevenue(load))}
+                  </td>
+                  <td className="py-2">
+                    <StatusBadge value={load.payment_status} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/types/LoadInput.ts
+++ b/frontend/src/types/LoadInput.ts
@@ -24,4 +24,7 @@ export interface LoadInput {
   odometer_start?: number | null;
   odometer_end?: number | null;
   payment_status: string;
+  truck_id?: string | null;
+  driver_id?: string | null;
+  trailer_id?: string | null;
 }

--- a/frontend/src/types/load.ts
+++ b/frontend/src/types/load.ts
@@ -34,6 +34,10 @@ export interface Load {
   truck_id?: string | null;
   driver_id?: string | null;
   trailer_id?: string | null;
+  // Joined labels, present on the single-load fetch (getLoad) only.
+  truck_unit?: string | null;
+  driver_name?: string | null;
+  trailer_unit?: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## What

Reworks the loads pages into the app's coherent design language and folds in the truck/driver/trailer entities.

### Loads list
- Four operational KPIs: this-month gross + loads delivered, avg rate/mile, outstanding AR, pipeline (booked + in-transit).
- Search + status/payment filters; leaner table (load # link, broker · agent, combined lane, amber accent on in-transit rows).

### Load detail
- A hub of `bg-plate` cards (route, fleet, revenue, mileage, cargo, dates, fuel, broker/agent, status) replacing the generic `PageHeader`/`MetricStrip` and tabs.
- **Fleet card** links to the truck/driver/trailer; `getLoad` now LEFT JOINs them in for the labels (verified against dev).
- RPM guarded against divide-by-zero.
- **Fuel section**: estimates from loaded + deadhead miles (badged `est.`), switching to actual odometer-derived miles once both readings are entered (`actual`). MPG/price stay labeled assumptions (`6.5 mpg · $5.50/gal`) until the fuel page feeds real numbers.

### Load form
- New **Fleet** section auto-assigns the sole truck/driver/trailer (picker only when more than one — the resolve-single-entity pattern). `createLoad`/`patchLoad` accept the fleet FKs with lenient UUID validation. Cleaned up a stray `console.log` and off-theme colors.

### Drill-down rule
- Agent references on both pages now link to the agent detail page. Standing rule: any entity with its own page must be a clickable link.

## Verification
- Strict build (`tsc -b && vite build`) clean; **100/100 tests** (new: `fuel` estimate + expanded `loads` KPIs).
- `getLoad` join run against dev — returns `truck_unit` / `driver_name` / `trailer_unit` correctly.

## Deploy
No migration (the `loads` fleet columns already exist from #? / migration 028). Prod needs a **backend redeploy** for the `getLoad` join + create/patch changes.