### PR TITLE
feat: re-skin agents comic elements to the adult-comic language

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.49.0",
+  "version": "1.50.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/agents/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard.tsx
@@ -76,8 +76,8 @@ export const AgentCard = ({
         <RatingMedallion rating={agent.rating} />
         {prestige.label && (
           <span
-            className="text-[11px] font-medium uppercase tracking-wide shrink-0"
-            style={{ color: prestige.fill }}
+            className="text-[13px] font-comic uppercase shrink-0"
+            style={{ color: prestige.fill, letterSpacing: "1px" }}
           >
             {prestige.label}
           </span>

--- a/frontend/src/components/agents/PrestigeBadge.tsx
+++ b/frontend/src/components/agents/PrestigeBadge.tsx
@@ -38,8 +38,8 @@ export const PrestigeBurst = ({
         <polygon
           points={POINTS}
           fill={m.fill}
-          stroke="#0d1117"
-          strokeWidth={1.5}
+          stroke="#0a0d13"
+          strokeWidth={2.4}
         />
       </svg>
       <span className="absolute inset-0 flex items-center justify-center">

--- a/frontend/src/components/agents/RatingStamp.tsx
+++ b/frontend/src/components/agents/RatingStamp.tsx
@@ -12,7 +12,7 @@ export const RatingStamp = ({ rating }: { rating?: number | null }) => {
   const s = rating ? STAMP[rating] : { label: "Unrated", color: "#9daabb" };
   return (
     <div
-      className="inline-block px-3.5 py-1 rotate-[-6deg] font-condensed font-semibold uppercase text-xl rounded"
+      className="inline-block px-4 py-1 rotate-[-6deg] font-comic uppercase text-2xl rounded"
       style={{
         border: `3px double ${s.color}`,
         color: s.color,

--- a/frontend/src/components/agents/TrophyCase.tsx
+++ b/frontend/src/components/agents/TrophyCase.tsx
@@ -66,12 +66,27 @@ export const TrophyCase = ({
   const boarded = (honors?.board ?? 0) > 0;
 
   return (
-    <div className="bg-plate rounded-lg p-4">
-      <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
-        Trophy case
-      </p>
+    <div
+      className="relative overflow-hidden rounded-lg p-4 border-2"
+      style={{ background: "#10151f", borderColor: "#e8940a" }}
+    >
+      <div
+        className="absolute top-0 right-0 w-28 h-28 pointer-events-none"
+        style={{
+          backgroundImage: "radial-gradient(#e8940a 1.3px, transparent 1.4px)",
+          backgroundSize: "7px 7px",
+          opacity: 0.12,
+        }}
+      />
+      <div className="relative">
+        <p
+          className="font-comic text-base mb-3"
+          style={{ color: "#f5b03a", letterSpacing: "1px" }}
+        >
+          TROPHY CASE
+        </p>
 
-      {!boarded ? (
+        {!boarded ? (
         <p className="text-sm text-muted-text">
           No quarterly top-5 finishes yet — takes 2+ delivered loads in a quarter
           to make the board.
@@ -81,7 +96,7 @@ export const TrophyCase = ({
           <div className="flex items-center gap-4 flex-wrap">
             <PrestigeBurst tier={tier} size={56} />
             <div>
-              <p className="font-condensed text-xl" style={{ color: meta.fill }}>
+              <p className="font-comic text-2xl leading-none" style={{ color: meta.fill }}>
                 {meta.label}
               </p>
               <div className="flex gap-4 text-sm mt-1">
@@ -116,7 +131,8 @@ export const TrophyCase = ({
         </>
       )}
 
-      {live && <Live standing={live} />}
+        {live && <Live standing={live} />}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## v1.50.0 — agents re-skin (the last queued follow-up)

Brings the older clean-comic agents surface up to the player card's adult-comic voice, so the whole app speaks one comic language.

- **Prestige bursts** — heavier ink outline (stroke 1.5 → 2.4), so they read as inked, not printed.
- **Rating stamp** (the hero verdict on agent detail) — moves to the **Bangers** display face.
- **Trophy case** — becomes a **noir card** (dark bg, amber ink border, halftone corner) with a Bangers tier label + header, matching the player card's trophy shelf.
- **Agent card** prestige label → Bangers.
- **TopAgents** (dashboard top-5) inherits the re-inked burst automatically.
- **Rating medallions** (functional list chips) stay clean — the adult-comic is an accent for celebratory elements only, not every chip.

No logic change — display only. Build clean; **157 tests** green. Couldn't preview the authed pages from here — worth a look at the agents list, an agent's detail (stamp + trophy case), and the dashboard top-5.