### PR TITLE
feat: fleet mile clubs — comic mileage milestones

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.39.0",
+  "version": "1.40.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/fleet/MileClub.tsx
+++ b/frontend/src/components/fleet/MileClub.tsx
@@ -1,0 +1,61 @@
+import { mileMilestone, fmtMiles } from "@/lib/metrics/mileClub";
+import { MilestoneBurst, MILE_TIER_COLOR } from "./MilestoneBurst";
+
+// The character-sheet banner: current mileage, earned club, and progress to the
+// next one. `unit` is "mi" for a truck/driver, "hub" for a trailer.
+export const MileClub = ({
+  miles,
+  unit = "mi",
+}: {
+  miles: number;
+  unit?: string;
+}) => {
+  const m = mileMilestone(miles);
+  const toNext = `${Math.round(m.toNext / 1000)}K to the ${fmtMiles(m.next)} club`;
+  const track = "#232c3f";
+
+  if (m.crossed == null) {
+    return (
+      <div className="mt-4">
+        <div className="flex justify-between items-baseline text-xs text-muted-text mb-1">
+          <span className="font-condensed text-lg text-light">
+            {miles.toLocaleString("en-US")} {unit}
+          </span>
+          <span>{toNext}</span>
+        </div>
+        <div className="h-2 rounded" style={{ background: track }}>
+          <div
+            className="h-2 rounded"
+            style={{ width: `${m.pct * 100}%`, background: MILE_TIER_COLOR.bronze }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const color = MILE_TIER_COLOR[m.tier!];
+  return (
+    <div className="flex items-center gap-3 mt-4">
+      <div className="shrink-0">
+        <MilestoneBurst tier={m.tier!} label={m.label!} size={52} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="font-condensed text-lg" style={{ color }}>
+          {m.title}
+        </p>
+        <div className="flex justify-between items-baseline text-xs text-muted-text mb-1">
+          <span>
+            {miles.toLocaleString("en-US")} {unit}
+          </span>
+          <span>{toNext}</span>
+        </div>
+        <div className="h-2 rounded" style={{ background: track }}>
+          <div
+            className="h-2 rounded"
+            style={{ width: `${m.pct * 100}%`, background: color }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/fleet/MilestoneBurst.tsx
+++ b/frontend/src/components/fleet/MilestoneBurst.tsx
@@ -1,0 +1,51 @@
+import type { MileTier } from "@/lib/metrics/mileClub";
+
+export const MILE_TIER_COLOR: Record<MileTier, string> = {
+  bronze: "#c77b3e",
+  silver: "#c3cad6",
+  gold: "#f5b03a",
+  platinum: "#dbe3f0",
+};
+const INK: Record<MileTier, string> = {
+  bronze: "#2a1a0a",
+  silver: "#1a2030",
+  gold: "#3a2400",
+  platinum: "#1a2030",
+};
+
+const POINTS =
+  "57,30 47.39,34.66 53.38,43.5 42.73,42.73 43.5,53.38 34.66,47.39 30,57 " +
+  "25.34,47.39 16.5,53.38 17.27,42.73 6.62,43.5 12.61,34.66 3,30 12.61,25.34 " +
+  "6.62,16.5 17.27,17.27 16.5,6.62 25.34,12.61 30,3 34.66,12.61 43.5,6.62 " +
+  "42.73,17.27 53.38,16.5 47.39,25.34";
+
+// A comic starburst stamped with the mile marker (e.g. "500K").
+export const MilestoneBurst = ({
+  tier,
+  label,
+  size = 58,
+}: {
+  tier: MileTier;
+  label: string;
+  size?: number;
+}) => (
+  <svg viewBox="0 0 60 60" width={size} height={size} className="block">
+    <polygon
+      points={POINTS}
+      fill={MILE_TIER_COLOR[tier]}
+      stroke="#0d1117"
+      strokeWidth={1.5}
+    />
+    <text
+      x={30}
+      y={34}
+      textAnchor="middle"
+      className="font-condensed"
+      fontWeight={600}
+      fontSize={label.length >= 4 ? 12 : 15}
+      fill={INK[tier]}
+    >
+      {label}
+    </text>
+  </svg>
+);

--- a/frontend/src/lib/metrics/mileClub.test.ts
+++ b/frontend/src/lib/metrics/mileClub.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { mileMilestone, fmtMiles } from "./mileClub";
+
+describe("fmtMiles", () => {
+  it("formats K and M markers", () => {
+    expect(fmtMiles(100000)).toBe("100K");
+    expect(fmtMiles(500000)).toBe("500K");
+    expect(fmtMiles(1000000)).toBe("1M");
+    expect(fmtMiles(1500000)).toBe("1.5M");
+  });
+});
+
+describe("mileMilestone", () => {
+  it("awards no club under 100K, but tracks progress to it", () => {
+    const m = mileMilestone(80000);
+    expect(m.crossed).toBeNull();
+    expect(m.tier).toBeNull();
+    expect(m.next).toBe(100000);
+    expect(m.pct).toBeCloseTo(0.8);
+  });
+
+  it("reads Workhorse (gold) at 568,737 with progress to the 1M club", () => {
+    const m = mileMilestone(568737);
+    expect(m.crossed).toBe(500000);
+    expect(m.tier).toBe("gold");
+    expect(m.title).toBe("Workhorse");
+    expect(m.label).toBe("500K");
+    expect(m.next).toBe(1000000);
+    expect(m.toNext).toBe(431263);
+    expect(m.pct).toBeCloseTo((568737 - 500000) / 500000);
+  });
+
+  it("reads Road Warrior (silver) closing on the 500K club", () => {
+    const m = mileMilestone(456123);
+    expect(m.tier).toBe("silver");
+    expect(m.label).toBe("250K");
+    expect(m.next).toBe(500000);
+  });
+
+  it("stays Million-Miler past 1M with a +500K next marker", () => {
+    const m = mileMilestone(1200000);
+    expect(m.tier).toBe("platinum");
+    expect(m.title).toBe("Million-Miler");
+    expect(m.label).toBe("1M");
+    expect(m.next).toBe(1500000);
+  });
+});

--- a/frontend/src/lib/metrics/mileClub.ts
+++ b/frontend/src/lib/metrics/mileClub.ts
@@ -1,0 +1,62 @@
+// Mileage "clubs" — a comic rank a truck/trailer/driver earns by odometer, the
+// fleet parallel to agent prestige. Named clubs run to 1M; beyond that we keep
+// minting +500K platinum markers.
+export type MileTier = "bronze" | "silver" | "gold" | "platinum";
+
+export const fmtMiles = (n: number): string => {
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000;
+    return `${Number.isInteger(m) ? m : m.toFixed(1)}M`;
+  }
+  return `${Math.round(n / 1000)}K`;
+};
+
+const markerAt = (i: number): number => {
+  const base = [100_000, 250_000, 500_000, 1_000_000];
+  return i < base.length ? base[i] : 1_000_000 + (i - 3) * 500_000;
+};
+const tierOf = (marker: number): MileTier =>
+  marker >= 1_000_000
+    ? "platinum"
+    : marker >= 500_000
+      ? "gold"
+      : marker >= 250_000
+        ? "silver"
+        : "bronze";
+const titleOf = (marker: number): string =>
+  marker >= 1_000_000
+    ? "Million-Miler"
+    : marker >= 500_000
+      ? "Workhorse"
+      : marker >= 250_000
+        ? "Road Warrior"
+        : "Seasoned";
+
+export interface Milestone {
+  crossed: number | null; // highest club marker reached; null under 100K
+  tier: MileTier | null;
+  title: string | null;
+  label: string | null; // "500K", "1M", "1.5M"
+  next: number; // next marker
+  toNext: number; // miles remaining to it
+  pct: number; // 0..1 progress from crossed → next
+}
+
+export const mileMilestone = (miles: number): Milestone => {
+  const m = Math.max(0, miles || 0);
+  let i = -1;
+  while (markerAt(i + 1) <= m) i++;
+  const crossed = i >= 0 ? markerAt(i) : null;
+  const next = markerAt(i + 1);
+  const prev = crossed ?? 0;
+  const pct = next > prev ? Math.max(0, Math.min(1, (m - prev) / (next - prev))) : 0;
+  return {
+    crossed,
+    tier: crossed != null ? tierOf(crossed) : null,
+    title: crossed != null ? titleOf(crossed) : null,
+    label: crossed != null ? fmtMiles(crossed) : null,
+    next,
+    toNext: Math.max(0, next - m),
+    pct,
+  };
+};

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -7,6 +7,7 @@ import { getDriver, patchDriver } from "@/services/driversService";
 import { useLoads } from "@/hooks/useLoads";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
+import { MileClub } from "@/components/fleet/MileClub";
 import { DRIVER_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
 
@@ -37,7 +38,9 @@ const DriverDetailPage = () => {
 
   useEffect(() => {
     if (!id) return;
-    getDriver(id).then(setDriver).catch(() => {});
+    getDriver(id)
+      .then(setDriver)
+      .catch(() => {});
   }, [id]);
 
   const driverLoads = useMemo(
@@ -55,8 +58,8 @@ const DriverDetailPage = () => {
       setEditing(false);
     } catch (e) {
       setError(
-        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
-          "Could not save",
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Could not save",
       );
     } finally {
       setBusy(false);
@@ -71,6 +74,11 @@ const DriverDetailPage = () => {
     );
 
   const revenue = driverLoads.reduce((s, l) => s + loadRev(l), 0);
+  const milesHauled = driverLoads.reduce(
+    (s, l) =>
+      l.load_status === "delivered" ? s + (Number(l.loaded_miles) || 0) : s,
+    0,
+  );
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -111,24 +119,37 @@ const DriverDetailPage = () => {
             <EntityForm
               title="Edit driver"
               fields={DRIVER_FIELDS}
-              initial={toFormValues(driver as unknown as Record<string, unknown>, DRIVER_FIELDS)}
+              initial={toFormValues(
+                driver as unknown as Record<string, unknown>,
+                DRIVER_FIELDS,
+              )}
               onSave={saveEdit}
               onCancel={() => setEditing(false)}
               busy={busy}
               error={error}
             />
           ) : (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <Spec label="Phone" value={driver.phone} />
-              <Spec label="Email" value={driver.email} />
-              <Spec
-                label="CDL"
-                value={driver.cdl_number ? `${driver.cdl_number} ${driver.cdl_state || ""}` : null}
-              />
-              <Spec label="CDL expires" value={formatDate(driver.cdl_expiration)} />
-              <Spec label="Endorsements" value={driver.endorsements} />
-              <Spec label="Hired" value={formatDate(driver.hire_date)} />
-            </div>
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <Spec label="Phone" value={driver.phone} />
+                <Spec label="Email" value={driver.email} />
+                <Spec
+                  label="CDL"
+                  value={
+                    driver.cdl_number
+                      ? `${driver.cdl_number} ${driver.cdl_state || ""}`
+                      : null
+                  }
+                />
+                <Spec
+                  label="CDL expires"
+                  value={formatDate(driver.cdl_expiration)}
+                />
+                <Spec label="Endorsements" value={driver.endorsements} />
+                <Spec label="Hired" value={formatDate(driver.hire_date)} />
+              </div>
+              <MileClub miles={milesHauled} />
+            </>
           )}
         </div>
       </div>
@@ -141,6 +162,12 @@ const DriverDetailPage = () => {
         <div className="bg-plate rounded-lg p-4">
           <p className="text-xs text-muted-text mb-1">Revenue · all time</p>
           <p className="text-2xl font-condensed">{money(revenue)}</p>
+        </div>
+        <div className="bg-plate rounded-lg p-4">
+          <p className="text-xs text-muted-text mb-1">Miles hauled</p>
+          <p className="text-2xl font-condensed">
+            {milesHauled.toLocaleString("en-US")}
+          </p>
         </div>
       </div>
 

--- a/frontend/src/pages/DriversPage.tsx
+++ b/frontend/src/pages/DriversPage.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { Plus } from "lucide-react";
 import type { Driver } from "@/types/driver";
 import { getDrivers, createDriver } from "@/services/driversService";
 import { AvatarFallback } from "@/components/fleet/AvatarFallback";
 import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
+import { MilestoneBurst } from "@/components/fleet/MilestoneBurst";
+import { mileMilestone } from "@/lib/metrics/mileClub";
+import { useLoads } from "@/hooks/useLoads";
 
 const FIELDS: FormField[] = [
   { name: "first_name", label: "First name", required: true },
@@ -24,6 +27,20 @@ const DriversPage = () => {
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { loads } = useLoads(0);
+
+  // Career miles hauled per driver, from their delivered loads.
+  const milesByDriver = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const l of loads) {
+      if (l.load_status !== "delivered" || !l.driver_id) continue;
+      map.set(
+        l.driver_id,
+        (map.get(l.driver_id) ?? 0) + (Number(l.loaded_miles) || 0),
+      );
+    }
+    return map;
+  }, [loads]);
 
   const load = () =>
     getDrivers()
@@ -44,8 +61,8 @@ const DriversPage = () => {
       await load();
     } catch (e) {
       const msg =
-        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
-        "Could not create the driver";
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Could not create the driver";
       setError(msg);
     } finally {
       setBusy(false);
@@ -80,31 +97,49 @@ const DriversPage = () => {
       {loading ? (
         <p className="text-muted-text">Loading…</p>
       ) : drivers.length === 0 ? (
-        <p className="text-muted-text">No drivers yet. Add one to get started.</p>
+        <p className="text-muted-text">
+          No drivers yet. Add one to get started.
+        </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {drivers.map((d) => (
-            <Link
-              key={d.driver_id}
-              to={`/drivers/${d.driver_id}`}
-              className="bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
-            >
-              <div className="w-16 h-16 rounded-full overflow-hidden bg-steel shrink-0">
-                {d.avatar_url ? (
-                  <img src={d.avatar_url} alt="" className="w-full h-full object-cover" />
-                ) : (
-                  <AvatarFallback kind="driver" />
+          {drivers.map((d) => {
+            const m = mileMilestone(milesByDriver.get(d.driver_id) ?? 0);
+            return (
+              <Link
+                key={d.driver_id}
+                to={`/drivers/${d.driver_id}`}
+                className="relative overflow-hidden bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
+              >
+                {m.crossed != null && (
+                  <div className="absolute -top-2 -right-2 rotate-[-8deg]">
+                    <MilestoneBurst tier={m.tier!} label={m.label!} size={44} />
+                  </div>
                 )}
-              </div>
-              <div className="min-w-0">
-                <p className="font-medium truncate">
-                  {d.first_name} {d.last_name}
-                </p>
-                <p className="text-xs text-muted-text truncate">{d.phone || d.email || "—"}</p>
-                <p className="text-xs text-muted-text">{d.active ? "active" : "inactive"}</p>
-              </div>
-            </Link>
-          ))}
+                <div className="w-16 h-16 rounded-full overflow-hidden bg-steel shrink-0">
+                  {d.avatar_url ? (
+                    <img
+                      src={d.avatar_url}
+                      alt=""
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <AvatarFallback kind="driver" />
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <p className="font-medium truncate">
+                    {d.first_name} {d.last_name}
+                  </p>
+                  <p className="text-xs text-muted-text truncate">
+                    {d.phone || d.email || "—"}
+                  </p>
+                  <p className="text-xs text-muted-text">
+                    {d.active ? "active" : "inactive"}
+                  </p>
+                </div>
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -9,9 +9,14 @@ import {
   getMaintenanceServices,
 } from "@/services/maintenanceService";
 import { useLoads } from "@/hooks/useLoads";
-import { computeDue, avgMilesPerMonth, maxOdometer } from "@/lib/metrics/maintenance";
+import {
+  computeDue,
+  avgMilesPerMonth,
+  maxOdometer,
+} from "@/lib/metrics/maintenance";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
+import { MileClub } from "@/components/fleet/MileClub";
 import { TRAILER_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
 
@@ -24,7 +29,9 @@ const Spec = ({
 }) => (
   <div>
     <p className="text-xs text-muted-text">{label}</p>
-    <p className="text-sm">{value === null || value === undefined || value === "" ? "—" : value}</p>
+    <p className="text-sm">
+      {value === null || value === undefined || value === "" ? "—" : value}
+    </p>
   </div>
 );
 
@@ -40,9 +47,15 @@ const TrailerDetailPage = () => {
 
   useEffect(() => {
     if (!id) return;
-    getTrailer(id).then(setTrailer).catch(() => {});
-    getMaintenanceItems().then(setItems).catch(() => {});
-    getMaintenanceServices().then(setServices).catch(() => {});
+    getTrailer(id)
+      .then(setTrailer)
+      .catch(() => {});
+    getMaintenanceItems()
+      .then(setItems)
+      .catch(() => {});
+    getMaintenanceServices()
+      .then(setServices)
+      .catch(() => {});
   }, [id]);
 
   // Latest hub reading, derived from the app: stored + newest trailer service.
@@ -76,8 +89,8 @@ const TrailerDetailPage = () => {
       setEditing(false);
     } catch (e) {
       setError(
-        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
-          "Could not save",
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Could not save",
       );
     } finally {
       setBusy(false);
@@ -108,10 +121,13 @@ const TrailerDetailPage = () => {
         <div className="flex-1">
           <div className="flex justify-between items-start">
             <div>
-              <h1 className="text-3xl font-condensed">Unit {trailer.unit_number}</h1>
+              <h1 className="text-3xl font-condensed">
+                Unit {trailer.unit_number}
+              </h1>
               <p className="text-muted-text text-sm mb-4 capitalize">
                 {trailer.trailer_type}
-                {trailer.length_ft ? ` · ${trailer.length_ft}'` : ""} · {trailer.status}
+                {trailer.length_ft ? ` · ${trailer.length_ft}'` : ""} ·{" "}
+                {trailer.status}
               </p>
             </div>
             {!editing && (
@@ -128,23 +144,44 @@ const TrailerDetailPage = () => {
             <EntityForm
               title="Edit trailer"
               fields={TRAILER_FIELDS}
-              initial={toFormValues(trailer as unknown as Record<string, unknown>, TRAILER_FIELDS)}
+              initial={toFormValues(
+                trailer as unknown as Record<string, unknown>,
+                TRAILER_FIELDS,
+              )}
               onSave={saveEdit}
               onCancel={() => setEditing(false)}
               busy={busy}
               error={error}
             />
           ) : (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <Spec label="Hubodometer · latest" value={`${hub.toLocaleString("en-US")} mi`} />
-              <Spec label="VIN" value={trailer.vin} />
-              <Spec
-                label="Plate"
-                value={trailer.plate_number ? `${trailer.plate_number} ${trailer.plate_state || ""}` : null}
-              />
-              <Spec label="Make" value={[trailer.year, trailer.make, trailer.model].filter(Boolean).join(" ")} />
-              <Spec label="In service" value={formatDate(trailer.in_service_date)} />
-            </div>
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <Spec
+                  label="Hubodometer · latest"
+                  value={`${hub.toLocaleString("en-US")} mi`}
+                />
+                <Spec label="VIN" value={trailer.vin} />
+                <Spec
+                  label="Plate"
+                  value={
+                    trailer.plate_number
+                      ? `${trailer.plate_number} ${trailer.plate_state || ""}`
+                      : null
+                  }
+                />
+                <Spec
+                  label="Make"
+                  value={[trailer.year, trailer.make, trailer.model]
+                    .filter(Boolean)
+                    .join(" ")}
+                />
+                <Spec
+                  label="In service"
+                  value={formatDate(trailer.in_service_date)}
+                />
+              </div>
+              <MileClub miles={hub} unit="hub" />
+            </>
           )}
         </div>
       </div>

--- a/frontend/src/pages/TrailersPage.tsx
+++ b/frontend/src/pages/TrailersPage.tsx
@@ -5,23 +5,47 @@ import type { Trailer } from "@/types/trailer";
 import { getTrailers, createTrailer } from "@/services/trailersService";
 import { AvatarFallback } from "@/components/fleet/AvatarFallback";
 import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
+import { MilestoneBurst } from "@/components/fleet/MilestoneBurst";
+import { mileMilestone } from "@/lib/metrics/mileClub";
 
 const FIELDS: FormField[] = [
-  { name: "unit_number", label: "Unit #", required: true, placeholder: "780991" },
+  {
+    name: "unit_number",
+    label: "Unit #",
+    required: true,
+    placeholder: "780991",
+  },
   {
     name: "trailer_type",
     label: "Type",
     type: "select",
-    options: ["flatbed", "step deck", "RGN", "lowboy", "double drop", "conestoga"],
+    options: [
+      "flatbed",
+      "step deck",
+      "RGN",
+      "lowboy",
+      "double drop",
+      "conestoga",
+    ],
   },
-  { name: "length_ft", label: "Length (ft)", type: "number", placeholder: "48" },
+  {
+    name: "length_ft",
+    label: "Length (ft)",
+    type: "number",
+    placeholder: "48",
+  },
   { name: "make", label: "Make", placeholder: "Utility" },
   { name: "model", label: "Model" },
   { name: "year", label: "Year", type: "number", placeholder: "2019" },
   { name: "vin", label: "VIN" },
   { name: "plate_number", label: "Plate", placeholder: "DTS780" },
   { name: "plate_state", label: "State", placeholder: "AL" },
-  { name: "current_hub", label: "Hubodometer", type: "number", placeholder: "456123" },
+  {
+    name: "current_hub",
+    label: "Hubodometer",
+    type: "number",
+    placeholder: "456123",
+  },
   {
     name: "status",
     label: "Status",
@@ -57,8 +81,8 @@ const TrailersPage = () => {
       await load();
     } catch (e) {
       const msg =
-        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
-        "Could not create the trailer";
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Could not create the trailer";
       setError(msg);
     } finally {
       setBusy(false);
@@ -93,34 +117,48 @@ const TrailersPage = () => {
       {loading ? (
         <p className="text-muted-text">Loading…</p>
       ) : trailers.length === 0 ? (
-        <p className="text-muted-text">No trailers yet. Add one to get started.</p>
+        <p className="text-muted-text">
+          No trailers yet. Add one to get started.
+        </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {trailers.map((t) => (
-            <Link
-              key={t.trailer_id}
-              to={`/trailers/${t.trailer_id}`}
-              className="bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
-            >
-              <div className="w-16 h-16 rounded-lg overflow-hidden bg-steel shrink-0">
-                {t.avatar_url ? (
-                  <img src={t.avatar_url} alt="" className="w-full h-full object-cover" />
-                ) : (
-                  <AvatarFallback kind="trailer" />
+          {trailers.map((t) => {
+            const m = mileMilestone(t.current_hub);
+            return (
+              <Link
+                key={t.trailer_id}
+                to={`/trailers/${t.trailer_id}`}
+                className="relative overflow-hidden bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
+              >
+                {m.crossed != null && (
+                  <div className="absolute -top-2 -right-2 rotate-[-8deg]">
+                    <MilestoneBurst tier={m.tier!} label={m.label!} size={44} />
+                  </div>
                 )}
-              </div>
-              <div className="min-w-0">
-                <p className="font-medium truncate">Unit {t.unit_number}</p>
-                <p className="text-xs text-muted-text truncate capitalize">
-                  {t.trailer_type}
-                  {t.length_ft ? ` · ${t.length_ft}'` : ""}
-                </p>
-                <p className="text-xs text-muted-text">
-                  {t.current_hub.toLocaleString("en-US")} mi · {t.status}
-                </p>
-              </div>
-            </Link>
-          ))}
+                <div className="w-16 h-16 rounded-lg overflow-hidden bg-steel shrink-0">
+                  {t.avatar_url ? (
+                    <img
+                      src={t.avatar_url}
+                      alt=""
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <AvatarFallback kind="trailer" />
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <p className="font-medium truncate">Unit {t.unit_number}</p>
+                  <p className="text-xs text-muted-text truncate capitalize">
+                    {t.trailer_type}
+                    {t.length_ft ? ` · ${t.length_ft}'` : ""}
+                  </p>
+                  <p className="text-xs text-muted-text">
+                    {t.current_hub.toLocaleString("en-US")} mi · {t.status}
+                  </p>
+                </div>
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -10,9 +10,14 @@ import {
   getMaintenanceServices,
 } from "@/services/maintenanceService";
 import { useLoads } from "@/hooks/useLoads";
-import { computeDue, avgMilesPerMonth, maxOdometer } from "@/lib/metrics/maintenance";
+import {
+  computeDue,
+  avgMilesPerMonth,
+  maxOdometer,
+} from "@/lib/metrics/maintenance";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
+import { MileClub } from "@/components/fleet/MileClub";
 import { TRUCK_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
 
@@ -29,7 +34,9 @@ const Spec = ({
 }) => (
   <div>
     <p className="text-xs text-muted-text">{label}</p>
-    <p className="text-sm">{value === null || value === undefined || value === "" ? "—" : value}</p>
+    <p className="text-sm">
+      {value === null || value === undefined || value === "" ? "—" : value}
+    </p>
   </div>
 );
 
@@ -45,9 +52,15 @@ const TruckDetailPage = () => {
 
   useEffect(() => {
     if (!id) return;
-    getTruck(id).then(setTruck).catch(() => {});
-    getMaintenanceItems().then(setItems).catch(() => {});
-    getMaintenanceServices().then(setServices).catch(() => {});
+    getTruck(id)
+      .then(setTruck)
+      .catch(() => {});
+    getMaintenanceItems()
+      .then(setItems)
+      .catch(() => {});
+    getMaintenanceServices()
+      .then(setServices)
+      .catch(() => {});
   }, [id]);
 
   const truckLoads = useMemo(
@@ -91,8 +104,8 @@ const TruckDetailPage = () => {
       setEditing(false);
     } catch (e) {
       setError(
-        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
-          "Could not save",
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Could not save",
       );
     } finally {
       setBusy(false);
@@ -125,10 +138,14 @@ const TruckDetailPage = () => {
         <div className="flex-1">
           <div className="flex justify-between items-start">
             <div>
-              <h1 className="text-3xl font-condensed">Unit {truck.unit_number}</h1>
+              <h1 className="text-3xl font-condensed">
+                Unit {truck.unit_number}
+              </h1>
               <p className="text-muted-text text-sm mb-4">
-                {[truck.year, truck.make, truck.model].filter(Boolean).join(" ")} ·{" "}
-                {truck.status}
+                {[truck.year, truck.make, truck.model]
+                  .filter(Boolean)
+                  .join(" ")}{" "}
+                · {truck.status}
               </p>
             </div>
             {!editing && (
@@ -145,29 +162,48 @@ const TruckDetailPage = () => {
             <EntityForm
               title="Edit truck"
               fields={TRUCK_FIELDS}
-              initial={toFormValues(truck as unknown as Record<string, unknown>, TRUCK_FIELDS)}
+              initial={toFormValues(
+                truck as unknown as Record<string, unknown>,
+                TRUCK_FIELDS,
+              )}
               onSave={saveEdit}
               onCancel={() => setEditing(false)}
               busy={busy}
               error={error}
             />
           ) : (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <Spec label="Unit #" value={truck.unit_number} />
-              <Spec label="Odometer · latest" value={`${odometer.toLocaleString("en-US")} mi`} />
-              <Spec label="VIN" value={truck.vin} />
-              <Spec
-                label="Plate"
-                value={truck.plate_number ? `${truck.plate_number} ${truck.plate_state || ""}` : null}
-              />
-              <Spec label="In service" value={formatDate(truck.in_service_date)} />
-            </div>
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <Spec label="Unit #" value={truck.unit_number} />
+                <Spec
+                  label="Odometer · latest"
+                  value={`${odometer.toLocaleString("en-US")} mi`}
+                />
+                <Spec label="VIN" value={truck.vin} />
+                <Spec
+                  label="Plate"
+                  value={
+                    truck.plate_number
+                      ? `${truck.plate_number} ${truck.plate_state || ""}`
+                      : null
+                  }
+                />
+                <Spec
+                  label="In service"
+                  value={formatDate(truck.in_service_date)}
+                />
+              </div>
+              <MileClub miles={odometer} />
+            </>
           )}
         </div>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Link to="/maintenance" className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors">
+        <Link
+          to="/maintenance"
+          className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors"
+        >
           <p className="text-xs text-muted-text mb-2">Maintenance</p>
           <div className="flex gap-3 text-sm">
             <span style={{ color: "#e24b4a" }}>{due.overdue} overdue</span>

--- a/frontend/src/pages/TrucksPage.tsx
+++ b/frontend/src/pages/TrucksPage.tsx
@@ -5,16 +5,28 @@ import type { Truck } from "@/types/truck";
 import { getTrucks, createTruck } from "@/services/trucksService";
 import { AvatarFallback } from "@/components/fleet/AvatarFallback";
 import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
+import { MilestoneBurst } from "@/components/fleet/MilestoneBurst";
+import { mileMilestone } from "@/lib/metrics/mileClub";
 
 const FIELDS: FormField[] = [
-  { name: "unit_number", label: "Unit #", required: true, placeholder: "580991" },
+  {
+    name: "unit_number",
+    label: "Unit #",
+    required: true,
+    placeholder: "580991",
+  },
   { name: "make", label: "Make", placeholder: "International" },
   { name: "model", label: "Model", placeholder: "LT625" },
   { name: "year", label: "Year", type: "number", placeholder: "2019" },
   { name: "vin", label: "VIN (17 chars)", placeholder: "3HSDZAPR…" },
   { name: "plate_number", label: "Plate", placeholder: "DTS625" },
   { name: "plate_state", label: "State", placeholder: "AL" },
-  { name: "current_odometer", label: "Odometer", type: "number", placeholder: "568737" },
+  {
+    name: "current_odometer",
+    label: "Odometer",
+    type: "number",
+    placeholder: "568737",
+  },
   {
     name: "status",
     label: "Status",
@@ -50,8 +62,8 @@ const TrucksPage = () => {
       await load();
     } catch (e) {
       const msg =
-        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
-        "Could not create the truck";
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Could not create the truck";
       setError(msg);
     } finally {
       setBusy(false);
@@ -86,33 +98,47 @@ const TrucksPage = () => {
       {loading ? (
         <p className="text-muted-text">Loading…</p>
       ) : trucks.length === 0 ? (
-        <p className="text-muted-text">No trucks yet. Add one to get started.</p>
+        <p className="text-muted-text">
+          No trucks yet. Add one to get started.
+        </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {trucks.map((t) => (
-            <Link
-              key={t.truck_id}
-              to={`/trucks/${t.truck_id}`}
-              className="bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
-            >
-              <div className="w-16 h-16 rounded-lg overflow-hidden bg-steel shrink-0">
-                {t.avatar_url ? (
-                  <img src={t.avatar_url} alt="" className="w-full h-full object-cover" />
-                ) : (
-                  <AvatarFallback kind="truck" />
+          {trucks.map((t) => {
+            const m = mileMilestone(t.current_odometer);
+            return (
+              <Link
+                key={t.truck_id}
+                to={`/trucks/${t.truck_id}`}
+                className="relative overflow-hidden bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
+              >
+                {m.crossed != null && (
+                  <div className="absolute -top-2 -right-2 rotate-[-8deg]">
+                    <MilestoneBurst tier={m.tier!} label={m.label!} size={44} />
+                  </div>
                 )}
-              </div>
-              <div className="min-w-0">
-                <p className="font-medium truncate">Unit {t.unit_number}</p>
-                <p className="text-xs text-muted-text truncate">
-                  {[t.year, t.make, t.model].filter(Boolean).join(" ") || "—"}
-                </p>
-                <p className="text-xs text-muted-text">
-                  {t.current_odometer.toLocaleString("en-US")} mi · {t.status}
-                </p>
-              </div>
-            </Link>
-          ))}
+                <div className="w-16 h-16 rounded-lg overflow-hidden bg-steel shrink-0">
+                  {t.avatar_url ? (
+                    <img
+                      src={t.avatar_url}
+                      alt=""
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <AvatarFallback kind="truck" />
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <p className="font-medium truncate">Unit {t.unit_number}</p>
+                  <p className="text-xs text-muted-text truncate">
+                    {[t.year, t.make, t.model].filter(Boolean).join(" ") || "—"}
+                  </p>
+                  <p className="text-xs text-muted-text">
+                    {t.current_odometer.toLocaleString("en-US")} mi · {t.status}
+                  </p>
+                </div>
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## What

A mileage-based rank that parallels agent prestige — the fleet earns clubs by odometer instead of leaderboards. Frontend-only, no backend, no migration.

- **Clubs:** 100K Seasoned (bronze) → 250K Road Warrior (silver) → 500K Workhorse (gold) → 1M Million-Miler (platinum); beyond 1M, +500K platinum markers. Under 100K, no badge.
- **Truck / trailer / driver detail** get a `MileClub` banner: the milestone burst, the rank title, and a progress bar to the next club. Trucks/trailers use the derived odometer/hub; drivers use **career loaded miles** (plus a new "Miles hauled" stat card).
- **List cards** (trucks/trailers/drivers) get a small corner milestone burst.

## Verification
- `mileMilestone()` is pure + unit-tested (clubs, tiers, titles, progress, past-1M markers). Build clean, 119/119 tests.
- Prettier-formatted the touched pages.