### PR TITLE
feat: fuel page (chunk 2) — EIA national diesel + total→price auto-calc

### DIFF
--- a/backend/src/routes/fuelEntryRoutes.js
+++ b/backend/src/routes/fuelEntryRoutes.js
@@ -7,6 +7,7 @@ import {
   patchFuelEntry,
   deleteFuelEntry,
 } from "../services/fuelEntryServices.js";
+import { getNationalDiesel } from "../services/fuelPriceService.js";
 
 const router = express.Router();
 router.use(requireAuth);
@@ -33,6 +34,18 @@ router.get("/", async (req, res) => {
       error: "Internal Server Error",
       message: err.message,
     });
+  }
+});
+
+// ---- NATIONAL DIESEL PRICE (EIA proxy, cached) ----
+// Must sit before the "/:fuel_entry_id" matcher so it isn't read as an id.
+router.get("/national-diesel", async (req, res) => {
+  try {
+    const diesel = await getNationalDiesel();
+    return res.status(200).json({ diesel });
+  } catch (err) {
+    // A blip at EIA should never break the fuel page — degrade to null.
+    return res.status(200).json({ diesel: null, message: err.message });
   }
 });
 

--- a/backend/src/services/fuelPriceService.js
+++ b/backend/src/services/fuelPriceService.js
@@ -1,0 +1,49 @@
+// National retail diesel price from the U.S. EIA, fetched server-side so the API
+// key never reaches the browser. Series EMD_EPD2D_PTE_NUS_DPG — weekly U.S.
+// No 2 Diesel retail price ($/gal). Cached in memory; the feed only updates once
+// a week (Monday), so there is no reason to hit EIA on every page load.
+
+const EIA_BASE = "https://api.eia.gov/v2/petroleum/pri/gnd/data/";
+const CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+let cache = null; // { data, fetchedAt }
+
+// Pure: map an EIA v2 petroleum response to our shape. `value` arrives as a
+// string, so coerce it; return null when the payload has no usable row.
+export const parseNationalDiesel = (json) => {
+  const row = json?.response?.data?.[0];
+  if (!row) return null;
+  const value = Number(row.value);
+  if (!Number.isFinite(value)) return null;
+  return {
+    value,
+    period: row.period, // 'YYYY-MM-DD' — the week the price is for
+    units: row.units ?? "$/GAL",
+    seriesDescription: row["series-description"] ?? null,
+  };
+};
+
+export const getNationalDiesel = async () => {
+  const now = Date.now();
+  if (cache && now - cache.fetchedAt < CACHE_TTL_MS) return cache.data;
+
+  const key = process.env.EIA_API_KEY;
+  if (!key) return null; // not configured — the page degrades gracefully
+
+  const params = new URLSearchParams({
+    frequency: "weekly",
+    "data[0]": "value",
+    "facets[duoarea][]": "NUS", // U.S. national
+    "facets[product][]": "EPD2D", // No 2 Diesel
+    "facets[process][]": "PTE", // Retail Sales
+    "sort[0][column]": "period",
+    "sort[0][direction]": "desc",
+    length: "1", // just the most recent week
+    api_key: key,
+  });
+
+  const res = await fetch(`${EIA_BASE}?${params}`);
+  if (!res.ok) throw new Error(`EIA request failed (${res.status})`);
+  const data = parseNationalDiesel(await res.json());
+  cache = { data, fetchedAt: now };
+  return data;
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.43.0",
+  "version": "1.44.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/fuel/DieselCompareCard.tsx
+++ b/frontend/src/components/fuel/DieselCompareCard.tsx
@@ -1,0 +1,71 @@
+import type { NationalDiesel } from "@/types/fuelEntry";
+import { Stamp } from "@/components/Stamp";
+
+const money3 = (n: number) => `$${n.toFixed(3)}`;
+
+const fmtWeek = (d: string) =>
+  new Date(d + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+// "You vs. national" — your blended cost/gal against the EIA weekly U.S. retail
+// diesel number. Beating the national average earns a comic win stamp.
+export const DieselCompareCard = ({
+  national,
+  yourCostPerGallon,
+}: {
+  national: NationalDiesel | null;
+  yourCostPerGallon: number | null;
+}) => {
+  if (!national) return null;
+
+  const delta =
+    yourCostPerGallon == null ? null : yourCostPerGallon - national.value;
+  const under = delta != null && delta < 0;
+  const deltaColor = delta == null ? "#9daabb" : under ? "#4ade80" : "#e8940a";
+
+  return (
+    <div className="bg-plate rounded-lg p-4 mt-4">
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <p className="text-xs text-muted-text uppercase tracking-wider">
+            You vs. national diesel
+          </p>
+          <p className="text-[11px] text-muted-text mt-0.5">
+            U.S. retail avg · week of {fmtWeek(national.period)} · EIA
+          </p>
+        </div>
+        {under && <Stamp label="Under the national" color="#4ade80" />}
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 mt-4">
+        <div>
+          <p className="text-xs text-muted-text">National avg</p>
+          <p className="text-2xl font-condensed mt-1 text-light">
+            {money3(national.value)}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-muted-text">Your avg / gal</p>
+          <p className="text-2xl font-condensed mt-1 text-light">
+            {yourCostPerGallon == null ? "—" : money3(yourCostPerGallon)}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-muted-text">
+            {delta == null ? "Difference" : under ? "You save" : "Over by"}
+          </p>
+          <p
+            className="text-2xl font-condensed mt-1"
+            style={{ color: deltaColor }}
+          >
+            {delta == null ? "—" : `${under ? "−" : "+"}$${Math.abs(delta).toFixed(3)}`}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/FuelEntriesPage.tsx
+++ b/frontend/src/pages/FuelEntriesPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
-import type { FuelEntry } from "@/types/fuelEntry";
+import type { FuelEntry, NationalDiesel } from "@/types/fuelEntry";
 import type { Truck } from "@/types/truck";
 import {
   getFuelEntries,
   createFuelEntry,
   deleteFuelEntry,
+  getNationalDiesel,
 } from "@/services/fuelService";
 import { getTrucks } from "@/services/trucksService";
 import {
@@ -17,6 +18,7 @@ import {
 import { Kpi } from "@/components/Kpi";
 import { MpgChart } from "@/components/fuel/MpgChart";
 import { WeeklyCostChart } from "@/components/fuel/WeeklyCostChart";
+import { DieselCompareCard } from "@/components/fuel/DieselCompareCard";
 
 const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const money2 = (n: number) =>
@@ -35,6 +37,7 @@ const lbl = "text-xs text-muted-text mb-1 block";
 const FuelEntriesPage = () => {
   const [entries, setEntries] = useState<FuelEntry[]>([]);
   const [trucks, setTrucks] = useState<Truck[]>([]);
+  const [national, setNational] = useState<NationalDiesel | null>(null);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -44,7 +47,7 @@ const FuelEntriesPage = () => {
   const [date, setDate] = useState("");
   const [odometer, setOdometer] = useState("");
   const [gallons, setGallons] = useState("");
-  const [price, setPrice] = useState("");
+  const [total, setTotal] = useState("");
   const [company, setCompany] = useState("");
   const [city, setCity] = useState("");
   const [stateCode, setStateCode] = useState("");
@@ -58,6 +61,13 @@ const FuelEntriesPage = () => {
       })
       .catch(() => {})
       .finally(() => setLoading(false));
+
+  // National diesel is best-effort — never let it block or break the page.
+  useEffect(() => {
+    getNationalDiesel()
+      .then(setNational)
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     load();
@@ -78,14 +88,25 @@ const FuelEntriesPage = () => {
     [entries],
   );
 
+  // Price/gallon is derived from the total paid ÷ gallons — the numbers on the
+  // receipt — rounded to the 3-decimal cents diesel is quoted in.
+  const g = parseFloat(gallons);
+  const t = parseFloat(total);
+  const computedPpg =
+    g > 0 && t > 0 && isFinite(g) && isFinite(t) ? t / g : null;
+
   const save = async () => {
     setError(null);
     if (!truckId) {
       setError("Add a truck first (Fleet → Trucks).");
       return;
     }
-    if (!date || !odometer || !gallons || !price || !stateCode.trim()) {
-      setError("Date, odometer, gallons, price, and state are required.");
+    if (!date || !odometer || !gallons || !total || !stateCode.trim()) {
+      setError("Date, odometer, gallons, total, and state are required.");
+      return;
+    }
+    if (computedPpg == null) {
+      setError("Enter gallons and total so price/gallon can be calculated.");
       return;
     }
     setBusy(true);
@@ -94,7 +115,7 @@ const FuelEntriesPage = () => {
         truck_id: truckId,
         fuel_date: date,
         gallons: parseFloat(gallons),
-        price_per_gallon: parseFloat(price),
+        price_per_gallon: Number(computedPpg.toFixed(3)),
         odometer_reading: parseInt(odometer, 10),
         company_name: company.trim() || null,
         fuel_city: city.trim() || null,
@@ -103,7 +124,7 @@ const FuelEntriesPage = () => {
       setDate("");
       setOdometer("");
       setGallons("");
-      setPrice("");
+      setTotal("");
       setCompany("");
       setCity("");
       setStateCode("");
@@ -188,6 +209,11 @@ const FuelEntriesPage = () => {
         <Kpi label="Total spend" value={money0(stats.totalSpend)} />
       </div>
 
+      <DieselCompareCard
+        national={national}
+        yourCostPerGallon={stats.avgCostPerGallon}
+      />
+
       {showForm && (
         <div className="bg-plate rounded-lg p-4 mt-4">
           <p className="text-sm font-medium mb-3">Add fill-up</p>
@@ -222,14 +248,19 @@ const FuelEntriesPage = () => {
               />
             </div>
             <div>
-              <label className={lbl}>Price / gal</label>
+              <label className={lbl}>Total $</label>
               <input
                 className={inputCls}
-                value={price}
+                value={total}
                 inputMode="decimal"
-                placeholder="4.033"
-                onChange={(e) => setPrice(e.target.value)}
+                placeholder="555.90"
+                onChange={(e) => setTotal(e.target.value)}
               />
+              <p className="text-[11px] mt-1 text-amber-light">
+                {computedPpg == null
+                  ? "= —/gal"
+                  : `= $${computedPpg.toFixed(3)}/gal`}
+              </p>
             </div>
             <div>
               <label className={lbl}>Vendor</label>

--- a/frontend/src/services/fuelService.ts
+++ b/frontend/src/services/fuelService.ts
@@ -1,5 +1,9 @@
 import api from "./api";
-import type { FuelEntry, FuelEntryInput } from "@/types/fuelEntry";
+import type {
+  FuelEntry,
+  FuelEntryInput,
+  NationalDiesel,
+} from "@/types/fuelEntry";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // Postgres numerics arrive as strings — coerce the money/volume fields.
@@ -25,4 +29,10 @@ export const createFuelEntry = async (
 
 export const deleteFuelEntry = async (id: string): Promise<void> => {
   await api.delete(`/fuel/${id}`);
+};
+
+// National retail diesel price (weekly, from EIA via our backend proxy).
+export const getNationalDiesel = async (): Promise<NationalDiesel | null> => {
+  const res = await api.get("/fuel/national-diesel");
+  return res.data.diesel ?? null;
 };

--- a/frontend/src/types/fuelEntry.ts
+++ b/frontend/src/types/fuelEntry.ts
@@ -13,6 +13,13 @@ export interface FuelEntry {
   updated_at: string;
 }
 
+export interface NationalDiesel {
+  value: number; // $/gal
+  period: string; // 'YYYY-MM-DD' — the week the price is for
+  units: string;
+  seriesDescription: string | null;
+}
+
 export interface FuelEntryInput {
   truck_id: string;
   fuel_date: string;


### PR DESCRIPTION
## Fuel page — Chunk 2

### National diesel price (EIA)
- **Backend proxy** `GET /fuel/national-diesel` — calls the EIA v2 petroleum API **server-side** so the API key stays on the server (`EIA_API_KEY`, never shipped to the browser).
- **Narrowed** to the one series we want: weekly **U.S. No 2 Diesel retail** (`EMD_EPD2D_PTE_NUS_DPG`, `product=EPD2D` / `process=PTE` / `duoarea=NUS`) instead of the ~5,000-row firehose. **Cached in memory 12h** — the feed only updates weekly.
- **Fails soft**: any EIA hiccup returns `null` (HTTP 200), so the fuel page never breaks; the compare card just hides.
- Frontend **"You vs. national diesel"** card: national average (with the week it's for) vs. your blended cost/gallon, plus an **"Under the national" win stamp** when you're beating it. Verified live: latest week 2026-07-06 = \$4.578/gal vs. your \$4.16 → \$0.42 under.

### Form auto-calc
- The add-fill-up form now takes **Total \$** and computes **price/gallon** (total ÷ gallons, to 3 decimals) live as you type — the two numbers on the receipt — instead of asking for price/gallon directly.

### Verification
- EIA query + parser verified against the **live API** (real response shape, string→number coercion).
- Backend router loads clean; frontend build + **131 tests** green.

### ⚠️ Deploy note
Set **`EIA_API_KEY`** in **Railway → Variables** for prod. Until it's set, the endpoint returns `null` and the compare card simply doesn't render (no breakage). Local/dev `.env` already has it.