### PR TITLE
feat: comic touches on Maintenance — health gauge + OVERDUE/DONE stamps

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.41.0",
+  "version": "1.42.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/Stamp.tsx
+++ b/frontend/src/components/Stamp.tsx
@@ -1,0 +1,20 @@
+// A comic rubber stamp — tier/status color, cocked at an angle. Shared by the
+// agent rating look, maintenance OVERDUE, and the service DONE! confirmation.
+export const Stamp = ({
+  label,
+  color,
+  size = "md",
+}: {
+  label: string;
+  color: string;
+  size?: "sm" | "md";
+}) => (
+  <span
+    className={`inline-block rotate-[-6deg] font-condensed font-semibold uppercase rounded ${
+      size === "sm" ? "text-[11px] px-2 py-0" : "text-sm px-2.5 py-0.5"
+    }`}
+    style={{ border: `3px double ${color}`, color, letterSpacing: "2px" }}
+  >
+    {label}
+  </span>
+);

--- a/frontend/src/components/maintenance/HealthGauge.tsx
+++ b/frontend/src/components/maintenance/HealthGauge.tsx
@@ -1,0 +1,94 @@
+import { Truck } from "lucide-react";
+import { fleetHealth } from "@/lib/metrics/maintenance";
+
+const rad = (deg: number) => (deg * Math.PI) / 180;
+// Score 0–100 maps across the 180° dial (180° left → 0° right).
+const needle = (score: number) => {
+  const theta = 180 - 1.8 * score;
+  return { x: 100 + 62 * Math.cos(rad(theta)), y: 100 - 62 * Math.sin(rad(theta)) };
+};
+
+const chip = (n: number, label: string, color: string) => (
+  <span
+    className="text-xs px-2.5 py-1 rounded"
+    style={{ background: "#1c2333", color }}
+  >
+    {n} {label}
+  </span>
+);
+
+interface Counts {
+  overdue: number;
+  soon: number;
+  ok: number;
+  unknown: number;
+}
+
+export const HealthGauge = ({ counts }: { counts: Counts }) => {
+  const h = fleetHealth(counts);
+  const n = needle(h.score ?? 0);
+
+  return (
+    <div className="bg-plate rounded-lg p-4 flex gap-5 items-center flex-wrap mb-4">
+      <svg viewBox="0 0 200 116" width={180} height={104} className="shrink-0">
+        <path
+          d="M20,100 A80,80 0 0 1 124.7,23.9"
+          fill="none"
+          stroke="#e24b4a"
+          strokeWidth={13}
+        />
+        <path
+          d="M124.7,23.9 A80,80 0 0 1 171.3,63.7"
+          fill="none"
+          stroke="#e8940a"
+          strokeWidth={13}
+        />
+        <path
+          d="M171.3,63.7 A80,80 0 0 1 180,100"
+          fill="none"
+          stroke="#1d9e75"
+          strokeWidth={13}
+        />
+        {h.score != null && (
+          <>
+            <line
+              x1={100}
+              y1={100}
+              x2={n.x}
+              y2={n.y}
+              stroke="#ebedf5"
+              strokeWidth={3}
+              strokeLinecap="round"
+            />
+            <circle cx={100} cy={100} r={6} fill="#ebedf5" />
+          </>
+        )}
+        <text
+          x={100}
+          y={90}
+          textAnchor="middle"
+          className="font-condensed"
+          fontSize={30}
+          fill="#ebedf5"
+        >
+          {h.score == null ? "—" : `${h.score}%`}
+        </text>
+      </svg>
+
+      <div className="flex-1 min-w-[180px]">
+        <p className="text-xs text-muted-text flex items-center gap-1.5">
+          <Truck size={15} style={{ color: "#e8940a" }} /> Fleet health
+        </p>
+        <p className="text-xl font-condensed mt-0.5" style={{ color: h.color }}>
+          {h.label}
+        </p>
+        <div className="flex gap-2 mt-3 flex-wrap">
+          {chip(counts.overdue, "overdue", "#e24b4a")}
+          {chip(counts.soon, "due soon", "#e8940a")}
+          {chip(counts.ok, "ok", "#1d9e75")}
+          {counts.unknown > 0 && chip(counts.unknown, "no baseline", "#9daabb")}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/maintenance/ScheduleTab.tsx
+++ b/frontend/src/components/maintenance/ScheduleTab.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/services/maintenanceService";
 import { computeDue, type Due, type DueLevel } from "@/lib/metrics/maintenance";
 import { MaintenanceItemForm } from "./MaintenanceItemForm";
+import { HealthGauge } from "./HealthGauge";
+import { Stamp } from "@/components/Stamp";
 
 interface Props {
   items: MaintenanceItem[];
@@ -118,15 +120,6 @@ export const ScheduleTab = ({
       setEditing(null);
     });
 
-  const chip = (label: string, n: number, color: string) => (
-    <span
-      className="text-xs px-2.5 py-1 rounded"
-      style={{ background: "#1c2333", color }}
-    >
-      {n} {label}
-    </span>
-  );
-
   if (items.length === 0 && !showForm) {
     return (
       <div className="bg-plate rounded-lg p-6 text-center">
@@ -175,6 +168,11 @@ export const ScheduleTab = ({
         </div>
       </div>
       <div className="text-right w-40 shrink-0">
+        {due.level === "overdue" && (
+          <div className="mb-1">
+            <Stamp label="Overdue" color="#e24b4a" size="sm" />
+          </div>
+        )}
         <p className="text-xs" style={{ color: META[due.level].color }}>
           {dueLabel(due)}
         </p>
@@ -204,12 +202,8 @@ export const ScheduleTab = ({
 
   return (
     <div>
+      <HealthGauge counts={counts} />
       <div className="flex flex-wrap gap-2 items-center mb-4">
-        {chip("overdue", counts.overdue, META.overdue.color)}
-        {chip("due soon", counts.soon, META.soon.color)}
-        {chip("ok", counts.ok, META.ok.color)}
-        {counts.unknown > 0 &&
-          chip("no baseline", counts.unknown, META.unknown.color)}
         <div className="ml-auto flex gap-2">
           <button
             className="bg-steel text-light px-2 py-1 rounded text-xs flex items-center gap-1"

--- a/frontend/src/components/maintenance/ServicesTab.tsx
+++ b/frontend/src/components/maintenance/ServicesTab.tsx
@@ -7,6 +7,7 @@ import {
   type ServiceInput,
 } from "@/services/maintenanceService";
 import { ServiceForm } from "./ServiceForm";
+import { Stamp } from "@/components/Stamp";
 
 interface Props {
   services: MaintenanceService[];
@@ -72,6 +73,7 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [justLogged, setJustLogged] = useState(false);
   // Month range for pulling a window of services (e.g. to re-enter into
   // Landstar's app). Presets cover the common cases; "Custom" reveals dropdowns.
   const [mode, setMode] = useState<RangeMode>("3m");
@@ -151,6 +153,8 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
     run(async () => {
       await createMaintenanceService(data);
       setShowForm(false);
+      setJustLogged(true);
+      window.setTimeout(() => setJustLogged(false), 2600);
     });
 
   return (
@@ -169,6 +173,13 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
           </button>
         )}
       </div>
+
+      {justLogged && (
+        <div className="flex items-center gap-3 bg-plate rounded-lg p-3 mb-3">
+          <Stamp label="Done!" color="#1d9e75" />
+          <span className="text-sm text-muted-text">Service logged.</span>
+        </div>
+      )}
 
       {error && <p className="text-destructive text-sm mb-3">{error}</p>}
 

--- a/frontend/src/lib/metrics/maintenance.test.ts
+++ b/frontend/src/lib/metrics/maintenance.test.ts
@@ -8,6 +8,7 @@ import {
   avgMilesPerMonth,
   maxOdometer,
   maintenanceAlerts,
+  fleetHealth,
 } from "./maintenance";
 
 const item = (over: Partial<MaintenanceItem>): MaintenanceItem => ({
@@ -239,5 +240,26 @@ describe("maxOdometer", () => {
     expect(maxOdometer(314697, 568387, null)).toBe(568387); // fuel-style fresh read wins
     expect(maxOdometer(null, undefined)).toBeNull();
     expect(maxOdometer(560000)).toBe(560000);
+  });
+});
+
+describe("fleetHealth", () => {
+  it("returns null when nothing is assessable", () => {
+    expect(fleetHealth({ overdue: 0, soon: 0, ok: 0 }).score).toBeNull();
+  });
+  it("is Healthy when all items are ok", () => {
+    const h = fleetHealth({ overdue: 0, soon: 0, ok: 10 });
+    expect(h.score).toBe(100);
+    expect(h.label).toBe("Healthy");
+  });
+  it("half-credits due-soon and zero-credits overdue", () => {
+    const h = fleetHealth({ overdue: 4, soon: 2, ok: 12 }); // (12 + 1) / 18
+    expect(h.score).toBe(72);
+    expect(h.label).toBe("Needs attention");
+  });
+  it("is Rough shape when everything is overdue", () => {
+    const h = fleetHealth({ overdue: 10, soon: 0, ok: 0 });
+    expect(h.score).toBe(0);
+    expect(h.label).toBe("Rough shape");
   });
 });

--- a/frontend/src/lib/metrics/maintenance.ts
+++ b/frontend/src/lib/metrics/maintenance.ts
@@ -166,3 +166,25 @@ export const maintenanceAlerts = (
   }
   return ranked.sort((a, b) => a.rank - b.rank).map((r) => r.alert);
 };
+
+// Overall fleet-upkeep score (0–100) from the schedule's due counts. Overdue
+// items count for nothing, due-soon for half; "no baseline" items sit out.
+export interface FleetHealth {
+  score: number | null; // null when there's nothing to assess
+  label: string;
+  color: string;
+}
+
+export const fleetHealth = (counts: {
+  overdue: number;
+  soon: number;
+  ok: number;
+}): FleetHealth => {
+  const assessable = counts.overdue + counts.soon + counts.ok;
+  if (assessable === 0)
+    return { score: null, label: "No data", color: "#9daabb" };
+  const score = Math.round(((counts.ok + 0.5 * counts.soon) / assessable) * 100);
+  if (score >= 85) return { score, label: "Healthy", color: "#1d9e75" };
+  if (score >= 60) return { score, label: "Needs attention", color: "#e8940a" };
+  return { score, label: "Rough shape", color: "#e24b4a" };
+};


### PR DESCRIPTION
## What

The final comic-sweep item. Frontend-only — no backend, no migration.

- **Fleet health gauge** tops the Schedule tab: a semicircular dial scored from the due counts via a new pure `fleetHealth()` — `(ok + ½·soon) ÷ assessable`, so overdue drags it down and "no baseline" items sit out — with a `Healthy` / `Needs attention` / `Rough shape` verdict and the existing count chips beside it.
- **`OVERDUE`** red ink-stamp on overdue schedule items.
- **`DONE!`** green stamp thunks in briefly when you log a service.
- Shared `Stamp` component (the ink-stamp primitive) backs both.

## Verification
- `fleetHealth()` unit-tested (null when nothing assessable, 100 all-ok, 72 for 4/2/12, 0 all-overdue). Build clean, 123/123 tests.