### PR TITLE
feat: comic touches on the dashboard — agent prestige on top-5, target burst

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.38.0",
+  "version": "1.39.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -39,6 +39,40 @@ const PaceBar = ({
   );
 };
 
+const BURST =
+  "57,30 47.39,34.66 53.38,43.5 42.73,42.73 43.5,53.38 34.66,47.39 30,57 " +
+  "25.34,47.39 16.5,53.38 17.27,42.73 6.62,43.5 12.61,34.66 3,30 12.61,25.34 " +
+  "6.62,16.5 17.27,17.27 16.5,6.62 25.34,12.61 30,3 34.66,12.61 43.5,6.62 " +
+  "42.73,17.27 53.38,16.5 47.39,25.34";
+
+// Pops when this week's booked gross clears the weekly target — a genuine win.
+const TargetBurst = () => (
+  <span
+    style={{ position: "relative", width: 52, height: 52, flexShrink: 0 }}
+    aria-hidden="true"
+  >
+    <svg
+      viewBox="0 0 60 60"
+      width={52}
+      height={52}
+      style={{ transform: "rotate(-8deg)" }}
+    >
+      <polygon points={BURST} fill={GREEN} stroke="#0d1117" strokeWidth={1.5} />
+      <text
+        x={30}
+        y={34}
+        textAnchor="middle"
+        className="font-condensed"
+        fontWeight={600}
+        fontSize={11}
+        fill="#04241a"
+      >
+        TARGET!
+      </text>
+    </svg>
+  </span>
+);
+
 export const RateTargetsCard = ({
   targets,
   rpm,
@@ -48,6 +82,10 @@ export const RateTargetsCard = ({
 }) => {
   const { ladder, gross, weekBooked, basis, ready } = targets;
   const markerRpm = rpm !== undefined ? rpm : basis.windowRpm;
+  const beatTarget =
+    gross.weeklyTarget != null &&
+    gross.weeklyTarget > 0 &&
+    weekBooked >= gross.weeklyTarget;
 
   return (
     <div className="bg-plate rounded-lg p-4">
@@ -76,7 +114,10 @@ export const RateTargetsCard = ({
 
           <div>
             <p className="text-xs text-muted-text">This week · booked</p>
-            <p className="text-xl font-condensed mt-1">{money(weekBooked)}</p>
+            <div className="flex items-center gap-2">
+              <p className="text-xl font-condensed mt-1">{money(weekBooked)}</p>
+              {beatTarget && <TargetBurst />}
+            </div>
             <PaceBar
               booked={weekBooked}
               floor={gross.weeklyBreakEven ?? 0}
@@ -86,6 +127,11 @@ export const RateTargetsCard = ({
               floor {money(gross.weeklyBreakEven)} · target{" "}
               {money(gross.weeklyTarget)}
             </p>
+            {beatTarget && (
+              <p className="text-xs mt-1" style={{ color: GREEN }}>
+                Beat target by {money(weekBooked - (gross.weeklyTarget ?? 0))}
+              </p>
+            )}
           </div>
 
           <div>

--- a/frontend/src/components/dashboard/TopAgents.tsx
+++ b/frontend/src/components/dashboard/TopAgents.tsx
@@ -1,13 +1,18 @@
 import { Link } from "react-router-dom";
 import type { AgentRevenue } from "@/lib/metrics/dashboard";
+import type { AgentHonors, LiveStanding } from "@/lib/metrics/agentLeaderboard";
+import { agentPrestige } from "@/lib/metrics/agentLeaderboard";
+import { PrestigeBurst } from "@/components/agents/PrestigeBadge";
 
 interface Props {
   agents: AgentRevenue[];
+  honors: Map<string, AgentHonors>;
+  standings: Map<string, LiveStanding>;
 }
 
 const fmtK = (n: number): string => `$${(n / 1000).toFixed(1)}k`;
 
-export const TopAgents = ({ agents }: Props) => {
+export const TopAgents = ({ agents, honors, standings }: Props) => {
   if (agents.length === 0)
     return (
       <p className="text-muted-text text-sm">
@@ -15,34 +20,56 @@ export const TopAgents = ({ agents }: Props) => {
       </p>
     );
 
-  const max = agents[0].revenue || 1;
-
   return (
     <div>
-      {agents.map((agent, i) => (
-        <Link
-          key={agent.agentId}
-          to={`/agents/${agent.agentId}`}
-          className="flex items-center gap-2 py-1.5 hover:opacity-80"
-        >
-          <span className="w-4 text-right text-xs text-muted-text">{i + 1}</span>
-          <span className="w-24 text-sm text-light truncate">{agent.agent}</span>
-          <span className="flex-1 h-1.5 bg-steel rounded-full">
+      {agents.map((agent, i) => {
+        const tier = agentPrestige(honors.get(agent.agentId));
+        const live = standings.get(agent.agentId);
+        const onBoard =
+          live &&
+          (live.result === "gold" ||
+            live.result === "silver" ||
+            live.result === "board");
+        return (
+          <Link
+            key={agent.agentId}
+            to={`/agents/${agent.agentId}`}
+            className="flex items-center gap-2.5 py-1.5 border-t border-[#232c3f] first:border-t-0 hover:opacity-80"
+          >
             <span
-              className="block h-1.5 bg-amber rounded-full"
-              style={{ width: `${(agent.revenue / max) * 100}%` }}
-            />
-          </span>
-          <span className="w-16 text-right">
-            <span className="block text-sm font-semibold text-light">
-              {fmtK(agent.revenue)}
+              className={`w-3.5 text-right font-condensed ${
+                i === 0 ? "text-amber" : "text-muted-text"
+              }`}
+            >
+              {i + 1}
             </span>
-            <span className="block text-[11px] text-muted-text">
-              {agent.loadCount} loads
+            <span className="w-[26px] shrink-0 flex justify-center">
+              <PrestigeBurst tier={tier} size={26} />
             </span>
-          </span>
-        </Link>
-      ))}
+            <span
+              className={`flex-1 text-sm truncate ${
+                i === 0 ? "text-amber-light" : "text-light"
+              }`}
+            >
+              {agent.agent}
+            </span>
+            {onBoard && (
+              <span
+                className="w-1.5 h-1.5 rounded-full bg-amber animate-pulse shrink-0"
+                title="on the board this quarter"
+              />
+            )}
+            <span className="text-right shrink-0">
+              <span className="block text-sm font-condensed">
+                {fmtK(agent.revenue)}
+              </span>
+              <span className="block text-[10px] text-muted-text">
+                {agent.loadCount} loads
+              </span>
+            </span>
+          </Link>
+        );
+      })}
     </div>
   );
 };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -16,6 +16,10 @@ import {
   getUpcomingLoads,
   getRecentDeliveredLoads,
 } from "@/lib/metrics/dashboard";
+import {
+  computeHonors,
+  currentQuarterStandings,
+} from "@/lib/metrics/agentLeaderboard";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { useMaintenanceAlerts } from "@/hooks/useMaintenanceAlerts";
 import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
@@ -94,6 +98,9 @@ const DashboardPage = () => {
   const monthlyRpm = getMonthlyRPM(loads);
   const outstanding = getOutstandingLoads(loads);
   const topAgents = getTopAgentsByRevenue(loads);
+  const now = new Date();
+  const agentHonors = computeHonors(loads, now);
+  const agentStandings = currentQuarterStandings(loads, now);
   const upcoming = getUpcomingLoads(loads);
   const recentLoads = getRecentDeliveredLoads(loads);
 
@@ -161,7 +168,11 @@ const DashboardPage = () => {
           <p className="text-xs text-muted-text mb-2">
             Top 5 agents · last 90 days
           </p>
-          <TopAgents agents={topAgents} />
+          <TopAgents
+            agents={topAgents}
+            honors={agentHonors}
+            standings={agentStandings}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## What

Two comic touches on the dashboard, both fed by data already there — no backend, no migration.

- **Top 5 agents** — each earner now wears their **prestige burst** (career rank: Champion gold crown, All-Star silver, Contender bronze) and a pulsing **LIVE dot** when they're currently on the board this quarter. Names still link to the agent detail page; `#1` gets the amber rank. Ties the agent comic system into the dashboard's most-viewed widget.
- **This week · booked** — when booked gross clears the weekly **target**, a green **`TARGET!`** starburst pops next to the number with a "Beat target by $X" line. Fires only on a genuine win.

## Verification
- Reuses `computeHonors` / `currentQuarterStandings` (already tested) + existing rate-target metrics; no new logic.
- Build clean, 114/114 tests.