### PR TITLE
fix: leaderboard awards only count completed quarters

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.37.0",
+  "version": "1.37.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/agentLeaderboard.test.ts
+++ b/frontend/src/lib/metrics/agentLeaderboard.test.ts
@@ -54,7 +54,8 @@ describe("computeHonors", () => {
     mk("B", "2026-05-01", 8000),
     mk("B", "2026-05-02", 7000),
   ];
-  const h = computeHonors(loads);
+  // Well after Q2 2026, so both quarters are completed and count.
+  const h = computeHonors(loads, new Date("2026-10-01T00:00:00.000Z"));
 
   it("board: 2+ loads, top 5 — counts A,B,C in Q1 and A,B in Q2", () => {
     expect(h.get("A")?.board).toBe(2);
@@ -76,6 +77,27 @@ describe("computeHonors", () => {
   it("C is on the board but never on the podium (only 2 loads)", () => {
     expect(h.get("C")?.gold).toBe(0);
     expect(h.get("C")?.silver).toBe(0);
+  });
+});
+
+describe("computeHonors — only completed quarters count", () => {
+  it("ignores the in-progress current quarter", () => {
+    const now = new Date("2026-05-15T00:00:00.000Z"); // 2026-Q2 still in progress
+    const loads = [
+      // Q1 (completed): A wins gold, B makes the board
+      mk("A", "2026-02-01", 10000),
+      mk("A", "2026-02-02", 10000),
+      mk("A", "2026-02-03", 10000),
+      mk("B", "2026-02-04", 5000),
+      mk("B", "2026-02-05", 5000),
+      // Q2 (current, in progress): A leads big — must NOT count yet
+      mk("A", "2026-05-01", 99999),
+      mk("A", "2026-05-02", 99999),
+      mk("A", "2026-05-03", 99999),
+    ];
+    const h = computeHonors(loads, now);
+    expect(h.get("A")).toEqual({ board: 1, gold: 1, silver: 0 }); // Q1 only
+    expect(h.get("B")?.board).toBe(1);
   });
 });
 
@@ -105,17 +127,19 @@ describe("agentSeasonLog", () => {
     mk("A", "2026-05-02", 6000),
   ];
 
+  const now = new Date("2026-10-01T00:00:00.000Z"); // both quarters completed
+
   it("returns an agent's quarter-by-quarter finish, oldest first", () => {
-    expect(agentSeasonLog(loads, "A").map((e) => [e.quarter, e.result])).toEqual(
-      [
-        ["2026-Q1", "gold"],
-        ["2026-Q2", "board"],
-      ],
-    );
+    expect(
+      agentSeasonLog(loads, "A", now).map((e) => [e.quarter, e.result]),
+    ).toEqual([
+      ["2026-Q1", "gold"],
+      ["2026-Q2", "board"],
+    ]);
   });
 
   it("marks a board finish that never reached the podium", () => {
-    expect(agentSeasonLog(loads, "C")).toEqual([
+    expect(agentSeasonLog(loads, "C", now)).toEqual([
       { quarter: "2026-Q1", result: "board", revenue: 25000, loads: 2 },
     ]);
   });

--- a/frontend/src/lib/metrics/agentLeaderboard.ts
+++ b/frontend/src/lib/metrics/agentLeaderboard.ts
@@ -48,15 +48,22 @@ const rankByRevenue = (entries: [string, QAgg][]): [string, QAgg][] =>
     (a, b) => b[1].revenue - a[1].revenue || a[0].localeCompare(b[0]),
   );
 
-export const computeHonors = (loads: Load[]): Map<string, AgentHonors> => {
+export const computeHonors = (
+  loads: Load[],
+  now: Date,
+): Map<string, AgentHonors> => {
   const honors = new Map<string, AgentHonors>();
+  const currentQ = quarterKey(now.toISOString());
   const bump = (agentId: string, key: keyof AgentHonors) => {
     const h = honors.get(agentId) ?? { board: 0, gold: 0, silver: 0 };
     h[key] += 1;
     honors.set(agentId, h);
   };
 
-  for (const [, agents] of byQuarterAgent(loads)) {
+  for (const [quarter, agents] of byQuarterAgent(loads)) {
+    // A quarter is only official once it has ended — the in-progress quarter
+    // (and any future-dated data) doesn't count toward awards.
+    if (quarter >= currentQ) continue;
     const entries = [...agents.entries()];
     // Board: 2+ loads, top 5 by revenue.
     const board = rankByRevenue(entries.filter(([, a]) => a.loads >= 2)).slice(
@@ -101,9 +108,12 @@ export interface SeasonEntry {
 export const agentSeasonLog = (
   loads: Load[],
   agentId: string,
+  now: Date,
 ): SeasonEntry[] => {
   const out: SeasonEntry[] = [];
+  const currentQ = quarterKey(now.toISOString());
   for (const [quarter, agents] of byQuarterAgent(loads)) {
+    if (quarter >= currentQ) continue; // completed quarters only
     const mine = agents.get(agentId);
     if (!mine) continue;
     const entries = [...agents.entries()];

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -58,11 +58,14 @@ const AgentDetailPage = () => {
 
   const agentId = agent?.agent_id;
   const honors = useMemo(
-    () => (agentId ? computeHonors(allLoads ?? []).get(agentId) : undefined),
+    () =>
+      agentId
+        ? computeHonors(allLoads ?? [], new Date()).get(agentId)
+        : undefined,
     [allLoads, agentId],
   );
   const season = useMemo(
-    () => (agentId ? agentSeasonLog(allLoads ?? [], agentId) : []),
+    () => (agentId ? agentSeasonLog(allLoads ?? [], agentId, new Date()) : []),
     [allLoads, agentId],
   );
 

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -33,7 +33,7 @@ const AgentsPage = () => {
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<SortKey>("rating");
 
-  const honors = useMemo(() => computeHonors(loads ?? []), [loads]);
+  const honors = useMemo(() => computeHonors(loads ?? [], new Date()), [loads]);
   const stats = useMemo(() => perAgentStats(loads ?? []), [loads]);
   const kpis = useMemo(
     () => rosterKpis(agents ?? [], loads ?? [], new Date()),


### PR DESCRIPTION
## Bug

Agent board/trophy/prestige standing was counting the **in-progress quarter**, so an agent leading the current quarter got credited an award before the quarter actually closed. Per the rule, a finish isn't official until the 90 days are up.

## Fix

`computeHonors` and `agentSeasonLog` now take a `now` and skip any quarter `>= quarterKey(now)` — the current quarter and any future-dated data. Only completed quarters award anything.

## Verification

- Cross-checked against the dev seed with completed-quarters-only SQL: Mike drops from `9 board / 7 gold` to `8 board / 6 gold` (shed the provisional Q3), still Champion; everyone else lands on 8 completed boards.
- New unit test asserts the in-progress quarter is ignored. Build clean, 111/111 tests.

Frontend-only, no migration.