### PR TITLE
feat: fold fuel odometer into the derived tractor odometer

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/hooks/useMaintenanceAlerts.ts
+++ b/frontend/src/hooks/useMaintenanceAlerts.ts
@@ -6,30 +6,39 @@ import type {
   MaintenanceService,
   MaintenanceUnit,
 } from "@/types/maintenance";
+import type { FuelEntry } from "@/types/fuelEntry";
 import {
   getMaintenanceItems,
   getMaintenanceServices,
 } from "@/services/maintenanceService";
+import { getFuelEntries } from "@/services/fuelService";
 import {
   maintenanceAlerts,
   currentTractorMiles,
   avgMilesPerMonth,
   maxOdometer,
 } from "@/lib/metrics/maintenance";
+import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 
 // Overdue / due-soon maintenance items as dashboard alerts. Empty (renders no
 // banners) until items exist and something is actually due.
 export const useMaintenanceAlerts = (loads: Load[]): Alert[] => {
   const [items, setItems] = useState<MaintenanceItem[]>([]);
   const [services, setServices] = useState<MaintenanceService[]>([]);
+  const [fuelEntries, setFuelEntries] = useState<FuelEntry[]>([]);
 
   useEffect(() => {
     let active = true;
-    Promise.all([getMaintenanceItems(), getMaintenanceServices()])
-      .then(([its, svcs]) => {
+    Promise.all([
+      getMaintenanceItems(),
+      getMaintenanceServices(),
+      getFuelEntries(),
+    ])
+      .then(([its, svcs, fuel]) => {
         if (!active) return;
         setItems(its);
         setServices(svcs);
+        setFuelEntries(fuel);
       })
       .catch(() => {});
     return () => {
@@ -52,9 +61,13 @@ export const useMaintenanceAlerts = (loads: Load[]): Alert[] => {
         }, null);
     };
     const currentMiles: Record<MaintenanceUnit, number | null> = {
-      tractor: maxOdometer(currentTractorMiles(loads), svcOdo("tractor")),
+      tractor: maxOdometer(
+        currentTractorMiles(loads),
+        svcOdo("tractor"),
+        maxFuelOdometer(fuelEntries),
+      ),
       trailer: maxOdometer(svcOdo("trailer")),
     };
     return maintenanceAlerts(items, currentMiles, now, avgMilesPerMonth(loads, now));
-  }, [items, services, loads]);
+  }, [items, services, fuelEntries, loads]);
 };

--- a/frontend/src/lib/metrics/fuelEconomy.test.ts
+++ b/frontend/src/lib/metrics/fuelEconomy.test.ts
@@ -6,6 +6,7 @@ import {
   fuelStats,
   avgWeeklyCost,
   weeklyCostSeries,
+  maxFuelOdometer,
 } from "./fuelEconomy";
 
 const e = (
@@ -85,5 +86,14 @@ describe("weeklyCostSeries", () => {
     const s = weeklyCostSeries(first4);
     expect(s.length).toBeGreaterThan(0);
     expect(s[0].weekStart <= s[s.length - 1].weekStart).toBe(true);
+  });
+});
+
+describe("maxFuelOdometer", () => {
+  it("returns the highest reading regardless of order", () => {
+    expect(maxFuelOdometer(first4)).toBe(572503);
+  });
+  it("returns null with no fill-ups", () => {
+    expect(maxFuelOdometer([])).toBeNull();
   });
 });

--- a/frontend/src/lib/metrics/fuelEconomy.ts
+++ b/frontend/src/lib/metrics/fuelEconomy.ts
@@ -152,3 +152,14 @@ export const weeklyCostSeries = (entries: FuelLike[]): WeekCost[] => {
     .map(([weekStart, cost]) => ({ weekStart, cost }))
     .sort((a, b) => a.weekStart.localeCompare(b.weekStart));
 };
+
+// Highest odometer reading across fill-ups (or null if none) — the fuel log is
+// usually the freshest odometer source, so it folds into the truck's derived
+// "latest odometer" alongside loads and service readings.
+export const maxFuelOdometer = (
+  entries: { odometer_reading: number }[],
+): number | null =>
+  entries.reduce<number | null>(
+    (m, e) => (m == null || e.odometer_reading > m ? e.odometer_reading : m),
+    null,
+  );

--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -1,15 +1,18 @@
 import { useState, useEffect, useMemo } from "react";
 import { useLoads } from "@/hooks/useLoads";
 import type { MaintenanceItem, MaintenanceService, MaintenanceUnit } from "@/types/maintenance";
+import type { FuelEntry } from "@/types/fuelEntry";
 import {
   getMaintenanceItems,
   getMaintenanceServices,
 } from "@/services/maintenanceService";
+import { getFuelEntries } from "@/services/fuelService";
 import {
   currentTractorMiles,
   avgMilesPerMonth,
   maxOdometer,
 } from "@/lib/metrics/maintenance";
+import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { ScheduleTab } from "@/components/maintenance/ScheduleTab";
 import { ServicesTab } from "@/components/maintenance/ServicesTab";
 
@@ -17,6 +20,7 @@ const MaintenancePage = () => {
   const { loads } = useLoads(0);
   const [items, setItems] = useState<MaintenanceItem[]>([]);
   const [services, setServices] = useState<MaintenanceService[]>([]);
+  const [fuelEntries, setFuelEntries] = useState<FuelEntry[]>([]);
   const [tab, setTab] = useState<"schedule" | "services">("schedule");
   const [refreshKey, setRefreshKey] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -24,11 +28,16 @@ const MaintenancePage = () => {
   useEffect(() => {
     let active = true;
     setLoading(true);
-    Promise.all([getMaintenanceItems(), getMaintenanceServices()])
-      .then(([its, svcs]) => {
+    Promise.all([
+      getMaintenanceItems(),
+      getMaintenanceServices(),
+      getFuelEntries(),
+    ])
+      .then(([its, svcs, fuel]) => {
         if (!active) return;
         setItems(its);
         setServices(svcs);
+        setFuelEntries(fuel);
       })
       .catch(() => {})
       .finally(() => {
@@ -56,13 +65,17 @@ const MaintenancePage = () => {
           return max == null || v > max ? v : max;
         }, null);
     };
-    // When the fuel page carries odometer, add its latest reading here — it'll
-    // usually be the freshest.
+    // The fuel log usually carries the freshest tractor odometer, so fold its
+    // latest reading in alongside loads and services.
     return {
-      tractor: maxOdometer(currentTractorMiles(loads), maxServiceOdo("tractor")),
+      tractor: maxOdometer(
+        currentTractorMiles(loads),
+        maxServiceOdo("tractor"),
+        maxFuelOdometer(fuelEntries),
+      ),
       trailer: maxOdometer(maxServiceOdo("trailer")),
     };
-  }, [loads, services]);
+  }, [loads, services, fuelEntries]);
 
   const milesPerMonth = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
 

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -3,18 +3,21 @@ import { useParams, Link } from "react-router-dom";
 import { Pencil } from "lucide-react";
 import type { Truck } from "@/types/truck";
 import type { Load } from "@/types/load";
+import type { FuelEntry } from "@/types/fuelEntry";
 import type { MaintenanceItem, MaintenanceService } from "@/types/maintenance";
 import { getTruck, patchTruck } from "@/services/trucksService";
 import {
   getMaintenanceItems,
   getMaintenanceServices,
 } from "@/services/maintenanceService";
+import { getFuelEntries } from "@/services/fuelService";
 import { useLoads } from "@/hooks/useLoads";
 import {
   computeDue,
   avgMilesPerMonth,
   maxOdometer,
 } from "@/lib/metrics/maintenance";
+import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
@@ -46,6 +49,7 @@ const TruckDetailPage = () => {
   const [truck, setTruck] = useState<Truck | null>(null);
   const [items, setItems] = useState<MaintenanceItem[]>([]);
   const [services, setServices] = useState<MaintenanceService[]>([]);
+  const [fuelEntries, setFuelEntries] = useState<FuelEntry[]>([]);
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -61,6 +65,9 @@ const TruckDetailPage = () => {
     getMaintenanceServices()
       .then(setServices)
       .catch(() => {});
+    getFuelEntries()
+      .then(setFuelEntries)
+      .catch(() => {});
   }, [id]);
 
   const truckLoads = useMemo(
@@ -69,18 +76,21 @@ const TruckDetailPage = () => {
   );
 
   // Latest odometer, derived from the app: stored value + newest load + newest
-  // service reading (fuel will fold in once it carries an odometer).
+  // service reading + newest fuel fill-up (fuel is usually the freshest).
   const odometer = useMemo(() => {
     if (!truck) return 0;
     const loadOdos = truckLoads.map((l) => l.odometer_end ?? null);
     const svcOdos = services
       .filter((s) => s.unit === "tractor" || s.unit === "both")
       .map((s) => s.odometer);
+    const fuelOdo = maxFuelOdometer(
+      fuelEntries.filter((f) => f.truck_id === id),
+    );
     return (
-      maxOdometer(truck.current_odometer, ...loadOdos, ...svcOdos) ??
+      maxOdometer(truck.current_odometer, ...loadOdos, ...svcOdos, fuelOdo) ??
       truck.current_odometer
     );
-  }, [truck, truckLoads, services]);
+  }, [truck, truckLoads, services, fuelEntries, id]);
 
   const mpm = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
   const due = useMemo(() => {


### PR DESCRIPTION
## Fold fuel odometer into the derived tractor odometer

Fill-ups carry an odometer reading and are usually the freshest source, but the app's derived "latest odometer" only looked at loads and service readings (both maintenance files even had a `// when the fuel page carries odometer…` TODO).

- New pure helper `maxFuelOdometer(entries)` (2 tests) — highest reading across fill-ups, or null.
- Folded into **all three** places the tractor odometer is derived so they stay coherent: `TruckDetailPage`, `MaintenancePage`, and `useMaintenanceAlerts`. Truck detail filters fuel by `truck_id`; the maintenance views (single-tractor assumption, same as `currentTractorMiles`) take the fleet max.
- **Trailer hub untouched** — fuel is truck-scoped.

Because the tractor odometer also drives the maintenance-due calculations, this makes "due soon / overdue" more accurate.

### Verification (dev)
Tractor odometer sources: stored 568,737 · loads 314,697 · services 568,737 · **fuel 582,450**. Derived latest goes from 568,737 → **582,450** (newest fill-up). Build + **133 tests** green.