### PR TITLE
feat: player-card True Net (draws excluded) + red/green metric colors

### DIFF
--- a/backend/db/migrations/031_obligation_draw.sql
+++ b/backend/db/migrations/031_obligation_draw.sql
@@ -1,0 +1,11 @@
+-- Owner draws (distributions) are not a business cost — they're profit taken
+-- out. Flag them so True Net can exclude them (a draw is a distribution of
+-- profit, not a cost), while the break-even / rate math still counts them as
+-- cash the owner needs to cover.
+ALTER TABLE obligations ADD COLUMN IF NOT EXISTS is_draw boolean NOT NULL DEFAULT false;
+
+-- Backfill: mark existing distribution / draw rows.
+UPDATE obligations
+SET is_draw = true
+WHERE is_draw = false
+  AND (label ILIKE '%distribution%' OR label ILIKE '%draw%' OR label ILIKE '%owner pay%');

--- a/backend/src/services/obligationServices.js
+++ b/backend/src/services/obligationServices.js
@@ -5,7 +5,7 @@ import { ValidationError, NotFoundError } from "../utils/error.js";
 export async function getObligations(user_id) {
   if (!user_id) throw new ValidationError("Missing user_id");
   const result = await db.query(
-    `SELECT obligation_id, label, amount, active
+    `SELECT obligation_id, label, amount, active, is_draw
      FROM obligations
      WHERE user_id = $1
      ORDER BY created_at`,
@@ -17,15 +17,15 @@ export async function getObligations(user_id) {
 // ---- CREATE ----
 export async function createObligation(user_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
-  const { label, amount } = data;
+  const { label, amount, is_draw } = data;
   if (!label || amount == null)
     throw new ValidationError("label and amount are required");
 
   const result = await db.query(
-    `INSERT INTO obligations (user_id, label, amount)
-     VALUES ($1, $2, $3)
-     RETURNING obligation_id, label, amount, active`,
-    [user_id, label, amount],
+    `INSERT INTO obligations (user_id, label, amount, is_draw)
+     VALUES ($1, $2, $3, $4)
+     RETURNING obligation_id, label, amount, active, is_draw`,
+    [user_id, label, amount, is_draw === true],
   );
   return result.rows[0];
 }
@@ -35,7 +35,7 @@ export async function patchObligation(user_id, obligation_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
   if (!obligation_id) throw new ValidationError("Missing obligation_id");
 
-  const allowedFields = ["label", "amount", "active"];
+  const allowedFields = ["label", "amount", "active", "is_draw"];
   const updates = [];
   const values = [];
   let index = 1;
@@ -56,7 +56,7 @@ export async function patchObligation(user_id, obligation_id, data) {
     `UPDATE obligations
        SET ${updates.join(", ")}
      WHERE obligation_id = $${index} AND user_id = $${index + 1}
-     RETURNING obligation_id, label, amount, active`,
+     RETURNING obligation_id, label, amount, active, is_draw`,
     values,
   );
   if (result.rowCount === 0) throw new NotFoundError("Obligation not found");

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.47.1",
+  "version": "1.48.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/expenses/ObligationsCard.tsx
+++ b/frontend/src/components/expenses/ObligationsCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Pencil, Trash2, Check, X, Plus, Eye, EyeOff } from "lucide-react";
+import { Pencil, Trash2, Check, X, Plus, Eye, EyeOff, HandCoins } from "lucide-react";
 import type { Obligation } from "@/types/obligation";
 import {
   createObligation,
@@ -61,7 +61,8 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
         Loan <span className="text-light">principal only</span> (not the full
         payment — interest is already counted on your P&amp;L), plus owner draws.
         These fold into the true cost in the KPIs above; toggle one inactive to
-        see the numbers without it.
+        see the numbers without it. Mark an owner draw (hand icon) to keep it out
+        of your card's True Net — it still counts toward break-even here.
       </p>
 
       <table className="w-full text-sm">
@@ -78,6 +79,11 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
                 ) : (
                   <span className={o.active ? "" : "opacity-40 line-through"}>
                     {o.label}
+                    {o.is_draw && (
+                      <span className="text-[10px] text-amber ml-1.5 align-middle">
+                        draw
+                      </span>
+                    )}
                   </span>
                 )}
               </td>
@@ -138,6 +144,23 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
                           }
                         />
                       )}
+                      <HandCoins
+                        size={16}
+                        className={`cursor-pointer ${o.is_draw ? "text-amber" : "hover:text-light opacity-50"}`}
+                        aria-label={
+                          o.is_draw
+                            ? "Owner draw — kept out of True Net (click to unmark)"
+                            : "Mark as owner draw (excluded from True Net)"
+                        }
+                        onClick={() =>
+                          !busy &&
+                          run(() =>
+                            patchObligation(o.obligation_id, {
+                              is_draw: !o.is_draw,
+                            }),
+                          )
+                        }
+                      />
                       <Pencil
                         size={16}
                         className="cursor-pointer hover:text-light"

--- a/frontend/src/components/playercard/PlayerCard.tsx
+++ b/frontend/src/components/playercard/PlayerCard.tsx
@@ -19,10 +19,24 @@ import type {
 } from "@/lib/metrics/playerCard";
 import { fmtMiles } from "@/lib/metrics/mileClub";
 import { RANK_TIERS } from "@/lib/constants/playerCard";
+import { DEADHEAD_TARGET } from "@/lib/constants/targets";
 import { MiniTrophyCard } from "@/components/comic/MiniTrophyCard";
 
 const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const pct1 = (n: number) => `${(n * 100).toFixed(1)}%`;
+
+const GREEN = "#4ade80";
+const RED = "#f87171";
+const AMBER = "#e8940a";
+
+// Colour a metric by where it actually stands — earned, not decorative.
+const profitColor = (n: number) => (n < 0 ? RED : GREEN);
+const deadheadColor = (pct: number | null): string | undefined => {
+  if (pct == null) return undefined;
+  if (pct <= DEADHEAD_TARGET) return GREEN;
+  if (pct <= DEADHEAD_TARGET * 1.5) return AMBER;
+  return RED;
+};
 
 const GRADE_META: Record<Grade, { label: string; fg: string; bg: string }> = {
   below: { label: "BELOW", fg: "#f87171", bg: "#3a1a1a" },
@@ -54,22 +68,28 @@ const GradeChip = ({ grade, value }: { grade: Grade | null; value?: string }) =>
   );
 };
 
+const gradeColor = (g: Grade | null): string | undefined =>
+  g ? GRADE_META[g].fg : undefined;
+
 const Stat = ({
   label,
   value,
   color,
   span2,
+  sub,
 }: {
   label: string;
   value: string;
   color?: string;
   span2?: boolean;
+  sub?: string;
 }) => (
   <div className={`bg-plate rounded-lg px-3 py-2 ${span2 ? "col-span-2" : ""}`}>
     <p className="text-[11px] text-muted-text">{label}</p>
     <p className="text-lg font-condensed truncate" style={color ? { color } : undefined}>
       {value}
     </p>
+    {sub && <p className="text-[10px] text-muted-text truncate">{sub}</p>}
   </div>
 );
 
@@ -89,7 +109,9 @@ const Record = ({
       <Icon size={13} style={{ color }} />
       {label}
     </p>
-    <p className="text-lg font-condensed mt-0.5">{value}</p>
+    <p className="text-lg font-condensed mt-0.5" style={{ color: value === "—" ? undefined : "#4ade80" }}>
+      {value}
+    </p>
   </div>
 );
 
@@ -183,7 +205,7 @@ export const PlayerCard = ({
           </span>
           <span className="text-[11px] text-muted-text">Rate</span>
           <GradeChip grade={rpmGrade} value={windowRpm != null ? `$${windowRpm.toFixed(2)}` : undefined} />
-          <span className="text-[11px] text-muted-text">Margin</span>
+          <span className="text-[11px] text-muted-text">Op margin</span>
           <GradeChip grade={marginGrade} value={season.netMargin != null ? pct1(season.netMargin) : undefined} />
           <span className="flex-1" />
           <span className="text-[11px] text-muted-text">Form</span>
@@ -210,13 +232,31 @@ export const PlayerCard = ({
         </span>
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-        <Stat label="Net revenue" value={money0(season.netRevenue)} />
-        <Stat label="Net profit" value={money0(season.netProfit)} color="#4ade80" />
-        <Stat label="Net margin" value={season.netMargin != null ? pct1(season.netMargin) : "—"} />
+        <Stat label="Net revenue" value={money0(season.netRevenue)} sub="net of Landstar" />
+        <Stat
+          label="Operating profit"
+          value={money0(season.netProfit)}
+          color={profitColor(season.netProfit)}
+          sub="before obligations"
+        />
+        <Stat
+          label="True net"
+          value={money0(season.trueNet)}
+          color={profitColor(season.trueNet)}
+          sub="what you keep, before draw"
+        />
         <Stat label="Loads" value={String(season.loads)} />
         <Stat label="Miles" value={Math.round(season.totalMiles).toLocaleString("en-US")} />
-        <Stat label="Deadhead" value={season.deadheadPct != null ? pct1(season.deadheadPct) : "—"} />
-        <Stat label="Avg RPM" value={season.avgRpm != null ? `$${season.avgRpm.toFixed(2)}` : "—"} />
+        <Stat
+          label="Deadhead"
+          value={season.deadheadPct != null ? pct1(season.deadheadPct) : "—"}
+          color={deadheadColor(season.deadheadPct)}
+        />
+        <Stat
+          label="Avg RPM"
+          value={season.avgRpm != null ? `$${season.avgRpm.toFixed(2)}` : "—"}
+          color={gradeColor(rpmGrade)}
+        />
         <Stat label="Best lane" value={season.bestLane?.lane ?? "—"} span2 />
       </div>
 

--- a/frontend/src/lib/metrics/playerCard.test.ts
+++ b/frontend/src/lib/metrics/playerCard.test.ts
@@ -122,6 +122,12 @@ describe("getSeasonStats", () => {
     expect(s.loads).toBe(2);
     expect(s.label).toBe("Apr–Jun 2026");
   });
+  it("subtracts only debt obligations for True Net (draws excluded upstream)", () => {
+    const s = getSeasonStats(periods, loads, NOW, 3, 2411); // $2,411/mo debt
+    expect(s.netProfit).toBeCloseTo(18774.33, 2); // operating unchanged
+    expect(s.trueNet).toBeCloseTo(18774.33 - 2411 * 3, 2); // − 3 months of debt
+    expect(s.trueNetMargin).toBeCloseTo((18774.33 - 7233) / 79346.84, 4);
+  });
   it("computes deadhead, avg rpm, and best lane over the window", () => {
     const s = getSeasonStats(periods, loads, NOW);
     expect(s.avgRpm).toBeCloseTo((3200 + 2600) / 1800, 3);

--- a/frontend/src/lib/metrics/playerCard.ts
+++ b/frontend/src/lib/metrics/playerCard.ts
@@ -81,8 +81,10 @@ export const rpmGrade = (rpm: number | null, ladder: RateLadder): Grade | null =
 export interface SeasonStats {
   label: string; // e.g. "Apr–Jun 2026"
   netRevenue: number; // P&L income (net of Landstar) over the window
-  netProfit: number; // income − COGS − expenses
-  netMargin: number | null;
+  netProfit: number; // operating profit: income − COGS − expenses
+  netMargin: number | null; // operating margin — the graded number
+  trueNet: number; // operating profit − debt obligations (draws excluded)
+  trueNetMargin: number | null;
   loads: number;
   totalMiles: number;
   loadedMiles: number;
@@ -108,6 +110,9 @@ export const getSeasonStats = (
   loads: Load[],
   now: Date,
   monthsBack = 3,
+  // Monthly DEBT obligations (owner draws excluded) — subtracted from operating
+  // profit to get True Net over the same months the P&L covers.
+  obligationsDebtMonthly = 0,
 ): SeasonStats => {
   const months = completeMonthsBefore(now, monthsBack);
 
@@ -121,6 +126,7 @@ export const getSeasonStats = (
     n++;
   }
   const netProfit = income - cost;
+  const trueNet = netProfit - obligationsDebtMonthly * n;
 
   const seasonLoads = loads.filter(
     (l) => l.load_status === "delivered" && inWindow(l.delivery_date, months),
@@ -157,6 +163,8 @@ export const getSeasonStats = (
     netRevenue: income,
     netProfit,
     netMargin: income > 0 ? netProfit / income : null,
+    trueNet,
+    trueNetMargin: income > 0 ? trueNet / income : null,
     loads: seasonLoads.length,
     totalMiles: total,
     loadedMiles: loaded,

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -85,8 +85,13 @@ const DriverDetailPage = () => {
   const card = useMemo(() => {
     if (driverLoads.length === 0) return null;
     const now = new Date();
+    // All active obligations (incl. the owner draw) drive break-even/rate; only
+    // the debt ones (draws excluded) subtract from True Net.
     const obligationsTotal = obligations
       .filter((o) => o.active)
+      .reduce((s, o) => s + Number(o.amount), 0);
+    const obligationsDebt = obligations
+      .filter((o) => o.active && !o.is_draw)
       .reduce((s, o) => s + Number(o.amount), 0);
     const lifetimeMiles = Math.max(
       0,
@@ -96,7 +101,7 @@ const DriverDetailPage = () => {
     );
     const basis = getCostBasis(periods, obligationsTotal, driverLoads, now);
     const ladder = getRateLadder(basis.breakEvenRpm, RATE_TIERS);
-    const season = getSeasonStats(periods, driverLoads, now);
+    const season = getSeasonStats(periods, driverLoads, now, 3, obligationsDebt);
     const rpmG = rpmGrade(basis.windowRpm, ladder);
     const marginG = marginGrade(season.netMargin);
     const bests = personalBests(driverLoads, fuel, now);

--- a/frontend/src/services/obligationsService.ts
+++ b/frontend/src/services/obligationsService.ts
@@ -7,6 +7,7 @@ const coerce = (o: any): Obligation => ({
   label: o.label,
   amount: Number(o.amount),
   active: o.active,
+  is_draw: o.is_draw ?? false,
 });
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -22,6 +23,7 @@ export const getObligations = async (): Promise<Obligation[]> => {
 export const createObligation = async (data: {
   label: string;
   amount: number;
+  is_draw?: boolean;
 }): Promise<Obligation> => {
   try {
     const res = await api.post("/obligations", data);
@@ -33,7 +35,7 @@ export const createObligation = async (data: {
 
 export const patchObligation = async (
   id: string,
-  data: Partial<{ label: string; amount: number; active: boolean }>,
+  data: Partial<{ label: string; amount: number; active: boolean; is_draw: boolean }>,
 ): Promise<void> => {
   try {
     await api.patch(`/obligations/${id}`, data);

--- a/frontend/src/types/obligation.ts
+++ b/frontend/src/types/obligation.ts
@@ -3,4 +3,5 @@ export interface Obligation {
   label: string;
   amount: number;
   active: boolean;
+  is_draw: boolean; // owner draw (distribution) — excluded from True Net
 }


### PR DESCRIPTION
## v1.48.0 — True Net + metric colors

Addresses two things on the player card: what "net profit" means, and coloring the metrics by good/bad.

### True Net (draws excluded)
- Headline profit becomes **True Net = operating profit − active DEBT obligations**. Owner draws are excluded (a draw is profit taken out, not a cost).
- Stat line reads as a waterfall: **net revenue → operating profit → true net** ("what you keep, before draw").
- **Grades and awards stay on operating P&L**, so toggling any obligation can never fire a false award or change a past grade — the gaming hole is closed at the root.
- Q2 example: $79.3k → $18.8k operating → **$11.5k true net** (− $2,411/mo loans × 3; the $1k draw excluded).

### Obligations gain `is_draw`
- Migration `031_obligation_draw.sql` (applied to dev + prod; Distribution backfilled as a draw).
- Backend service returns/accepts `is_draw`; Expenses obligations card gets a per-row **owner-draw toggle** (hand icon). Draws stay in break-even/rate math, drop out of True Net.

### Metric colors
- Avg RPM off the rate ladder, deadhead off the deadhead target, profit by sign, records green; volume stats (revenue, loads, miles, best lane) stay neutral. Op-margin grade relabeled "Op margin" so it isn't confused with True Net.

### Verified
- Strict build clean; **154 tests** (+1 True Net). Obligation `is_draw` SQL round-tripped on dev (insert/patch/select), test row cleaned up. Migration idempotent, applied both DBs.