### PR TITLE
feat: compliance hub — document expiry tracking + dashboard alerts

### DIFF
--- a/backend/db/migrations/030_compliance.sql
+++ b/backend/db/migrations/030_compliance.sql
@@ -1,0 +1,30 @@
+-- Compliance documents with renewal/expiry tracking. One row per trackable doc,
+-- scoped to the user and optionally linked to a driver / truck / trailer.
+--
+-- CDL is intentionally NOT stored here: it lives on the driver record (number,
+-- state, expiration, endorsements are driver identity). The compliance hub reads
+-- it and is the sole edit surface; the driver page shows it read-only. Everything
+-- genuinely new -- medical card, DOT inspection, HVUT 2290, registration, UCR,
+-- IFTA license, LLC annual report -- lives in this table.
+
+CREATE TABLE IF NOT EXISTS compliance_items (
+  compliance_item_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      uuid NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  scope        text NOT NULL CHECK (scope IN ('business', 'driver', 'truck', 'trailer')),
+  driver_id    uuid REFERENCES drivers(driver_id)   ON DELETE CASCADE,
+  truck_id     uuid REFERENCES trucks(truck_id)     ON DELETE CASCADE,
+  trailer_id   uuid REFERENCES trailers(trailer_id) ON DELETE CASCADE,
+  label        text NOT NULL,
+  category     text,             -- license | medical | registration | inspection | tax | insurance | authority | other
+  issued_on    date,
+  expires_on   date,             -- the date the alert engine keys on
+  renewal_months integer,        -- cadence, so "mark renewed" can bump the next due date
+  warn_lead_days integer NOT NULL DEFAULT 30,
+  doc_number   text,
+  notes        text,
+  active       boolean NOT NULL DEFAULT true,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_items_user ON compliance_items(user_id);

--- a/backend/src/routes/complianceRoutes.js
+++ b/backend/src/routes/complianceRoutes.js
@@ -1,0 +1,85 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import {
+  getComplianceItems,
+  createComplianceItem,
+  patchComplianceItem,
+  deleteComplianceItem,
+} from "../services/complianceServices.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+const handle = (err, res) => {
+  if (err.type === "validation")
+    return res
+      .status(err.statusCode)
+      .json({ error: err.message, details: err.details });
+  if (err.type === "not_found")
+    return res.status(err.statusCode).json({ error: err.message });
+  return res
+    .status(500)
+    .json({ error: "Internal Server Error", message: err.message });
+};
+
+// ---- LIST ----
+router.get("/", async (req, res) => {
+  try {
+    const compliance_items = await getComplianceItems(req.user.user_id);
+    return res.status(200).json({
+      message: "Compliance items retrieved successfully",
+      count: compliance_items.length,
+      compliance_items,
+    });
+  } catch (err) {
+    return handle(err, res);
+  }
+});
+
+// ---- CREATE ----
+router.post("/", async (req, res) => {
+  try {
+    const compliance_item = await createComplianceItem(
+      req.user.user_id,
+      req.body,
+    );
+    return res
+      .status(201)
+      .json({ message: "Compliance item created successfully", compliance_item });
+  } catch (err) {
+    return handle(err, res);
+  }
+});
+
+// ---- PATCH ----
+router.patch("/:compliance_item_id", async (req, res) => {
+  try {
+    const compliance_item = await patchComplianceItem(
+      req.user.user_id,
+      req.params.compliance_item_id,
+      req.body,
+    );
+    return res
+      .status(200)
+      .json({ message: "Compliance item updated successfully", compliance_item });
+  } catch (err) {
+    return handle(err, res);
+  }
+});
+
+// ---- DELETE ----
+router.delete("/:compliance_item_id", async (req, res) => {
+  try {
+    const compliance_item = await deleteComplianceItem(
+      req.user.user_id,
+      req.params.compliance_item_id,
+    );
+    return res
+      .status(200)
+      .json({ message: "Compliance item deleted successfully", compliance_item });
+  } catch (err) {
+    return handle(err, res);
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -22,6 +22,7 @@ import obligationRouter from "./routes/obligationRoutes.js";
 import maintenanceRouter from "./routes/maintenanceRoutes.js";
 import trailerRouter from "./routes/trailerRoutes.js";
 import avatarRouter from "./routes/avatarRoutes.js";
+import complianceRouter from "./routes/complianceRoutes.js";
 
 const app = express();
 
@@ -49,6 +50,7 @@ app.use("/agents/:agent_id/notes", agentNoteRoutes);
 app.use("/expenses", expenseRouter);
 app.use("/obligations", obligationRouter);
 app.use("/maintenance", maintenanceRouter);
+app.use("/compliance", complianceRouter);
 app.use("/trailers", trailerRouter);
 app.use("/avatars", avatarRouter);
 

--- a/backend/src/services/complianceServices.js
+++ b/backend/src/services/complianceServices.js
@@ -1,0 +1,170 @@
+import { db } from "../../db/pool.js";
+import {
+  validateComplianceCreate,
+  validateCompliancePatch,
+} from "../utils/validation/complianceValidation.js";
+import { ValidationError, NotFoundError } from "../utils/error.js";
+
+const COLUMNS = `
+  compliance_item_id, user_id, scope, driver_id, truck_id, trailer_id,
+  label, category, issued_on, expires_on, renewal_months, warn_lead_days,
+  doc_number, notes, active, created_at, updated_at
+`;
+
+const WRITABLE = [
+  "scope",
+  "driver_id",
+  "truck_id",
+  "trailer_id",
+  "label",
+  "category",
+  "issued_on",
+  "expires_on",
+  "renewal_months",
+  "warn_lead_days",
+  "doc_number",
+  "notes",
+  "active",
+];
+
+// The entity column each non-business scope must point at, and its table.
+const SCOPE_ENTITY = {
+  driver: { col: "driver_id", table: "drivers", id: "driver_id" },
+  truck: { col: "truck_id", table: "trucks", id: "truck_id" },
+  trailer: { col: "trailer_id", table: "trailers", id: "trailer_id" },
+};
+
+// Confirm a linked entity belongs to the user; throw if not.
+async function assertOwns(user_id, table, idCol, idValue) {
+  const r = await db.query(
+    `SELECT 1 FROM ${table} WHERE user_id = $1 AND ${idCol} = $2`,
+    [user_id, idValue],
+  );
+  if (r.rowCount === 0) throw new NotFoundError(`${table.slice(0, -1)} not found`);
+}
+
+// Given a scope, resolve which entity id must be present + owned. Business
+// scope clears all three entity links.
+async function reconcileScope(user_id, scope, data) {
+  if (scope === "business") {
+    data.driver_id = null;
+    data.truck_id = null;
+    data.trailer_id = null;
+    return;
+  }
+  const entity = SCOPE_ENTITY[scope];
+  const idValue = data[entity.col];
+  if (!idValue) throw new ValidationError(`${scope} scope requires ${entity.col}`);
+  await assertOwns(user_id, entity.table, entity.id, idValue);
+  // Null the other two links so a row never points at more than its scope.
+  for (const s of Object.values(SCOPE_ENTITY))
+    if (s.col !== entity.col) data[s.col] = null;
+}
+
+export async function getComplianceItems(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const result = await db.query(
+    `SELECT ${COLUMNS} FROM compliance_items
+     WHERE user_id = $1
+     ORDER BY expires_on ASC NULLS LAST, label ASC`,
+    [user_id],
+  );
+  return result.rows;
+}
+
+export async function createComplianceItem(user_id, body) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+
+  for (const field in body)
+    if (!WRITABLE.includes(field))
+      throw new ValidationError(`${field} not allowed`);
+
+  const errors = validateComplianceCreate(body);
+  if (errors.length > 0) throw new ValidationError("Validation failed", errors);
+
+  const data = { ...body };
+  await reconcileScope(user_id, data.scope, data);
+
+  const fields = ["user_id"];
+  const values = [user_id];
+  const placeholders = ["$1"];
+  let index = 2;
+
+  for (const field of WRITABLE) {
+    if (data[field] !== undefined) {
+      fields.push(field);
+      values.push(data[field]);
+      placeholders.push(`$${index}`);
+      index++;
+    }
+  }
+
+  const result = await db.query(
+    `INSERT INTO compliance_items (${fields.join(", ")})
+     VALUES (${placeholders.join(", ")})
+     RETURNING ${COLUMNS}`,
+    values,
+  );
+  return result.rows[0];
+}
+
+export async function patchComplianceItem(user_id, compliance_item_id, body) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!compliance_item_id) throw new ValidationError("Missing compliance_item_id");
+
+  for (const field in body)
+    if (!WRITABLE.includes(field))
+      throw new ValidationError(`${field} not allowed`);
+
+  const errors = validateCompliancePatch(body);
+  if (errors.length > 0) throw new ValidationError("Validation failed", errors);
+
+  const data = { ...body };
+  // If the scope itself is changing, re-validate its entity link. If only an
+  // entity link is changing without a scope, confirm ownership of it.
+  if (data.scope !== undefined) {
+    await reconcileScope(user_id, data.scope, data);
+  } else {
+    for (const s of Object.values(SCOPE_ENTITY))
+      if (data[s.col]) await assertOwns(user_id, s.table, s.id, data[s.col]);
+  }
+
+  const updates = [];
+  const values = [];
+  let index = 1;
+  for (const field of WRITABLE) {
+    if (data[field] !== undefined) {
+      updates.push(`${field} = $${index}`);
+      values.push(data[field]);
+      index++;
+    }
+  }
+  if (updates.length === 0)
+    throw new ValidationError("No valid fields provided for update");
+
+  updates.push("updated_at = NOW()");
+  values.push(user_id, compliance_item_id);
+
+  const result = await db.query(
+    `UPDATE compliance_items SET ${updates.join(", ")}
+     WHERE user_id = $${index} AND compliance_item_id = $${index + 1}
+     RETURNING ${COLUMNS}`,
+    values,
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Compliance item not found");
+  return result.rows[0];
+}
+
+export async function deleteComplianceItem(user_id, compliance_item_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!compliance_item_id) throw new ValidationError("Missing compliance_item_id");
+
+  const result = await db.query(
+    `DELETE FROM compliance_items
+     WHERE user_id = $1 AND compliance_item_id = $2
+     RETURNING ${COLUMNS}`,
+    [user_id, compliance_item_id],
+  );
+  if (result.rowCount === 0) throw new NotFoundError("Compliance item not found");
+  return result.rows[0];
+}

--- a/backend/src/utils/validation/complianceValidation.js
+++ b/backend/src/utils/validation/complianceValidation.js
@@ -1,0 +1,103 @@
+import { isValidType, isDateValid, isValidUUID } from "../helper.js";
+
+/**
+ * Fields to validate:
+ * scope, label, category, issued_on, expires_on,
+ * renewal_months, warn_lead_days, doc_number, notes,
+ * driver_id, truck_id, trailer_id
+ */
+
+const SCOPES = ["business", "driver", "truck", "trailer"];
+
+const dateRule = (name) => (value, errors) => {
+  if (value === null) return; // clearing a date is allowed
+  if (!isValidType("string", value)) {
+    errors.push(`${name} must be a string`);
+    return;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length !== 10) errors.push(`${name} must be 10 chars (yyyy-mm-dd)`);
+  else if (!isDateValid(trimmed)) errors.push(`Invalid date for ${name}`);
+};
+
+const uuidRule = (name) => (value, errors) => {
+  if (value === null) return;
+  if (!isValidType("string", value) || !isValidUUID(value))
+    errors.push(`${name} must be a valid UUID`);
+};
+
+const rules = {
+  scope: (value, errors) => {
+    if (!isValidType("string", value) || !SCOPES.includes(value))
+      errors.push("scope must be one of business, driver, truck, trailer");
+  },
+  label: (value, errors) => {
+    if (!isValidType("string", value)) {
+      errors.push("label must be a string");
+      return;
+    }
+    const trimmed = value.trim();
+    if (trimmed.length === 0) errors.push("label cannot be blank");
+    if (trimmed.length > 120) errors.push("label cannot be more than 120 chars");
+  },
+  category: (value, errors) => {
+    if (value === null || value === undefined) return;
+    if (!isValidType("string", value)) errors.push("category must be a string");
+    else if (value.trim().length > 40)
+      errors.push("category cannot be more than 40 chars");
+  },
+  issued_on: dateRule("issued_on"),
+  expires_on: dateRule("expires_on"),
+  renewal_months: (value, errors) => {
+    if (value === null || value === undefined) return;
+    if (!isValidType("integer", value)) {
+      errors.push("renewal_months must be an integer");
+      return;
+    }
+    if (value < 1 || value > 120)
+      errors.push("renewal_months must be between 1 and 120");
+  },
+  warn_lead_days: (value, errors) => {
+    if (value === undefined) return;
+    if (!isValidType("integer", value)) {
+      errors.push("warn_lead_days must be an integer");
+      return;
+    }
+    if (value < 0 || value > 365)
+      errors.push("warn_lead_days must be between 0 and 365");
+  },
+  doc_number: (value, errors) => {
+    if (value === null || value === undefined) return;
+    if (!isValidType("string", value)) errors.push("doc_number must be a string");
+    else if (value.trim().length > 60)
+      errors.push("doc_number cannot be more than 60 chars");
+  },
+  notes: (value, errors) => {
+    if (value === null || value === undefined) return;
+    if (!isValidType("string", value)) errors.push("notes must be a string");
+    else if (value.trim().length > 500)
+      errors.push("notes cannot be more than 500 chars");
+  },
+  driver_id: uuidRule("driver_id"),
+  truck_id: uuidRule("truck_id"),
+  trailer_id: uuidRule("trailer_id"),
+};
+
+export const validateComplianceCreate = (data) => {
+  const errors = [];
+  if (data.scope === undefined) errors.push("Missing scope");
+  if (data.label === undefined) errors.push("Missing label");
+
+  for (const field in data) {
+    if (rules[field]) rules[field](data[field], errors);
+  }
+  return errors;
+};
+
+export const validateCompliancePatch = (data) => {
+  const errors = [];
+  for (const field in data) {
+    if (rules[field]) rules[field](data[field], errors);
+  }
+  return errors;
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.45.0",
+  "version": "1.46.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import { LoadDetailPage } from "@/pages/LoadDetailPage";
 import { SwatchesPage } from "@/pages/SwatchesPage";
 import SignupPage from "@/pages/SignupPage";
 import GuidePage from "@/pages/GuidePage";
+import CompliancePage from "@/pages/CompliancePage";
 
 // Code-split Lanes — it bundles the US map topology (~600KB), so it should only
 // load when the page is actually visited, not on every app start.
@@ -57,6 +58,7 @@ const App = () => {
           />
           <Route path="/expenses" element={<ExpensesPage />} />
           <Route path="/maintenance" element={<MaintenancePage />} />
+          <Route path="/compliance" element={<CompliancePage />} />
           <Route path="/agents" element={<AgentsPage />} />
           <Route path="/agents/:agent_id" element={<AgentDetailPage />} />
           <Route path="/fuel-entries" element={<FuelEntriesPage />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -41,6 +41,7 @@ const nav: Entry[] = [
       { to: "/fuel-entries", label: "Fuel" },
     ],
   },
+  { to: "/compliance", label: "Compliance" },
   { to: "/expenses", label: "Expenses" },
   { to: "/guide", label: "Guide" },
 ];

--- a/frontend/src/components/compliance/ComplianceItemForm.tsx
+++ b/frontend/src/components/compliance/ComplianceItemForm.tsx
@@ -1,0 +1,211 @@
+import { useState } from "react";
+import type {
+  ComplianceItem,
+  ComplianceItemInput,
+  ComplianceScope,
+} from "@/types/compliance";
+
+const inputCls = "bg-steel rounded px-2 py-1.5 text-sm w-full text-light";
+const lbl = "text-xs text-muted-text mb-1 block";
+
+export const CATEGORIES = [
+  "license",
+  "medical",
+  "registration",
+  "inspection",
+  "tax",
+  "insurance",
+  "authority",
+  "other",
+];
+
+type Preset = {
+  label: string;
+  category: string;
+  renewal_months?: number;
+  warn?: number;
+};
+
+// Common owner-operator docs per section, so adding one is mostly entering a
+// date rather than typing labels from scratch.
+export const PRESETS: Record<ComplianceScope, Preset[]> = {
+  business: [
+    { label: "LLC annual report", category: "authority", renewal_months: 12 },
+    { label: "UCR registration", category: "authority", renewal_months: 12 },
+    { label: "IFTA license", category: "authority", renewal_months: 12 },
+    { label: "MCS-150 biennial update", category: "authority", renewal_months: 24 },
+    { label: "BOC-3 process agent", category: "authority" },
+    { label: "Drug & alcohol consortium", category: "other", renewal_months: 12 },
+  ],
+  driver: [
+    { label: "Medical card (DOT physical)", category: "medical", renewal_months: 24, warn: 45 },
+    { label: "TWIC card", category: "license", renewal_months: 60, warn: 60 },
+    { label: "Hazmat endorsement", category: "license", renewal_months: 60, warn: 60 },
+    { label: "MVR / annual review", category: "other", renewal_months: 12 },
+  ],
+  truck: [
+    { label: "Apportioned registration (IRP)", category: "registration", renewal_months: 12, warn: 45 },
+    { label: "Annual DOT inspection", category: "inspection", renewal_months: 12 },
+    { label: "HVUT Form 2290", category: "tax", renewal_months: 12, warn: 45 },
+    { label: "State registration", category: "registration", renewal_months: 12 },
+  ],
+  trailer: [
+    { label: "Annual DOT inspection", category: "inspection", renewal_months: 12 },
+    { label: "Registration", category: "registration", renewal_months: 12 },
+  ],
+};
+
+interface Props {
+  scope: ComplianceScope;
+  initial?: ComplianceItem | null;
+  onSave: (data: Omit<ComplianceItemInput, "scope">) => Promise<void>;
+  onCancel: () => void;
+  busy: boolean;
+  error: string | null;
+}
+
+export const ComplianceItemForm = ({
+  scope,
+  initial,
+  onSave,
+  onCancel,
+  busy,
+  error,
+}: Props) => {
+  const [label, setLabel] = useState(initial?.label ?? "");
+  const [category, setCategory] = useState(initial?.category ?? "");
+  const [expiresOn, setExpiresOn] = useState(initial?.expires_on?.slice(0, 10) ?? "");
+  const [warnDays, setWarnDays] = useState(String(initial?.warn_lead_days ?? 30));
+  const [renewal, setRenewal] = useState(
+    initial?.renewal_months != null ? String(initial.renewal_months) : "",
+  );
+  const [docNumber, setDocNumber] = useState(initial?.doc_number ?? "");
+  const [local, setLocal] = useState<string | null>(null);
+
+  const applyPreset = (name: string) => {
+    const p = PRESETS[scope].find((x) => x.label === name);
+    if (!p) return;
+    setLabel(p.label);
+    setCategory(p.category);
+    if (p.renewal_months != null) setRenewal(String(p.renewal_months));
+    if (p.warn != null) setWarnDays(String(p.warn));
+  };
+
+  const submit = async () => {
+    setLocal(null);
+    if (!label.trim()) {
+      setLocal("Give the document a name.");
+      return;
+    }
+    await onSave({
+      label: label.trim(),
+      category: category || null,
+      expires_on: expiresOn || null,
+      warn_lead_days: parseInt(warnDays, 10) || 30,
+      renewal_months: renewal ? parseInt(renewal, 10) : null,
+      doc_number: docNumber.trim() || null,
+    });
+  };
+
+  return (
+    <div className="bg-steel rounded-lg p-3 mt-2">
+      {!initial && (
+        <div className="mb-3">
+          <label className={lbl}>Start from a common doc</label>
+          <select
+            className={inputCls}
+            defaultValue=""
+            onChange={(e) => applyPreset(e.target.value)}
+          >
+            <option value="">Choose…</option>
+            {PRESETS[scope].map((p) => (
+              <option key={p.label} value={p.label}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="sm:col-span-2">
+          <label className={lbl}>Document</label>
+          <input
+            className={inputCls}
+            value={label}
+            placeholder="Medical card (DOT physical)"
+            onChange={(e) => setLabel(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={lbl}>Expires</label>
+          <input
+            type="date"
+            className={inputCls}
+            value={expiresOn}
+            onChange={(e) => setExpiresOn(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={lbl}>Category</label>
+          <select
+            className={inputCls}
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            <option value="">—</option>
+            {CATEGORIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={lbl}>Warn me (days before)</label>
+          <input
+            className={inputCls}
+            value={warnDays}
+            inputMode="numeric"
+            onChange={(e) => setWarnDays(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className={lbl}>Renews every (months)</label>
+          <input
+            className={inputCls}
+            value={renewal}
+            inputMode="numeric"
+            placeholder="12"
+            onChange={(e) => setRenewal(e.target.value)}
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <label className={lbl}>Reference # (optional)</label>
+          <input
+            className={inputCls}
+            value={docNumber}
+            onChange={(e) => setDocNumber(e.target.value)}
+          />
+        </div>
+      </div>
+      {(local || error) && (
+        <p className="text-destructive text-sm mt-2">{local || error}</p>
+      )}
+      <div className="flex gap-2 mt-3">
+        <button
+          className="bg-amber text-steel px-3 py-1.5 rounded text-sm font-semibold disabled:opacity-50"
+          onClick={submit}
+          disabled={busy}
+        >
+          {busy ? "Saving…" : initial ? "Save" : "Add document"}
+        </button>
+        <button
+          className="bg-plate text-light px-3 py-1.5 rounded text-sm"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/hooks/useComplianceAlerts.ts
+++ b/frontend/src/hooks/useComplianceAlerts.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect, useMemo } from "react";
+import type { Alert } from "@/types/alert";
+import type { ComplianceItem } from "@/types/compliance";
+import type { Driver } from "@/types/driver";
+import { getComplianceItems } from "@/services/complianceService";
+import { getDrivers } from "@/services/driversService";
+import {
+  complianceAlerts,
+  itemToCheckable,
+  cdlToCheckable,
+} from "@/lib/metrics/compliance";
+
+// Expiring / expired compliance docs as dashboard alerts. Combines the tracked
+// compliance items with the CDL read off each driver record. Empty until
+// something is actually due, so it costs no banner space.
+export const useComplianceAlerts = (): Alert[] => {
+  const [items, setItems] = useState<ComplianceItem[]>([]);
+  const [drivers, setDrivers] = useState<Driver[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    Promise.all([getComplianceItems(), getDrivers()])
+      .then(([ci, dr]) => {
+        if (!active) return;
+        setItems(ci);
+        setDrivers(dr);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return useMemo(() => {
+    const now = new Date();
+    const checkables = [
+      ...items.map(itemToCheckable),
+      ...drivers.filter((d) => d.cdl_expiration).map(cdlToCheckable),
+    ];
+    return complianceAlerts(checkables, now);
+  }, [items, drivers]);
+};

--- a/frontend/src/lib/fleetFields.ts
+++ b/frontend/src/lib/fleetFields.ts
@@ -35,15 +35,13 @@ export const TRUCK_FIELDS: FormField[] = [
   { name: "in_service_date", label: "In service", type: "date" },
 ];
 
+// CDL (number, state, expiration, endorsements) is intentionally absent here —
+// it's managed on the Compliance page and shown read-only on the driver page.
 export const DRIVER_FIELDS: FormField[] = [
   { name: "first_name", label: "First name", required: true },
   { name: "last_name", label: "Last name", required: true },
   { name: "phone", label: "Phone" },
   { name: "email", label: "Email" },
-  { name: "cdl_number", label: "CDL #" },
-  { name: "cdl_state", label: "CDL state", placeholder: "AL" },
-  { name: "cdl_expiration", label: "CDL expires", type: "date" },
-  { name: "endorsements", label: "Endorsements", placeholder: "H, N, T" },
   { name: "hire_date", label: "Hire date", type: "date" },
 ];
 

--- a/frontend/src/lib/metrics/compliance.test.ts
+++ b/frontend/src/lib/metrics/compliance.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  daysUntil,
+  computeComplianceDue,
+  complianceSummary,
+  complianceAlerts,
+  type Checkable,
+} from "./compliance";
+
+const NOW = new Date("2026-07-10T12:00:00Z");
+
+const chk = (over: Partial<Checkable>): Checkable => ({
+  id: "x",
+  label: "Doc",
+  scope: "driver",
+  expires_on: null,
+  warn_lead_days: 30,
+  ...over,
+});
+
+describe("daysUntil", () => {
+  it("counts whole days in UTC, no day-shift", () => {
+    expect(daysUntil("2026-07-31", NOW)).toBe(21);
+    expect(daysUntil("2026-07-10", NOW)).toBe(0);
+    expect(daysUntil("2026-07-01", NOW)).toBe(-9);
+  });
+});
+
+describe("computeComplianceDue", () => {
+  it("valid when beyond the lead window", () => {
+    expect(computeComplianceDue({ expires_on: "2026-12-01", warn_lead_days: 30 }, NOW).level).toBe("valid");
+  });
+  it("expiring inside the lead window (inclusive)", () => {
+    expect(computeComplianceDue({ expires_on: "2026-07-31", warn_lead_days: 30 }, NOW).level).toBe("expiring");
+    expect(computeComplianceDue({ expires_on: "2026-08-09", warn_lead_days: 30 }, NOW).level).toBe("expiring");
+  });
+  it("expired the day after it lapses", () => {
+    expect(computeComplianceDue({ expires_on: "2026-07-09", warn_lead_days: 30 }, NOW).level).toBe("expired");
+  });
+  it("unknown with no expiry", () => {
+    expect(computeComplianceDue({ expires_on: null, warn_lead_days: 30 }, NOW).level).toBe("unknown");
+  });
+});
+
+describe("complianceSummary", () => {
+  it("counts by level", () => {
+    const s = complianceSummary(
+      [
+        chk({ expires_on: "2026-12-01" }), // valid
+        chk({ expires_on: "2026-07-31" }), // expiring
+        chk({ expires_on: null }), // unknown
+      ],
+      NOW,
+    );
+    expect(s).toMatchObject({ valid: 1, expiring: 1, expired: 0, unknown: 1, status: "cleared" });
+  });
+  it("grounds on an expired driver/vehicle doc", () => {
+    const s = complianceSummary([chk({ scope: "truck", expires_on: "2026-06-01" })], NOW);
+    expect(s.status).toBe("grounded");
+    expect(s.expired).toBe(1);
+  });
+  it("an expired business doc counts but does not ground", () => {
+    const s = complianceSummary([chk({ scope: "business", expires_on: "2026-06-01" })], NOW);
+    expect(s.status).toBe("cleared");
+    expect(s.expired).toBe(1);
+  });
+});
+
+describe("complianceAlerts", () => {
+  it("emits expired (critical) before expiring (warning)", () => {
+    const alerts = complianceAlerts(
+      [
+        chk({ id: "a", label: "Med card", expires_on: "2026-07-31" }), // expiring
+        chk({ id: "b", label: "Inspection", scope: "truck", expires_on: "2026-07-01" }), // expired
+        chk({ id: "c", label: "2290", scope: "truck", expires_on: "2027-01-01" }), // valid → no alert
+      ],
+      NOW,
+    );
+    expect(alerts.map((a) => a.id)).toEqual(["compliance-b", "compliance-a"]);
+    expect(alerts[0]).toMatchObject({ kind: "compliance", severity: "critical" });
+    expect(alerts[1]).toMatchObject({ severity: "warning", actionHref: "/compliance" });
+  });
+  it("is empty when everything is valid", () => {
+    expect(complianceAlerts([chk({ expires_on: "2030-01-01" })], NOW)).toEqual([]);
+  });
+});

--- a/frontend/src/lib/metrics/compliance.ts
+++ b/frontend/src/lib/metrics/compliance.ts
@@ -1,0 +1,143 @@
+// Compliance is maintenance's twin, keyed on dates instead of miles. Each
+// tracked document has an expiry; the engine flags it valid / expiring / expired
+// and emits alerts into the shared dashboard region.
+import type { Alert } from "@/types/alert";
+import type { ComplianceScope } from "@/types/compliance";
+
+export type ComplianceLevel = "valid" | "expiring" | "expired" | "unknown";
+
+export interface ComplianceDue {
+  level: ComplianceLevel;
+  daysRemaining: number | null;
+  expiresOn: string | null;
+}
+
+// Anything the engine can evaluate: a real compliance_item OR the CDL read off a
+// driver record. Kept minimal so both sources can be mapped to it.
+export interface Checkable {
+  id: string;
+  label: string;
+  scope: ComplianceScope;
+  expires_on: string | null;
+  warn_lead_days: number;
+  actionHref?: string;
+}
+
+// CDL renewals take a while, so warn earlier than the 30-day default.
+export const CDL_WARN_LEAD_DAYS = 45;
+
+// Map the two sources — real compliance items and the CDL read off a driver —
+// onto a common Checkable so the engine treats them identically.
+export const itemToCheckable = (i: {
+  compliance_item_id: string;
+  label: string;
+  scope: ComplianceScope;
+  expires_on: string | null;
+  warn_lead_days: number;
+}): Checkable => ({
+  id: i.compliance_item_id,
+  label: i.label,
+  scope: i.scope,
+  expires_on: i.expires_on,
+  warn_lead_days: i.warn_lead_days,
+  actionHref: "/compliance",
+});
+
+export const cdlToCheckable = (d: {
+  driver_id: string;
+  first_name: string;
+  last_name: string;
+  cdl_expiration: string | null;
+}): Checkable => ({
+  id: `cdl-${d.driver_id}`,
+  label: `CDL — ${d.first_name} ${d.last_name}`.trim(),
+  scope: "driver",
+  expires_on: d.cdl_expiration,
+  warn_lead_days: CDL_WARN_LEAD_DAYS,
+  actionHref: "/compliance",
+});
+
+const DAY = 86400000;
+
+// Whole-day difference from `now` to a 'YYYY-MM-DD' date, computed in UTC so a
+// date never day-shifts across a timezone. Positive = future, negative = past.
+export const daysUntil = (isoDate: string, now: Date): number => {
+  const target = new Date(isoDate.slice(0, 10) + "T00:00:00Z").getTime();
+  const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return Math.round((target - today) / DAY);
+};
+
+export const computeComplianceDue = (
+  item: { expires_on: string | null; warn_lead_days: number },
+  now: Date,
+): ComplianceDue => {
+  if (!item.expires_on)
+    return { level: "unknown", daysRemaining: null, expiresOn: null };
+  const days = daysUntil(item.expires_on, now);
+  const lead = item.warn_lead_days ?? 30;
+  const level: ComplianceLevel =
+    days < 0 ? "expired" : days <= lead ? "expiring" : "valid";
+  return { level, daysRemaining: days, expiresOn: item.expires_on };
+};
+
+export interface ComplianceSummary {
+  valid: number;
+  expiring: number;
+  expired: number;
+  unknown: number;
+  // "grounded" only when a roll-blocking (driver/vehicle) doc has expired; an
+  // expired business doc counts but doesn't take the truck off the road.
+  status: "cleared" | "grounded";
+}
+
+const rollBlocking = (scope: ComplianceScope) => scope !== "business";
+
+export const complianceSummary = (
+  items: Checkable[],
+  now: Date,
+): ComplianceSummary => {
+  let valid = 0;
+  let expiring = 0;
+  let expired = 0;
+  let unknown = 0;
+  let grounded = false;
+  for (const c of items) {
+    const { level } = computeComplianceDue(c, now);
+    if (level === "valid") valid++;
+    else if (level === "expiring") expiring++;
+    else if (level === "expired") {
+      expired++;
+      if (rollBlocking(c.scope)) grounded = true;
+    } else unknown++;
+  }
+  return { valid, expiring, expired, unknown, status: grounded ? "grounded" : "cleared" };
+};
+
+// Expiring/expired docs as dashboard alerts, most-urgent first.
+export const complianceAlerts = (items: Checkable[], now: Date): Alert[] => {
+  const alerts: { alert: Alert; rank: number; days: number }[] = [];
+  for (const c of items) {
+    const due = computeComplianceDue(c, now);
+    if (due.level !== "expired" && due.level !== "expiring") continue;
+    const expired = due.level === "expired";
+    const days = due.daysRemaining ?? 0;
+    alerts.push({
+      rank: expired ? 0 : 1,
+      days,
+      alert: {
+        id: `compliance-${c.id}`,
+        kind: "compliance",
+        severity: expired ? "critical" : "warning",
+        message: `${c.label} ${
+          expired
+            ? `expired ${Math.abs(days)}d ago`
+            : `expires in ${days}d`
+        }`,
+        actionHref: c.actionHref ?? "/compliance",
+      },
+    });
+  }
+  return alerts
+    .sort((a, b) => a.rank - b.rank || a.days - b.days)
+    .map((a) => a.alert);
+};

--- a/frontend/src/pages/CompliancePage.tsx
+++ b/frontend/src/pages/CompliancePage.tsx
@@ -1,0 +1,500 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Building2,
+  User,
+  Truck as TruckIcon,
+  Container,
+  HeartPulse,
+  ShieldCheck,
+  ClipboardCheck,
+  Receipt,
+  FileText,
+  BadgeCheck,
+  Plus,
+  Pencil,
+  Trash2,
+  ExternalLink,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type {
+  ComplianceItem,
+  ComplianceItemInput,
+  ComplianceScope,
+} from "@/types/compliance";
+import type { Driver } from "@/types/driver";
+import type { Truck } from "@/types/truck";
+import type { Trailer } from "@/types/trailer";
+import {
+  getComplianceItems,
+  createComplianceItem,
+  updateComplianceItem,
+  deleteComplianceItem,
+} from "@/services/complianceService";
+import { getDrivers, patchDriver } from "@/services/driversService";
+import { getTrucks } from "@/services/trucksService";
+import { getTrailers } from "@/services/trailersService";
+import {
+  computeComplianceDue,
+  complianceSummary,
+  itemToCheckable,
+  cdlToCheckable,
+  CDL_WARN_LEAD_DAYS,
+  type ComplianceLevel,
+} from "@/lib/metrics/compliance";
+import { Kpi } from "@/components/Kpi";
+import { Stamp } from "@/components/Stamp";
+import { ComplianceItemForm } from "@/components/compliance/ComplianceItemForm";
+
+const fmtDate = (d: string) =>
+  new Date(d.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+const catIcon = (cat: string | null): LucideIcon =>
+  (
+    ({
+      medical: HeartPulse,
+      license: BadgeCheck,
+      registration: FileText,
+      inspection: ClipboardCheck,
+      tax: Receipt,
+      insurance: ShieldCheck,
+      authority: Building2,
+    }) as Record<string, LucideIcon>
+  )[cat ?? ""] ?? FileText;
+
+const PILL: Record<ComplianceLevel, { label: string; bg: string; fg: string }> = {
+  valid: { label: "Valid", bg: "#1a3a2a", fg: "#4ade80" },
+  expiring: { label: "Expiring", bg: "#3a2a0a", fg: "#e8940a" },
+  expired: { label: "Expired", bg: "#3a1a1a", fg: "#f87171" },
+  unknown: { label: "No date", bg: "#1a2a3a", fg: "#60a5fa" },
+};
+
+const inputCls = "bg-steel rounded px-2 py-1.5 text-sm w-full text-light";
+const lbl = "text-xs text-muted-text mb-1 block";
+
+const entityCol: Record<ComplianceScope, "driver_id" | "truck_id" | "trailer_id" | null> =
+  { business: null, driver: "driver_id", truck: "truck_id", trailer: "trailer_id" };
+
+const CompliancePage = () => {
+  const [items, setItems] = useState<ComplianceItem[]>([]);
+  const [drivers, setDrivers] = useState<Driver[]>([]);
+  const [trucks, setTrucks] = useState<Truck[]>([]);
+  const [trailers, setTrailers] = useState<Trailer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Which section is mid-add (scope + optional entity id), and which item is
+  // mid-edit / which driver's CDL is being edited.
+  const [adding, setAdding] = useState<{ scope: ComplianceScope; entityId: string | null } | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [cdlDriver, setCdlDriver] = useState<Driver | null>(null);
+
+  const load = () =>
+    Promise.all([getComplianceItems(), getDrivers(), getTrucks(), getTrailers()])
+      .then(([ci, dr, tr, tl]) => {
+        setItems(ci);
+        setDrivers(dr);
+        setTrucks(tr);
+        setTrailers(tl);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const now = new Date();
+  const checkables = [
+    ...items.map(itemToCheckable),
+    ...drivers.filter((d) => d.cdl_expiration).map(cdlToCheckable),
+  ];
+  const summary = complianceSummary(checkables, now);
+
+  const closeForms = () => {
+    setAdding(null);
+    setEditingId(null);
+    setCdlDriver(null);
+    setError(null);
+  };
+
+  const saveNew = async (
+    scope: ComplianceScope,
+    entityId: string | null,
+    data: Omit<ComplianceItemInput, "scope">,
+  ) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const col = entityCol[scope];
+      const payload: ComplianceItemInput = { scope, ...data };
+      if (col && entityId) payload[col] = entityId;
+      await createComplianceItem(payload);
+      closeForms();
+      await load();
+    } catch (e) {
+      setError(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveEdit = async (id: string, data: Omit<ComplianceItemInput, "scope">) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await updateComplianceItem(id, data);
+      closeForms();
+      await load();
+    } catch (e) {
+      setError(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    setBusy(true);
+    try {
+      await deleteComplianceItem(id);
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveCdl = async (driver: Driver, patch: Partial<Driver>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await patchDriver(driver.driver_id, patch);
+      setDrivers((ds) => ds.map((d) => (d.driver_id === driver.driver_id ? updated : d)));
+      closeForms();
+    } catch (e) {
+      setError(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const itemRow = (item: ComplianceItem) => {
+    const due = computeComplianceDue(item, now);
+    const pill = PILL[due.level];
+    const Icon = catIcon(item.category);
+    if (editingId === item.compliance_item_id)
+      return (
+        <div key={item.compliance_item_id} className="border-t border-[#3b4660] pt-2">
+          <ComplianceItemForm
+            scope={item.scope}
+            initial={item}
+            onSave={(d) => saveEdit(item.compliance_item_id, d)}
+            onCancel={closeForms}
+            busy={busy}
+            error={error}
+          />
+        </div>
+      );
+    return (
+      <div
+        key={item.compliance_item_id}
+        className="flex items-center gap-3 py-3 border-t border-[#3b4660]"
+      >
+        <span
+          className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
+          style={{ background: pill.bg, color: pill.fg }}
+        >
+          <Icon size={16} />
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="truncate">{item.label}</p>
+          <p className="text-xs text-muted-text truncate">
+            {item.doc_number ? `#${item.doc_number}` : item.category || ""}
+            {item.renewal_months ? ` · renews every ${item.renewal_months} mo` : ""}
+          </p>
+        </div>
+        <div className="text-right shrink-0 min-w-[92px]">
+          <p className="text-xs text-muted-text whitespace-nowrap">
+            {due.expiresOn ? fmtDate(due.expiresOn) : "no date"}
+          </p>
+          {due.daysRemaining != null && (
+            <p className="text-[11px]" style={{ color: pill.fg }}>
+              {due.daysRemaining < 0
+                ? `${Math.abs(due.daysRemaining)}d ago`
+                : `${due.daysRemaining}d left`}
+            </p>
+          )}
+        </div>
+        <span
+          className="text-[11px] px-2 py-0.5 rounded-full shrink-0"
+          style={{ background: pill.bg, color: pill.fg }}
+        >
+          {pill.label}
+        </span>
+        <div className="flex gap-1.5 shrink-0">
+          <Pencil
+            size={14}
+            className="cursor-pointer text-muted-text hover:text-light"
+            aria-label="Edit"
+            onClick={() => {
+              closeForms();
+              setEditingId(item.compliance_item_id);
+            }}
+          />
+          <Trash2
+            size={14}
+            className="cursor-pointer text-muted-text hover:text-destructive"
+            aria-label="Delete"
+            onClick={() => remove(item.compliance_item_id)}
+          />
+        </div>
+      </div>
+    );
+  };
+
+  // The CDL row is backed by the driver record: editable here, read-only on the
+  // driver page. Its own due is computed off cdl_expiration.
+  const cdlRow = (driver: Driver) => {
+    const due = computeComplianceDue(
+      { expires_on: driver.cdl_expiration, warn_lead_days: CDL_WARN_LEAD_DAYS },
+      now,
+    );
+    const pill = PILL[due.level];
+    if (cdlDriver?.driver_id === driver.driver_id)
+      return <CdlForm key="cdl-edit" driver={driver} onSave={saveCdl} onCancel={closeForms} busy={busy} error={error} />;
+    return (
+      <div key={`cdl-${driver.driver_id}`} className="flex items-center gap-3 py-3 border-t border-[#3b4660]">
+        <span className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0" style={{ background: pill.bg, color: pill.fg }}>
+          <BadgeCheck size={16} />
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="truncate">CDL{driver.cdl_number ? ` · ${driver.cdl_number}` : ""}{driver.cdl_state ? ` (${driver.cdl_state})` : ""}</p>
+          <p className="text-xs text-muted-text truncate">
+            {driver.endorsements ? `endorsements: ${driver.endorsements}` : "commercial driver license"}
+          </p>
+        </div>
+        <div className="text-right shrink-0 min-w-[92px]">
+          <p className="text-xs text-muted-text whitespace-nowrap">
+            {due.expiresOn ? fmtDate(due.expiresOn) : "no date"}
+          </p>
+          {due.daysRemaining != null && (
+            <p className="text-[11px]" style={{ color: pill.fg }}>
+              {due.daysRemaining < 0 ? `${Math.abs(due.daysRemaining)}d ago` : `${due.daysRemaining}d left`}
+            </p>
+          )}
+        </div>
+        <span className="text-[11px] px-2 py-0.5 rounded-full shrink-0" style={{ background: pill.bg, color: pill.fg }}>
+          {pill.label}
+        </span>
+        <div className="flex gap-1.5 shrink-0">
+          <Pencil size={14} className="cursor-pointer text-muted-text hover:text-light" aria-label="Edit CDL" onClick={() => { closeForms(); setCdlDriver(driver); }} />
+        </div>
+      </div>
+    );
+  };
+
+  const section = (
+    key: string,
+    title: string,
+    Icon: LucideIcon,
+    scope: ComplianceScope,
+    entityId: string | null,
+    link: string | null,
+    rows: ComplianceItem[],
+    leadRow?: React.ReactNode,
+  ) => {
+    const isAdding = adding?.scope === scope && adding?.entityId === entityId;
+    return (
+      <div key={key} className="bg-plate rounded-lg px-4 pb-3 pt-1 mt-4">
+        <div className="flex items-center gap-2 py-3">
+          <Icon size={18} className="text-amber-light" />
+          <span className="font-condensed text-lg">{title}</span>
+          {link && (
+            <Link to={link} className="text-xs text-status-info-text hover:underline flex items-center gap-0.5">
+              <ExternalLink size={12} />
+            </Link>
+          )}
+          <span className="flex-1" />
+          <button
+            className="text-amber border border-amber rounded px-2 py-0.5 text-xs font-condensed uppercase tracking-wide flex items-center gap-1"
+            onClick={() => {
+              closeForms();
+              setAdding({ scope, entityId });
+            }}
+          >
+            <Plus size={13} /> Add
+          </button>
+        </div>
+        {leadRow}
+        {rows.map(itemRow)}
+        {leadRow == null && rows.length === 0 && !isAdding && (
+          <p className="text-sm text-muted-text py-2 border-t border-[#3b4660]">
+            Nothing tracked yet.
+          </p>
+        )}
+        {isAdding && (
+          <div className="border-t border-[#3b4660] pt-2">
+            <ComplianceItemForm
+              scope={scope}
+              onSave={(d) => saveNew(scope, entityId, d)}
+              onCancel={closeForms}
+              busy={busy}
+              error={error}
+            />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const grounded = summary.status === "grounded";
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <div className="flex justify-between items-start gap-3 flex-wrap mb-2">
+        <div>
+          <h1 className="text-3xl font-condensed">Compliance</h1>
+          <p className="text-xs text-muted-text">Road-legal status · Delgado Trucking Services</p>
+        </div>
+        <div className="text-right">
+          <Stamp
+            label={grounded ? "Grounded" : "Cleared to roll"}
+            color={grounded ? "#f87171" : "#4ade80"}
+          />
+          <p className="text-[11px] text-muted-text mt-1">
+            {summary.expired > 0
+              ? `${summary.expired} expired · ${summary.expiring} expiring soon`
+              : summary.expiring > 0
+                ? `${summary.expiring} document${summary.expiring > 1 ? "s" : ""} expiring soon`
+                : "All documents current"}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 mt-4">
+        <Kpi label="Valid" value={String(summary.valid)} valueClass="text-status-positive-text" />
+        <Kpi label="Expiring soon" value={String(summary.expiring)} valueClass={summary.expiring ? "text-amber" : "text-light"} />
+        <Kpi label="Expired" value={String(summary.expired)} valueClass={summary.expired ? "text-destructive" : "text-light"} />
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-text mt-6">Loading…</p>
+      ) : (
+        <>
+          {section("business", "Business", Building2, "business", null, null,
+            items.filter((i) => i.scope === "business"))}
+
+          {drivers.map((d) =>
+            section(
+              `driver-${d.driver_id}`,
+              `Driver · ${d.first_name} ${d.last_name}`.trim(),
+              User,
+              "driver",
+              d.driver_id,
+              `/drivers/${d.driver_id}`,
+              items.filter((i) => i.scope === "driver" && i.driver_id === d.driver_id),
+              cdlRow(d),
+            ),
+          )}
+
+          {trucks.map((t) =>
+            section(
+              `truck-${t.truck_id}`,
+              `Vehicle · Unit ${t.unit_number}`,
+              TruckIcon,
+              "truck",
+              t.truck_id,
+              `/trucks/${t.truck_id}`,
+              items.filter((i) => i.scope === "truck" && i.truck_id === t.truck_id),
+            ),
+          )}
+
+          {trailers.map((t) =>
+            section(
+              `trailer-${t.trailer_id}`,
+              `Trailer · Unit ${t.unit_number}`,
+              Container,
+              "trailer",
+              t.trailer_id,
+              `/trailers/${t.trailer_id}`,
+              items.filter((i) => i.scope === "trailer" && i.trailer_id === t.trailer_id),
+            ),
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+// Inline CDL editor — writes the four CDL fields back to the driver record.
+const CdlForm = ({
+  driver,
+  onSave,
+  onCancel,
+  busy,
+  error,
+}: {
+  driver: Driver;
+  onSave: (d: Driver, patch: Partial<Driver>) => Promise<void>;
+  onCancel: () => void;
+  busy: boolean;
+  error: string | null;
+}) => {
+  const [number, setNumber] = useState(driver.cdl_number ?? "");
+  const [state, setState] = useState(driver.cdl_state ?? "");
+  const [exp, setExp] = useState(driver.cdl_expiration?.slice(0, 10) ?? "");
+  const [endorsements, setEndorsements] = useState(driver.endorsements ?? "");
+  return (
+    <div className="bg-steel rounded-lg p-3 border-t border-[#3b4660]">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className={lbl}>CDL #</label>
+          <input className={inputCls} value={number} onChange={(e) => setNumber(e.target.value)} />
+        </div>
+        <div>
+          <label className={lbl}>State</label>
+          <input className={inputCls} value={state} maxLength={2} placeholder="AL" onChange={(e) => setState(e.target.value)} />
+        </div>
+        <div>
+          <label className={lbl}>Expires</label>
+          <input type="date" className={inputCls} value={exp} onChange={(e) => setExp(e.target.value)} />
+        </div>
+        <div>
+          <label className={lbl}>Endorsements</label>
+          <input className={inputCls} value={endorsements} placeholder="H, N, T" onChange={(e) => setEndorsements(e.target.value)} />
+        </div>
+      </div>
+      {error && <p className="text-destructive text-sm mt-2">{error}</p>}
+      <div className="flex gap-2 mt-3">
+        <button
+          className="bg-amber text-steel px-3 py-1.5 rounded text-sm font-semibold disabled:opacity-50"
+          disabled={busy}
+          onClick={() =>
+            onSave(driver, {
+              cdl_number: number.trim() || null,
+              cdl_state: state.trim().toUpperCase() || null,
+              cdl_expiration: exp || null,
+              endorsements: endorsements.trim() || null,
+            })
+          }
+        >
+          {busy ? "Saving…" : "Save CDL"}
+        </button>
+        <button className="bg-plate text-light px-3 py-1.5 rounded text-sm" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const errText = (e: unknown): string =>
+  (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+  "Could not save";
+
+export default CompliancePage;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/metrics/agentLeaderboard";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { useMaintenanceAlerts } from "@/hooks/useMaintenanceAlerts";
+import { useComplianceAlerts } from "@/hooks/useComplianceAlerts";
 import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
 import { RevenueChart } from "@/components/RevenueChart";
 import { RpmChart } from "@/components/RpmChart";
@@ -65,7 +66,7 @@ const DashboardPage = () => {
     error: tripsError,
   } = useTrips(refreshKey);
   const targets = useRateTargets(loads);
-  const alerts = useMaintenanceAlerts(loads);
+  const alerts = [...useMaintenanceAlerts(loads), ...useComplianceAlerts()];
 
   const isLoading = loadsLoading || tripsLoading;
   const error = loadsError || tripsError;

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -148,6 +148,13 @@ const DriverDetailPage = () => {
                 <Spec label="Endorsements" value={driver.endorsements} />
                 <Spec label="Hired" value={formatDate(driver.hire_date)} />
               </div>
+              <p className="text-xs text-muted-text mt-2">
+                CDL is managed on the{" "}
+                <Link to="/compliance" className="text-status-info-text hover:underline">
+                  Compliance page
+                </Link>
+                .
+              </p>
               <MileClub miles={milesHauled} />
             </>
           )}

--- a/frontend/src/services/complianceService.ts
+++ b/frontend/src/services/complianceService.ts
@@ -1,0 +1,26 @@
+import api from "./api";
+import type { ComplianceItem, ComplianceItemInput } from "@/types/compliance";
+
+export const getComplianceItems = async (): Promise<ComplianceItem[]> => {
+  const res = await api.get("/compliance");
+  return res.data.compliance_items;
+};
+
+export const createComplianceItem = async (
+  data: ComplianceItemInput,
+): Promise<ComplianceItem> => {
+  const res = await api.post("/compliance", data);
+  return res.data.compliance_item;
+};
+
+export const updateComplianceItem = async (
+  id: string,
+  data: Partial<ComplianceItemInput>,
+): Promise<ComplianceItem> => {
+  const res = await api.patch(`/compliance/${id}`, data);
+  return res.data.compliance_item;
+};
+
+export const deleteComplianceItem = async (id: string): Promise<void> => {
+  await api.delete(`/compliance/${id}`);
+};

--- a/frontend/src/types/compliance.ts
+++ b/frontend/src/types/compliance.ts
@@ -1,0 +1,35 @@
+export type ComplianceScope = "business" | "driver" | "truck" | "trailer";
+
+export interface ComplianceItem {
+  compliance_item_id: string;
+  scope: ComplianceScope;
+  driver_id: string | null;
+  truck_id: string | null;
+  trailer_id: string | null;
+  label: string;
+  category: string | null;
+  issued_on: string | null; // 'YYYY-MM-DD'
+  expires_on: string | null; // 'YYYY-MM-DD' — the date the engine keys on
+  renewal_months: number | null;
+  warn_lead_days: number;
+  doc_number: string | null;
+  notes: string | null;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ComplianceItemInput {
+  scope: ComplianceScope;
+  driver_id?: string | null;
+  truck_id?: string | null;
+  trailer_id?: string | null;
+  label: string;
+  category?: string | null;
+  issued_on?: string | null;
+  expires_on?: string | null;
+  renewal_months?: number | null;
+  warn_lead_days?: number;
+  doc_number?: string | null;
+  notes?: string | null;
+}


### PR DESCRIPTION
Closes #190.

## Compliance hub (v1.46.0)

One page tracking every renewal/expiry-dated document across **business**, **driver**, and **vehicle** scopes. Compliance is maintenance's twin — the same due engine, keyed on dates instead of miles — feeding the dashboard alert region already wired for `kind: "compliance"`.

### Backend
- `030_compliance.sql` — `compliance_items` table (already applied to dev + prod).
- CRUD service with per-scope entity-ownership checks + validation; `/compliance` routes.

### Engine (10 new tests)
- `computeComplianceDue` — valid / expiring / expired / unknown, whole-day UTC math (no day-shift).
- `complianceSummary` — counts + **cleared/grounded** status (grounded only on an expired driver/vehicle doc; an expired business doc counts but doesn't ground the truck).
- `complianceAlerts` — expired (critical) before expiring (warning).

### Page
- Green **CLEARED TO ROLL** / red **GROUNDED** stamp + valid/expiring/expired summary.
- Per-entity sections (Business, Driver · name, Vehicle · unit) with drill-down links, inline add/edit/delete, and common-doc presets so setup is dates-not-typing.
- **CDL** is now managed here (writes back to the driver record) and read-only on the driver page — one source of truth.
- **Compliance** added as a top-level sidebar item.

### Verification
- Strict build clean; **143 tests** green (+10 compliance).
- Service SQL exercised against real dev DB (all three scopes insert + list query + ordering) — not just unit tests.
- Migration applied to dev and prod (idempotent `CREATE TABLE IF NOT EXISTS`).

⚠️ Couldn't preview the authed page from here — worth clicking through the add/edit flows and CDL editor on prod.