### PR TITLE
feat: live provisional current-quarter standing (agent card + detail)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.37.1",
+  "version": "1.38.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/agents/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard.tsx
@@ -1,9 +1,22 @@
 import { Link } from "react-router";
 import type { Agent } from "@/types/agent";
-import type { AgentHonors, AgentStat } from "@/lib/metrics/agentLeaderboard";
+import type {
+  AgentHonors,
+  AgentStat,
+  LiveStanding,
+} from "@/lib/metrics/agentLeaderboard";
 import { agentPrestige } from "@/lib/metrics/agentLeaderboard";
 import { RatingMedallion } from "./RatingMedallion";
 import { PrestigeBadge, PRESTIGE_META } from "./PrestigeBadge";
+
+// Short live blurb — only shown on the card when the agent is currently on the
+// board this quarter, so it stays a highlight rather than clutter.
+const liveBlurb = (live: LiveStanding): string | null => {
+  if (live.result === "gold") return "leading this quarter";
+  if (live.result === "silver") return "running 2nd this quarter";
+  if (live.result === "board") return `#${live.boardRank} this quarter`;
+  return null;
+};
 
 const money0 = (n: number) =>
   n.toLocaleString("en-US", {
@@ -26,13 +39,16 @@ export const AgentCard = ({
   agent,
   stats,
   honors,
+  live,
 }: {
   agent: Agent;
   stats?: AgentStat;
   honors?: AgentHonors;
+  live?: LiveStanding | null;
 }) => {
   const tier = agentPrestige(honors);
   const prestige = PRESTIGE_META[tier];
+  const blurb = live ? liveBlurb(live) : null;
 
   return (
     <Link
@@ -67,6 +83,14 @@ export const AgentCard = ({
           </span>
         )}
       </div>
+
+      {blurb && (
+        <div className="mt-2 flex items-center gap-1.5 text-[11px]">
+          <span className="w-1.5 h-1.5 rounded-full bg-amber animate-pulse" />
+          <span className="text-amber font-medium">LIVE</span>
+          <span className="text-muted-text">{blurb}</span>
+        </div>
+      )}
 
       <div className="mt-2.5 pt-2 border-t border-[#3b4660] text-xs text-muted-text">
         {stats?.loadCount ?? 0} loads · {money0(stats?.revenue ?? 0)} ·{" "}

--- a/frontend/src/components/agents/TrophyCase.tsx
+++ b/frontend/src/components/agents/TrophyCase.tsx
@@ -1,5 +1,9 @@
 import { Trophy, Star, Minus } from "lucide-react";
-import type { AgentHonors, SeasonEntry } from "@/lib/metrics/agentLeaderboard";
+import type {
+  AgentHonors,
+  SeasonEntry,
+  LiveStanding,
+} from "@/lib/metrics/agentLeaderboard";
 import { agentPrestige } from "@/lib/metrics/agentLeaderboard";
 import { PrestigeBurst, PRESTIGE_META } from "./PrestigeBadge";
 
@@ -7,6 +11,39 @@ const qLabel = (q: string) => {
   const [year, n] = q.split("-Q");
   return `Q${n} '${year.slice(2)}`;
 };
+
+// Provisional standing this quarter — visible but NOT part of the official
+// record until the quarter closes.
+const liveText = (s: LiveStanding) => {
+  if (s.result === "gold") return "leading — provisional gold";
+  if (s.result === "silver") return "running 2nd — provisional silver";
+  if (s.result === "board") return `currently #${s.boardRank} — on the board`;
+  if (s.boardRank == null) return `${s.loads} load${s.loads === 1 ? "" : "s"} — needs 2+ to make the board`;
+  return `currently #${s.boardRank} — outside the top 5`;
+};
+
+const Live = ({ standing }: { standing: LiveStanding }) => (
+  <div className="mt-4 flex items-center gap-3 rounded-lg border border-dashed border-amber/50 px-3 py-2">
+    <span className="flex items-center gap-1.5 text-[11px] font-semibold text-amber shrink-0">
+      <span className="w-2 h-2 rounded-full bg-amber animate-pulse" /> LIVE
+    </span>
+    {standing.result === "gold" || standing.result === "silver" ? (
+      <Trophy
+        size={16}
+        style={{
+          color: standing.result === "gold" ? "#f5b03a" : "#c3cad6",
+          opacity: 0.7,
+        }}
+      />
+    ) : standing.result === "board" ? (
+      <Star size={16} style={{ color: "#e8940a", opacity: 0.7 }} />
+    ) : null}
+    <p className="text-sm text-muted-text">
+      <span className="text-light">{qLabel(standing.quarter)} in progress</span>{" "}
+      · {liveText(standing)}
+    </p>
+  </div>
+);
 
 const resultIcon = (r: SeasonEntry["result"]) => {
   if (r === "gold") return <Trophy size={18} style={{ color: "#f5b03a" }} />;
@@ -18,9 +55,11 @@ const resultIcon = (r: SeasonEntry["result"]) => {
 export const TrophyCase = ({
   honors,
   log,
+  live,
 }: {
   honors?: AgentHonors;
   log: SeasonEntry[];
+  live?: LiveStanding | null;
 }) => {
   const tier = agentPrestige(honors);
   const meta = PRESTIGE_META[tier];
@@ -76,6 +115,8 @@ export const TrophyCase = ({
           </div>
         </>
       )}
+
+      {live && <Live standing={live} />}
     </div>
   );
 };

--- a/frontend/src/lib/metrics/agentLeaderboard.test.ts
+++ b/frontend/src/lib/metrics/agentLeaderboard.test.ts
@@ -6,6 +6,7 @@ import {
   rosterKpis,
   agentPrestige,
   agentSeasonLog,
+  currentQuarterStanding,
 } from "./agentLeaderboard";
 
 // Minimal delivered-load factory. Revenue = linehaul (fsc/accessorials 0).
@@ -142,6 +143,31 @@ describe("agentSeasonLog", () => {
     expect(agentSeasonLog(loads, "C", now)).toEqual([
       { quarter: "2026-Q1", result: "board", revenue: 25000, loads: 2 },
     ]);
+  });
+});
+
+describe("currentQuarterStanding", () => {
+  const now = new Date("2026-08-15T00:00:00.000Z"); // 2026-Q3 in progress
+  const loads = [
+    mk("A", "2026-07-01", 10000),
+    mk("A", "2026-07-02", 10000),
+    mk("A", "2026-07-03", 10000), // 3 loads → provisional gold
+    mk("B", "2026-07-04", 5000),
+    mk("B", "2026-07-05", 5000), // 2 loads → board #2
+  ];
+
+  it("reports provisional gold for the current quarter leader", () => {
+    expect(currentQuarterStanding(loads, "A", now)?.result).toBe("gold");
+  });
+
+  it("reports a board position for a 2-load agent", () => {
+    const b = currentQuarterStanding(loads, "B", now);
+    expect(b?.result).toBe("board");
+    expect(b?.boardRank).toBe(2);
+  });
+
+  it("returns null for an agent with no loads this quarter", () => {
+    expect(currentQuarterStanding(loads, "Z", now)).toBeNull();
   });
 });
 

--- a/frontend/src/lib/metrics/agentLeaderboard.ts
+++ b/frontend/src/lib/metrics/agentLeaderboard.ts
@@ -131,6 +131,55 @@ export const agentSeasonLog = (
   return out;
 };
 
+// The agent's provisional standing in the CURRENT (in-progress) quarter — shown
+// as a live, not-yet-official figure. null when they've run nothing this
+// quarter. `boardRank` is their position in the 2+-load board race.
+export interface LiveStanding {
+  quarter: string;
+  result: "gold" | "silver" | "board" | "ran";
+  boardRank: number | null;
+  loads: number;
+  revenue: number;
+}
+
+// Every agent's provisional standing this quarter, in one pass (for the roster).
+export const currentQuarterStandings = (
+  loads: Load[],
+  now: Date,
+): Map<string, LiveStanding> => {
+  const currentQ = quarterKey(now.toISOString());
+  const out = new Map<string, LiveStanding>();
+  const agents = byQuarterAgent(loads).get(currentQ);
+  if (!agents) return out;
+
+  const entries = [...agents.entries()];
+  const boardRanked = rankByRevenue(entries.filter(([, a]) => a.loads >= 2));
+  const podium = rankByRevenue(entries.filter(([, a]) => a.loads >= 3));
+
+  for (const [agentId, agg] of entries) {
+    const idx = boardRanked.findIndex(([id]) => id === agentId);
+    let result: LiveStanding["result"] = "ran";
+    if (podium[0]?.[0] === agentId) result = "gold";
+    else if (podium[1]?.[0] === agentId) result = "silver";
+    else if (idx >= 0 && idx < 5) result = "board";
+    out.set(agentId, {
+      quarter: currentQ,
+      result,
+      boardRank: idx >= 0 ? idx + 1 : null,
+      loads: agg.loads,
+      revenue: agg.revenue,
+    });
+  }
+  return out;
+};
+
+export const currentQuarterStanding = (
+  loads: Load[],
+  agentId: string,
+  now: Date,
+): LiveStanding | null =>
+  currentQuarterStandings(loads, now).get(agentId) ?? null;
+
 // ---- per-agent card stats ----
 
 export interface AgentStat {

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -18,6 +18,7 @@ import {
   agentPrestige,
   computeHonors,
   agentSeasonLog,
+  currentQuarterStanding,
 } from "@/lib/metrics/agentLeaderboard";
 import {
   getLoadCount,
@@ -66,6 +67,11 @@ const AgentDetailPage = () => {
   );
   const season = useMemo(
     () => (agentId ? agentSeasonLog(allLoads ?? [], agentId, new Date()) : []),
+    [allLoads, agentId],
+  );
+  const live = useMemo(
+    () =>
+      agentId ? currentQuarterStanding(allLoads ?? [], agentId, new Date()) : null,
     [allLoads, agentId],
   );
 
@@ -194,7 +200,7 @@ const AgentDetailPage = () => {
       </div>
 
       <div className="mt-4">
-        <TrophyCase honors={honors} log={season} />
+        <TrophyCase honors={honors} log={season} live={live} />
       </div>
 
       <div className="bg-plate rounded-lg p-4 mt-4">

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -8,6 +8,7 @@ import {
   computeHonors,
   perAgentStats,
   rosterKpis,
+  currentQuarterStandings,
 } from "@/lib/metrics/agentLeaderboard";
 
 const money0 = (n: number) =>
@@ -35,6 +36,10 @@ const AgentsPage = () => {
 
   const honors = useMemo(() => computeHonors(loads ?? [], new Date()), [loads]);
   const stats = useMemo(() => perAgentStats(loads ?? []), [loads]);
+  const standings = useMemo(
+    () => currentQuarterStandings(loads ?? [], new Date()),
+    [loads],
+  );
   const kpis = useMemo(
     () => rosterKpis(agents ?? [], loads ?? [], new Date()),
     [agents, loads],
@@ -167,6 +172,7 @@ const AgentsPage = () => {
               agent={agent}
               stats={stats.get(agent.agent_id)}
               honors={honors.get(agent.agent_id)}
+              live={standings.get(agent.agent_id)}
             />
           ))}
         </div>


### PR DESCRIPTION
## What

The in-progress quarter no longer counts toward official awards (v1.37.1), so this surfaces it as a **provisional, live** standing instead — visible but clearly not part of the permanent record.

- **Detail trophy case:** a dashed, pulsing `LIVE` callout — e.g. *"Q3 '26 in progress · leading — provisional gold"* / *"currently #2 — on the board"*.
- **Agent card:** a compact `● LIVE` pill, shown only when the agent is currently on the board this quarter (so it highlights who's hot without re-cluttering the card — using the room the trophy tally used to take).

All derived from loads; no backend, no migration.

## Verification
- New `currentQuarterStandings` computes every agent's provisional finish in one pass; `currentQuarterStanding` is the single-agent view.
- Build clean, 114/114 tests (added current-quarter standing coverage).