### PR TITLE
feat: fuel page (chunk 1) — MPG-per-tank economy + weekly cost

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.42.1",
+  "version": "1.43.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/fuel/MpgChart.tsx
+++ b/frontend/src/components/fuel/MpgChart.tsx
@@ -1,0 +1,70 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import type { MpgWindow } from "@/lib/metrics/fuelEconomy";
+
+const fmtDate = (d: string) =>
+  new Date(d.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+export const MpgChart = ({ windows }: { windows: MpgWindow[] }) => (
+  <div className="bg-plate rounded-lg p-4">
+    <h3 className="text-sm font-medium mb-1 text-light">MPG per tank</h3>
+    <p className="text-xs text-muted-text mb-4">One point per full tank</p>
+    {windows.length === 0 ? (
+      <p className="text-sm text-muted-text py-8 text-center">
+        Log two full tanks to chart your MPG.
+      </p>
+    ) : (
+      <ResponsiveContainer width="100%" height={240}>
+        <LineChart data={windows} margin={{ top: 8, right: 14, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#2a3347" vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={fmtDate}
+            stroke="#9daabb"
+            fontSize={11}
+            tickLine={false}
+            axisLine={{ stroke: "#2a3347" }}
+          />
+          <YAxis
+            stroke="#9daabb"
+            fontSize={11}
+            tickLine={false}
+            axisLine={false}
+            domain={["dataMin - 0.5", "dataMax + 0.5"]}
+            tickFormatter={(v) => Number(v).toFixed(1)}
+            width={32}
+          />
+          <Tooltip
+            contentStyle={{
+              background: "#1c2333",
+              border: "1px solid #2a3347",
+              borderRadius: 8,
+              color: "#ebedf5",
+              fontSize: 12,
+            }}
+            labelFormatter={(l) => fmtDate(l as string)}
+            formatter={(v) => [`${Number(v).toFixed(2)} mpg`, "MPG"]}
+          />
+          <Line
+            type="monotone"
+            dataKey="mpg"
+            stroke="#e8940a"
+            strokeWidth={2}
+            dot={{ r: 3, fill: "#e8940a" }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    )}
+  </div>
+);

--- a/frontend/src/components/fuel/WeeklyCostChart.tsx
+++ b/frontend/src/components/fuel/WeeklyCostChart.tsx
@@ -1,0 +1,88 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import type { WeekCost } from "@/lib/metrics/fuelEconomy";
+
+const fmtWeek = (d: string) =>
+  new Date(d + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+
+export const WeeklyCostChart = ({
+  data,
+  avg,
+}: {
+  data: WeekCost[];
+  avg: number | null;
+}) => (
+  <div className="bg-plate rounded-lg p-4">
+    <h3 className="text-sm font-medium mb-1 text-light">Weekly fuel cost</h3>
+    <p className="text-xs text-muted-text mb-4">
+      Spend per week{avg != null ? " · dashed = 90-day avg" : ""}
+    </p>
+    {data.length === 0 ? (
+      <p className="text-sm text-muted-text py-8 text-center">
+        No fill-ups logged yet.
+      </p>
+    ) : (
+      <ResponsiveContainer width="100%" height={240}>
+        <BarChart data={data} margin={{ top: 8, right: 14, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#2a3347" vertical={false} />
+          <XAxis
+            dataKey="weekStart"
+            tickFormatter={fmtWeek}
+            stroke="#9daabb"
+            fontSize={11}
+            tickLine={false}
+            axisLine={{ stroke: "#2a3347" }}
+          />
+          <YAxis
+            stroke="#9daabb"
+            fontSize={11}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(v) => `$${(v / 1000).toFixed(1)}k`}
+            width={38}
+          />
+          <Tooltip
+            cursor={{ fill: "rgba(255,255,255,0.04)" }}
+            contentStyle={{
+              background: "#1c2333",
+              border: "1px solid #2a3347",
+              borderRadius: 8,
+              color: "#ebedf5",
+              fontSize: 12,
+            }}
+            labelFormatter={(l) => `Week of ${fmtWeek(l as string)}`}
+            formatter={(v) => [money0(Number(v)), "Cost"]}
+          />
+          {avg != null && (
+            <ReferenceLine
+              y={avg}
+              stroke="#9daabb"
+              strokeDasharray="4 4"
+              label={{
+                value: `avg ${money0(avg)}`,
+                fill: "#9daabb",
+                fontSize: 10,
+                position: "right",
+              }}
+            />
+          )}
+          <Bar dataKey="cost" fill="#e8940a" radius={[3, 3, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    )}
+  </div>
+);

--- a/frontend/src/lib/metrics/fuelEconomy.test.ts
+++ b/frontend/src/lib/metrics/fuelEconomy.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  isFull,
+  entryCost,
+  mpgWindows,
+  fuelStats,
+  avgWeeklyCost,
+  weeklyCostSeries,
+} from "./fuelEconomy";
+
+const e = (
+  odometer_reading: number,
+  gallons: number,
+  price_per_gallon: number,
+  fuel_date: string,
+) => ({ odometer_reading, gallons, price_per_gallon, fuel_date });
+
+// First four real fill-ups from the Fuelly export → one complete MPG window.
+const first4 = [
+  e(570368, 131.91, 4.639, "2026-05-24"), // full (opens the window)
+  e(570967, 79.78, 4.589, "2026-05-26"), // partial
+  e(571651, 114.425, 4.462, "2026-05-28"), // <120 → partial (Fuelly says "Full")
+  e(572503, 135.1, 4.322, "2026-05-30"), // full (closes the window)
+];
+
+describe("isFull", () => {
+  it("uses the 120-gallon threshold, not Fuelly's column", () => {
+    expect(isFull(e(0, 131.91, 4, "2026-01-01"))).toBe(true);
+    expect(isFull(e(0, 120, 4, "2026-01-01"))).toBe(true);
+    expect(isFull(e(0, 114.425, 4, "2026-01-01"))).toBe(false);
+    expect(isFull(e(0, 84.63, 4, "2026-01-01"))).toBe(false);
+  });
+});
+
+describe("entryCost", () => {
+  it("is gallons × price", () => {
+    expect(entryCost(e(0, 100, 4.5, "2026-01-01"))).toBeCloseTo(450);
+  });
+});
+
+describe("mpgWindows", () => {
+  it("closes a window on each full, counting partials since the last full", () => {
+    const w = mpgWindows(first4);
+    expect(w).toHaveLength(1);
+    expect(w[0].miles).toBe(2135); // 572503 - 570368
+    expect(w[0].gallons).toBeCloseTo(329.305); // 79.78 + 114.425 + 135.1
+    expect(w[0].mpg).toBeCloseTo(6.483, 2);
+  });
+
+  it("ignores fills before the first full (no baseline)", () => {
+    const w = mpgWindows([e(1000, 80, 4, "2026-01-01"), ...first4]);
+    expect(w).toHaveLength(1); // the leading partial is dropped
+  });
+});
+
+describe("fuelStats", () => {
+  it("aggregates miles, gallons, MPG, and per-gallon cost", () => {
+    const s = fuelStats(first4, new Date("2026-06-01T00:00:00.000Z"));
+    expect(s.totalMiles).toBe(2135);
+    expect(s.avgMpg).toBeCloseTo(6.483, 2);
+    expect(s.totalGallons).toBeCloseTo(461.215); // all four fills
+    expect(s.avgCostPerGallon).toBeCloseTo(s.totalSpend / s.totalGallons);
+  });
+});
+
+describe("avgWeeklyCost", () => {
+  it("divides last-90-day spend by the weeks of data present", () => {
+    // Two fills a week apart, $700 each → ~$700/week over a 1-week span.
+    const now = new Date("2026-06-15T00:00:00.000Z");
+    const entries = [
+      e(1000, 100, 7, "2026-06-01"),
+      e(1500, 100, 7, "2026-06-08"),
+    ];
+    const w = avgWeeklyCost(entries, now);
+    expect(w).not.toBeNull();
+    expect(w!).toBeGreaterThan(600);
+  });
+  it("returns null with nothing in the window", () => {
+    expect(avgWeeklyCost([], new Date("2026-06-15T00:00:00Z"))).toBeNull();
+  });
+});
+
+describe("weeklyCostSeries", () => {
+  it("buckets spend by ISO week, oldest first", () => {
+    const s = weeklyCostSeries(first4);
+    expect(s.length).toBeGreaterThan(0);
+    expect(s[0].weekStart <= s[s.length - 1].weekStart).toBe(true);
+  });
+});

--- a/frontend/src/lib/metrics/fuelEconomy.ts
+++ b/frontend/src/lib/metrics/fuelEconomy.ts
@@ -1,0 +1,154 @@
+// Fuel-page economy math. A fill-up of 120+ gallons is a FULL tank; anything
+// less is a PARTIAL that rolls into the next full. MPG is measured between
+// fulls: miles ÷ every gallon added since the previous full.
+export const FULL_THRESHOLD = 120;
+
+interface FuelLike {
+  gallons: number | string; // Postgres numeric → string
+  price_per_gallon: number | string;
+  odometer_reading: number;
+  fuel_date: string; // 'YYYY-MM-DD'
+}
+
+const gal = (e: FuelLike) => Number(e.gallons);
+const ppg = (e: FuelLike) => Number(e.price_per_gallon);
+export const entryCost = (e: FuelLike): number => gal(e) * ppg(e);
+export const isFull = (e: FuelLike): boolean => gal(e) >= FULL_THRESHOLD;
+
+export interface MpgWindow {
+  toOdometer: number;
+  date: string; // the closing full's date
+  miles: number;
+  gallons: number;
+  cost: number;
+  mpg: number;
+}
+
+// One window per full tank: gallons = partials since the last full + this full.
+export const mpgWindows = (entries: FuelLike[]): MpgWindow[] => {
+  const sorted = [...entries].sort(
+    (a, b) => a.odometer_reading - b.odometer_reading,
+  );
+  const windows: MpgWindow[] = [];
+  let open: FuelLike | null = null;
+  let gallons = 0;
+  let cost = 0;
+  for (const e of sorted) {
+    if (!open) {
+      // Nothing counts until the first full tank establishes a baseline.
+      if (isFull(e)) {
+        open = e;
+        gallons = 0;
+        cost = 0;
+      }
+      continue;
+    }
+    gallons += gal(e);
+    cost += entryCost(e);
+    if (isFull(e)) {
+      const miles = e.odometer_reading - open.odometer_reading;
+      if (miles > 0 && gallons > 0) {
+        windows.push({
+          toOdometer: e.odometer_reading,
+          date: e.fuel_date,
+          miles,
+          gallons,
+          cost,
+          mpg: miles / gallons,
+        });
+      }
+      open = e;
+      gallons = 0;
+      cost = 0;
+    }
+  }
+  return windows;
+};
+
+export interface FuelStats {
+  entryCount: number;
+  totalGallons: number;
+  totalSpend: number;
+  avgCostPerGallon: number | null;
+  totalMiles: number;
+  avgMpg: number | null;
+  costPerMile: number | null;
+  bestMpg: number | null;
+  worstMpg: number | null;
+  avgWeeklyCost90: number | null;
+  windows: MpgWindow[];
+}
+
+// Rolling-90-day average weekly fuel cost. Divides by the actual span of data
+// in the window (7–90 days) so it reads as the real weekly rate before there's
+// a full 90 days of history, converging to the strict 90-day average after.
+export const avgWeeklyCost = (
+  entries: FuelLike[],
+  now: Date,
+): number | null => {
+  const cutoff = new Date(now);
+  cutoff.setUTCDate(cutoff.getUTCDate() - 90);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  const inWindow = entries.filter((e) => e.fuel_date.slice(0, 10) >= cutoffStr);
+  if (inWindow.length === 0) return null;
+
+  const spend = inWindow.reduce((s, e) => s + entryCost(e), 0);
+  const earliest = inWindow.reduce(
+    (min, e) => (e.fuel_date < min ? e.fuel_date : min),
+    inWindow[0].fuel_date,
+  );
+  const days = Math.max(
+    7,
+    Math.min(
+      90,
+      Math.round(
+        (now.getTime() - new Date(earliest.slice(0, 10) + "T00:00:00Z").getTime()) /
+          86_400_000,
+      ),
+    ),
+  );
+  return spend / (days / 7);
+};
+
+export const fuelStats = (entries: FuelLike[], now: Date): FuelStats => {
+  const windows = mpgWindows(entries);
+  const totalGallons = entries.reduce((s, e) => s + gal(e), 0);
+  const totalSpend = entries.reduce((s, e) => s + entryCost(e), 0);
+  const totalMiles = windows.reduce((s, w) => s + w.miles, 0);
+  const windowGallons = windows.reduce((s, w) => s + w.gallons, 0);
+  const windowSpend = windows.reduce((s, w) => s + w.cost, 0);
+  const mpgs = windows.map((w) => w.mpg);
+  return {
+    entryCount: entries.length,
+    totalGallons,
+    totalSpend,
+    avgCostPerGallon: totalGallons > 0 ? totalSpend / totalGallons : null,
+    totalMiles,
+    avgMpg: windowGallons > 0 ? totalMiles / windowGallons : null,
+    costPerMile: totalMiles > 0 ? windowSpend / totalMiles : null,
+    bestMpg: mpgs.length ? Math.max(...mpgs) : null,
+    worstMpg: mpgs.length ? Math.min(...mpgs) : null,
+    avgWeeklyCost90: avgWeeklyCost(entries, now),
+    windows,
+  };
+};
+
+export interface WeekCost {
+  weekStart: string; // Monday, 'YYYY-MM-DD'
+  cost: number;
+}
+
+// Fuel spend bucketed by ISO week (Monday start), oldest first — for the chart.
+export const weeklyCostSeries = (entries: FuelLike[]): WeekCost[] => {
+  const buckets = new Map<string, number>();
+  for (const e of entries) {
+    const d = new Date(e.fuel_date.slice(0, 10) + "T00:00:00Z");
+    const monday = new Date(d);
+    monday.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+    const key = monday.toISOString().slice(0, 10);
+    buckets.set(key, (buckets.get(key) ?? 0) + entryCost(e));
+  }
+  return [...buckets.entries()]
+    .map(([weekStart, cost]) => ({ weekStart, cost }))
+    .sort((a, b) => a.weekStart.localeCompare(b.weekStart));
+};

--- a/frontend/src/pages/FuelEntriesPage.tsx
+++ b/frontend/src/pages/FuelEntriesPage.tsx
@@ -1,5 +1,394 @@
+import { useEffect, useMemo, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import type { FuelEntry } from "@/types/fuelEntry";
+import type { Truck } from "@/types/truck";
+import {
+  getFuelEntries,
+  createFuelEntry,
+  deleteFuelEntry,
+} from "@/services/fuelService";
+import { getTrucks } from "@/services/trucksService";
+import {
+  fuelStats,
+  weeklyCostSeries,
+  isFull,
+  entryCost,
+} from "@/lib/metrics/fuelEconomy";
+import { Kpi } from "@/components/Kpi";
+import { MpgChart } from "@/components/fuel/MpgChart";
+import { WeeklyCostChart } from "@/components/fuel/WeeklyCostChart";
+
+const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+const money2 = (n: number) =>
+  n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+const fmtDate = (d: string) =>
+  new Date(d.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "2-digit",
+    timeZone: "UTC",
+  });
+
+const inputCls = "bg-steel rounded px-2 py-1.5 text-sm w-full text-light";
+const lbl = "text-xs text-muted-text mb-1 block";
+
 const FuelEntriesPage = () => {
-  return <div>Fuel Entries Page (placeholder)</div>;
+  const [entries, setEntries] = useState<FuelEntry[]>([]);
+  const [trucks, setTrucks] = useState<Truck[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [truckId, setTruckId] = useState("");
+  const [date, setDate] = useState("");
+  const [odometer, setOdometer] = useState("");
+  const [gallons, setGallons] = useState("");
+  const [price, setPrice] = useState("");
+  const [company, setCompany] = useState("");
+  const [city, setCity] = useState("");
+  const [stateCode, setStateCode] = useState("");
+
+  const load = () =>
+    Promise.all([getFuelEntries(), getTrucks()])
+      .then(([e, t]) => {
+        setEntries(e);
+        setTrucks(t);
+        if (t.length === 1) setTruckId(t[0].truck_id);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const now = new Date();
+  const stats = useMemo(() => fuelStats(entries, now), [entries]);
+  const weekly = useMemo(() => weeklyCostSeries(entries), [entries]);
+  // Per-full MPG, keyed by the closing odometer of each window.
+  const mpgByOdo = useMemo(() => {
+    const m = new Map<number, number>();
+    for (const w of stats.windows) m.set(w.toOdometer, w.mpg);
+    return m;
+  }, [stats]);
+
+  const rows = useMemo(
+    () => [...entries].sort((a, b) => b.odometer_reading - a.odometer_reading),
+    [entries],
+  );
+
+  const save = async () => {
+    setError(null);
+    if (!truckId) {
+      setError("Add a truck first (Fleet → Trucks).");
+      return;
+    }
+    if (!date || !odometer || !gallons || !price || !stateCode.trim()) {
+      setError("Date, odometer, gallons, price, and state are required.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await createFuelEntry({
+        truck_id: truckId,
+        fuel_date: date,
+        gallons: parseFloat(gallons),
+        price_per_gallon: parseFloat(price),
+        odometer_reading: parseInt(odometer, 10),
+        company_name: company.trim() || null,
+        fuel_city: city.trim() || null,
+        fuel_state: stateCode.trim().toUpperCase(),
+      });
+      setDate("");
+      setOdometer("");
+      setGallons("");
+      setPrice("");
+      setCompany("");
+      setCity("");
+      setStateCode("");
+      setShowForm(false);
+      await load();
+    } catch (e) {
+      setError(
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Could not save the fill-up",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await deleteFuelEntry(id);
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const truck = trucks.find((t) => t.truck_id === truckId);
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <div className="flex justify-between items-start mb-6 gap-3">
+        <div>
+          <h1 className="text-3xl font-condensed">Fuel</h1>
+          {truck && (
+            <p className="text-xs text-muted-text">
+              Unit {truck.unit_number}
+              {[truck.make, truck.model].filter(Boolean).length
+                ? ` · ${[truck.make, truck.model].filter(Boolean).join(" ")}`
+                : ""}
+            </p>
+          )}
+        </div>
+        {!showForm && (
+          <button
+            className="bg-amber text-steel px-3 py-2 rounded-lg text-sm font-semibold flex items-center gap-1 shrink-0"
+            onClick={() => setShowForm(true)}
+          >
+            <Plus size={15} /> Add fill-up
+          </button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
+        <Kpi
+          label="Avg MPG"
+          value={stats.avgMpg == null ? "—" : stats.avgMpg.toFixed(2)}
+        />
+        <Kpi
+          label="Cost / mile"
+          value={
+            stats.costPerMile == null ? "—" : `$${stats.costPerMile.toFixed(2)}`
+          }
+        />
+        <Kpi
+          label="Cost / gallon"
+          value={
+            stats.avgCostPerGallon == null
+              ? "—"
+              : `$${stats.avgCostPerGallon.toFixed(2)}`
+          }
+        />
+        <Kpi
+          label="Avg weekly · 90d"
+          value={
+            stats.avgWeeklyCost90 == null ? "—" : money0(stats.avgWeeklyCost90)
+          }
+        />
+        <Kpi
+          label="Total gallons"
+          value={Math.round(stats.totalGallons).toLocaleString("en-US")}
+        />
+        <Kpi label="Total spend" value={money0(stats.totalSpend)} />
+      </div>
+
+      {showForm && (
+        <div className="bg-plate rounded-lg p-4 mt-4">
+          <p className="text-sm font-medium mb-3">Add fill-up</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3">
+            <div>
+              <label className={lbl}>Date</label>
+              <input
+                type="date"
+                className={inputCls}
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className={lbl}>Odometer</label>
+              <input
+                className={inputCls}
+                value={odometer}
+                inputMode="numeric"
+                placeholder="582450"
+                onChange={(e) => setOdometer(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className={lbl}>Gallons</label>
+              <input
+                className={inputCls}
+                value={gallons}
+                inputMode="decimal"
+                placeholder="137.8"
+                onChange={(e) => setGallons(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className={lbl}>Price / gal</label>
+              <input
+                className={inputCls}
+                value={price}
+                inputMode="decimal"
+                placeholder="4.033"
+                onChange={(e) => setPrice(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className={lbl}>Vendor</label>
+              <input
+                className={inputCls}
+                value={company}
+                placeholder="Pilot"
+                onChange={(e) => setCompany(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className={lbl}>City</label>
+              <input
+                className={inputCls}
+                value={city}
+                onChange={(e) => setCity(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className={lbl}>State</label>
+              <input
+                className={inputCls}
+                value={stateCode}
+                maxLength={2}
+                placeholder="AL"
+                onChange={(e) => setStateCode(e.target.value)}
+              />
+            </div>
+            {trucks.length > 1 && (
+              <div>
+                <label className={lbl}>Truck</label>
+                <select
+                  className={inputCls}
+                  value={truckId}
+                  onChange={(e) => setTruckId(e.target.value)}
+                >
+                  <option value="">Select…</option>
+                  {trucks.map((t) => (
+                    <option key={t.truck_id} value={t.truck_id}>
+                      Unit {t.unit_number}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+          <p className="text-[11px] text-muted-text mt-2">
+            120+ gallons counts as a full tank; anything less is a partial.
+          </p>
+          {error && <p className="text-destructive text-sm mt-2">{error}</p>}
+          <div className="flex gap-2 mt-3">
+            <button
+              className="bg-amber text-steel px-3 py-1.5 rounded text-sm font-semibold disabled:opacity-50"
+              onClick={save}
+              disabled={busy}
+            >
+              {busy ? "Saving…" : "Save fill-up"}
+            </button>
+            <button
+              className="bg-steel text-light px-3 py-1.5 rounded text-sm"
+              onClick={() => {
+                setShowForm(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
+        <MpgChart windows={stats.windows} />
+        <WeeklyCostChart data={weekly} avg={stats.avgWeeklyCost90} />
+      </div>
+
+      <div className="bg-plate rounded-lg p-4 mt-4 overflow-x-auto">
+        <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
+          Fill-ups
+        </p>
+        {loading ? (
+          <p className="text-sm text-muted-text">Loading…</p>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-muted-text">
+            No fill-ups yet — add your first above.
+          </p>
+        ) : (
+          <table className="w-full text-sm min-w-[620px]">
+            <thead>
+              <tr className="text-xs text-muted-text text-left">
+                <th className="font-normal pb-2 pr-4">Date</th>
+                <th className="font-normal pb-2 pr-4">Odometer</th>
+                <th className="font-normal pb-2 pr-4 text-right">Gallons</th>
+                <th className="font-normal pb-2 pr-4">Type</th>
+                <th className="font-normal pb-2 pr-4">Vendor</th>
+                <th className="font-normal pb-2 pr-4 text-right">$/gal</th>
+                <th className="font-normal pb-2 pr-4 text-right">Total</th>
+                <th className="font-normal pb-2 pr-4 text-right">MPG</th>
+                <th className="font-normal pb-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((e) => {
+                const full = isFull(e);
+                const mpg = mpgByOdo.get(e.odometer_reading);
+                return (
+                  <tr
+                    key={e.fuel_entry_id}
+                    className="border-t border-[#3b4660]"
+                  >
+                    <td className="py-2 pr-4 whitespace-nowrap">
+                      {fmtDate(e.fuel_date)}
+                    </td>
+                    <td className="py-2 pr-4 whitespace-nowrap text-muted-text">
+                      {e.odometer_reading.toLocaleString("en-US")}
+                    </td>
+                    <td className="py-2 pr-4 text-right whitespace-nowrap">
+                      {e.gallons.toFixed(1)}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <span
+                        className="text-[11px] px-2 py-0.5 rounded-full"
+                        style={{
+                          background: full ? "#1a3a2a" : "#3a2a0a",
+                          color: full ? "#4ade80" : "#e8940a",
+                        }}
+                      >
+                        {full ? "Full" : "Partial"}
+                      </span>
+                    </td>
+                    <td className="py-2 pr-4 text-muted-text">
+                      {e.company_name || "—"}
+                    </td>
+                    <td className="py-2 pr-4 text-right whitespace-nowrap">
+                      ${e.price_per_gallon.toFixed(3)}
+                    </td>
+                    <td className="py-2 pr-4 text-right whitespace-nowrap">
+                      {money2(entryCost(e))}
+                    </td>
+                    <td className="py-2 pr-4 text-right whitespace-nowrap">
+                      {full && mpg != null ? mpg.toFixed(2) : "—"}
+                    </td>
+                    <td className="py-2 text-right">
+                      <Trash2
+                        size={14}
+                        className="cursor-pointer text-muted-text hover:text-destructive"
+                        aria-label="Delete"
+                        onClick={() => remove(e.fuel_entry_id)}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default FuelEntriesPage;

--- a/frontend/src/services/fuelService.ts
+++ b/frontend/src/services/fuelService.ts
@@ -1,0 +1,28 @@
+import api from "./api";
+import type { FuelEntry, FuelEntryInput } from "@/types/fuelEntry";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Postgres numerics arrive as strings — coerce the money/volume fields.
+const coerce = (f: any): FuelEntry => ({
+  ...f,
+  gallons: Number(f.gallons),
+  price_per_gallon: Number(f.price_per_gallon),
+  odometer_reading: Number(f.odometer_reading),
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export const getFuelEntries = async (): Promise<FuelEntry[]> => {
+  const res = await api.get("/fuel");
+  return res.data.fuel_entries.map(coerce);
+};
+
+export const createFuelEntry = async (
+  data: FuelEntryInput,
+): Promise<FuelEntry> => {
+  const res = await api.post("/fuel", data);
+  return coerce(res.data.fuel_entry);
+};
+
+export const deleteFuelEntry = async (id: string): Promise<void> => {
+  await api.delete(`/fuel/${id}`);
+};

--- a/frontend/src/types/fuelEntry.ts
+++ b/frontend/src/types/fuelEntry.ts
@@ -1,0 +1,25 @@
+export interface FuelEntry {
+  fuel_entry_id: string;
+  truck_id: string;
+  trip_id: string | null;
+  fuel_date: string; // 'YYYY-MM-DD'
+  gallons: number;
+  price_per_gallon: number;
+  odometer_reading: number;
+  company_name: string | null;
+  fuel_city: string | null;
+  fuel_state: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface FuelEntryInput {
+  truck_id: string;
+  fuel_date: string;
+  gallons: number;
+  price_per_gallon: number;
+  odometer_reading: number;
+  company_name?: string | null;
+  fuel_city?: string | null;
+  fuel_state: string;
+}


### PR DESCRIPTION
## Fuel page — Chunk 1

Turns the placeholder fuel page into a working fuel-economy tracker on the existing `fuel_entries` backend. No CSV importer — the app *is* the fuel tracker now; fills go in through a manual form (and I've seeded the ~17 existing Fuelly fills into dev for verification).

### Jason's fill-up rule
- **120+ gallons = full tank; less = partial.** Partials roll into the next full.
- MPG is measured **between fulls**: odometer delta ÷ all gallons added since the last full (including the closing full).

### What's on the page
- **6 KPIs:** Avg MPG, Cost/mile, Cost/gallon, Avg weekly (rolling 90d), Total gallons, Total spend.
- **MPG per tank** line chart (one point per full).
- **Weekly fuel cost** bar chart with the 90-day average as a dashed reference line.
- **Add fill-up** form (single-truck auto-resolves; state uppercased).
- **Fill-up log** with full/partial badges and per-tank MPG.

### Verification
- `fuelEconomy.ts` engine covered by 8 unit tests (131 total pass).
- Metrics cross-checked against the seeded dev data: 17 fills → 9 full / 8 partial, 1,975.33 gal, \$8,213.42 spend, \$4.16/gal, avg MPG 6.55.

Chunk 2 (EIA national diesel price vs. own cost/gal) follows once the API key is set.