### PR TITLE
feat: player card phase 2 — award pops on login (marquee + burst)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.48.0",
+  "version": "1.49.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/comic/AwardPopHost.tsx
+++ b/frontend/src/components/comic/AwardPopHost.tsx
@@ -1,0 +1,68 @@
+import { useState, useEffect } from "react";
+import {
+  Truck,
+  Medal,
+  Trophy,
+  Flame,
+  Package,
+  Layers,
+  Users,
+  Gauge,
+  type LucideIcon,
+} from "lucide-react";
+import type { Award } from "@/lib/metrics/awards";
+import { MarqueeAward } from "./MarqueeAward";
+import { BurstAward } from "./BurstAward";
+
+const ICONS: Record<string, LucideIcon> = {
+  truck: Truck,
+  medal: Medal,
+  trophy: Trophy,
+  flame: Flame,
+  package: Package,
+  stack: Layers,
+  users: Users,
+  gauge: Gauge,
+};
+const iconFor = (n: string): LucideIcon => ICONS[n] ?? Trophy;
+
+// Orchestrates the celebration: a marquee takes over the screen (one at a time);
+// bursts stack in the corner and auto-fade. Marquees block bursts until dismissed.
+export const AwardPopHost = ({ pops }: { pops: Award[] }) => {
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const dismiss = (id: string) =>
+    setDismissed((d) => {
+      const n = new Set(d);
+      n.add(id);
+      return n;
+    });
+
+  const visible = pops.filter((p) => !dismissed.has(p.id));
+  const marquee = visible.find((p) => p.tier === "marquee");
+  const bursts = marquee ? [] : visible.filter((p) => p.tier === "burst").slice(0, 4);
+
+  const burstKey = bursts.map((b) => b.id).join(",");
+  useEffect(() => {
+    if (!burstKey) return;
+    const ids = burstKey.split(",");
+    const timers = ids.map((id, idx) => setTimeout(() => dismiss(id), 5000 + idx * 600));
+    return () => timers.forEach(clearTimeout);
+  }, [burstKey]);
+
+  if (!marquee && bursts.length === 0) return null;
+
+  return (
+    <>
+      {bursts.length > 0 && (
+        <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 items-end">
+          {bursts.map((b) => (
+            <BurstAward key={b.id} award={b} Icon={iconFor(b.icon)} onDismiss={() => dismiss(b.id)} />
+          ))}
+        </div>
+      )}
+      {marquee && (
+        <MarqueeAward award={marquee} Icon={iconFor(marquee.icon)} onDismiss={() => dismiss(marquee.id)} />
+      )}
+    </>
+  );
+};

--- a/frontend/src/components/comic/BurstAward.tsx
+++ b/frontend/src/components/comic/BurstAward.tsx
@@ -1,0 +1,36 @@
+import type { LucideIcon } from "lucide-react";
+import type { Award } from "@/lib/metrics/awards";
+import { ComicBurst } from "@/components/comic/ComicBurst";
+
+// A frequent re-earnable win — the comic burst presses in as a corner toast and
+// fades. Click to dismiss early.
+export const BurstAward = ({
+  award,
+  Icon,
+  onDismiss,
+}: {
+  award: Award;
+  Icon: LucideIcon;
+  onDismiss: () => void;
+}) => (
+  <button
+    onClick={onDismiss}
+    className="flex items-center gap-3 rounded-[13px] border pl-2.5 pr-4 py-2.5 text-left w-[300px] max-w-[86vw]"
+    style={{ background: "#10151f", borderColor: "#2a3347", animation: "award-toast-in .4s ease both" }}
+  >
+    <span style={{ animation: "award-press .5s cubic-bezier(.2,.8,.3,1.3) both" }}>
+      <ComicBurst size={44} fill="#e8940a">
+        <Icon size={19} />
+      </ComicBurst>
+    </span>
+    <span className="min-w-0">
+      <span
+        className="block font-comic text-base"
+        style={{ color: "#f5b03a", letterSpacing: "1px" }}
+      >
+        {award.name}
+      </span>
+      <span className="block text-xs text-muted-text truncate">{award.detail}</span>
+    </span>
+  </button>
+);

--- a/frontend/src/components/comic/MarqueeAward.tsx
+++ b/frontend/src/components/comic/MarqueeAward.tsx
@@ -1,0 +1,118 @@
+import type { LucideIcon } from "lucide-react";
+import type { Award } from "@/lib/metrics/awards";
+
+// Ray endpoints for the sunburst behind the medallion.
+const RAYS: [number, number][] = [
+  [50, 2], [83, 17], [98, 50], [83, 83], [50, 98], [17, 83], [2, 50], [17, 17],
+  [67, 6], [94, 33], [94, 67], [67, 94], [33, 94], [6, 67], [6, 33], [33, 6],
+];
+
+const CONFETTI = [
+  { left: "22%", color: "#e8940a", delay: ".1s" },
+  { left: "38%", color: "#4ade80", delay: ".5s" },
+  { left: "54%", color: "#f5b03a", delay: ".9s" },
+  { left: "68%", color: "#60a5fa", delay: ".3s" },
+  { left: "80%", color: "#e8940a", delay: ".7s" },
+];
+
+const kicker = (id: string): string =>
+  id.startsWith("rank:")
+    ? "RANK UP"
+    : id.startsWith("mileclub:")
+      ? "MILE CLUB"
+      : id.startsWith("strong-season:")
+        ? "STRONG SEASON"
+        : "AWARD UNLOCKED";
+
+// A rare, big win — takes over the screen with the card flying in, a shine
+// sweep, a slow ray-burst, and confetti.
+export const MarqueeAward = ({
+  award,
+  Icon,
+  onDismiss,
+}: {
+  award: Award;
+  Icon: LucideIcon;
+  onDismiss: () => void;
+}) => (
+  <div
+    className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-hidden"
+    style={{ background: "rgba(6,9,15,0.74)" }}
+  >
+    {CONFETTI.map((c, i) => (
+      <span
+        key={i}
+        className="absolute rounded-[1px]"
+        style={{
+          left: c.left,
+          top: "-10px",
+          width: 7,
+          height: 7,
+          background: c.color,
+          animation: `award-fall 2.4s linear ${c.delay} infinite`,
+        }}
+      />
+    ))}
+    <div
+      className="relative w-[330px] max-w-[92vw] rounded-[18px] px-6 pt-5 pb-4 text-center overflow-hidden"
+      style={{
+        background: "#10151f",
+        border: "2px solid #e8940a",
+        animation: "award-pop .6s cubic-bezier(.2,.9,.25,1.2) both",
+      }}
+    >
+      <div
+        className="absolute top-0 h-full pointer-events-none"
+        style={{
+          left: "-60%",
+          width: "45%",
+          background: "rgba(245,176,58,.16)",
+          transform: "skewX(-20deg)",
+          animation: "award-shine 1.6s ease-in-out .5s infinite",
+        }}
+      />
+      <svg
+        className="absolute left-1/2 -ml-[75px] top-1.5"
+        width="150"
+        height="150"
+        viewBox="0 0 100 100"
+        style={{ animation: "award-spin 14s linear infinite", opacity: 0.5 }}
+        aria-hidden="true"
+      >
+        <g stroke="#e8940a" strokeWidth="2.5">
+          {RAYS.map((r, i) => (
+            <line key={i} x1="50" y1="50" x2={r[0]} y2={r[1]} />
+          ))}
+        </g>
+      </svg>
+      <div
+        className="relative mx-auto w-[78px] h-[78px] rounded-full flex items-center justify-center"
+        style={{ background: "#3a2a0a", border: "3px solid #e8940a", color: "#f5b03a" }}
+      >
+        <Icon size={38} />
+      </div>
+      <div className="font-comic mt-3" style={{ color: "#f5b03a", letterSpacing: "3px", fontSize: 15 }}>
+        ★ {kicker(award.id)} ★
+      </div>
+      <div className="font-comic mt-1" style={{ fontSize: 28, letterSpacing: "1px", lineHeight: 1 }}>
+        {award.name.replace(/^Rank up — /, "")}
+      </div>
+      <div className="text-sm text-muted-text mt-2.5">{award.detail}</div>
+      <button
+        onClick={onDismiss}
+        className="mt-4 font-comic cursor-pointer"
+        style={{
+          background: "#e8940a",
+          color: "#10151f",
+          border: "none",
+          borderRadius: 9,
+          padding: "9px 22px",
+          fontSize: 15,
+          letterSpacing: "1px",
+        }}
+      >
+        LET'S ROLL
+      </button>
+    </div>
+  </div>
+);

--- a/frontend/src/hooks/useAwardPops.ts
+++ b/frontend/src/hooks/useAwardPops.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect } from "react";
+import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+import type { FuelEntry } from "@/types/fuelEntry";
+import type { Truck } from "@/types/truck";
+import type { Obligation } from "@/types/obligation";
+import { getExpensePeriods } from "@/services/expensesService";
+import { getFuelEntries } from "@/services/fuelService";
+import { getTrucks } from "@/services/trucksService";
+import { getObligations } from "@/services/obligationsService";
+import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
+import { earnedAwards, newAwards, type Award } from "@/lib/metrics/awards";
+
+// Per-device "seen" store. Earned-award facts are objective (computed from data);
+// which ones a device has already celebrated is per-device — that's what lets
+// Jason and Brandie each catch every award once on their own screen even though
+// they share the login.
+const KEY = "dash.awards.v1";
+interface Store {
+  baselined: boolean;
+  seen: string[];
+}
+const read = (): Store => {
+  try {
+    const s = JSON.parse(localStorage.getItem(KEY) || "");
+    if (s && Array.isArray(s.seen)) return { baselined: !!s.baselined, seen: s.seen };
+  } catch {
+    /* fresh device */
+  }
+  return { baselined: false, seen: [] };
+};
+const write = (s: Store) => {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(s));
+  } catch {
+    /* storage disabled — pops just won't persist */
+  }
+};
+
+// Computes the awards newly earned since this device last looked. On a device's
+// first-ever load it silently baselines the current set (no day-one flood), so
+// only things earned AFTER that fire a celebration.
+export const useAwardPops = (loads: Load[]): { pops: Award[] } => {
+  const [pops, setPops] = useState<Award[]>([]);
+  const [data, setData] = useState<{
+    periods: ExpensePeriod[];
+    fuel: FuelEntry[];
+    trucks: Truck[];
+    obligations: Obligation[];
+  } | null>(null);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    Promise.all([getExpensePeriods(), getFuelEntries(), getTrucks(), getObligations()])
+      .then(([periods, fuel, trucks, obligations]) =>
+        setData({ periods, fuel, trucks, obligations }),
+      )
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!data || loads.length === 0 || done) return;
+    setDone(true);
+
+    const now = new Date();
+    const lifetimeMiles = Math.max(
+      0,
+      ...data.trucks.map((t) => Number(t.current_odometer) || 0),
+      maxFuelOdometer(data.fuel) ?? 0,
+      ...loads.map((l) => Number(l.odometer_end) || 0),
+    );
+    const obligationsDebtMonthly = data.obligations
+      .filter((o) => o.active && !o.is_draw)
+      .reduce((s, o) => s + Number(o.amount), 0);
+
+    const earned = earnedAwards({
+      loads,
+      periods: data.periods,
+      fuel: data.fuel,
+      lifetimeMiles,
+      obligationsDebtMonthly,
+      now,
+    });
+    const currentIds = earned.map((a) => a.id);
+    const store = read();
+
+    if (!store.baselined) {
+      write({ baselined: true, seen: currentIds }); // silent baseline
+      return;
+    }
+    const fresh = newAwards(earned, new Set(store.seen));
+    if (fresh.length > 0) {
+      write({ baselined: true, seen: [...new Set([...store.seen, ...currentIds])] });
+      setPops(fresh);
+    }
+  }, [data, loads, done]);
+
+  return { pops };
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -181,3 +181,24 @@
   border: none !important;
   box-shadow: none !important;
 }
+
+/* --- Award pop animations (player card celebration layer) --- */
+@keyframes award-pop {
+  from { transform: scale(0.82) translateY(10px); opacity: 0; }
+  to { transform: scale(1) translateY(0); opacity: 1; }
+}
+@keyframes award-shine {
+  0% { left: -60%; }
+  55%, 100% { left: 130%; }
+}
+@keyframes award-spin { to { transform: rotate(360deg); } }
+@keyframes award-fall { to { transform: translateY(240px) rotate(320deg); opacity: 0.2; } }
+@keyframes award-press {
+  0% { transform: scale(0.4) rotate(-12deg); opacity: 0; }
+  60% { transform: scale(1.06) rotate(2deg); opacity: 1; }
+  100% { transform: scale(1) rotate(0); }
+}
+@keyframes award-toast-in {
+  from { transform: translateX(40px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}

--- a/frontend/src/lib/metrics/awards.test.ts
+++ b/frontend/src/lib/metrics/awards.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import { earnedAwards, newAwards, type Award } from "./awards";
+
+const NOW = new Date("2026-07-10T12:00:00Z");
+
+const L = (o: Record<string, unknown>): Load =>
+  ({
+    load_status: "delivered",
+    agent_id: "ag1",
+    agent: "Redwood",
+    delivery_date: "2026-05-12",
+    loaded_miles: 1000,
+    deadhead_miles: 0,
+    linehaul: "3000",
+    fuel_surcharge: "0",
+    total_accessorials: "0",
+    origin_market: "Dallas",
+    delivery_market: "Atlanta",
+    ...o,
+  }) as unknown as Load;
+
+describe("earnedAwards", () => {
+  it("emits rank, mile club, relationship, and best-week ids", () => {
+    const loads = Array.from({ length: 6 }, (_, k) => L({ load_id: `x${k}` }));
+    const ids = earnedAwards({
+      loads,
+      periods: [],
+      fuel: [],
+      lifetimeMiles: 582450,
+      obligationsDebtMonthly: 2411,
+      now: NOW,
+    }).map((a) => a.id);
+    expect(ids).toContain("rank:road-captain");
+    expect(ids).toContain("mileclub:500000");
+    expect(ids.some((x) => x.startsWith("relationship:ag1:5"))).toBe(true);
+    expect(ids.some((x) => x.startsWith("best-week:"))).toBe(true);
+  });
+
+  it("re-earns: a bigger best week yields a new id so it pops again", () => {
+    const base = { periods: [], fuel: [], lifetimeMiles: 0, obligationsDebtMonthly: 0, now: NOW };
+    const a = earnedAwards({ ...base, loads: [L({ load_id: "1", linehaul: "4000" })] });
+    const b = earnedAwards({ ...base, loads: [L({ load_id: "1", linehaul: "5000" })] });
+    const idA = a.find((x) => x.id.startsWith("best-week:"))!.id;
+    const idB = b.find((x) => x.id.startsWith("best-week:"))!.id;
+    expect(idA).not.toBe(idB);
+  });
+});
+
+describe("newAwards", () => {
+  it("drops seen ids and orders marquee before burst", () => {
+    const earned: Award[] = [
+      { id: "best-week:5000", tier: "burst", name: "", detail: "", icon: "" },
+      { id: "rank:road-captain", tier: "marquee", name: "", detail: "", icon: "" },
+      { id: "seen-one", tier: "burst", name: "", detail: "", icon: "" },
+    ];
+    const fresh = newAwards(earned, new Set(["seen-one"]));
+    expect(fresh.map((a) => a.id)).toEqual(["rank:road-captain", "best-week:5000"]);
+  });
+});

--- a/frontend/src/lib/metrics/awards.ts
+++ b/frontend/src/lib/metrics/awards.ts
@@ -1,0 +1,129 @@
+// The set of awards currently earned, each with a STABLE id that changes only
+// when the award is genuinely re-earned (a new record, a new tier). The pop
+// system diffs this against a per-device "seen" list: anything whose id isn't
+// seen is new and fires a celebration. Encoding the value/threshold in the id is
+// what makes "beat your own best" re-pop while an unchanged best stays quiet.
+import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+import type { FuelEntry } from "@/types/fuelEntry";
+import {
+  careerRank,
+  getSeasonStats,
+  marginGrade,
+  personalBests,
+} from "./playerCard";
+import { mileMilestone } from "./mileClub";
+
+export type AwardTier = "marquee" | "burst";
+
+export interface Award {
+  id: string;
+  tier: AwardTier;
+  name: string;
+  detail: string;
+  icon: string; // mapped to a lucide icon in the UI
+}
+
+const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+
+export interface AwardInputs {
+  loads: Load[];
+  periods: ExpensePeriod[];
+  fuel: FuelEntry[];
+  lifetimeMiles: number;
+  obligationsDebtMonthly: number;
+  now: Date;
+}
+
+const RELATIONSHIP_MARKS = [5, 10, 25, 50, 100];
+const CENTURY_MARKS = [500, 250, 100];
+
+export const earnedAwards = (i: AwardInputs): Award[] => {
+  const out: Award[] = [];
+
+  // ---- Marquee: career rank ----
+  const rank = careerRank(i.lifetimeMiles);
+  out.push({
+    id: `rank:${rank.key}`,
+    tier: "marquee",
+    name: `Rank up — ${rank.name}`,
+    detail: `${Math.round(rank.miles).toLocaleString("en-US")} lifetime miles`,
+    icon: "truck",
+  });
+
+  // ---- Marquee: mile club ----
+  const mm = mileMilestone(i.lifetimeMiles);
+  if (mm.crossed != null && mm.label)
+    out.push({
+      id: `mileclub:${mm.crossed}`,
+      tier: "marquee",
+      name: `${mm.label} Mile Club`,
+      detail: mm.title ?? "Lifetime",
+      icon: "medal",
+    });
+
+  // ---- Marquee: strong season ----
+  const season = getSeasonStats(i.periods, i.loads, i.now, 3, i.obligationsDebtMonthly);
+  if (marginGrade(season.netMargin) === "strong")
+    out.push({
+      id: `strong-season:${season.label}`,
+      tier: "marquee",
+      name: "Strong Season",
+      detail: `${season.label} · ${season.netMargin != null ? (season.netMargin * 100).toFixed(1) : "?"}% margin`,
+      icon: "trophy",
+    });
+
+  // ---- Burst: personal bests (re-fire when the record improves) ----
+  const pb = personalBests(i.loads, i.fuel, i.now);
+  if (pb.bestWeekRevenue != null)
+    out.push({ id: `best-week:${Math.round(pb.bestWeekRevenue)}`, tier: "burst", name: "Personal Best Week", detail: `${money(pb.bestWeekRevenue)} in a week`, icon: "trophy" });
+  if (pb.bestMpg != null)
+    out.push({ id: `best-mpg:${pb.bestMpg.toFixed(1)}`, tier: "burst", name: "Feather Foot", detail: `New best tank — ${pb.bestMpg.toFixed(1)} mpg`, icon: "flame" });
+  if (pb.biggestLoad != null)
+    out.push({ id: `biggest-load:${Math.round(pb.biggestLoad)}`, tier: "burst", name: "Heavy Purse", detail: `Biggest load — ${money(pb.biggestLoad)}`, icon: "package" });
+  if (pb.mostLoadsInWeek != null)
+    out.push({ id: `most-loads:${pb.mostLoadsInWeek}`, tier: "burst", name: "Busy Week", detail: `${pb.mostLoadsInWeek} loads in a week`, icon: "stack" });
+  if (pb.lowestDeadheadPct != null)
+    out.push({ id: `best-deadhead:${(pb.lowestDeadheadPct * 100).toFixed(1)}`, tier: "burst", name: "Tight Lines", detail: `Deadhead down to ${(pb.lowestDeadheadPct * 100).toFixed(1)}%`, icon: "gauge" });
+
+  // ---- Burst: relationship milestones (per agent) ----
+  const byAgent = new Map<string, { name: string; count: number }>();
+  for (const l of i.loads)
+    if (l.load_status === "delivered" && l.agent_id) {
+      const a = byAgent.get(l.agent_id) ?? { name: l.agent, count: 0 };
+      a.count += 1;
+      byAgent.set(l.agent_id, a);
+    }
+  for (const [agentId, a] of byAgent) {
+    const mark = [...RELATIONSHIP_MARKS].reverse().find((x) => a.count >= x);
+    if (mark)
+      out.push({ id: `relationship:${agentId}:${mark}`, tier: "burst", name: "Relationship Builder", detail: `${a.name} ×${mark}`, icon: "users" });
+  }
+
+  // ---- Burst: century of loads ----
+  const delivered = i.loads.filter((l) => l.load_status === "delivered").length;
+  const century = CENTURY_MARKS.find((x) => delivered >= x);
+  if (century)
+    out.push({ id: `century:${century}`, tier: "burst", name: `${century} Loads`, detail: "Career milestone", icon: "stack" });
+
+  return out;
+};
+
+// Sample awards for previewing the celebration UI (dashboard `?awarddemo`) —
+// since a real device silently baselines on first load, this is how you see the
+// pop without waiting to earn one.
+export const DEMO_AWARDS: Award[] = [
+  { id: "demo:rank", tier: "marquee", name: "Rank up — Road Captain", detail: "582,450 lifetime miles and climbing.", icon: "truck" },
+  { id: "demo:tightlines", tier: "burst", name: "Tight Lines", detail: "Deadhead down to 7.2%", icon: "gauge" },
+  { id: "demo:feather", tier: "burst", name: "Feather Foot", detail: "New best tank — 6.9 mpg", icon: "flame" },
+];
+
+// Split newly-earned awards against a seen-id set. Marquee first (they take over
+// the screen), then bursts.
+export const newAwards = (earned: Award[], seen: Set<string>): Award[] => {
+  const fresh = earned.filter((a) => !seen.has(a.id));
+  return [
+    ...fresh.filter((a) => a.tier === "marquee"),
+    ...fresh.filter((a) => a.tier === "burst"),
+  ];
+};

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -23,6 +23,9 @@ import {
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { useMaintenanceAlerts } from "@/hooks/useMaintenanceAlerts";
 import { useComplianceAlerts } from "@/hooks/useComplianceAlerts";
+import { useAwardPops } from "@/hooks/useAwardPops";
+import { AwardPopHost } from "@/components/comic/AwardPopHost";
+import { DEMO_AWARDS } from "@/lib/metrics/awards";
 import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
 import { RevenueChart } from "@/components/RevenueChart";
 import { RpmChart } from "@/components/RpmChart";
@@ -67,6 +70,9 @@ const DashboardPage = () => {
   } = useTrips(refreshKey);
   const targets = useRateTargets(loads);
   const alerts = [...useMaintenanceAlerts(loads), ...useComplianceAlerts()];
+  const { pops } = useAwardPops(loads);
+  // `?awarddemo` on the dashboard previews the celebration UI on demand.
+  const awardDemo = window.location.search.includes("awarddemo");
 
   const isLoading = loadsLoading || tripsLoading;
   const error = loadsError || tripsError;
@@ -120,6 +126,8 @@ const DashboardPage = () => {
 
   return (
     <div className="p-6 bg-iron text-light min-h-screen font-body">
+      <AwardPopHost pops={awardDemo ? DEMO_AWARDS : pops} />
+
       <h1 className="text-3xl font-condensed mb-6">Dashboard</h1>
 
       <AlertBanners alerts={alerts} />


### PR DESCRIPTION
## v1.49.0 — the celebration layer

On the dashboard, newly-earned awards fire:
- **Marquee** takes over the screen for rare/big wins (rank-ups, mile clubs, strong seasons) — card flies in with a shine sweep, ray-burst, and confetti.
- **Bursts** stack in the corner and auto-fade for the frequent re-earnable ones (personal bests, relationship milestones, century).

### Engine (`awards.ts`, 3 tests)
`earnedAwards()` emits **stable ids that change only on genuine re-earn** — a bigger best week yields a new id (pops again), an unchanged best stays quiet. Composes the phase-1 metrics.

### Per-device "seen"
localStorage, never backend — so Jason and Brandie each catch every award once on their own screen despite sharing the login. **A device's first load silently baselines** the current set (no day-one flood); only things earned after that pop.

### Preview
Dashboard `?awarddemo` shows a sample marquee (dismiss → reveals bursts) — since a real device baselines silently, this is how to see a pop without waiting to earn one.

### Verified
Strict build clean; **157 tests** (+3). Frontend-only, no backend/migration. Couldn't preview the authed dashboard from here — worth a look via `?awarddemo`.