### PR TITLE
feat: agents list + detail redesign — comic rating, leaderboard, prestige

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.36.0",
+  "version": "1.37.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import TrailerDetailPage from "@/pages/TrailerDetailPage";
 import { LoadDetailPage } from "@/pages/LoadDetailPage";
 import { SwatchesPage } from "@/pages/SwatchesPage";
 import SignupPage from "@/pages/SignupPage";
+import GuidePage from "@/pages/GuidePage";
 
 // Code-split Lanes — it bundles the US map topology (~600KB), so it should only
 // load when the page is actually visited, not on every app start.
@@ -65,6 +66,7 @@ const App = () => {
           <Route path="/drivers/:id" element={<DriverDetailPage />} />
           <Route path="/trailers" element={<TrailersPage />} />
           <Route path="/trailers/:id" element={<TrailerDetailPage />} />
+          <Route path="/guide" element={<GuidePage />} />
         </Route>
       </Route>
 

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -42,6 +42,7 @@ const nav: Entry[] = [
     ],
   },
   { to: "/expenses", label: "Expenses" },
+  { to: "/guide", label: "Guide" },
 ];
 
 const AppSidebar = () => {

--- a/frontend/src/components/agents/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard.tsx
@@ -1,0 +1,77 @@
+import { Link } from "react-router";
+import type { Agent } from "@/types/agent";
+import type { AgentHonors, AgentStat } from "@/lib/metrics/agentLeaderboard";
+import { agentPrestige } from "@/lib/metrics/agentLeaderboard";
+import { RatingMedallion } from "./RatingMedallion";
+import { PrestigeBadge, PRESTIGE_META } from "./PrestigeBadge";
+
+const money0 = (n: number) =>
+  n.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+
+const fmtDate = (d: string | null) =>
+  d
+    ? new Date(d.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        timeZone: "UTC",
+      })
+    : "—";
+
+export const AgentCard = ({
+  agent,
+  stats,
+  honors,
+}: {
+  agent: Agent;
+  stats?: AgentStat;
+  honors?: AgentHonors;
+}) => {
+  const tier = agentPrestige(honors);
+  const prestige = PRESTIGE_META[tier];
+
+  return (
+    <Link
+      to={`/agents/${agent.agent_id}`}
+      className="relative overflow-hidden block bg-plate border border-[#3b4660] rounded-lg p-3.5 hover:border-amber transition-colors"
+    >
+      <PrestigeBadge tier={tier} />
+
+      <div className="flex gap-3 items-center">
+        <div className="size-11 rounded-full bg-steel border-2 border-amber flex items-center justify-center font-condensed font-semibold text-lg text-amber-light shrink-0">
+          {agent.first_name.charAt(0)}
+          {agent.last_name.charAt(0)}
+        </div>
+        <div className="min-w-0">
+          <p className="font-condensed text-lg leading-tight truncate">
+            {agent.first_name} {agent.last_name}
+          </p>
+          <p className="text-xs text-muted-text truncate">
+            {agent.broker_name} · Landstar
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 mt-2.5">
+        <RatingMedallion rating={agent.rating} />
+        {prestige.label && (
+          <span
+            className="text-[11px] font-medium uppercase tracking-wide shrink-0"
+            style={{ color: prestige.fill }}
+          >
+            {prestige.label}
+          </span>
+        )}
+      </div>
+
+      <div className="mt-2.5 pt-2 border-t border-[#3b4660] text-xs text-muted-text">
+        {stats?.loadCount ?? 0} loads · {money0(stats?.revenue ?? 0)} ·{" "}
+        {fmtDate(stats?.lastWorked ?? null)}
+      </div>
+    </Link>
+  );
+};

--- a/frontend/src/components/agents/PrestigeBadge.tsx
+++ b/frontend/src/components/agents/PrestigeBadge.tsx
@@ -1,0 +1,63 @@
+import { ChevronUp, Star, Crown, Flame } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { PrestigeTier } from "@/lib/metrics/agentLeaderboard";
+
+// A single tier-colored starburst — the agent's career rank at a glance. It
+// levels up over the years instead of piling on counts. `rookie` shows nothing.
+export const PRESTIGE_META: Record<
+  PrestigeTier,
+  { label: string; fill: string; ink: string; icon: LucideIcon | null }
+> = {
+  rookie: { label: "", fill: "", ink: "", icon: null },
+  contender: { label: "Contender", fill: "#c77b3e", ink: "#2a1a0a", icon: ChevronUp },
+  "all-star": { label: "All-Star", fill: "#c3cad6", ink: "#1a2030", icon: Star },
+  champion: { label: "Champion", fill: "#f5b03a", ink: "#3a2400", icon: Crown },
+  legend: { label: "Legend", fill: "#dbe3f0", ink: "#1a2030", icon: Flame },
+};
+
+const POINTS =
+  "57,30 47.39,34.66 53.38,43.5 42.73,42.73 43.5,53.38 34.66,47.39 30,57 " +
+  "25.34,47.39 16.5,53.38 17.27,42.73 6.62,43.5 12.61,34.66 3,30 12.61,25.34 " +
+  "6.62,16.5 17.27,17.27 16.5,6.62 25.34,12.61 30,3 34.66,12.61 43.5,6.62 " +
+  "42.73,17.27 53.38,16.5 47.39,25.34";
+
+// The emblem on its own (no positioning) — used inline in the guide.
+export const PrestigeBurst = ({
+  tier,
+  size = 66,
+}: {
+  tier: PrestigeTier;
+  size?: number;
+}) => {
+  const m = PRESTIGE_META[tier];
+  if (!m.icon) return null;
+  const Icon = m.icon;
+  return (
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
+      <svg viewBox="0 0 60 60" width={size} height={size} className="block">
+        <polygon
+          points={POINTS}
+          fill={m.fill}
+          stroke="#0d1117"
+          strokeWidth={1.5}
+        />
+      </svg>
+      <span className="absolute inset-0 flex items-center justify-center">
+        <Icon size={Math.round(size * 0.3)} color={m.ink} />
+      </span>
+    </div>
+  );
+};
+
+// The corner sticker on an agent card.
+export const PrestigeBadge = ({ tier }: { tier: PrestigeTier }) => {
+  if (!PRESTIGE_META[tier].icon) return null;
+  return (
+    <div
+      className="absolute -top-2.5 -right-2.5 rotate-[-8deg]"
+      aria-hidden="true"
+    >
+      <PrestigeBurst tier={tier} size={66} />
+    </div>
+  );
+};

--- a/frontend/src/components/agents/RatingMedallion.tsx
+++ b/frontend/src/components/agents/RatingMedallion.tsx
@@ -1,0 +1,34 @@
+import { Crown, ThumbsUp, Minus, AlertTriangle, Ban } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+// The 1–5 alignment tiers as bold comic medallions — one clear verdict instead
+// of five stars. (System unchanged; only the display.)
+const TIERS: Record<number, { label: string; cls: string; Icon: LucideIcon }> = {
+  5: { label: "Call first", cls: "bg-amber text-steel", Icon: Crown },
+  4: { label: "Good", cls: "bg-[#2fae6b] text-[#06231a]", Icon: ThumbsUp },
+  3: { label: "Default", cls: "bg-[#45526e] text-light", Icon: Minus },
+  2: { label: "Avoid", cls: "bg-[#d9761c] text-steel", Icon: AlertTriangle },
+  1: { label: "Blacklist", cls: "bg-[#d23b3b] text-white", Icon: Ban },
+};
+
+export const RatingMedallion = ({
+  rating,
+  size = "sm",
+}: {
+  rating?: number | null;
+  size?: "sm" | "lg";
+}) => {
+  const pad = size === "lg" ? "text-sm px-3 py-1.5" : "text-xs px-2.5 py-1";
+  const base = `inline-flex items-center gap-1.5 rounded font-condensed uppercase tracking-wide ${pad}`;
+
+  if (!rating)
+    return <span className={`${base} bg-steel text-muted-text`}>Unrated</span>;
+
+  const t = TIERS[rating];
+  const Icon = t.Icon;
+  return (
+    <span className={`${base} ${t.cls}`}>
+      <Icon size={size === "lg" ? 16 : 13} /> {t.label}
+    </span>
+  );
+};

--- a/frontend/src/components/agents/RatingStamp.tsx
+++ b/frontend/src/components/agents/RatingStamp.tsx
@@ -1,0 +1,25 @@
+// The "hero" rating display for the agent detail page — a comic rubber stamp,
+// tier-colored and cocked at an angle. (The list view uses RatingMedallion.)
+const STAMP: Record<number, { label: string; color: string }> = {
+  5: { label: "Call first", color: "#e8940a" },
+  4: { label: "Good", color: "#3fbf78" },
+  3: { label: "Default", color: "#9daabb" },
+  2: { label: "Avoid", color: "#e0822e" },
+  1: { label: "Blacklist", color: "#e24b4a" },
+};
+
+export const RatingStamp = ({ rating }: { rating?: number | null }) => {
+  const s = rating ? STAMP[rating] : { label: "Unrated", color: "#9daabb" };
+  return (
+    <div
+      className="inline-block px-3.5 py-1 rotate-[-6deg] font-condensed font-semibold uppercase text-xl rounded"
+      style={{
+        border: `3px double ${s.color}`,
+        color: s.color,
+        letterSpacing: "2px",
+      }}
+    >
+      {s.label}
+    </div>
+  );
+};

--- a/frontend/src/components/agents/TrophyCase.tsx
+++ b/frontend/src/components/agents/TrophyCase.tsx
@@ -1,0 +1,81 @@
+import { Trophy, Star, Minus } from "lucide-react";
+import type { AgentHonors, SeasonEntry } from "@/lib/metrics/agentLeaderboard";
+import { agentPrestige } from "@/lib/metrics/agentLeaderboard";
+import { PrestigeBurst, PRESTIGE_META } from "./PrestigeBadge";
+
+const qLabel = (q: string) => {
+  const [year, n] = q.split("-Q");
+  return `Q${n} '${year.slice(2)}`;
+};
+
+const resultIcon = (r: SeasonEntry["result"]) => {
+  if (r === "gold") return <Trophy size={18} style={{ color: "#f5b03a" }} />;
+  if (r === "silver") return <Trophy size={18} style={{ color: "#c3cad6" }} />;
+  if (r === "board") return <Star size={18} style={{ color: "#e8940a" }} />;
+  return <Minus size={16} className="text-muted-text" />;
+};
+
+export const TrophyCase = ({
+  honors,
+  log,
+}: {
+  honors?: AgentHonors;
+  log: SeasonEntry[];
+}) => {
+  const tier = agentPrestige(honors);
+  const meta = PRESTIGE_META[tier];
+  const boarded = (honors?.board ?? 0) > 0;
+
+  return (
+    <div className="bg-plate rounded-lg p-4">
+      <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
+        Trophy case
+      </p>
+
+      {!boarded ? (
+        <p className="text-sm text-muted-text">
+          No quarterly top-5 finishes yet — takes 2+ delivered loads in a quarter
+          to make the board.
+        </p>
+      ) : (
+        <>
+          <div className="flex items-center gap-4 flex-wrap">
+            <PrestigeBurst tier={tier} size={56} />
+            <div>
+              <p className="font-condensed text-xl" style={{ color: meta.fill }}>
+                {meta.label}
+              </p>
+              <div className="flex gap-4 text-sm mt-1">
+                <span style={{ color: "#f5b03a" }}>
+                  <Trophy size={15} className="inline -mt-0.5" /> {honors!.gold}{" "}
+                  gold
+                </span>
+                <span style={{ color: "#c3cad6" }}>
+                  <Trophy size={15} className="inline -mt-0.5" /> {honors!.silver}{" "}
+                  silver
+                </span>
+                <span style={{ color: "#e8940a" }}>
+                  <Star size={15} className="inline -mt-0.5" /> {honors!.board}{" "}
+                  boards
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex gap-3 mt-4 overflow-x-auto border-t border-[#3b4660] pt-3">
+            {log.map((e) => (
+              <div key={e.quarter} className="text-center min-w-[54px]">
+                <div className="text-[11px] text-muted-text">
+                  {qLabel(e.quarter)}
+                </div>
+                <div className="flex justify-center mt-1">
+                  {resultIcon(e.result)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/lib/metrics/agentLeaderboard.test.ts
+++ b/frontend/src/lib/metrics/agentLeaderboard.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  quarterKey,
+  computeHonors,
+  perAgentStats,
+  rosterKpis,
+  agentPrestige,
+  agentSeasonLog,
+} from "./agentLeaderboard";
+
+// Minimal delivered-load factory. Revenue = linehaul (fsc/accessorials 0).
+const mk = (
+  agent_id: string,
+  delivery_date: string,
+  linehaul: number,
+  overrides: Record<string, unknown> = {},
+) =>
+  ({
+    agent_id,
+    load_status: "delivered",
+    delivery_date,
+    pickup_date: delivery_date,
+    linehaul: String(linehaul),
+    fuel_surcharge: "0",
+    total_accessorials: "0",
+    ...overrides,
+  }) as any;
+
+describe("quarterKey", () => {
+  it("maps months to calendar quarters", () => {
+    expect(quarterKey("2026-02-15")).toBe("2026-Q1");
+    expect(quarterKey("2026-05-01")).toBe("2026-Q2");
+    expect(quarterKey("2026-09-30")).toBe("2026-Q3");
+    expect(quarterKey("2026-12-31")).toBe("2026-Q4");
+  });
+});
+
+describe("computeHonors", () => {
+  // Q1: A 3 loads/$30k, B 3 loads/$20k, C 2 loads/$25k, D 1 load/$9k
+  // Q2: A 3 loads/$40k, B 2 loads/$15k
+  const loads = [
+    mk("A", "2026-02-10", 10000),
+    mk("A", "2026-02-11", 10000),
+    mk("A", "2026-02-12", 10000),
+    mk("B", "2026-03-01", 10000),
+    mk("B", "2026-03-02", 5000),
+    mk("B", "2026-03-03", 5000),
+    mk("C", "2026-01-15", 12500),
+    mk("C", "2026-01-16", 12500),
+    mk("D", "2026-02-20", 9000),
+    mk("A", "2026-05-10", 20000),
+    mk("A", "2026-05-11", 10000),
+    mk("A", "2026-05-12", 10000),
+    mk("B", "2026-05-01", 8000),
+    mk("B", "2026-05-02", 7000),
+  ];
+  const h = computeHonors(loads);
+
+  it("board: 2+ loads, top 5 — counts A,B,C in Q1 and A,B in Q2", () => {
+    expect(h.get("A")?.board).toBe(2);
+    expect(h.get("B")?.board).toBe(2);
+    expect(h.get("C")?.board).toBe(1);
+  });
+
+  it("D (single load) never makes the board", () => {
+    expect(h.get("D")).toBeUndefined();
+  });
+
+  it("gold/silver: 3+ loads only — A golds both quarters, B silver once", () => {
+    expect(h.get("A")?.gold).toBe(2);
+    expect(h.get("A")?.silver).toBe(0);
+    expect(h.get("B")?.gold).toBe(0);
+    expect(h.get("B")?.silver).toBe(1); // Q1 #2; Q2 B has only 2 loads → no podium
+  });
+
+  it("C is on the board but never on the podium (only 2 loads)", () => {
+    expect(h.get("C")?.gold).toBe(0);
+    expect(h.get("C")?.silver).toBe(0);
+  });
+});
+
+describe("agentPrestige", () => {
+  it("ranks by career record (rookie → legend)", () => {
+    expect(agentPrestige(undefined)).toBe("rookie");
+    expect(agentPrestige({ board: 0, gold: 0, silver: 0 })).toBe("rookie");
+    expect(agentPrestige({ board: 4, gold: 0, silver: 0 })).toBe("contender");
+    expect(agentPrestige({ board: 5, gold: 0, silver: 2 })).toBe("all-star");
+    expect(agentPrestige({ board: 6, gold: 2, silver: 5 })).toBe("all-star"); // 2 golds < 3
+    expect(agentPrestige({ board: 9, gold: 3, silver: 1 })).toBe("champion");
+    expect(agentPrestige({ board: 12, gold: 8, silver: 0 })).toBe("legend");
+  });
+});
+
+describe("agentSeasonLog", () => {
+  const loads = [
+    mk("A", "2026-02-01", 10000),
+    mk("A", "2026-02-02", 10000),
+    mk("A", "2026-02-03", 10000),
+    mk("B", "2026-03-01", 10000),
+    mk("B", "2026-03-02", 5000),
+    mk("B", "2026-03-03", 5000),
+    mk("C", "2026-01-15", 12500),
+    mk("C", "2026-01-16", 12500),
+    mk("A", "2026-05-01", 6000),
+    mk("A", "2026-05-02", 6000),
+  ];
+
+  it("returns an agent's quarter-by-quarter finish, oldest first", () => {
+    expect(agentSeasonLog(loads, "A").map((e) => [e.quarter, e.result])).toEqual(
+      [
+        ["2026-Q1", "gold"],
+        ["2026-Q2", "board"],
+      ],
+    );
+  });
+
+  it("marks a board finish that never reached the podium", () => {
+    expect(agentSeasonLog(loads, "C")).toEqual([
+      { quarter: "2026-Q1", result: "board", revenue: 25000, loads: 2 },
+    ]);
+  });
+});
+
+describe("perAgentStats", () => {
+  it("counts non-cancelled loads, sums delivered revenue, tracks last delivery", () => {
+    const s = perAgentStats([
+      mk("A", "2026-02-10", 10000),
+      mk("A", "2026-03-10", 5000),
+      mk("A", "2026-01-01", 3000, { load_status: "cancelled" }),
+    ]);
+    const a = s.get("A");
+    expect(a?.loadCount).toBe(2); // cancelled excluded
+    expect(a?.revenue).toBe(15000);
+    expect(a?.lastWorked).toBe("2026-03-10");
+  });
+});
+
+describe("rosterKpis", () => {
+  const now = new Date("2026-07-15T00:00:00.000Z");
+  const agents = [
+    { agent_id: "A", rating: 5 },
+    { agent_id: "B", rating: 2 },
+    { agent_id: "C", rating: null },
+  ] as any;
+
+  it("counts roster, call-first, avoid, and the last-90d top earner", () => {
+    const loads = [
+      mk("A", "2026-07-01", 9000), // in window
+      mk("B", "2026-07-02", 4000), // in window
+      mk("A", "2026-01-01", 99999), // outside 90d — ignored for topEarner
+    ];
+    const k = rosterKpis(agents, loads, now);
+    expect(k.total).toBe(3);
+    expect(k.rated).toBe(2);
+    expect(k.callFirst).toBe(1);
+    expect(k.avoid).toBe(1);
+    expect(k.topEarner?.agentId).toBe("A");
+    expect(k.topEarner?.revenue).toBe(9000);
+    expect(k.activeCount).toBe(2);
+  });
+});

--- a/frontend/src/lib/metrics/agentLeaderboard.ts
+++ b/frontend/src/lib/metrics/agentLeaderboard.ts
@@ -1,0 +1,204 @@
+import type { Load } from "@/types/load";
+import type { Agent } from "@/types/agent";
+import { loadRevenue } from "./loads";
+
+// Agent achievements, tallied over calendar-quarter leaderboards derived from
+// delivered loads. The board (starburst) is more inclusive than the podium
+// (trophies): you make the board more easily than you win the quarter.
+export interface AgentHonors {
+  board: number; // quarters finished top-5 (2+ loads)
+  gold: number; // quarters finished #1 (3+ loads)
+  silver: number; // quarters finished #2 (3+ loads)
+}
+
+// Calendar-quarter key for a delivered load's date, e.g. "2026-Q3".
+export const quarterKey = (dateStr: string): string => {
+  const d = new Date(String(dateStr).slice(0, 10) + "T00:00:00Z");
+  const q = Math.floor(d.getUTCMonth() / 3) + 1;
+  return `${d.getUTCFullYear()}-Q${q}`;
+};
+
+interface QAgg {
+  revenue: number;
+  loads: number;
+}
+
+// Delivered loads → quarter → agent → { revenue, loads }.
+const byQuarterAgent = (loads: Load[]): Map<string, Map<string, QAgg>> => {
+  const out = new Map<string, Map<string, QAgg>>();
+  for (const l of loads) {
+    if (l.load_status !== "delivered" || !l.delivery_date || !l.agent_id) continue;
+    const q = quarterKey(l.delivery_date);
+    let agents = out.get(q);
+    if (!agents) {
+      agents = new Map();
+      out.set(q, agents);
+    }
+    const cur = agents.get(l.agent_id) ?? { revenue: 0, loads: 0 };
+    cur.revenue += loadRevenue(l);
+    cur.loads += 1;
+    agents.set(l.agent_id, cur);
+  }
+  return out;
+};
+
+// Revenue desc, then agent_id asc so ties resolve deterministically.
+const rankByRevenue = (entries: [string, QAgg][]): [string, QAgg][] =>
+  [...entries].sort(
+    (a, b) => b[1].revenue - a[1].revenue || a[0].localeCompare(b[0]),
+  );
+
+export const computeHonors = (loads: Load[]): Map<string, AgentHonors> => {
+  const honors = new Map<string, AgentHonors>();
+  const bump = (agentId: string, key: keyof AgentHonors) => {
+    const h = honors.get(agentId) ?? { board: 0, gold: 0, silver: 0 };
+    h[key] += 1;
+    honors.set(agentId, h);
+  };
+
+  for (const [, agents] of byQuarterAgent(loads)) {
+    const entries = [...agents.entries()];
+    // Board: 2+ loads, top 5 by revenue.
+    const board = rankByRevenue(entries.filter(([, a]) => a.loads >= 2)).slice(
+      0,
+      5,
+    );
+    for (const [agentId] of board) bump(agentId, "board");
+    // Podium: 3+ loads, #1 gold, #2 silver.
+    const podium = rankByRevenue(entries.filter(([, a]) => a.loads >= 3));
+    if (podium[0]) bump(podium[0][0], "gold");
+    if (podium[1]) bump(podium[1][0], "silver");
+  }
+  return honors;
+};
+
+// Career rank from the honors record. This replaces the raw ×counts on the
+// card; the full board/gold/silver breakdown lives in the detail trophy case.
+export type PrestigeTier =
+  | "rookie"
+  | "contender"
+  | "all-star"
+  | "champion"
+  | "legend";
+
+export const agentPrestige = (h?: AgentHonors): PrestigeTier => {
+  if (!h || h.board === 0) return "rookie";
+  if (h.gold >= 8) return "legend";
+  if (h.gold >= 3) return "champion";
+  if (h.gold >= 1 || h.silver >= 1) return "all-star";
+  return "contender";
+};
+
+// One agent's quarter-by-quarter leaderboard record (oldest first) for the
+// detail-page trophy case. `result` is their finish that quarter.
+export interface SeasonEntry {
+  quarter: string; // "2026-Q3"
+  result: "gold" | "silver" | "board" | "ran";
+  revenue: number;
+  loads: number;
+}
+
+export const agentSeasonLog = (
+  loads: Load[],
+  agentId: string,
+): SeasonEntry[] => {
+  const out: SeasonEntry[] = [];
+  for (const [quarter, agents] of byQuarterAgent(loads)) {
+    const mine = agents.get(agentId);
+    if (!mine) continue;
+    const entries = [...agents.entries()];
+    const podium = rankByRevenue(entries.filter(([, a]) => a.loads >= 3));
+    const board = rankByRevenue(entries.filter(([, a]) => a.loads >= 2))
+      .slice(0, 5)
+      .map(([id]) => id);
+    let result: SeasonEntry["result"] = "ran";
+    if (podium[0]?.[0] === agentId) result = "gold";
+    else if (podium[1]?.[0] === agentId) result = "silver";
+    else if (board.includes(agentId)) result = "board";
+    out.push({ quarter, result, revenue: mine.revenue, loads: mine.loads });
+  }
+  out.sort((a, b) => a.quarter.localeCompare(b.quarter));
+  return out;
+};
+
+// ---- per-agent card stats ----
+
+export interface AgentStat {
+  loadCount: number; // non-cancelled loads
+  revenue: number; // delivered gross
+  lastWorked: string | null; // 'YYYY-MM-DD' of the latest delivery
+}
+
+export const perAgentStats = (loads: Load[]): Map<string, AgentStat> => {
+  const out = new Map<string, AgentStat>();
+  for (const l of loads) {
+    if (!l.agent_id) continue;
+    const s = out.get(l.agent_id) ?? {
+      loadCount: 0,
+      revenue: 0,
+      lastWorked: null,
+    };
+    if (l.load_status !== "cancelled") s.loadCount += 1;
+    if (l.load_status === "delivered") {
+      s.revenue += loadRevenue(l);
+      if (l.delivery_date) {
+        const dd = l.delivery_date.slice(0, 10);
+        if (!s.lastWorked || dd > s.lastWorked) s.lastWorked = dd;
+      }
+    }
+    out.set(l.agent_id, s);
+  }
+  return out;
+};
+
+// ---- page KPIs ----
+
+export interface RosterKpis {
+  total: number;
+  rated: number;
+  callFirst: number; // rating 5
+  avoid: number; // rating 1 or 2
+  topEarner: { agentId: string; revenue: number } | null; // last 90 days
+  activeCount: number; // agents with a non-cancelled load picked up in last 90d
+}
+
+export const rosterKpis = (
+  agents: Agent[],
+  loads: Load[],
+  now: Date,
+): RosterKpis => {
+  const cutoff = new Date(now);
+  cutoff.setUTCDate(cutoff.getUTCDate() - 90);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+
+  const rev90 = new Map<string, number>();
+  const active = new Set<string>();
+  for (const l of loads) {
+    if (!l.agent_id) continue;
+    const pd = l.pickup_date?.slice(0, 10);
+    if (pd && pd >= cutoffStr && l.load_status !== "cancelled")
+      active.add(l.agent_id);
+    if (
+      l.load_status === "delivered" &&
+      l.delivery_date &&
+      l.delivery_date.slice(0, 10) >= cutoffStr
+    ) {
+      rev90.set(l.agent_id, (rev90.get(l.agent_id) ?? 0) + loadRevenue(l));
+    }
+  }
+
+  let topEarner: RosterKpis["topEarner"] = null;
+  for (const [agentId, revenue] of rev90) {
+    if (!topEarner || revenue > topEarner.revenue)
+      topEarner = { agentId, revenue };
+  }
+
+  return {
+    total: agents.length,
+    rated: agents.filter((a) => a.rating != null).length,
+    callFirst: agents.filter((a) => a.rating === 5).length,
+    avoid: agents.filter((a) => a.rating === 1 || a.rating === 2).length,
+    topEarner,
+    activeCount: active.size,
+  };
+};

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -1,99 +1,106 @@
-import { useState } from "react";
-import { useAgent } from "@/hooks/useAgent";
+import { useState, useMemo } from "react";
+import { Link } from "react-router";
+import { Mail, Phone, StickyNote, Star } from "lucide-react";
 
+import { useAgent } from "@/hooks/useAgent";
+import { useLoads } from "@/hooks/useLoads";
 import { createAgentNote } from "@/services/createAgentNoteService";
 
-// Components
-import { RatingDisplay } from "@/components/RatingDisplay";
 import RatingForm from "@/components/RatingForm";
-import { Button } from "@/components/ui/button";
-import { MetricStrip } from "@/components/MetricStrip";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { Kpi } from "@/components/Kpi";
 import { StatusBadge } from "@/components/StatusBadge";
-import { Link } from "react-router";
-import { StickyNote } from "lucide-react";
-import { Star } from "lucide-react";
-import { Textarea } from "@/components/ui/textarea";
-import { Input } from "@/components/ui/input";
+import { RatingStamp } from "@/components/agents/RatingStamp";
+import { TrophyCase } from "@/components/agents/TrophyCase";
+import { PRESTIGE_META } from "@/components/agents/PrestigeBadge";
+import { fmtRpm, rpmTextClass } from "@/components/lanes/rpmStyle";
 
-// Helpers
+import {
+  agentPrestige,
+  computeHonors,
+  agentSeasonLog,
+} from "@/lib/metrics/agentLeaderboard";
 import {
   getLoadCount,
+  getGrossRevenue,
   getAverageRPM,
   getCancelledCount,
-  getGrossRevenue,
   getLastLoadDate,
+  buildTimeline,
 } from "@/lib/metrics/agent";
-import { buildTimeline } from "@/lib/metrics/agent";
+import { loadRevenue } from "@/lib/metrics/loads";
 
-// Icons
-import { Mail } from "lucide-react";
-import { Phone } from "lucide-react";
+const money0 = (n: number) =>
+  n.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+
+const fmtDate = (d?: string | null) =>
+  d
+    ? new Date(String(d).slice(0, 10) + "T00:00:00Z").toLocaleDateString(
+        "en-US",
+        { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" },
+      )
+    : "—";
 
 const AgentDetailPage = () => {
-  // ---- REACT STATE ----
   const [refreshKey, setRefreshKey] = useState(0);
   const [showRatingForm, setShowRatingForm] = useState(false);
   const { agent, loads, notes, ratingHistory, isLoading, error } =
     useAgent(refreshKey);
+  const { loads: allLoads } = useLoads(0);
 
-  // ---- NOTE COMPOSER STATE ----
   const [noteText, setNoteText] = useState("");
   const [noteInitials, setNoteInitials] = useState("");
   const [noteError, setNoteError] = useState<string | null>(null);
   const [savingNote, setSavingNote] = useState(false);
 
-  const logs = buildTimeline(notes, ratingHistory);
-
-  if (!agent) {
-    return (
-      <div>
-        <p>No agent found</p>
-      </div>
-    );
-  }
+  const agentId = agent?.agent_id;
+  const honors = useMemo(
+    () => (agentId ? computeHonors(allLoads ?? []).get(agentId) : undefined),
+    [allLoads, agentId],
+  );
+  const season = useMemo(
+    () => (agentId ? agentSeasonLog(allLoads ?? [], agentId) : []),
+    [allLoads, agentId],
+  );
 
   if (isLoading)
     return (
-      <div>
-        <p>...Loading agent</p>
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <p className="text-muted-text">Loading agent...</p>
       </div>
     );
-
   if (error)
     return (
-      <div>
-        <p>{error}</p>
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <p className="text-destructive">{error}</p>
       </div>
     );
+  if (!agent) return null;
 
-  // ---- HANDLERS ----
-  const handleEditRating = () => {
-    setShowRatingForm(true);
-  };
+  const tier = agentPrestige(honors);
+  const prestige = PRESTIGE_META[tier];
+  const grossRev = getGrossRevenue(loads);
+  const rpm = getAverageRPM(loads);
+  const lastWorked = getLastLoadDate(loads);
+  const logs = buildTimeline(notes, ratingHistory);
+  const agentLoads = [...(loads ?? [])].sort((a, b) =>
+    b.pickup_date.localeCompare(a.pickup_date),
+  );
 
   const handleSuccess = () => {
-    setRefreshKey((prev) => prev + 1);
+    setRefreshKey((p) => p + 1);
     setShowRatingForm(false);
   };
 
   const handleAddNote = async () => {
     setNoteError(null);
-
     if (!noteText.trim() || !noteInitials.trim()) {
       setNoteError("A note and your initials are required");
       return;
     }
-
-    if (!agent) return; // agent is in scope; guard for TS
-
     try {
       setSavingNote(true);
       await createAgentNote(agent.agent_id, {
@@ -102,7 +109,7 @@ const AgentDetailPage = () => {
       });
       setNoteText("");
       setNoteInitials("");
-      setRefreshKey((prev) => prev + 1); // refetch → new note appears in timeline
+      setRefreshKey((p) => p + 1);
     } catch (e) {
       setNoteError(e instanceof Error ? e.message : "Failed to add note");
     } finally {
@@ -111,15 +118,14 @@ const AgentDetailPage = () => {
   };
 
   return (
-    <>
-      {/* Modal */}
-      {showRatingForm && agent && (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      {showRatingForm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div
             className="absolute inset-0 bg-black/50"
             onClick={() => setShowRatingForm(false)}
           />
-          <div className="relative w-[450px] max-h-[90vh] bg-card text-foreground overflow-y-auto shadow-xl rounded-lg p-6">
+          <div className="relative w-[450px] max-h-[90vh] bg-iron text-light overflow-y-auto shadow-xl rounded-lg p-6 border border-plate">
             <RatingForm
               agent={agent}
               onSuccess={handleSuccess}
@@ -128,285 +134,226 @@ const AgentDetailPage = () => {
           </div>
         </div>
       )}
-      <div className="p-6 bg-iron text-light font-body">
-        <div className="flex justify-between">
-          {/* Left side of header */}
-          <div>
-            <div className="flex gap-4">
-              <div className="flex rounded-full items-center bg-steel justify-center size-20 text-4xl font-display text-light">
-                {agent.first_name.charAt(0)} {agent.last_name.charAt(0)}
-              </div>
-              <div className="text-4xl text-light font-condensed">
-                {agent.first_name + " " + agent.last_name}
-                <p className="text-xl text-muted-text">
-                  {agent.broker_name} · Landstar Agent
-                </p>
-              </div>
-            </div>
-            <RatingDisplay rating={agent.rating} />
+
+      <Link to="/agents" className="text-xs text-muted-text hover:text-light">
+        ← Agents
+      </Link>
+
+      <div className="flex justify-between items-start mt-3 mb-6 gap-4">
+        <div className="flex gap-4 items-center">
+          <div className="size-16 rounded-full bg-steel border-2 border-amber flex items-center justify-center font-condensed font-semibold text-2xl text-amber-light shrink-0">
+            {agent.first_name.charAt(0)}
+            {agent.last_name.charAt(0)}
           </div>
-          {/* Right side of header */}
           <div>
-            <Button onClick={handleEditRating}>Edit Rating</Button>
+            <h1 className="text-3xl font-condensed leading-none">
+              {agent.first_name} {agent.last_name}
+            </h1>
+            <p className="text-sm text-muted-text mt-1">
+              {agent.broker_name} · Landstar Agent
+            </p>
+            {prestige.label && (
+              <p
+                className="text-xs font-medium uppercase tracking-wide mt-1"
+                style={{ color: prestige.fill }}
+              >
+                {prestige.label}
+              </p>
+            )}
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          <RatingStamp rating={agent.rating} />
+          <div className="mt-3">
+            <button
+              onClick={() => setShowRatingForm(true)}
+              className="bg-steel text-light px-3 py-1.5 rounded text-sm border border-[#3b4660]"
+            >
+              Edit rating
+            </button>
           </div>
         </div>
       </div>
-      <div className="bg-iron pl-4">
-        <MetricStrip
-          cards={[
-            {
-              label: "Loads",
-              value: getLoadCount(loads),
-              format: "number",
-            },
-            {
-              label: "Gross Revenue",
-              value: getGrossRevenue(loads),
-              format: "currency",
-            },
-            {
-              label: "Average RPM",
-              value: getAverageRPM(loads),
-              format: "currency",
-            },
-            {
-              label: "Cancelled",
-              value: getCancelledCount(loads),
-              format: "number",
-            },
-            {
-              label: "Last Worked",
-              value: getLastLoadDate(loads)
-                ? new Date(getLastLoadDate(loads)!).toLocaleDateString(
-                    "en-US",
-                    {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                      timeZone: "UTC",
-                    },
-                  )
-                : "Never",
-              format: "string",
-            },
-          ]}
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+        <Kpi label="Loads" value={String(getLoadCount(loads))} />
+        <Kpi
+          label="Gross revenue"
+          value={grossRev == null ? "—" : money0(grossRev)}
         />
+        <Kpi
+          label="Avg rate/mile"
+          value={fmtRpm(rpm)}
+          valueClass={rpmTextClass(rpm)}
+        />
+        <Kpi label="Cancelled" value={String(getCancelledCount(loads))} />
+        <Kpi label="Last worked" value={lastWorked ? fmtDate(lastWorked) : "Never"} />
       </div>
-      <div className="grid grid-cols-4 bg-plate">
-        {/* Main Content Area */}
-        <div className="col-span-3">
-          <div className="bg-plate p-2 m-2 text-xs">
-            <h3 className="text-lg text-muted-text uppercase tracking-wider font-condensed bg-plate">
-              Loads Run with this agent
-            </h3>
-            <div className="bg-steel text-xs">
-              <Table className="text-xs">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Load #</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Origin</TableHead>
-                    <TableHead>Destination</TableHead>
-                    <TableHead>Pickup Date</TableHead>
-                    <TableHead>Delivery Date</TableHead>
-                    <TableHead>Gross Revenue</TableHead>
-                    <TableHead>Payment Status</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {loads.map((load) => (
-                    <TableRow
-                      key={load.load_id}
-                      className={
-                        load.load_status === "in_transit"
-                          ? "border-l-4 border-l-primary"
-                          : ""
-                      }
-                    >
-                      <TableCell className="text-foreground hover:text-primary hover:underline cursor-pointer">
-                        <Link to={`/loads/${load.load_id}`}>
-                          {load.load_number}
-                        </Link>
-                      </TableCell>
-                      <TableCell>
-                        <StatusBadge value={load.load_status} />
-                      </TableCell>
-                      <TableCell>
-                        {load.origin_city + ", " + load.origin_state}
-                      </TableCell>
-                      <TableCell>
-                        {load.destination_city + ", " + load.destination_state}
-                      </TableCell>
-                      <TableCell>
-                        {new Date(load.pickup_date).toLocaleDateString(
-                          "en-US",
-                          {
-                            month: "short",
-                            day: "numeric",
-                            year: "numeric",
-                            timeZone: "UTC",
-                          },
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        {load.delivery_date
-                          ? new Date(load.delivery_date).toLocaleDateString(
-                              "en-US",
-                              {
-                                month: "short",
-                                day: "numeric",
-                                year: "numeric",
-                                timeZone: "UTC",
-                              },
-                            )
-                          : "-"}
-                      </TableCell>
-                      <TableCell>
-                        {(
-                          Number(load.linehaul) +
-                          Number(load.fuel_surcharge) +
-                          Number(load.total_accessorials)
-                        ).toLocaleString("en-US", {
-                          style: "currency",
-                          currency: "USD",
-                        })}
-                      </TableCell>
-                      <TableCell>
-                        <StatusBadge value={load.payment_status} />
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-            {/* ACTIVITY TIMELINE */}
-            <div className="bg-plate p-2 m-2">
-              <h3 className="text-lg text-muted-text uppercase tracking-wider font-condensed mb-3">
-                Activity
-              </h3>
-              {/* Note composer */}
-              <div className="bg-steel/30 rounded-sm p-3 mb-4 flex flex-col gap-2">
-                <Textarea
-                  placeholder="Add a note about this agent..."
-                  value={noteText}
-                  onChange={(e) => setNoteText(e.target.value)}
-                  className="text-sm"
-                />
-                <div className="flex items-center gap-2">
-                  <Input
-                    placeholder="Initials"
-                    maxLength={5}
-                    value={noteInitials}
-                    onChange={(e) => setNoteInitials(e.target.value)}
-                    className="w-24 text-sm"
-                  />
-                  <Button
-                    onClick={handleAddNote}
-                    disabled={savingNote}
-                    className="ml-auto"
+
+      <div className="mt-4">
+        <TrophyCase honors={honors} log={season} />
+      </div>
+
+      <div className="bg-plate rounded-lg p-4 mt-4">
+        <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
+          Loads with this agent
+        </p>
+        {agentLoads.length === 0 ? (
+          <p className="text-sm text-muted-text">No loads yet.</p>
+        ) : (
+          <div className="overflow-x-auto max-h-96 overflow-y-auto">
+            <table className="w-full text-sm min-w-[560px]">
+              <thead>
+                <tr className="text-xs text-muted-text text-left">
+                  <th className="font-normal pb-2 pr-4">Load #</th>
+                  <th className="font-normal pb-2 pr-4">Status</th>
+                  <th className="font-normal pb-2 pr-4">Lane</th>
+                  <th className="font-normal pb-2 pr-4">Pickup</th>
+                  <th className="font-normal pb-2 pr-4 text-right">Gross</th>
+                  <th className="font-normal pb-2">Payment</th>
+                </tr>
+              </thead>
+              <tbody>
+                {agentLoads.map((load) => (
+                  <tr
+                    key={load.load_id}
+                    className="border-t border-[#3b4660]"
                   >
-                    {savingNote ? "Saving..." : "Add Note"}
-                  </Button>
-                </div>
-                {noteError && (
-                  <p className="text-destructive text-sm">{noteError}</p>
-                )}
-              </div>
-              {logs.length === 0 ? (
-                <p className="text-sm text-muted-text italic px-2 py-4">
-                  No activity yet
-                </p>
-              ) : (
-                <div className="flex flex-col gap-2">
-                  {logs.map((log) => {
-                    const date = new Date(log.timestamp).toLocaleDateString(
-                      "en-US",
-                      {
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                        timeZone: "UTC",
-                      },
-                    );
-
-                    if (log.type === "rating") {
-                      return (
-                        <div
-                          key={log.data.id}
-                          className="flex gap-3 items-start border-l-2 border-l-primary bg-steel/40 px-3 py-2 rounded-sm"
-                        >
-                          <Star
-                            size={14}
-                            className="text-primary mt-1 shrink-0"
-                            fill="var(--color-primary)"
-                          />
-                          <div className="text-sm">
-                            <p className="text-foreground">
-                              Rating changed{" "}
-                              <span className="text-muted-text">
-                                {log.data.old_rating ?? "—"}
-                              </span>{" "}
-                              →{" "}
-                              <span className="text-primary font-semibold">
-                                {log.data.new_rating}
-                              </span>
-                            </p>
-                            <p className="text-muted-text">{log.data.reason}</p>
-                            <p className="text-xs text-muted-text mt-1">
-                              {date} · {log.data.changed_by}
-                            </p>
-                          </div>
-                        </div>
-                      );
-                    }
-
-                    return (
-                      <div
-                        key={log.data.id}
-                        className="flex gap-3 items-start border-l-2 border-l-iron bg-steel/20 px-3 py-2 rounded-sm"
+                    <td className="py-2 pr-4 whitespace-nowrap">
+                      <Link
+                        to={`/loads/${load.load_id}`}
+                        className="text-amber-light hover:underline font-medium"
                       >
-                        <StickyNote
-                          size={14}
-                          className="text-muted-text mt-1 shrink-0"
-                        />
-                        <div className="text-sm">
-                          <p className="text-foreground">{log.data.note}</p>
-                          <p className="text-xs text-muted-text mt-1">
-                            {date} · {log.data.created_by}
-                          </p>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
+                        {load.load_number}
+                      </Link>
+                    </td>
+                    <td className="py-2 pr-4">
+                      <StatusBadge value={load.load_status} />
+                    </td>
+                    <td className="py-2 pr-4 whitespace-nowrap">
+                      {load.origin_city}, {load.origin_state}{" "}
+                      <span className="text-muted-text">→</span>{" "}
+                      {load.destination_city}, {load.destination_state}
+                    </td>
+                    <td className="py-2 pr-4 text-muted-text whitespace-nowrap">
+                      {fmtDate(load.pickup_date)}
+                    </td>
+                    <td className="py-2 pr-4 text-right whitespace-nowrap">
+                      {money0(loadRevenue(load))}
+                    </td>
+                    <td className="py-2">
+                      <StatusBadge value={load.payment_status} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+        <div className="md:col-span-2 bg-plate rounded-lg p-4">
+          <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
+            Activity
+          </p>
+          <div className="bg-steel/40 rounded p-3 mb-4">
+            <textarea
+              className="bg-steel rounded px-2 py-1.5 text-sm w-full text-light placeholder:text-muted-text"
+              placeholder="Add a note about this agent…"
+              rows={2}
+              value={noteText}
+              onChange={(e) => setNoteText(e.target.value)}
+            />
+            <div className="flex items-center gap-2 mt-2">
+              <input
+                className="bg-steel rounded px-2 py-1.5 text-sm w-24 text-light placeholder:text-muted-text"
+                placeholder="Initials"
+                maxLength={5}
+                value={noteInitials}
+                onChange={(e) => setNoteInitials(e.target.value)}
+              />
+              <button
+                onClick={handleAddNote}
+                disabled={savingNote}
+                className="ml-auto bg-amber text-steel px-3 py-1.5 rounded text-sm font-semibold disabled:opacity-50"
+              >
+                {savingNote ? "Saving…" : "Add note"}
+              </button>
+            </div>
+            {noteError && (
+              <p className="text-destructive text-sm mt-2">{noteError}</p>
+            )}
+          </div>
+
+          {logs.length === 0 ? (
+            <p className="text-sm text-muted-text italic px-1 py-2">
+              No activity yet
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {logs.map((log) =>
+                log.type === "rating" ? (
+                  <div
+                    key={log.data.id}
+                    className="border-l-2 border-l-amber bg-steel/40 px-3 py-2 rounded-sm"
+                  >
+                    <p className="text-sm">
+                      <Star size={13} className="inline text-amber -mt-0.5" />{" "}
+                      Rating changed{" "}
+                      <span className="text-muted-text">
+                        {log.data.old_rating ?? "—"}
+                      </span>{" "}
+                      → <span className="text-amber font-semibold">
+                        {log.data.new_rating}
+                      </span>
+                    </p>
+                    {log.data.reason && (
+                      <p className="text-sm text-muted-text">{log.data.reason}</p>
+                    )}
+                    <p className="text-xs text-muted-text mt-1">
+                      {fmtDate(log.timestamp)} · {log.data.changed_by}
+                    </p>
+                  </div>
+                ) : (
+                  <div
+                    key={log.data.id}
+                    className="border-l-2 border-l-[#3b4660] bg-steel/20 px-3 py-2 rounded-sm"
+                  >
+                    <p className="text-sm">
+                      <StickyNote
+                        size={13}
+                        className="inline text-muted-text -mt-0.5"
+                      />{" "}
+                      {log.data.note}
+                    </p>
+                    <p className="text-xs text-muted-text mt-1">
+                      {fmtDate(log.timestamp)} · {log.data.created_by}
+                    </p>
+                  </div>
+                ),
               )}
             </div>
-          </div>
+          )}
         </div>
-        {/* Sidebar Area */}
-        <div className="col-span-1 bg-plate p-4 border-l-1 border-iron text-foreground">
-          <h2 className="text-md mt-2 mb-2 uppercase text-muted-text tracking-wider">
+
+        <div className="bg-plate rounded-lg p-4">
+          <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
             Contact
-          </h2>
-          <p className="text-sm text-muted-text mb-4">
-            <Mail size="16px" />{" "}
-            <span className="text-foreground">
-              {agent.email ? agent.email : "No email provided"}
-            </span>
           </p>
-          <p className="text-sm text-muted-text mb-4">
-            <Phone size="16px" />{" "}
-            <span className="text-foreground">
-              {agent.phone ? agent.phone : "No phone number provided"}
-            </span>
+          <p className="text-sm mb-2 break-words">
+            <Mail size={14} className="inline text-muted-text mr-1.5 -mt-0.5" />
+            {agent.email || "No email"}
           </p>
-          <p className="text-sm text-muted-text">Preferred Method</p>
-          <p className="text-sm text-foreground capitalize">
-            {agent.preferred_contact}
+          <p className="text-sm mb-3">
+            <Phone size={14} className="inline text-muted-text mr-1.5 -mt-0.5" />
+            {agent.phone || "No phone"}
           </p>
+          <p className="text-xs text-muted-text">Preferred</p>
+          <p className="text-sm capitalize">{agent.preferred_contact || "—"}</p>
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -1,64 +1,180 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { useAgents } from "@/hooks/useAgents";
-import { RatingDisplay } from "@/components/RatingDisplay";
+import { useLoads } from "@/hooks/useLoads";
+import { Kpi } from "@/components/Kpi";
+import { AgentCard } from "@/components/agents/AgentCard";
+import {
+  computeHonors,
+  perAgentStats,
+  rosterKpis,
+} from "@/lib/metrics/agentLeaderboard";
+
+const money0 = (n: number) =>
+  n.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+
+type SortKey = "rating" | "revenue" | "recent";
+const SORTS: [SortKey, string][] = [
+  ["rating", "Rating"],
+  ["revenue", "Revenue"],
+  ["recent", "Recently worked"],
+];
+
+const plural = (n: number) => (n !== 1 ? "s" : "");
 
 const AgentsPage = () => {
   const { agents, isLoading, error } = useAgents();
+  const { loads, isLoading: loadsLoading } = useLoads(0);
 
-  // Sort by rating desc; unrated (null) sinks to the bottom
-  const sortedAgents = useMemo(() => {
-    return [...agents].sort((a, b) => (b.rating ?? -1) - (a.rating ?? -1));
-  }, [agents]);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortKey>("rating");
 
-  if (isLoading)
+  const honors = useMemo(() => computeHonors(loads ?? []), [loads]);
+  const stats = useMemo(() => perAgentStats(loads ?? []), [loads]);
+  const kpis = useMemo(
+    () => rosterKpis(agents ?? [], loads ?? [], new Date()),
+    [agents, loads],
+  );
+
+  const shown = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const filtered = (agents ?? []).filter(
+      (a) =>
+        !q ||
+        `${a.first_name} ${a.last_name} ${a.broker_name}`
+          .toLowerCase()
+          .includes(q),
+    );
+    const rev = (id: string) => stats.get(id)?.revenue ?? 0;
+    const worked = (id: string) => stats.get(id)?.lastWorked ?? "";
+    // Break rating ties by career achievement so the more decorated agent
+    // (e.g. the Champion) leads within a tier.
+    const honorScore = (id: string) => {
+      const h = honors.get(id);
+      return h ? h.gold * 10000 + h.silver * 100 + h.board : 0;
+    };
+    return [...filtered].sort((a, b) => {
+      if (sort === "revenue") return rev(b.agent_id) - rev(a.agent_id);
+      if (sort === "recent")
+        return worked(b.agent_id).localeCompare(worked(a.agent_id));
+      return (
+        (b.rating ?? -1) - (a.rating ?? -1) ||
+        honorScore(b.agent_id) - honorScore(a.agent_id) ||
+        rev(b.agent_id) - rev(a.agent_id)
+      );
+    });
+  }, [agents, stats, honors, search, sort]);
+
+  if (isLoading || loadsLoading)
     return (
-      <div className="p-6 bg-iron text-light font-body">
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
         <p className="text-muted-text">Loading agents...</p>
       </div>
     );
 
   if (error)
     return (
-      <div className="p-6 bg-iron text-light font-body">
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
         <p className="text-destructive">{error}</p>
       </div>
     );
 
+  const top = kpis.topEarner
+    ? (agents ?? []).find((a) => a.agent_id === kpis.topEarner!.agentId)
+    : null;
+
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
-      <h1 className="text-3xl font-condensed text-light mb-6">Agents</h1>
-
-      <div className="flex flex-col gap-2">
-        {sortedAgents.map((agent) => (
-          <Link
-            key={agent.agent_id}
-            to={`/agents/${agent.agent_id}`}
-            className="flex items-center gap-4 bg-plate hover:bg-steel border border-iron rounded-lg p-3 transition-colors"
-          >
-            {/* Monogram */}
-            <div className="flex rounded-full items-center bg-steel justify-center size-12 text-lg font-display text-light shrink-0">
-              {agent.first_name.charAt(0)}
-              {agent.last_name.charAt(0)}
-            </div>
-
-            {/* Name + broker */}
-            <div className="flex-1 min-w-0">
-              <p className="font-medium text-light">
-                {agent.first_name + " " + agent.last_name}
-              </p>
-              <p className="text-sm text-muted-text">
-                {agent.broker_name} · Landstar Agent
-              </p>
-            </div>
-
-            {/* Rating pinned right */}
-            <div className="shrink-0">
-              <RatingDisplay rating={agent.rating} />
-            </div>
-          </Link>
-        ))}
+      <div className="flex justify-between items-baseline mb-6">
+        <h1 className="text-3xl font-condensed text-light">Agents</h1>
+        <Link
+          to="/guide"
+          className="text-xs text-muted-text hover:text-amber-light"
+        >
+          How this works →
+        </Link>
       </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Kpi
+          label="Roster"
+          value={String(kpis.total)}
+          sub={`${kpis.rated} rated`}
+        />
+        <Kpi
+          label="Go-to bench"
+          value={String(kpis.callFirst)}
+          valueClass="text-amber"
+          sub={`call first · ${kpis.avoid} to avoid`}
+        />
+        {top ? (
+          <Link to={`/agents/${top.agent_id}`}>
+            <Kpi
+              label="Top earner"
+              value={`${top.first_name.charAt(0)}. ${top.last_name}`}
+              sub={`${money0(kpis.topEarner!.revenue)} · 90 days`}
+            />
+          </Link>
+        ) : (
+          <Kpi label="Top earner" value="—" sub="no delivered loads · 90 days" />
+        )}
+        <Kpi
+          label="Active agents"
+          value={String(kpis.activeCount)}
+          sub="worked · last 90 days"
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 mt-4 mb-4">
+        <input
+          className="bg-plate rounded px-3 py-2 text-sm flex-1 min-w-[180px] text-light placeholder:text-muted-text"
+          placeholder="Search name or broker"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <div className="flex gap-1 bg-plate rounded-lg p-1">
+          {SORTS.map(([key, label]) => (
+            <button
+              key={key}
+              onClick={() => setSort(key)}
+              className={`px-2.5 py-1 rounded text-sm ${
+                sort === key
+                  ? "bg-amber text-steel font-semibold"
+                  : "text-muted-text"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {shown.length === 0 ? (
+        <p className="text-muted-text text-sm">
+          {(agents ?? []).length === 0
+            ? "No agents yet."
+            : "No agents match your search."}
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {shown.map((agent) => (
+            <AgentCard
+              key={agent.agent_id}
+              agent={agent}
+              stats={stats.get(agent.agent_id)}
+              honors={honors.get(agent.agent_id)}
+            />
+          ))}
+        </div>
+      )}
+
+      <p className="text-xs text-muted-text mt-6">
+        {shown.length} agent{plural(shown.length)}
+      </p>
     </div>
   );
 };

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1,0 +1,126 @@
+import { Trophy } from "lucide-react";
+import { RatingMedallion } from "@/components/agents/RatingMedallion";
+import { PrestigeBurst, PRESTIGE_META } from "@/components/agents/PrestigeBadge";
+import type { PrestigeTier } from "@/lib/metrics/agentLeaderboard";
+
+const RATINGS: [number, string][] = [
+  [5, "Your go-to. Call these agents before anyone else."],
+  [4, "Solid and reliable — happy to run their freight."],
+  [3, "Neutral baseline. No strong feelings either way."],
+  [2, "Steer clear unless the load is worth it."],
+  [1, "Don't run their freight."],
+];
+
+const TIERS: [PrestigeTier, string][] = [
+  ["contender", "Made a quarterly top 5 (2+ loads that quarter)."],
+  ["all-star", "Won a gold or silver trophy."],
+  ["champion", "Took gold in 3 or more quarters."],
+  ["legend", "Took gold in 8 or more quarters."],
+];
+
+const Section = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <section className="bg-plate rounded-lg p-5 mb-4">
+    <h2 className="font-condensed text-xl mb-3">{title}</h2>
+    {children}
+  </section>
+);
+
+const GuidePage = () => (
+  <div className="p-6 bg-iron text-light font-body min-h-screen">
+    <div className="max-w-3xl">
+      <h1 className="text-3xl font-condensed mb-1">Guide</h1>
+      <p className="text-muted-text text-sm mb-6">
+        How agents get rated, ranked, and awarded.
+      </p>
+
+      <Section title="Agent ratings">
+        <p className="text-sm text-muted-text mb-4">
+          You set these by hand — your call on who to work with. They show as a
+          medallion on every agent, highest first.
+        </p>
+        <div className="flex flex-col gap-3">
+          {RATINGS.map(([r, desc]) => (
+            <div key={r} className="flex items-center gap-4">
+              <div className="w-32 shrink-0">
+                <RatingMedallion rating={r} />
+              </div>
+              <p className="text-sm text-muted-text">{desc}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="The quarterly leaderboard">
+        <p className="text-sm text-muted-text">
+          Ratings are your opinion; this is the scoreboard. Every calendar
+          quarter, your agents are ranked by the revenue on the loads they
+          actually delivered. Two things fall out of it — trophies, and a career
+          rank — and both stick with the agent for good.
+        </p>
+      </Section>
+
+      <Section title="Trophies">
+        <p className="text-sm text-muted-text mb-4">
+          Awarded each quarter to the agents who ran at least 3 loads.
+        </p>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-4">
+            <span
+              className="w-24 shrink-0 flex items-center gap-1.5 font-medium"
+              style={{ color: "#f5b03a" }}
+            >
+              <Trophy size={18} /> Gold
+            </span>
+            <p className="text-sm text-muted-text">
+              Finished #1 in delivered revenue that quarter.
+            </p>
+          </div>
+          <div className="flex items-center gap-4">
+            <span
+              className="w-24 shrink-0 flex items-center gap-1.5 font-medium"
+              style={{ color: "#c3cad6" }}
+            >
+              <Trophy size={18} /> Silver
+            </span>
+            <p className="text-sm text-muted-text">Finished #2 that quarter.</p>
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Career rank">
+        <p className="text-sm text-muted-text mb-4">
+          Boards and trophies roll up into a single rank — the starburst in the
+          corner of the agent's card. It never clutters and only ever levels up.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {TIERS.map(([tier, desc]) => (
+            <div key={tier} className="flex items-center gap-3">
+              <PrestigeBurst tier={tier} size={54} />
+              <div>
+                <p
+                  className="font-condensed text-lg"
+                  style={{ color: PRESTIGE_META[tier].fill }}
+                >
+                  {PRESTIGE_META[tier].label}
+                </p>
+                <p className="text-sm text-muted-text">{desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="text-xs text-muted-text mt-4">
+          The full record — every board, gold, and silver by quarter — lives on
+          each agent's own page.
+        </p>
+      </Section>
+    </div>
+  </div>
+);
+
+export default GuidePage;


### PR DESCRIPTION
## What

Reworks the agents pages into the app's coherent design, with a comic-book layer over the existing 1–5 rating system. Frontend-only — **no backend, no migration**.

### Agents list
- A roster of character cards: monogram emblem, a tier **medallion** replacing the five stars (`Call first` → `Blacklist`), per-agent stats, and a prestige starburst.
- Four KPIs (roster, go-to bench, top earner *linking through*, active agents), search, and sort. Rating ties break by career achievement so the Champion leads.
- Subtle "How this works →" link into the guide.

### Leaderboard & awards (derived from loads history, by calendar quarter)
- **Board** (starburst) = quarterly top 5 by delivered revenue, 2+ loads.
- **Gold / silver trophies** = #1 / #2 among agents who ran 3+ loads that quarter.
- These roll up into a single **career rank** — Contender → All-Star → Champion → Legend — shown as the badge on the card. It replaces the raw tallies, so cards stay a fixed size no matter how many seasons stack up.

### Agent detail
- Coherent hub: the **ink-stamp** rating, a **trophy case** (rank, gold/silver/board counts, and a quarter-by-quarter record), the loads table (load # links through; columns aligned), and the restyled activity timeline + contact.

### Guide
- New `/guide` page (sidebar link) explaining ratings, the quarterly leaderboard, trophies, and prestige — built from the real components so it can't drift.

## Verification
- Strict build clean; **110/110 tests** (new `agentLeaderboard` suite covers quarterly board/gold/silver, prestige tiers, and the per-agent season log).
- Leaderboard logic cross-checked against dev data with SQL mirroring the frontend.

## Deploy
No migration, no backend change. Just a frontend deploy.