### PR TITLE
feat: player card phase 1 — driver page becomes the operator's card

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Barlow+Condensed:wght@400;500;600&family=Barlow:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Bangers&family=Bebas+Neue&family=Barlow+Condensed:wght@400;500;600&family=Barlow:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
     <title>dash</title>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.46.0",
+  "version": "1.47.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/comic/ComicBurst.tsx
+++ b/frontend/src/components/comic/ComicBurst.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+
+// The jagged comic impact-burst — the shared emblem shape behind award icons and
+// sound-effect pops. Adult-comic: hard ink outline, flat fill, no gradient.
+const POINTS =
+  "340,150 288.9,173.8 321.2,220 265,215 270,271.2 223.8,238.9 200,290 " +
+  "176.2,238.9 130,271.2 135,215 78.8,220 111.1,173.8 60,150 111.1,126.2 " +
+  "78.8,80 135,85 130,28.8 176.2,61.1 200,10 223.8,61.1 270,28.8 265,85 " +
+  "321.2,80 288.9,126.2";
+
+export const ComicBurst = ({
+  size = 44,
+  fill = "#e8940a",
+  stroke = "#0a0d13",
+  strokeWidth = 10,
+  children,
+  className = "",
+}: {
+  size?: number;
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  children?: ReactNode;
+  className?: string;
+}) => (
+  <span
+    className={`relative inline-flex items-center justify-center shrink-0 ${className}`}
+    style={{ width: size, height: size }}
+  >
+    <svg
+      viewBox="0 0 400 300"
+      width={size}
+      height={size}
+      className="absolute inset-0"
+      aria-hidden="true"
+    >
+      <polygon points={POINTS} fill={fill} stroke={stroke} strokeWidth={strokeWidth} />
+    </svg>
+    <span className="relative flex items-center justify-center" style={{ color: stroke }}>
+      {children}
+    </span>
+  </span>
+);

--- a/frontend/src/components/comic/MiniTrophyCard.tsx
+++ b/frontend/src/components/comic/MiniTrophyCard.tsx
@@ -1,0 +1,36 @@
+import type { LucideIcon } from "lucide-react";
+import { ComicBurst } from "@/components/comic/ComicBurst";
+
+// A collectible award card for the trophy shelf. Gold trophies (mile clubs,
+// strong seasons) get the gold foil edge; everything else the amber ink edge.
+export const MiniTrophyCard = ({
+  name,
+  detail,
+  Icon,
+  gold = false,
+}: {
+  name: string;
+  detail: string;
+  Icon: LucideIcon;
+  gold?: boolean;
+}) => (
+  <div
+    className="w-[120px] shrink-0 rounded-[10px] overflow-hidden border-2"
+    style={{ background: "#12161c", borderColor: gold ? "#f5b03a" : "#e8940a" }}
+  >
+    <div
+      className="text-center font-comic uppercase py-[3px] px-1 truncate"
+      style={{ background: "#0a0d13", color: "#f5b03a", fontSize: 10, letterSpacing: "2px" }}
+    >
+      {name}
+    </div>
+    <div className="flex flex-col items-center pt-2 pb-2 px-1">
+      <ComicBurst size={40} fill={gold ? "#f5b03a" : "#e8940a"}>
+        <Icon size={17} />
+      </ComicBurst>
+      <span className="text-[10px] text-center mt-1.5 leading-tight" style={{ color: "#c9b58f" }}>
+        {detail}
+      </span>
+    </div>
+  </div>
+);

--- a/frontend/src/components/playercard/PlayerCard.tsx
+++ b/frontend/src/components/playercard/PlayerCard.tsx
@@ -1,0 +1,250 @@
+import type { ReactNode } from "react";
+import {
+  Truck,
+  Trophy,
+  Flame,
+  Package,
+  Layers,
+  Users,
+  Medal,
+  TrendingDown,
+  type LucideIcon,
+} from "lucide-react";
+import type {
+  Grade,
+  CareerRank,
+  SeasonStats,
+  PersonalBests,
+  Trophy as TrophyData,
+} from "@/lib/metrics/playerCard";
+import { fmtMiles } from "@/lib/metrics/mileClub";
+import { RANK_TIERS } from "@/lib/constants/playerCard";
+import { MiniTrophyCard } from "@/components/comic/MiniTrophyCard";
+
+const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+const pct1 = (n: number) => `${(n * 100).toFixed(1)}%`;
+
+const GRADE_META: Record<Grade, { label: string; fg: string; bg: string }> = {
+  below: { label: "BELOW", fg: "#f87171", bg: "#3a1a1a" },
+  minimum: { label: "MINIMUM", fg: "#e8940a", bg: "#3a2a0a" },
+  target: { label: "TARGET", fg: "#4ade80", bg: "#1a3a2a" },
+  strong: { label: "STRONG", fg: "#fbbf24", bg: "#3a300a" },
+};
+
+const TROPHY_ICON: Record<string, LucideIcon> = {
+  medal: Medal,
+  users: Users,
+  stack: Layers,
+  trophy: Trophy,
+  flame: Flame,
+};
+
+const GradeChip = ({ grade, value }: { grade: Grade | null; value?: string }) => {
+  if (!grade)
+    return <span className="text-[11px] px-2 py-0.5 rounded-full bg-plate text-muted-text">—</span>;
+  const m = GRADE_META[grade];
+  return (
+    <span
+      className="text-[11px] font-semibold px-2 py-0.5 rounded-full whitespace-nowrap"
+      style={{ background: m.bg, color: m.fg }}
+    >
+      {m.label}
+      {value ? ` · ${value}` : ""}
+    </span>
+  );
+};
+
+const Stat = ({
+  label,
+  value,
+  color,
+  span2,
+}: {
+  label: string;
+  value: string;
+  color?: string;
+  span2?: boolean;
+}) => (
+  <div className={`bg-plate rounded-lg px-3 py-2 ${span2 ? "col-span-2" : ""}`}>
+    <p className="text-[11px] text-muted-text">{label}</p>
+    <p className="text-lg font-condensed truncate" style={color ? { color } : undefined}>
+      {value}
+    </p>
+  </div>
+);
+
+const Record = ({
+  Icon,
+  label,
+  value,
+  color,
+}: {
+  Icon: LucideIcon;
+  label: string;
+  value: string;
+  color: string;
+}) => (
+  <div className="rounded-[11px] border border-plate px-3 py-2.5" style={{ background: "#10151f" }}>
+    <p className="text-[11px] text-muted-text flex items-center gap-1.5">
+      <Icon size={13} style={{ color }} />
+      {label}
+    </p>
+    <p className="text-lg font-condensed mt-0.5">{value}</p>
+  </div>
+);
+
+export interface PlayerCardProps {
+  name: string;
+  business: string;
+  avatar: ReactNode;
+  rank: CareerRank;
+  season: SeasonStats;
+  rpmGrade: Grade | null;
+  marginGrade: Grade | null;
+  form: Grade | null;
+  windowRpm: number | null;
+  bests: PersonalBests;
+  trophies: TrophyData[];
+}
+
+export const PlayerCard = ({
+  name,
+  business,
+  avatar,
+  rank,
+  season,
+  rpmGrade,
+  marginGrade,
+  form,
+  windowRpm,
+  bests,
+  trophies,
+}: PlayerCardProps) => {
+  const stars =
+    "★".repeat(rank.index + 1) + "☆".repeat(RANK_TIERS.length - rank.index - 1);
+
+  return (
+    <div>
+      {/* ---- card header ---- */}
+      <div
+        className="relative overflow-hidden rounded-2xl border-2 p-4"
+        style={{ background: "#10151f", borderColor: "#e8940a" }}
+      >
+        <div
+          className="absolute top-0 right-0 w-32 h-32 pointer-events-none"
+          style={{
+            backgroundImage: "radial-gradient(#e8940a 1.3px, transparent 1.4px)",
+            backgroundSize: "7px 7px",
+            opacity: 0.14,
+          }}
+        />
+        <div className="flex gap-4 items-start relative">
+          <div className="shrink-0">{avatar}</div>
+          <div className="flex-1 min-w-0">
+            <h1 className="font-condensed text-3xl leading-none">{name}</h1>
+            <p className="text-xs text-muted-text mb-3">{business}</p>
+            <div className="flex items-center gap-3">
+              <div
+                className="w-11 h-11 rounded-full flex items-center justify-center shrink-0"
+                style={{ background: "#3a2a0a", border: "2px solid #e8940a", color: "#f5b03a" }}
+              >
+                <Truck size={20} />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div
+                  className="font-comic text-xl leading-none"
+                  style={{ color: "#f5e6c8", letterSpacing: "1px" }}
+                >
+                  {rank.name}
+                </div>
+                <div className="text-[10px] text-muted-text mt-0.5">
+                  <span style={{ color: "#f5b03a", letterSpacing: "1px" }}>{stars}</span> · Career rank
+                </div>
+                <div className="h-1.5 rounded bg-plate mt-1 overflow-hidden">
+                  <div className="h-full" style={{ width: `${rank.pct * 100}%`, background: "#e8940a" }} />
+                </div>
+                {rank.next && (
+                  <div className="text-[9.5px] text-muted-text mt-0.5">
+                    {fmtMiles(rank.toNext)} to {rank.next.name}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* season form strip */}
+        <div
+          className="flex items-center gap-2 flex-wrap mt-4 pt-3 border-t relative"
+          style={{ borderColor: "#2a3347" }}
+        >
+          <span className="font-condensed text-sm tracking-wide text-muted-text">
+            SEASON · {season.label}
+          </span>
+          <span className="text-[11px] text-muted-text">Rate</span>
+          <GradeChip grade={rpmGrade} value={windowRpm != null ? `$${windowRpm.toFixed(2)}` : undefined} />
+          <span className="text-[11px] text-muted-text">Margin</span>
+          <GradeChip grade={marginGrade} value={season.netMargin != null ? pct1(season.netMargin) : undefined} />
+          <span className="flex-1" />
+          <span className="text-[11px] text-muted-text">Form</span>
+          {form ? (
+            <span
+              className="font-comic px-2.5 py-0.5 rounded-full"
+              style={{ background: GRADE_META[form].bg, color: GRADE_META[form].fg, letterSpacing: "2px", fontSize: 14 }}
+            >
+              {GRADE_META[form].label}
+            </span>
+          ) : (
+            <span className="text-[11px] text-muted-text">— needs a full month</span>
+          )}
+        </div>
+      </div>
+
+      {/* ---- season stat line ---- */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mt-3">
+        <Stat label="Net revenue" value={money0(season.netRevenue)} />
+        <Stat label="Net profit" value={money0(season.netProfit)} color="#4ade80" />
+        <Stat label="Loads" value={String(season.loads)} />
+        <Stat label="Miles" value={Math.round(season.totalMiles).toLocaleString("en-US")} />
+        <Stat label="Deadhead" value={season.deadheadPct != null ? pct1(season.deadheadPct) : "—"} />
+        <Stat label="Avg RPM" value={season.avgRpm != null ? `$${season.avgRpm.toFixed(2)}` : "—"} />
+        <Stat label="Best lane" value={season.bestLane?.lane ?? "—"} span2 />
+      </div>
+
+      {/* ---- personal bests ---- */}
+      <div className="flex items-baseline gap-2 mt-6">
+        <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
+          PERSONAL BESTS
+        </span>
+        <span className="text-[11px] text-muted-text">— top one and it re-earns</span>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2">
+        <Record Icon={Trophy} label="Top week" color="#f5b03a" value={bests.bestWeekRevenue != null ? money0(bests.bestWeekRevenue) : "—"} />
+        <Record Icon={TrendingDown} label="Best deadhead" color="#4ade80" value={bests.lowestDeadheadPct != null ? pct1(bests.lowestDeadheadPct) : "—"} />
+        <Record Icon={Flame} label="Best tank" color="#e8940a" value={bests.bestMpg != null ? `${bests.bestMpg.toFixed(1)} mpg` : "—"} />
+        <Record Icon={Package} label="Biggest load" color="#f5b03a" value={bests.biggestLoad != null ? money0(bests.biggestLoad) : "—"} />
+        <Record Icon={Layers} label="Most loads / wk" color="#60a5fa" value={bests.mostLoadsInWeek != null ? String(bests.mostLoadsInWeek) : "—"} />
+      </div>
+
+      {/* ---- trophy shelf ---- */}
+      {trophies.length > 0 && (
+        <>
+          <div className="font-comic text-lg mt-6" style={{ color: "#f5b03a" }}>
+            TROPHY SHELF
+          </div>
+          <div className="flex flex-wrap gap-2.5 mt-2">
+            {trophies.map((t) => (
+              <MiniTrophyCard
+                key={t.key}
+                name={t.name}
+                detail={t.detail}
+                Icon={TROPHY_ICON[t.icon] ?? Trophy}
+                gold={t.key === "mileclub" || t.key === "strong-season"}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -62,6 +62,8 @@
   --font-display: "Bebas Neue", sans-serif;
   --font-condensed: "Barlow Condensed", sans-serif;
   --font-body: "Barlow", sans-serif;
+  /* Adult-comic accent face — used only on the player card / awards / prestige */
+  --font-comic: "Bangers", system-ui, sans-serif;
 
   /* --------------------------------------------------------
     SEMANTIC TOKENS

--- a/frontend/src/lib/constants/playerCard.ts
+++ b/frontend/src/lib/constants/playerCard.ts
@@ -1,0 +1,15 @@
+// Career prestige ladder for the owner-operator, earned by lifetime rig miles
+// (the truck's odometer — the tangible career number). Names parallel the agent
+// prestige ladder so the two systems feel of a piece. Only ever climbs.
+export const RANK_TIERS = [
+  { key: "rookie", name: "Rookie", min: 0 },
+  { key: "roadrunner", name: "Roadrunner", min: 100_000 },
+  { key: "veteran", name: "Veteran", min: 300_000 },
+  { key: "road-captain", name: "Road Captain", min: 500_000 },
+  { key: "highway-legend", name: "Highway Legend", min: 1_000_000 },
+] as const;
+
+// Net operating-margin bands (P&L basis: (income − COGS − expenses) / income,
+// net of Landstar). Locked with Jason against his real 6-month data + the
+// owner-operator industry curve. Values are fractions of net revenue.
+export const MARGIN_BANDS = { strong: 0.27, target: 0.17, minimum: 0.08 } as const;

--- a/frontend/src/lib/metrics/playerCard.test.ts
+++ b/frontend/src/lib/metrics/playerCard.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+import type { FuelEntry } from "@/types/fuelEntry";
+import {
+  careerRank,
+  marginGrade,
+  rpmGrade,
+  worseGrade,
+  getSeasonStats,
+  personalBests,
+  earnedTrophies,
+} from "./playerCard";
+
+const NOW = new Date("2026-07-10T12:00:00Z");
+
+const mkLoad = (o: Partial<Load>): Load => ({
+  load_id: "l",
+  load_number: "L1",
+  load_type: "flatbed",
+  load_status: "delivered",
+  broker_id: "b",
+  broker: "Broker",
+  agent_id: "ag1",
+  agent: "Redwood",
+  agent_email: null,
+  pickup_date: "2026-05-01",
+  origin_market_id: "o",
+  origin_city: "Dallas",
+  origin_state: "TX",
+  origin_market: "Dallas",
+  destination_market_id: "d",
+  destination_city: "Atlanta",
+  destination_state: "GA",
+  delivery_market: "Atlanta",
+  deadhead_miles: 0,
+  loaded_miles: 1000,
+  linehaul: "3000",
+  fuel_surcharge: "0",
+  total_accessorials: "0",
+  commodity: null,
+  payment_status: "paid",
+  created_at: "2026-05-01",
+  updated_at: "2026-05-01",
+  ...o,
+});
+
+const mkPeriod = (
+  month: string,
+  income: number,
+  cogs: number,
+  expense: number,
+): ExpensePeriod =>
+  ({
+    period_month: month,
+    income_total: income,
+    cogs_total: cogs,
+    expense_total: expense,
+  }) as ExpensePeriod;
+
+describe("careerRank", () => {
+  it("places 582k as Road Captain climbing to Highway Legend", () => {
+    const r = careerRank(582450);
+    expect(r.name).toBe("Road Captain");
+    expect(r.next?.name).toBe("Highway Legend");
+    expect(r.pct).toBeCloseTo(0.165, 2);
+  });
+  it("a newcomer is a Rookie", () => {
+    expect(careerRank(40000).name).toBe("Rookie");
+  });
+  it("tops out at Highway Legend with no next", () => {
+    const r = careerRank(1_200_000);
+    expect(r.name).toBe("Highway Legend");
+    expect(r.next).toBeNull();
+    expect(r.pct).toBe(1);
+  });
+});
+
+describe("grades", () => {
+  it("marginGrade bands at 8/17/27", () => {
+    expect(marginGrade(0.3)).toBe("strong");
+    expect(marginGrade(0.27)).toBe("strong");
+    expect(marginGrade(0.2)).toBe("target");
+    expect(marginGrade(0.1)).toBe("minimum");
+    expect(marginGrade(0.05)).toBe("below");
+    expect(marginGrade(null)).toBeNull();
+  });
+  it("rpmGrade rides the rate ladder", () => {
+    const ladder = { walkAway: 4, minimum: 4.6, target: 5.4, strong: 6.4 };
+    expect(rpmGrade(6.5, ladder)).toBe("strong");
+    expect(rpmGrade(5.5, ladder)).toBe("target");
+    expect(rpmGrade(4.2, ladder)).toBe("minimum");
+    expect(rpmGrade(3.5, ladder)).toBe("below");
+    expect(rpmGrade(null, ladder)).toBeNull();
+  });
+  it("worseGrade takes the lower, tolerating nulls", () => {
+    expect(worseGrade("strong", "target")).toBe("target");
+    expect(worseGrade("below", "strong")).toBe("below");
+    expect(worseGrade(null, "target")).toBe("target");
+    expect(worseGrade(null, null)).toBeNull();
+  });
+});
+
+describe("getSeasonStats", () => {
+  const periods = [
+    mkPeriod("2026-04-01", 22698.78, 6896.44, 12337.67),
+    mkPeriod("2026-05-01", 28833.36, 5776.47, 13258.66),
+    mkPeriod("2026-06-01", 27814.70, 4127.62, 18175.65),
+    mkPeriod("2026-07-01", 9999, 0, 0), // in-progress month — excluded
+  ];
+  const loads = [
+    mkLoad({ load_id: "a", delivery_date: "2026-05-12", loaded_miles: 1000, deadhead_miles: 100, linehaul: "3200", odometer_start: 570000, odometer_end: 571200, origin_market: "Dallas", delivery_market: "Atlanta" }),
+    mkLoad({ load_id: "b", delivery_date: "2026-06-15", loaded_miles: 800, deadhead_miles: 200, linehaul: "2600", odometer_start: 572000, odometer_end: 573100, origin_market: "Houston", delivery_market: "Memphis" }),
+    mkLoad({ load_id: "c", delivery_date: "2026-07-05", loaded_miles: 500, linehaul: "9999" }), // in-progress month — excluded
+  ];
+
+  it("blends the 3 complete months, excludes the in-progress one", () => {
+    const s = getSeasonStats(periods, loads, NOW);
+    expect(s.months).toBe(3);
+    expect(s.netRevenue).toBeCloseTo(79346.84, 2);
+    expect(s.netMargin).toBeCloseTo(0.2366, 3);
+    expect(s.loads).toBe(2);
+    expect(s.label).toBe("Apr–Jun 2026");
+  });
+  it("computes deadhead, avg rpm, and best lane over the window", () => {
+    const s = getSeasonStats(periods, loads, NOW);
+    expect(s.avgRpm).toBeCloseTo((3200 + 2600) / 1800, 3);
+    expect(s.deadheadPct).toBeCloseTo(300 / 2100, 3);
+    expect(s.bestLane?.lane).toBe("Dallas → Atlanta");
+  });
+});
+
+describe("personalBests", () => {
+  const fuel = [
+    { odometer_reading: 570368, gallons: 131.91, price_per_gallon: 4.639, fuel_date: "2026-05-24" },
+    { odometer_reading: 570967, gallons: 79.78, price_per_gallon: 4.589, fuel_date: "2026-05-26" },
+    { odometer_reading: 571651, gallons: 114.425, price_per_gallon: 4.462, fuel_date: "2026-05-28" },
+    { odometer_reading: 572503, gallons: 135.1, price_per_gallon: 4.322, fuel_date: "2026-05-30" },
+  ] as unknown as FuelEntry[];
+
+  it("finds best week, biggest load, most loads/week, lowest deadhead", () => {
+    const loads = [
+      mkLoad({ load_id: "a", delivery_date: "2026-05-12", linehaul: "3200", loaded_miles: 1000, deadhead_miles: 100 }),
+      mkLoad({ load_id: "c", delivery_date: "2026-05-13", linehaul: "1000", loaded_miles: 500, deadhead_miles: 50 }),
+      mkLoad({ load_id: "b", delivery_date: "2026-06-15", linehaul: "2600", loaded_miles: 800, deadhead_miles: 200 }),
+    ];
+    const pb = personalBests(loads, fuel, NOW);
+    expect(pb.bestWeekRevenue).toBeCloseTo(4200, 2);
+    expect(pb.mostLoadsInWeek).toBe(2);
+    expect(pb.biggestLoad).toBeCloseTo(3200, 2);
+    expect(pb.lowestDeadheadPct).toBeCloseTo(150 / 1650, 3);
+    expect(pb.bestMpg).toBeCloseTo(6.483, 2);
+  });
+});
+
+describe("earnedTrophies", () => {
+  it("awards mile club, relationship, century, strong season, feather foot", () => {
+    const loads = Array.from({ length: 100 }, (_, i) =>
+      mkLoad({ load_id: `x${i}`, agent_id: "ag1", agent: "Redwood" }),
+    );
+    const t = earnedTrophies({ lifetimeMiles: 582450, loads, bestMpg: 6.5, seasonMargin: "strong" });
+    const keys = t.map((x) => x.key);
+    expect(keys).toContain("mileclub");
+    expect(keys).toContain("relationship");
+    expect(keys).toContain("century");
+    expect(keys).toContain("strong-season");
+    expect(keys).toContain("feather-foot");
+    expect(t.find((x) => x.key === "mileclub")?.name).toBe("500K Club");
+  });
+});

--- a/frontend/src/lib/metrics/playerCard.ts
+++ b/frontend/src/lib/metrics/playerCard.ts
@@ -1,0 +1,278 @@
+// Player-card math for the owner-operator. Composes the engines we already
+// trust — rate ladder, P&L margin, fuel, mile clubs — into a career rank, a
+// current-season grade, personal-best records, and earned trophies. Pure; take
+// `now` explicitly so it's testable.
+import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+import type { FuelEntry } from "@/types/fuelEntry";
+import {
+  loadRevenue,
+  completeMonthsBefore,
+  type RateLadder,
+} from "./rateTargets";
+import { mileMilestone } from "./mileClub";
+import { fuelStats } from "./fuelEconomy";
+import { RANK_TIERS, MARGIN_BANDS } from "@/lib/constants/playerCard";
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+export type Grade = "below" | "minimum" | "target" | "strong";
+const ORDER: Grade[] = ["below", "minimum", "target", "strong"];
+
+// The lower of two grades (a weakness in either dimension caps the season).
+export const worseGrade = (a: Grade | null, b: Grade | null): Grade | null => {
+  if (a == null) return b;
+  if (b == null) return a;
+  return ORDER.indexOf(a) <= ORDER.indexOf(b) ? a : b;
+};
+
+// ---------- career rank ----------
+export interface CareerRank {
+  key: string;
+  name: string;
+  index: number;
+  next: { name: string; min: number } | null;
+  toNext: number; // miles to the next tier
+  pct: number; // 0..1 progress within the current tier
+  miles: number;
+}
+
+export const careerRank = (lifetimeMiles: number): CareerRank => {
+  const miles = Math.max(0, lifetimeMiles || 0);
+  let i = 0;
+  for (let k = RANK_TIERS.length - 1; k >= 0; k--) {
+    if (miles >= RANK_TIERS[k].min) {
+      i = k;
+      break;
+    }
+  }
+  const cur = RANK_TIERS[i];
+  const next = i < RANK_TIERS.length - 1 ? RANK_TIERS[i + 1] : null;
+  const span = next ? next.min - cur.min : 0;
+  return {
+    key: cur.key,
+    name: cur.name,
+    index: i,
+    next: next ? { name: next.name, min: next.min } : null,
+    toNext: next ? Math.max(0, next.min - miles) : 0,
+    pct: next && span > 0 ? Math.min(1, (miles - cur.min) / span) : 1,
+    miles,
+  };
+};
+
+// ---------- season grades ----------
+export const marginGrade = (pct: number | null): Grade | null => {
+  if (pct == null) return null;
+  if (pct >= MARGIN_BANDS.strong) return "strong";
+  if (pct >= MARGIN_BANDS.target) return "target";
+  if (pct >= MARGIN_BANDS.minimum) return "minimum";
+  return "below";
+};
+
+// Where your rate lands on your own break-even ladder.
+export const rpmGrade = (rpm: number | null, ladder: RateLadder): Grade | null => {
+  if (rpm == null || ladder.walkAway == null) return null;
+  if (ladder.strong != null && rpm >= ladder.strong) return "strong";
+  if (ladder.target != null && rpm >= ladder.target) return "target";
+  return rpm >= ladder.walkAway ? "minimum" : "below";
+};
+
+// ---------- season stat line ----------
+export interface SeasonStats {
+  label: string; // e.g. "Apr–Jun 2026"
+  netRevenue: number; // P&L income (net of Landstar) over the window
+  netProfit: number; // income − COGS − expenses
+  netMargin: number | null;
+  loads: number;
+  totalMiles: number;
+  loadedMiles: number;
+  deadheadPct: number | null;
+  avgRpm: number | null; // gross revenue ÷ loaded mile
+  bestLane: { lane: string; revenue: number } | null;
+  months: number; // months with a P&L in the window
+}
+
+const inWindow = (
+  d: string | null | undefined,
+  months: { year: number; month: number }[],
+): boolean => {
+  if (!d) return false;
+  const dt = new Date(d);
+  return months.some(
+    (m) => dt.getUTCFullYear() === m.year && dt.getUTCMonth() === m.month,
+  );
+};
+
+export const getSeasonStats = (
+  periods: ExpensePeriod[],
+  loads: Load[],
+  now: Date,
+  monthsBack = 3,
+): SeasonStats => {
+  const months = completeMonthsBefore(now, monthsBack);
+
+  let income = 0;
+  let cost = 0;
+  let n = 0;
+  for (const p of periods) {
+    if (!inWindow(p.period_month, months)) continue;
+    income += p.income_total ?? 0;
+    cost += (p.cogs_total ?? 0) + (p.expense_total ?? 0);
+    n++;
+  }
+  const netProfit = income - cost;
+
+  const seasonLoads = loads.filter(
+    (l) => l.load_status === "delivered" && inWindow(l.delivery_date, months),
+  );
+  const loaded = seasonLoads.reduce((s, l) => s + Number(l.loaded_miles || 0), 0);
+  const dead = seasonLoads.reduce((s, l) => s + Number(l.deadhead_miles || 0), 0);
+  // Prefer the odometer window; fall back to loaded + deadhead when a load has
+  // no odometer readings, so "miles" never reads 0 while loaded miles exist.
+  const total = seasonLoads.reduce((s, l) => {
+    const odo =
+      l.odometer_end != null && l.odometer_start != null
+        ? Number(l.odometer_end) - Number(l.odometer_start)
+        : 0;
+    return s + (odo > 0 ? odo : Number(l.loaded_miles || 0) + Number(l.deadhead_miles || 0));
+  }, 0);
+  const revenue = seasonLoads.reduce((s, l) => s + loadRevenue(l), 0);
+
+  const laneRev = new Map<string, number>();
+  for (const l of seasonLoads) {
+    const lane = `${l.origin_market} → ${l.delivery_market}`;
+    laneRev.set(lane, (laneRev.get(lane) ?? 0) + loadRevenue(l));
+  }
+  let bestLane: { lane: string; revenue: number } | null = null;
+  for (const [lane, rev] of laneRev)
+    if (!bestLane || rev > bestLane.revenue) bestLane = { lane, revenue: rev };
+
+  const label =
+    months.length > 0
+      ? `${MONTHS[months[0].month]}–${MONTHS[months[months.length - 1].month]} ${months[months.length - 1].year}`
+      : "—";
+
+  return {
+    label,
+    netRevenue: income,
+    netProfit,
+    netMargin: income > 0 ? netProfit / income : null,
+    loads: seasonLoads.length,
+    totalMiles: total,
+    loadedMiles: loaded,
+    deadheadPct: loaded + dead > 0 ? dead / (loaded + dead) : null,
+    avgRpm: loaded > 0 ? revenue / loaded : null,
+    bestLane,
+    months: n,
+  };
+};
+
+// ---------- personal bests (records) ----------
+export interface PersonalBests {
+  bestWeekRevenue: number | null;
+  lowestDeadheadPct: number | null;
+  bestMpg: number | null;
+  biggestLoad: number | null;
+  mostLoadsInWeek: number | null;
+}
+
+const weekKey = (iso: string): string => {
+  const d = new Date(iso.slice(0, 10) + "T00:00:00Z");
+  const monday = new Date(d);
+  monday.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+  return monday.toISOString().slice(0, 10);
+};
+
+export const personalBests = (
+  loads: Load[],
+  fuel: FuelEntry[],
+  now: Date,
+): PersonalBests => {
+  const delivered = loads.filter(
+    (l) => l.load_status === "delivered" && l.delivery_date,
+  );
+
+  const weeks = new Map<string, { rev: number; count: number; loaded: number; dead: number }>();
+  for (const l of delivered) {
+    const k = weekKey(l.delivery_date!);
+    const w = weeks.get(k) ?? { rev: 0, count: 0, loaded: 0, dead: 0 };
+    w.rev += loadRevenue(l);
+    w.count += 1;
+    w.loaded += Number(l.loaded_miles || 0);
+    w.dead += Number(l.deadhead_miles || 0);
+    weeks.set(k, w);
+  }
+
+  let bestWeekRevenue: number | null = null;
+  let mostLoadsInWeek: number | null = null;
+  let lowestDeadheadPct: number | null = null;
+  for (const w of weeks.values()) {
+    if (bestWeekRevenue == null || w.rev > bestWeekRevenue) bestWeekRevenue = w.rev;
+    if (mostLoadsInWeek == null || w.count > mostLoadsInWeek) mostLoadsInWeek = w.count;
+    const t = w.loaded + w.dead;
+    if (t > 0) {
+      const dh = w.dead / t;
+      if (lowestDeadheadPct == null || dh < lowestDeadheadPct) lowestDeadheadPct = dh;
+    }
+  }
+
+  const biggestLoad = delivered.reduce<number | null>((m, l) => {
+    const r = loadRevenue(l);
+    return m == null || r > m ? r : m;
+  }, null);
+
+  return {
+    bestWeekRevenue,
+    lowestDeadheadPct,
+    bestMpg: fuelStats(fuel, now).bestMpg,
+    biggestLoad,
+    mostLoadsInWeek,
+  };
+};
+
+// ---------- earned trophies (phase-1 set) ----------
+export interface Trophy {
+  key: string;
+  name: string;
+  icon: string; // lucide/tabler-ish name the UI maps to
+  detail: string;
+}
+
+export const earnedTrophies = (opts: {
+  lifetimeMiles: number;
+  loads: Load[];
+  bestMpg: number | null;
+  seasonMargin: Grade | null;
+}): Trophy[] => {
+  const out: Trophy[] = [];
+
+  const mm = mileMilestone(opts.lifetimeMiles);
+  if (mm.crossed != null && mm.label)
+    out.push({ key: "mileclub", name: `${mm.label} Club`, icon: "medal", detail: mm.title ?? "Lifetime" });
+
+  const byAgent = new Map<string, { name: string; count: number }>();
+  for (const l of opts.loads)
+    if (l.load_status === "delivered" && l.agent_id) {
+      const a = byAgent.get(l.agent_id) ?? { name: l.agent, count: 0 };
+      a.count += 1;
+      byAgent.set(l.agent_id, a);
+    }
+  let topAgent: { name: string; count: number } | null = null;
+  for (const a of byAgent.values())
+    if (!topAgent || a.count > topAgent.count) topAgent = a;
+  if (topAgent && topAgent.count >= 5)
+    out.push({ key: "relationship", name: "Relationship Builder", icon: "users", detail: `${topAgent.name} ×${topAgent.count}` });
+
+  const delivered = opts.loads.filter((l) => l.load_status === "delivered").length;
+  const century = [500, 250, 100].find((m) => delivered >= m);
+  if (century)
+    out.push({ key: "century", name: `${century} Loads`, icon: "stack", detail: "Career" });
+
+  if (opts.seasonMargin === "strong")
+    out.push({ key: "strong-season", name: "Strong Season", icon: "trophy", detail: "Margin ≥ 27%" });
+
+  if (opts.bestMpg != null)
+    out.push({ key: "feather-foot", name: "Feather Foot", icon: "flame", detail: `${opts.bestMpg.toFixed(1)} mpg best` });
+
+  return out;
+};

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -3,13 +3,33 @@ import { useParams, Link } from "react-router-dom";
 import { Pencil } from "lucide-react";
 import type { Driver } from "@/types/driver";
 import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+import type { FuelEntry } from "@/types/fuelEntry";
+import type { Truck } from "@/types/truck";
+import type { Obligation } from "@/types/obligation";
 import { getDriver, patchDriver } from "@/services/driversService";
+import { getExpensePeriods } from "@/services/expensesService";
+import { getObligations } from "@/services/obligationsService";
+import { getFuelEntries } from "@/services/fuelService";
+import { getTrucks } from "@/services/trucksService";
 import { useLoads } from "@/hooks/useLoads";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
-import { MileClub } from "@/components/fleet/MileClub";
 import { DRIVER_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
+import { getCostBasis, getRateLadder } from "@/lib/metrics/rateTargets";
+import { RATE_TIERS } from "@/lib/constants/targets";
+import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
+import {
+  careerRank,
+  getSeasonStats,
+  marginGrade,
+  rpmGrade,
+  worseGrade,
+  personalBests,
+  earnedTrophies,
+} from "@/lib/metrics/playerCard";
+import { PlayerCard } from "@/components/playercard/PlayerCard";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const loadRev = (l: Load) =>
@@ -32,6 +52,10 @@ const DriverDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const { loads } = useLoads(0);
   const [driver, setDriver] = useState<Driver | null>(null);
+  const [periods, setPeriods] = useState<ExpensePeriod[]>([]);
+  const [obligations, setObligations] = useState<Obligation[]>([]);
+  const [fuel, setFuel] = useState<FuelEntry[]>([]);
+  const [trucks, setTrucks] = useState<Truck[]>([]);
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,10 +67,56 @@ const DriverDetailPage = () => {
       .catch(() => {});
   }, [id]);
 
+  // Business-level inputs for the card (P&L, obligations, fuel, odometer).
+  useEffect(() => {
+    getExpensePeriods().then(setPeriods).catch(() => {});
+    getObligations().then(setObligations).catch(() => {});
+    getFuelEntries().then(setFuel).catch(() => {});
+    getTrucks().then(setTrucks).catch(() => {});
+  }, []);
+
   const driverLoads = useMemo(
     () => loads.filter((l) => l.driver_id === id),
     [loads, id],
   );
+
+  // The player card only makes sense for a driver who actually hauls; a
+  // dispatch-only driver (e.g. Brandie) keeps the plain page.
+  const card = useMemo(() => {
+    if (driverLoads.length === 0) return null;
+    const now = new Date();
+    const obligationsTotal = obligations
+      .filter((o) => o.active)
+      .reduce((s, o) => s + Number(o.amount), 0);
+    const lifetimeMiles = Math.max(
+      0,
+      ...trucks.map((t) => Number(t.current_odometer) || 0),
+      maxFuelOdometer(fuel) ?? 0,
+      ...driverLoads.map((l) => Number(l.odometer_end) || 0),
+    );
+    const basis = getCostBasis(periods, obligationsTotal, driverLoads, now);
+    const ladder = getRateLadder(basis.breakEvenRpm, RATE_TIERS);
+    const season = getSeasonStats(periods, driverLoads, now);
+    const rpmG = rpmGrade(basis.windowRpm, ladder);
+    const marginG = marginGrade(season.netMargin);
+    const bests = personalBests(driverLoads, fuel, now);
+    const trophies = earnedTrophies({
+      lifetimeMiles,
+      loads: driverLoads,
+      bestMpg: bests.bestMpg,
+      seasonMargin: marginG,
+    });
+    return {
+      rank: careerRank(lifetimeMiles),
+      season,
+      rpmGrade: rpmG,
+      marginGrade: marginG,
+      form: worseGrade(rpmG, marginG),
+      windowRpm: basis.windowRpm,
+      bests,
+      trophies,
+    };
+  }, [driverLoads, periods, obligations, fuel, trucks]);
 
   const saveEdit = async (data: Record<string, unknown>) => {
     if (!driver) return;
@@ -79,6 +149,18 @@ const DriverDetailPage = () => {
       l.load_status === "delivered" ? s + (Number(l.loaded_miles) || 0) : s,
     0,
   );
+  const name = `${driver.first_name} ${driver.last_name}`;
+
+  const avatar = (
+    <EntityAvatar
+      kind="driver"
+      id={driver.driver_id}
+      avatarUrl={driver.avatar_url}
+      size={118}
+      allowVariant
+      onUpdated={(u) => setDriver({ ...driver, avatar_url: u })}
+    />
+  );
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -86,51 +168,53 @@ const DriverDetailPage = () => {
         ← Drivers
       </Link>
 
-      <div className="flex flex-col md:flex-row gap-6 mt-3 mb-6">
-        <EntityAvatar
-          kind="driver"
-          id={driver.driver_id}
-          avatarUrl={driver.avatar_url}
-          size={180}
-          allowVariant
-          onUpdated={(u) => setDriver({ ...driver, avatar_url: u })}
-        />
-        <div className="flex-1">
-          <div className="flex justify-between items-start">
-            <div>
-              <h1 className="text-3xl font-condensed">
-                {driver.first_name} {driver.last_name}
-              </h1>
-              <p className="text-muted-text text-sm mb-4">
-                {driver.active ? "Active driver" : "Inactive"}
-              </p>
-            </div>
-            {!editing && (
-              <button
-                onClick={() => setEditing(true)}
-                className="bg-steel text-light px-2 py-1 rounded text-xs flex items-center gap-1"
-              >
-                <Pencil size={13} /> Edit
-              </button>
-            )}
+      {card ? (
+        <div className="mt-3">
+          <PlayerCard
+            name={name}
+            business="Delgado Trucking Services · Owner-Operator"
+            avatar={avatar}
+            rank={card.rank}
+            season={card.season}
+            rpmGrade={card.rpmGrade}
+            marginGrade={card.marginGrade}
+            form={card.form}
+            windowRpm={card.windowRpm}
+            bests={card.bests}
+            trophies={card.trophies}
+          />
+        </div>
+      ) : (
+        <div className="flex flex-col md:flex-row gap-6 mt-3 mb-2 items-start">
+          {avatar}
+          <div>
+            <h1 className="text-3xl font-condensed">{name}</h1>
+            <p className="text-muted-text text-sm">
+              {driver.active ? "Active driver" : "Inactive"}
+            </p>
           </div>
+        </div>
+      )}
 
-          {editing ? (
-            <EntityForm
-              title="Edit driver"
-              fields={DRIVER_FIELDS}
-              initial={toFormValues(
-                driver as unknown as Record<string, unknown>,
-                DRIVER_FIELDS,
-              )}
-              onSave={saveEdit}
-              onCancel={() => setEditing(false)}
-              busy={busy}
-              error={error}
-            />
-          ) : (
-            <>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {/* driver details — demoted below the card, still fully editable */}
+      <div className="bg-plate rounded-lg p-4 mt-4">
+        {editing ? (
+          <EntityForm
+            title="Edit driver"
+            fields={DRIVER_FIELDS}
+            initial={toFormValues(
+              driver as unknown as Record<string, unknown>,
+              DRIVER_FIELDS,
+            )}
+            onSave={saveEdit}
+            onCancel={() => setEditing(false)}
+            busy={busy}
+            error={error}
+          />
+        ) : (
+          <>
+            <div className="flex justify-between items-start gap-3">
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 flex-1">
                 <Spec label="Phone" value={driver.phone} />
                 <Spec label="Email" value={driver.email} />
                 <Spec
@@ -141,44 +225,49 @@ const DriverDetailPage = () => {
                       : null
                   }
                 />
-                <Spec
-                  label="CDL expires"
-                  value={formatDate(driver.cdl_expiration)}
-                />
+                <Spec label="CDL expires" value={formatDate(driver.cdl_expiration)} />
                 <Spec label="Endorsements" value={driver.endorsements} />
                 <Spec label="Hired" value={formatDate(driver.hire_date)} />
               </div>
-              <p className="text-xs text-muted-text mt-2">
-                CDL is managed on the{" "}
-                <Link to="/compliance" className="text-status-info-text hover:underline">
-                  Compliance page
-                </Link>
-                .
-              </p>
-              <MileClub miles={milesHauled} />
-            </>
-          )}
-        </div>
+              <button
+                onClick={() => setEditing(true)}
+                className="bg-steel text-light px-2 py-1 rounded text-xs flex items-center gap-1 shrink-0"
+              >
+                <Pencil size={13} /> Edit
+              </button>
+            </div>
+            <p className="text-xs text-muted-text mt-2">
+              CDL is managed on the{" "}
+              <Link to="/compliance" className="text-status-info-text hover:underline">
+                Compliance page
+              </Link>
+              .
+            </p>
+          </>
+        )}
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
-        <div className="bg-plate rounded-lg p-4">
-          <p className="text-xs text-muted-text mb-1">Loads hauled</p>
-          <p className="text-2xl font-condensed">{driverLoads.length}</p>
+      {/* plain-page stats for a non-hauling driver (hauling stats live in the card) */}
+      {!card && (
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-4">
+          <div className="bg-plate rounded-lg p-4">
+            <p className="text-xs text-muted-text mb-1">Loads hauled</p>
+            <p className="text-2xl font-condensed">{driverLoads.length}</p>
+          </div>
+          <div className="bg-plate rounded-lg p-4">
+            <p className="text-xs text-muted-text mb-1">Revenue · all time</p>
+            <p className="text-2xl font-condensed">{money(revenue)}</p>
+          </div>
+          <div className="bg-plate rounded-lg p-4">
+            <p className="text-xs text-muted-text mb-1">Miles hauled</p>
+            <p className="text-2xl font-condensed">
+              {milesHauled.toLocaleString("en-US")}
+            </p>
+          </div>
         </div>
-        <div className="bg-plate rounded-lg p-4">
-          <p className="text-xs text-muted-text mb-1">Revenue · all time</p>
-          <p className="text-2xl font-condensed">{money(revenue)}</p>
-        </div>
-        <div className="bg-plate rounded-lg p-4">
-          <p className="text-xs text-muted-text mb-1">Miles hauled</p>
-          <p className="text-2xl font-condensed">
-            {milesHauled.toLocaleString("en-US")}
-          </p>
-        </div>
-      </div>
+      )}
 
-      <div className="bg-plate rounded-lg p-4">
+      <div className="bg-plate rounded-lg p-4 mt-4">
         <p className="text-xs text-muted-text mb-2">Recent loads</p>
         {driverLoads.length === 0 ? (
           <p className="text-sm text-muted-text">None for this driver yet.</p>


### PR DESCRIPTION
## Player card — phase 1 (v1.47.0)

The hauling driver's page header becomes the **player card**. Phase 2 (award bursts + marquee pops + per-device "seen") follows.

### What's on it
- **Career rank** — Rookie → Roadrunner → Veteran → Road Captain → Highway Legend, from lifetime rig miles (582k → Road Captain), with a progress bar + tier pips.
- **Current-season grade** — worst-of two sub-grades, both shown: **RPM** vs your own rate ladder, and **net margin** vs the locked bands (Strong ≥27 / Target 17–27 / Minimum 8–17 / Below <8). Net margin is the P&L operating margin, net of Landstar.
- **Season stat line** — net revenue, net profit, loads, miles, deadhead, avg RPM, best lane.
- **Personal bests** — top week, best deadhead, best tank, biggest load, most loads/week ("top one and it re-earns").
- **Trophy shelf** — mile club, Relationship Builder, Century, Strong Season, Feather Foot, as wrapping mini-cards.

### Engine
`lib/metrics/playerCard.ts` (10 tests) composes engines we already trust — `getCostBasis`/`getRateLadder`, P&L `netMargin`, `fuelStats.bestMpg`, `mileMilestone`. Bands live in `lib/constants/playerCard.ts`.

### Adult-comic accent language
Bangers display face (`--font-comic`), ink-outlined `ComicBurst` + `MiniTrophyCard` primitives, halftone dot texture — **scoped to the card only**; the rest of the app stays the clean dark dashboard. (Agents re-skin to match is the logged follow-up.)

### Verified
- Strict build clean; **153 tests** (+10). Engine unit-verified against Jason's real Apr–Jun P&L (23.7% margin) and 582k → Road Captain.
- Real-data checks vs prod: all 56 loads are driver-assigned (card renders), windowRPM $6.30, biggest load $10,065, best week $14,086 — all sane.

### ⚠️ Notes for eyeballing
- Couldn't preview the authed page from here — **needs a visual look** (font load, burst SVG, avatar-in-card, halftone).
- **Deadhead reads 0%** because `deadhead_miles` aren't entered on the loads — real data, not a bug.
- Given the true-cost break-even (incl. obligations), the RPM sub-grade likely grades **Minimum**, so season **Form ≈ Minimum** — honest, not the mock's Target.