### PR TITLE
feat: comic touches on Lanes — flame on hottest lane, crown on best market

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.40.0",
+  "version": "1.41.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/lanes/LanesKpis.tsx
+++ b/frontend/src/components/lanes/LanesKpis.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+import { Flame, Truck, Crown } from "lucide-react";
 import type { LanesSummary } from "@/lib/metrics/lanes";
 import { fmtRpm, rpmTextClass } from "./rpmStyle";
 
@@ -7,17 +9,22 @@ interface Props {
 
 const Card = ({
   label,
+  icon,
   title,
   rpm,
   loads,
 }: {
   label: string;
+  icon: ReactNode;
   title: string;
   rpm: number | null;
   loads: number;
 }) => (
   <div className="bg-plate rounded-lg p-4">
-    <p className="text-xs text-muted-text">{label}</p>
+    <p className="text-xs text-muted-text flex items-center gap-1.5">
+      {icon}
+      {label}
+    </p>
     <p className="text-base font-condensed text-light mt-1">{title}</p>
     <p className="text-sm mt-1">
       <span className={`font-semibold ${rpmTextClass(rpm)}`}>{fmtRpm(rpm)}</span>
@@ -26,13 +33,20 @@ const Card = ({
   </div>
 );
 
-const EmptyCard = ({ label }: { label: string }) => (
+const EmptyCard = ({ label, icon }: { label: string; icon: ReactNode }) => (
   <div className="bg-plate rounded-lg p-4">
-    <p className="text-xs text-muted-text">{label}</p>
+    <p className="text-xs text-muted-text flex items-center gap-1.5">
+      {icon}
+      {label}
+    </p>
     <p className="text-base font-condensed text-muted-text mt-1">—</p>
     <p className="text-sm text-muted-text mt-1">not enough data</p>
   </div>
 );
+
+const FLAME = <Flame size={14} style={{ color: "#e8621e" }} />;
+const TRUCK = <Truck size={14} className="text-muted-text" />;
+const CROWN = <Crown size={14} className="text-amber" />;
 
 export const LanesKpis = ({ summary }: Props) => {
   const { topRpmLane, highestVolumeLane, bestOriginMarket } = summary;
@@ -42,32 +56,35 @@ export const LanesKpis = ({ summary }: Props) => {
       {topRpmLane ? (
         <Card
           label="Top RPM lane"
+          icon={FLAME}
           title={topRpmLane.lane}
           rpm={topRpmLane.avgRpm}
           loads={topRpmLane.loadCount}
         />
       ) : (
-        <EmptyCard label="Top RPM lane" />
+        <EmptyCard label="Top RPM lane" icon={FLAME} />
       )}
       {highestVolumeLane ? (
         <Card
           label="Highest volume"
+          icon={TRUCK}
           title={highestVolumeLane.lane}
           rpm={highestVolumeLane.avgRpm}
           loads={highestVolumeLane.loadCount}
         />
       ) : (
-        <EmptyCard label="Highest volume" />
+        <EmptyCard label="Highest volume" icon={TRUCK} />
       )}
       {bestOriginMarket ? (
         <Card
           label="Best origin market"
+          icon={CROWN}
           title={bestOriginMarket.market}
           rpm={bestOriginMarket.avgRpm}
           loads={bestOriginMarket.loadCount}
         />
       ) : (
-        <EmptyCard label="Best origin market" />
+        <EmptyCard label="Best origin market" icon={CROWN} />
       )}
     </div>
   );

--- a/frontend/src/components/lanes/LanesMap.tsx
+++ b/frontend/src/components/lanes/LanesMap.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from "react";
+import { Flame } from "lucide-react";
 import { geoAlbersUsa, geoPath } from "d3-geo";
 import { feature } from "topojson-client";
 import type { FeatureCollection, Geometry } from "geojson";
@@ -23,6 +24,12 @@ const pathGen = geoPath(projection);
 const RAMP = ["#6b4e12", "#9a6c0e", "#c8890a", "#e8940a", "#f5b03a"];
 const NO_DATA = "#2a3347";
 
+// lucide "flame" path, filled solid for a comic pin on your best-paying states.
+const FLAME_PATH =
+  "M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 " +
+  ".5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 " +
+  "1-3a2.5 2.5 0 0 0 2.5 2.5z";
+
 interface HoverState {
   x: number;
   y: number;
@@ -38,6 +45,22 @@ export const LanesMap = ({ data, windowDays }: Props) => {
     [data],
   );
 
+  // Top-paying states (by windowed RPM) get a flame pin at their centroid.
+  const hotStates = useMemo(
+    () =>
+      usStates.features
+        .map((f) => ({ f, d: data[f.properties.name] }))
+        .filter((s) => s.d && s.d.avgRpm != null && s.d.loadCount >= 3)
+        .sort((a, b) => (b.d!.avgRpm ?? 0) - (a.d!.avgRpm ?? 0))
+        .slice(0, 3)
+        .map((s) => {
+          const [cx, cy] = pathGen.centroid(s.f);
+          return { name: s.f.properties.name, cx, cy };
+        })
+        .filter((h) => Number.isFinite(h.cx) && Number.isFinite(h.cy)),
+    [data],
+  );
+
   const colorFor = (name: string): string => {
     const datum = data[name];
     if (!datum) return NO_DATA;
@@ -50,9 +73,10 @@ export const LanesMap = ({ data, windowDays }: Props) => {
 
   return (
     <div ref={containerRef} className="bg-plate rounded-lg p-4 relative">
-      <p className="text-xs text-muted-text mb-2">
-        Footprint · shaded by loads (past year) · hover for RPM (last{" "}
-        {windowDays} days)
+      <p className="text-xs text-muted-text mb-2 flex items-center gap-1 flex-wrap">
+        Footprint · shaded by loads ·
+        <Flame size={12} style={{ color: "#e8621e" }} /> best-paying states ·
+        hover for RPM ({windowDays}d)
       </p>
       <svg viewBox="0 0 900 560" className="w-full">
         {usStates.features.map((f, i) => {
@@ -80,6 +104,21 @@ export const LanesMap = ({ data, windowDays }: Props) => {
             />
           );
         })}
+        {hotStates.map((h) => (
+          <g
+            key={h.name}
+            transform={`translate(${h.cx},${h.cy}) scale(0.95) translate(-12,-12)`}
+            style={{ pointerEvents: "none" }}
+          >
+            <path
+              d={FLAME_PATH}
+              fill="#e8621e"
+              stroke="#0d1117"
+              strokeWidth={1.2}
+              strokeLinejoin="round"
+            />
+          </g>
+        ))}
       </svg>
       {hover && (
         <div


### PR DESCRIPTION
## What

Two comic touches on the Lanes page, both from existing lane metrics — no backend, no migration.

- **KPI badges:** a **flame** on the Top RPM lane, a **truck** on Highest volume, a **crown** on the Best origin market.
- **Map flame pins:** the footprint map keeps its amber load-count shading, and now drops **flame pins on your top 3 best-paying states** (by windowed RPM, min 3 footprint loads) at each state's centroid — so shading shows *where you run* and flames show *where it pays*. Pins are `pointer-events: none` so state hover still works; legend updated.

## Verification
- Build clean, 119/119 tests (reuses `getLanesSummary` / per-state `avgRpm`, no new logic).