### PR TITLE
feat: grind meter — weekly target-beating streak on the dashboard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.50.1",
+  "version": "1.51.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/GrindMeter.tsx
+++ b/frontend/src/components/dashboard/GrindMeter.tsx
@@ -1,0 +1,141 @@
+import { Flame } from "lucide-react";
+import type { Load } from "@/types/load";
+import { useGrind } from "@/hooks/useGrind";
+import type { WeekStatus } from "@/lib/metrics/grind";
+import { Stamp } from "@/components/Stamp";
+
+const CELL: Record<WeekStatus, string> = {
+  target: "#4ade80",
+  breakeven: "#e8940a",
+  below: "#f87171",
+  home: "#2a3347",
+};
+
+const thisWeekLine = (
+  s: WeekStatus,
+): { text: string; color: string } => {
+  switch (s) {
+    case "target":
+      return { text: "On pace — you're beating target this week.", color: "#4ade80" };
+    case "breakeven":
+      return { text: "Covering costs — a stronger load beats target.", color: "#e8940a" };
+    case "below":
+      return { text: "Below break-even this week.", color: "#f87171" };
+    default:
+      return { text: "No loads logged this week yet.", color: "#9daabb" };
+  }
+};
+
+const Dot = ({ color, label }: { color: string; label: string }) => (
+  <span className="text-[11px] text-muted-text">
+    <span
+      className="inline-block w-2.5 h-2.5 rounded-[3px] align-middle mr-1.5"
+      style={{ background: color }}
+    />
+    {label}
+  </span>
+);
+
+export const GrindMeter = ({ loads }: { loads: Load[] }) => {
+  const grind = useGrind(loads);
+  if (!grind || !grind.hasLadder || grind.weeks.length === 0) return null;
+
+  const { currentStreak, bestStreak, weeks, thisWeek } = grind;
+  const cold = currentStreak === 0;
+  const status = thisWeekLine(thisWeek);
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-2xl border-2 p-4 mb-6"
+      style={{ background: "#10151f", borderColor: "#e8940a" }}
+    >
+      <div
+        className="absolute top-0 right-0 w-28 h-28 pointer-events-none"
+        style={{
+          backgroundImage: "radial-gradient(#e8940a 1.3px, transparent 1.4px)",
+          backgroundSize: "7px 7px",
+          opacity: 0.12,
+        }}
+      />
+
+      <div className="relative flex items-center gap-2 mb-3">
+        <span className="font-comic text-xl" style={{ color: "#f5b03a" }}>
+          THE GRIND
+        </span>
+        <span className="flex-1" />
+        {currentStreak >= 5 && <Stamp label="On fire!" color="#f87171" size="sm" />}
+      </div>
+
+      <div className="relative flex items-center gap-4 flex-wrap">
+        <div className="flex items-center gap-3">
+          <Flame size={50} style={{ color: cold ? "#9daabb" : "#e8940a" }} />
+          <div className="leading-none">
+            {cold ? (
+              <>
+                <span className="font-comic text-3xl" style={{ color: "#9daabb" }}>
+                  COLD
+                </span>
+                <div className="text-xs text-muted-text mt-1.5">
+                  beat target this week to light it
+                </div>
+              </>
+            ) : (
+              <>
+                <span className="font-comic text-4xl" style={{ color: "#f5b03a" }}>
+                  {currentStreak}
+                </span>
+                <span className="font-comic text-lg ml-1">
+                  {currentStreak === 1 ? "WEEK" : "WEEKS"}
+                </span>
+                <div className="text-xs text-muted-text mt-1">
+                  on a target-beating streak
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+        <span className="flex-1" />
+        <div className="text-right">
+          <div className="text-[11px] tracking-wide text-muted-text">PERSONAL BEST</div>
+          <div className="font-comic text-2xl" style={{ color: "#c9b58f" }}>
+            {bestStreak} {bestStreak === 1 ? "WK" : "WKS"}
+          </div>
+        </div>
+      </div>
+
+      <div className="relative mt-4">
+        <div className="flex gap-1 flex-wrap">
+          {weeks.map((w) => (
+            <span
+              key={w.start}
+              className="w-5 h-5 rounded-[5px] shrink-0"
+              style={{ background: CELL[w.status] }}
+              title={w.start}
+            />
+          ))}
+          <span
+            className="w-5 h-5 rounded-[5px] shrink-0"
+            style={{ border: "2px dashed #e8940a" }}
+            title="this week"
+          />
+        </div>
+        <div className="flex justify-between text-[10px] text-muted-text mt-1.5">
+          <span>← {weeks.length} weeks</span>
+          <span>this week</span>
+        </div>
+      </div>
+
+      <div className="relative flex gap-x-4 gap-y-1 flex-wrap mt-3">
+        <Dot color="#4ade80" label="Beat target" />
+        <Dot color="#e8940a" label="Covered break-even" />
+        <Dot color="#f87171" label="Below" />
+        <Dot color="#2a3347" label="Home" />
+      </div>
+
+      <div className="relative mt-3.5 border-t border-plate pt-2.5 text-[13px]">
+        <span style={{ color: status.color, fontWeight: 600 }}>This week — </span>
+        <span className="text-muted-text">{status.text}</span>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/hooks/useAwardPops.ts
+++ b/frontend/src/hooks/useAwardPops.ts
@@ -9,6 +9,7 @@ import { getFuelEntries } from "@/services/fuelService";
 import { getTrucks } from "@/services/trucksService";
 import { getObligations } from "@/services/obligationsService";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
+import { computeGrind } from "@/lib/metrics/grind";
 import { earnedAwards, newAwards, type Award } from "@/lib/metrics/awards";
 
 // Per-device "seen" store. Earned-award facts are objective (computed from data);
@@ -72,6 +73,10 @@ export const useAwardPops = (loads: Load[]): { pops: Award[] } => {
     const obligationsDebtMonthly = data.obligations
       .filter((o) => o.active && !o.is_draw)
       .reduce((s, o) => s + Number(o.amount), 0);
+    const obligationsAllActive = data.obligations
+      .filter((o) => o.active)
+      .reduce((s, o) => s + Number(o.amount), 0);
+    const grind = computeGrind(loads, data.periods, obligationsAllActive, now);
 
     const earned = earnedAwards({
       loads,
@@ -79,6 +84,7 @@ export const useAwardPops = (loads: Load[]): { pops: Award[] } => {
       fuel: data.fuel,
       lifetimeMiles,
       obligationsDebtMonthly,
+      streak: grind.currentStreak,
       now,
     });
     const currentIds = earned.map((a) => a.id);

--- a/frontend/src/hooks/useGrind.ts
+++ b/frontend/src/hooks/useGrind.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect, useMemo } from "react";
+import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+import type { Obligation } from "@/types/obligation";
+import { getExpensePeriods } from "@/services/expensesService";
+import { getObligations } from "@/services/obligationsService";
+import { computeGrind, type Grind } from "@/lib/metrics/grind";
+
+// Fetches the P&L + obligations the rate ladder needs, then grades every pay-week
+// into the grind streak. Null until there's data.
+export const useGrind = (loads: Load[]): Grind | null => {
+  const [periods, setPeriods] = useState<ExpensePeriod[] | null>(null);
+  const [obligations, setObligations] = useState<Obligation[] | null>(null);
+
+  useEffect(() => {
+    getExpensePeriods().then(setPeriods).catch(() => {});
+    getObligations().then(setObligations).catch(() => {});
+  }, []);
+
+  return useMemo(() => {
+    if (!periods || !obligations || loads.length === 0) return null;
+    const obligationsMonthly = obligations
+      .filter((o) => o.active)
+      .reduce((s, o) => s + Number(o.amount), 0);
+    return computeGrind(loads, periods, obligationsMonthly, new Date());
+  }, [periods, obligations, loads]);
+};

--- a/frontend/src/lib/metrics/awards.ts
+++ b/frontend/src/lib/metrics/awards.ts
@@ -32,11 +32,13 @@ export interface AwardInputs {
   fuel: FuelEntry[];
   lifetimeMiles: number;
   obligationsDebtMonthly: number;
+  streak?: number; // current grind streak (weeks beating target)
   now: Date;
 }
 
 const RELATIONSHIP_MARKS = [5, 10, 25, 50, 100];
 const CENTURY_MARKS = [500, 250, 100];
+const STREAK_MARKS = [12, 8, 4];
 
 export const earnedAwards = (i: AwardInputs): Award[] => {
   const out: Award[] = [];
@@ -105,6 +107,13 @@ export const earnedAwards = (i: AwardInputs): Award[] => {
   const century = CENTURY_MARKS.find((x) => delivered >= x);
   if (century)
     out.push({ id: `century:${century}`, tier: "burst", name: `${century} Loads`, detail: "Career milestone", icon: "stack" });
+
+  // ---- Burst: grind streak milestones ----
+  if (i.streak) {
+    const mark = STREAK_MARKS.find((x) => i.streak! >= x);
+    if (mark)
+      out.push({ id: `on-a-roll:${mark}`, tier: "burst", name: "On a Roll", detail: `${i.streak}-week target streak`, icon: "flame" });
+  }
 
   return out;
 };

--- a/frontend/src/lib/metrics/grind.test.ts
+++ b/frontend/src/lib/metrics/grind.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import {
+  classify,
+  currentStreakOf,
+  bestStreakOf,
+  type WeekStatus,
+} from "./grind";
+
+const ladder = { walkAway: 4, minimum: 4.6, target: 6, strong: 6.4 };
+
+describe("classify", () => {
+  it("grades a week's rpm against the ladder", () => {
+    expect(classify(null, ladder)).toBe("home");
+    expect(classify(6.5, ladder)).toBe("target");
+    expect(classify(6, ladder)).toBe("target");
+    expect(classify(5, ladder)).toBe("breakeven");
+    expect(classify(3.5, ladder)).toBe("below");
+  });
+});
+
+describe("currentStreakOf", () => {
+  const S = (a: WeekStatus[]) => currentStreakOf(a);
+  it("counts trailing target weeks", () => {
+    expect(S(["below", "target", "target", "target"])).toBe(3);
+  });
+  it("skips home weeks without breaking", () => {
+    expect(S(["target", "target", "home", "target"])).toBe(3);
+    expect(S(["target", "target", "home", "home"])).toBe(2);
+  });
+  it("breaks on a below or break-even week", () => {
+    expect(S(["target", "breakeven", "target", "target"])).toBe(2);
+    expect(S(["target", "below"])).toBe(0);
+  });
+});
+
+describe("bestStreakOf", () => {
+  it("finds the longest target run, home weeks neutral", () => {
+    expect(bestStreakOf(["target", "target", "below", "target", "target", "target"])).toBe(3);
+    expect(bestStreakOf(["target", "home", "target"])).toBe(2);
+    expect(bestStreakOf(["below", "breakeven", "home"])).toBe(0);
+  });
+});

--- a/frontend/src/lib/metrics/grind.ts
+++ b/frontend/src/lib/metrics/grind.ts
@@ -1,0 +1,118 @@
+// The grind meter — a week-over-week motivation layer. Each pay-week is graded
+// on the SAME rate ladder the dashboard uses: did your rate per loaded mile beat
+// target (green), just cover break-even (amber), or slip below (red)? A week you
+// delivered nothing is a home/neutral week (grey) — it doesn't count, but it
+// doesn't break your streak either. The streak is consecutive target-beating
+// weeks; home weeks are skipped.
+import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+import {
+  payWeekRange,
+  getWeekRpm,
+  getRateLadder,
+  getCostBasis,
+  type RateLadder,
+} from "./rateTargets";
+import { PAY_WEEK_START_DOW, RATE_TIERS } from "@/lib/constants/targets";
+
+const WEEK_MS = 7 * 86400000;
+
+export type WeekStatus = "target" | "breakeven" | "below" | "home";
+
+export interface GrindWeek {
+  start: string; // 'YYYY-MM-DD'
+  status: WeekStatus;
+  rpm: number | null;
+}
+
+export interface Grind {
+  weeks: GrindWeek[]; // last N complete weeks, oldest → newest (the strip)
+  currentStreak: number; // consecutive target weeks (home skips, else breaks)
+  bestStreak: number;
+  thisWeek: WeekStatus; // the in-progress week
+  thisWeekRpm: number | null;
+  hasLadder: boolean; // false when there's no P&L to grade against
+}
+
+export const classify = (rpm: number | null, ladder: RateLadder): WeekStatus => {
+  if (rpm == null) return "home";
+  if (ladder.target != null && rpm >= ladder.target) return "target";
+  if (ladder.walkAway != null && rpm >= ladder.walkAway) return "breakeven";
+  return "below";
+};
+
+// Consecutive target weeks from the most recent backward; home weeks skip
+// (neither extend nor break), anything else stops the run.
+export const currentStreakOf = (statuses: WeekStatus[]): number => {
+  let s = 0;
+  for (let i = statuses.length - 1; i >= 0; i--) {
+    if (statuses[i] === "home") continue;
+    if (statuses[i] === "target") s++;
+    else break;
+  }
+  return s;
+};
+
+// Longest target run across all weeks; home weeks are neutral (don't reset).
+export const bestStreakOf = (statuses: WeekStatus[]): number => {
+  let best = 0;
+  let run = 0;
+  for (const st of statuses) {
+    if (st === "home") continue;
+    if (st === "target") {
+      run++;
+      if (run > best) best = run;
+    } else run = 0;
+  }
+  return best;
+};
+
+export const computeGrind = (
+  loads: Load[],
+  periods: ExpensePeriod[],
+  obligationsMonthly: number,
+  now: Date,
+  weeksToShow = 14,
+): Grind => {
+  const basis = getCostBasis(periods, obligationsMonthly, loads, now);
+  const ladder = getRateLadder(basis.breakEvenRpm, RATE_TIERS);
+  const hasLadder = ladder.walkAway != null && ladder.target != null;
+
+  const current = payWeekRange(now, PAY_WEEK_START_DOW);
+  const thisWeekRpm = getWeekRpm(loads, current.start, current.end);
+  const thisWeek: WeekStatus = hasLadder ? classify(thisWeekRpm, ladder) : "home";
+
+  const delivered = loads.filter(
+    (l) => l.load_status === "delivered" && l.delivery_date,
+  );
+  if (!hasLadder || delivered.length === 0)
+    return { weeks: [], currentStreak: 0, bestStreak: 0, thisWeek, thisWeekRpm, hasLadder };
+
+  let earliest = delivered[0].delivery_date!;
+  for (const l of delivered)
+    if (l.delivery_date! < earliest) earliest = l.delivery_date!;
+  const firstStart = payWeekRange(
+    new Date(earliest.slice(0, 10) + "T00:00:00Z"),
+    PAY_WEEK_START_DOW,
+  ).start;
+
+  const weeks: GrindWeek[] = [];
+  for (let t = firstStart.getTime(); t < current.start.getTime(); t += WEEK_MS) {
+    const ws = new Date(t);
+    const rpm = getWeekRpm(loads, ws, new Date(t + WEEK_MS));
+    weeks.push({ start: ws.toISOString().slice(0, 10), status: classify(rpm, ladder), rpm });
+    if (weeks.length > 200) break; // safety cap
+  }
+
+  const statuses = weeks.map((w) => w.status);
+  const currentStreak = currentStreakOf(statuses);
+
+  return {
+    weeks: weeks.slice(-weeksToShow),
+    currentStreak,
+    bestStreak: Math.max(bestStreakOf(statuses), currentStreak),
+    thisWeek,
+    thisWeekRpm,
+    hasLadder,
+  };
+};

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -27,6 +27,7 @@ import { useAwardPops } from "@/hooks/useAwardPops";
 import { AwardPopHost } from "@/components/comic/AwardPopHost";
 import { DEMO_AWARDS } from "@/lib/metrics/awards";
 import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
+import { GrindMeter } from "@/components/dashboard/GrindMeter";
 import { RevenueChart } from "@/components/RevenueChart";
 import { RpmChart } from "@/components/RpmChart";
 import { OutstandingLoadsList } from "@/components/OutstandingLoadsList";
@@ -166,6 +167,11 @@ const DashboardPage = () => {
       {/* Rate & pace targets */}
       <div className="mt-6">
         <RateTargetsCard targets={targets} rpm={targets.weekRpm} />
+      </div>
+
+      {/* The grind — weekly target-beating streak */}
+      <div className="mt-6">
+        <GrindMeter loads={loads} />
       </div>
 
       {/* Revenue chart + top agents */}


### PR DESCRIPTION
## v1.51.0 — the grind meter

A dashboard motivation layer. Each pay-week is graded on the **same rate ladder the dashboard uses**:
- 🟢 **beat target** · 🟡 **covered break-even** · 🔴 **below** · ⬜ **home** (zero deliveries)

The **streak** is consecutive target-beating weeks; **home weeks are skipped** so rest never breaks it. The card shows the current streak (flame), your personal best, a **14-week strip**, and this-week status, with an **ON FIRE** stamp past a 5-week run.

Streak milestones (**4 / 8 / 12 weeks**) fire the "On a Roll" burst through the award-pop system built last session.

### Engine (`grind.ts`, 5 tests)
Reuses `getCostBasis`/`getRateLadder` + `getWeekRpm`. **Home weeks inferred as zero-delivery weeks** — upgrades to real home data when the per-diem tracker lands.

### Verified vs real data
His weeks produce a genuine mix — a ~5-week green run late May–June, recent weeks slipped to amber, so his current streak reads low right now (honest; target is a high bar) with a best ~5. No bug — the meter is doing its job.

Build clean; **162 tests** (+5). Frontend-only, no backend/migration. Couldn't preview the authed dashboard — worth a look.