### PR TITLE
feat: season recap — tiered month / quarter / year Wrapped posters

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.51.1",
+  "version": "1.52.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { SwatchesPage } from "@/pages/SwatchesPage";
 import SignupPage from "@/pages/SignupPage";
 import GuidePage from "@/pages/GuidePage";
 import CompliancePage from "@/pages/CompliancePage";
+import RecapPage from "@/pages/RecapPage";
 
 // Code-split Lanes — it bundles the US map topology (~600KB), so it should only
 // load when the page is actually visited, not on every app start.
@@ -59,6 +60,7 @@ const App = () => {
           <Route path="/expenses" element={<ExpensesPage />} />
           <Route path="/maintenance" element={<MaintenancePage />} />
           <Route path="/compliance" element={<CompliancePage />} />
+          <Route path="/recap" element={<RecapPage />} />
           <Route path="/agents" element={<AgentsPage />} />
           <Route path="/agents/:agent_id" element={<AgentDetailPage />} />
           <Route path="/fuel-entries" element={<FuelEntriesPage />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -43,6 +43,7 @@ const nav: Entry[] = [
   },
   { to: "/compliance", label: "Compliance" },
   { to: "/expenses", label: "Expenses" },
+  { to: "/recap", label: "Recap" },
   { to: "/guide", label: "Guide" },
 ];
 

--- a/frontend/src/components/recap/RecapPoster.tsx
+++ b/frontend/src/components/recap/RecapPoster.tsx
@@ -1,0 +1,157 @@
+import { Truck, MapPin, Star } from "lucide-react";
+import type { RecapStats } from "@/lib/metrics/recap";
+
+const kMoney = (n: number) =>
+  n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${Math.round(n)}`;
+const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+const num = (n: number) => Math.round(n).toLocaleString("en-US");
+
+const Tile = ({
+  value,
+  label,
+  color = "#f5e6c8",
+}: {
+  value: string;
+  label: string;
+  color?: string;
+}) => (
+  <div className="rounded-[10px] px-3 py-2.5 text-center" style={{ background: "#1c2333" }}>
+    <div className="font-comic text-[22px] leading-none" style={{ color }}>
+      {value}
+    </div>
+    <div className="text-[10px] text-muted-text mt-1 tracking-wide">{label}</div>
+  </div>
+);
+
+const Hero = ({
+  value,
+  label,
+  color,
+}: {
+  value: string;
+  label: string;
+  color: string;
+}) => (
+  <div className="flex-1 rounded-xl px-2 py-3 text-center" style={{ background: "#0a0d13" }}>
+    <div className="font-comic text-3xl leading-none" style={{ color }}>
+      {value}
+    </div>
+    <div className="text-[11px] text-muted-text mt-1 tracking-wider">{label}</div>
+  </div>
+);
+
+export const RecapPoster = ({
+  stats,
+  rank,
+  truckAvatarUrl,
+}: {
+  stats: RecapStats;
+  rank: string;
+  truckAvatarUrl?: string | null;
+}) => {
+  const isYear = stats.scope === "year";
+  const edge = isYear ? "#f5b03a" : "#e8940a";
+  const kicker = isYear ? "GRAND FINALE · THE" : "RECAP ·";
+  const title = isYear ? `${stats.label} SEASON` : stats.label;
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-2xl border-2 max-w-[600px] mx-auto"
+      style={{ background: "#10151f", borderColor: edge }}
+    >
+      <div
+        className="absolute top-0 right-0 w-40 h-40 pointer-events-none"
+        style={{
+          backgroundImage: "radial-gradient(#e8940a 1.3px, transparent 1.4px)",
+          backgroundSize: "8px 8px",
+          opacity: 0.13,
+        }}
+      />
+
+      {isYear && (
+        <div
+          className="relative h-44 sm:h-52 border-b-2 flex items-center justify-center overflow-hidden"
+          style={{ borderColor: edge, background: "#0a0d13" }}
+        >
+          {truckAvatarUrl ? (
+            <img
+              src={truckAvatarUrl}
+              alt="Your truck"
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <Truck size={72} style={{ color: "#2a3347" }} />
+          )}
+        </div>
+      )}
+
+      <div className="relative p-5 sm:p-6">
+        <div className="text-center mb-5">
+          <div className="font-comic tracking-[4px] text-xs" style={{ color: "#9daabb" }}>
+            DELGADO TRUCKING · {kicker}
+          </div>
+          <div className="font-comic leading-none" style={{ color: edge, fontSize: isYear ? 44 : 34 }}>
+            {title}
+          </div>
+          <div
+            className="inline-flex items-center gap-1.5 mt-2.5 rounded-full px-3 py-0.5"
+            style={{ background: "#3a2a0a", border: "1px solid #e8940a" }}
+          >
+            <Truck size={14} style={{ color: "#f5b03a" }} />
+            <span className="font-comic tracking-wide text-[14px] uppercase" style={{ color: "#f5e6c8" }}>
+              {rank}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex gap-2 mb-2.5">
+          <Hero value={kMoney(stats.gross)} label="HAULED" color="#4ade80" />
+          <Hero value={num(stats.loadedMiles)} label="MILES" color="#f5b03a" />
+          <Hero value={String(stats.states)} label="STATES" color="#60a5fa" />
+        </div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <Tile value={String(stats.loads)} label="LOADS" />
+          <Tile value={stats.bestWeek != null ? kMoney(stats.bestWeek) : "—"} label="BEST WEEK" />
+          <Tile value={stats.biggestLoad != null ? kMoney(stats.biggestLoad) : "—"} label="BIGGEST LOAD" />
+          <Tile value={stats.longestHaul != null ? num(stats.longestHaul) : "—"} label="LONGEST HAUL (MI)" />
+          <Tile value={stats.bestMpg != null ? stats.bestMpg.toFixed(1) : "—"} label="BEST TANK (MPG)" />
+          <Tile value={stats.avgRpm != null ? `$${stats.avgRpm.toFixed(2)}` : "—"} label="AVG RPM" />
+        </div>
+
+        {stats.netProfit != null && (
+          <div className="grid grid-cols-3 gap-2 mt-2">
+            <Tile value={money0(stats.netProfit)} label="NET PROFIT" color="#4ade80" />
+            {stats.bestMonth && <Tile value={stats.bestMonth.label.split(" ")[0]} label="BEST MONTH" color="#4ade80" />}
+            {stats.hardestMonth && <Tile value={stats.hardestMonth.label.split(" ")[0]} label="HARDEST MONTH" color="#f87171" />}
+          </div>
+        )}
+
+        <div className="flex gap-2 flex-wrap mt-2.5">
+          <div className="flex-1 min-w-[180px] rounded-[10px] px-3 py-2.5" style={{ background: "#1c2333" }}>
+            <div className="text-[10px] text-muted-text tracking-wide">
+              <MapPin size={12} className="inline -mt-0.5" style={{ color: "#e8940a" }} /> TOP LANE
+            </div>
+            <div className="font-comic text-[17px] mt-0.5" style={{ color: "#f5b03a" }}>
+              {stats.topLane ?? "—"}
+            </div>
+          </div>
+          <div className="flex-1 min-w-[150px] rounded-[10px] px-3 py-2.5" style={{ background: "#1c2333" }}>
+            <div className="text-[10px] text-muted-text tracking-wide">
+              <Star size={12} className="inline -mt-0.5" style={{ color: "#e8940a" }} /> TOP AGENT
+            </div>
+            <div className="font-comic text-[17px] mt-0.5" style={{ color: "#f5b03a" }}>
+              {stats.topAgent ?? "—"}
+            </div>
+          </div>
+        </div>
+
+        <div className="text-center mt-4 border-t border-plate pt-3">
+          <span className="font-comic tracking-[2px] text-[13px]" style={{ color: "#9daabb" }}>
+            {stats.states} OF 48 STATES · BEST STREAK {stats.bestStreak} WK · KEEP ROLLING
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/lib/metrics/recap.test.ts
+++ b/frontend/src/lib/metrics/recap.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { ExpensePeriod } from "@/types/expense";
+import type { FuelEntry } from "@/types/fuelEntry";
+import { rangeFor, resolvePeriod, computeRecap } from "./recap";
+
+const NOW = new Date("2026-07-11T12:00:00Z");
+
+const L = (o: Record<string, unknown>): Load =>
+  ({
+    load_status: "delivered",
+    fuel_surcharge: "0",
+    total_accessorials: "0",
+    agent: "Redwood",
+    ...o,
+  }) as unknown as Load;
+
+const P = (month: string, income: number, cogs: number, expense: number): ExpensePeriod =>
+  ({ period_month: month, income_total: income, cogs_total: cogs, expense_total: expense }) as ExpensePeriod;
+
+describe("rangeFor / resolvePeriod", () => {
+  it("labels each scope", () => {
+    expect(rangeFor("year", 2026, 0).label).toBe("2026");
+    expect(rangeFor("quarter", 2026, 1).label).toBe("Q2 2026");
+    expect(rangeFor("month", 2026, 5).label).toBe("Jun 2026");
+  });
+  it("resolves the most recent complete period", () => {
+    expect(resolvePeriod("month", 0, NOW).label).toBe("Jun 2026");
+    expect(resolvePeriod("quarter", 0, NOW).label).toBe("Q2 2026");
+    expect(resolvePeriod("year", 0, NOW).label).toBe("2026");
+    expect(resolvePeriod("month", 1, NOW).label).toBe("May 2026");
+  });
+});
+
+describe("computeRecap", () => {
+  const loads = [
+    L({ load_id: "a", delivery_date: "2026-05-12", linehaul: "3200", loaded_miles: 1000, origin_state: "TX", destination_state: "GA", origin_market: "Dallas", delivery_market: "Atlanta" }),
+    L({ load_id: "b", delivery_date: "2026-06-15", linehaul: "2600", loaded_miles: 800, origin_state: "TX", destination_state: "TN", origin_market: "Houston", delivery_market: "Memphis" }),
+    L({ load_id: "c", delivery_date: "2025-12-30", linehaul: "9999", loaded_miles: 500, origin_state: "CA", destination_state: "NV", origin_market: "LA", delivery_market: "Vegas" }), // prior year — excluded
+  ];
+  const periods = [
+    P("2026-05-01", 28833, 5776, 13258),
+    P("2026-06-01", 27814, 4127, 18175),
+  ];
+
+  it("aggregates the year's highlights", () => {
+    const r = computeRecap(loads, [] as FuelEntry[], periods, 0, rangeFor("year", 2026, 0), "year", NOW);
+    expect(r.gross).toBe(5800);
+    expect(r.loadedMiles).toBe(1800);
+    expect(r.states).toBe(3); // TX, GA, TN — prior-year CA/NV excluded
+    expect(r.loads).toBe(2);
+    expect(r.biggestLoad).toBe(3200);
+    expect(r.longestHaul).toBe(1000);
+    expect(r.avgRpm).toBeCloseTo(5800 / 1800, 3);
+    expect(r.topLane).toBe("Dallas → Atlanta");
+    expect(r.topAgent).toBe("Redwood");
+  });
+
+  it("rolls up P&L with best / hardest month", () => {
+    const r = computeRecap(loads, [] as FuelEntry[], periods, 0, rangeFor("year", 2026, 0), "year", NOW);
+    expect(r.netProfit).toBe(9799 + 5512);
+    expect(r.bestMonth).toMatchObject({ label: "May 2026", profit: 9799 });
+    expect(r.hardestMonth).toMatchObject({ label: "Jun 2026", profit: 5512 });
+  });
+});

--- a/frontend/src/lib/metrics/recap.ts
+++ b/frontend/src/lib/metrics/recap.ts
@@ -1,0 +1,198 @@
+// Season recap — a "Wrapped"-style highlight reel for any period (a month, a
+// quarter, or the whole year). Pure aggregation over data we already have.
+import type { Load } from "@/types/load";
+import type { FuelEntry } from "@/types/fuelEntry";
+import type { ExpensePeriod } from "@/types/expense";
+import {
+  loadRevenue,
+  getWeekBookedGross,
+  getGrossTargets,
+  getCostBasis,
+  payWeekRange,
+} from "./rateTargets";
+import { mpgWindows } from "./fuelEconomy";
+import { classify, bestStreakOf, type WeekStatus } from "./grind";
+import {
+  PAY_WEEK_START_DOW,
+  RATE_TIERS,
+  WORKING_DAYS_PER_MONTH,
+} from "@/lib/constants/targets";
+
+const WEEK_MS = 7 * 86400000;
+export const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+export type RecapScope = "month" | "quarter" | "year";
+
+export interface RecapRange {
+  start: Date;
+  end: Date;
+  label: string; // "Jun 2026" / "Q2 2026" / "2026"
+}
+
+// Range for a scope: unit = month(0-11) for month, quarter(0-3) for quarter,
+// ignored for year.
+export const rangeFor = (scope: RecapScope, year: number, unit: number): RecapRange => {
+  if (scope === "year")
+    return {
+      start: new Date(Date.UTC(year, 0, 1)),
+      end: new Date(Date.UTC(year + 1, 0, 1)),
+      label: `${year}`,
+    };
+  if (scope === "quarter") {
+    const m = unit * 3;
+    return {
+      start: new Date(Date.UTC(year, m, 1)),
+      end: new Date(Date.UTC(year, m + 3, 1)),
+      label: `Q${unit + 1} ${year}`,
+    };
+  }
+  return {
+    start: new Date(Date.UTC(year, unit, 1)),
+    end: new Date(Date.UTC(year, unit + 1, 1)),
+    label: `${MONTHS[unit]} ${year}`,
+  };
+};
+
+// The period `periodsAgo` complete periods before now (0 = most recent complete).
+export const resolvePeriod = (
+  scope: RecapScope,
+  periodsAgo: number,
+  now: Date,
+): RecapRange => {
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth();
+  if (scope === "year") return rangeFor("year", y - periodsAgo, 0);
+  if (scope === "quarter") {
+    const totalQ = y * 4 + Math.floor(m / 3) - 1 - periodsAgo;
+    return rangeFor("quarter", Math.floor(totalQ / 4), ((totalQ % 4) + 4) % 4);
+  }
+  const totalM = y * 12 + m - 1 - periodsAgo;
+  return rangeFor("month", Math.floor(totalM / 12), ((totalM % 12) + 12) % 12);
+};
+
+const inRange = (d: string | null | undefined, r: RecapRange): boolean => {
+  if (!d) return false;
+  const t = new Date(d.slice(0, 10) + "T00:00:00Z").getTime();
+  return t >= r.start.getTime() && t < r.end.getTime();
+};
+
+export interface RecapStats {
+  scope: RecapScope;
+  label: string;
+  gross: number;
+  loadedMiles: number;
+  states: number;
+  loads: number;
+  bestWeek: number | null;
+  biggestLoad: number | null;
+  longestHaul: number | null;
+  bestMpg: number | null;
+  avgRpm: number | null;
+  topLane: string | null;
+  topAgent: string | null;
+  netProfit: number | null;
+  bestMonth: { label: string; profit: number } | null;
+  hardestMonth: { label: string; profit: number } | null;
+  bestStreak: number;
+}
+
+export const computeRecap = (
+  loads: Load[],
+  fuel: FuelEntry[],
+  periods: ExpensePeriod[],
+  obligationsMonthly: number,
+  range: RecapRange,
+  scope: RecapScope,
+  now: Date,
+): RecapStats => {
+  const mine = loads.filter((l) => l.load_status === "delivered" && inRange(l.delivery_date, range));
+
+  const gross = mine.reduce((s, l) => s + loadRevenue(l), 0);
+  const loadedMiles = mine.reduce((s, l) => s + Number(l.loaded_miles || 0), 0);
+
+  const stateSet = new Set<string>();
+  for (const l of mine) {
+    if (l.origin_state) stateSet.add(l.origin_state);
+    if (l.destination_state) stateSet.add(l.destination_state);
+  }
+
+  const biggestLoad = mine.reduce<number | null>((m, l) => {
+    const r = loadRevenue(l);
+    return m == null || r > m ? r : m;
+  }, null);
+  const longestHaul = mine.reduce<number | null>((m, l) => {
+    const v = Number(l.loaded_miles || 0);
+    return m == null || v > m ? v : m;
+  }, null);
+
+  const laneRev = new Map<string, number>();
+  const agentRev = new Map<string, number>();
+  for (const l of mine) {
+    const lane = `${l.origin_market} → ${l.delivery_market}`;
+    laneRev.set(lane, (laneRev.get(lane) ?? 0) + loadRevenue(l));
+    if (l.agent) agentRev.set(l.agent, (agentRev.get(l.agent) ?? 0) + loadRevenue(l));
+  }
+  const topOf = (m: Map<string, number>): string | null => {
+    let best: string | null = null;
+    let bv = -1;
+    for (const [k, v] of m) if (v > bv) { bv = v; best = k; }
+    return best;
+  };
+
+  // best MPG tank whose closing fill lands in the range
+  let bestMpg: number | null = null;
+  for (const w of mpgWindows(fuel)) if (inRange(w.date, range) && (bestMpg == null || w.mpg > bestMpg)) bestMpg = w.mpg;
+
+  // P&L: net profit + best / hardest month over the range
+  let netProfit: number | null = null;
+  const monthly: { label: string; profit: number }[] = [];
+  for (const p of periods) {
+    if (!inRange(p.period_month, range)) continue;
+    const profit = (p.income_total ?? 0) - (p.cogs_total ?? 0) - (p.expense_total ?? 0);
+    netProfit = (netProfit ?? 0) + profit;
+    const d = new Date(p.period_month);
+    monthly.push({ label: `${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`, profit });
+  }
+  let bestMonth: { label: string; profit: number } | null = null;
+  let hardestMonth: { label: string; profit: number } | null = null;
+  if (monthly.length >= 2) {
+    bestMonth = monthly.reduce((a, b) => (b.profit > a.profit ? b : a));
+    hardestMonth = monthly.reduce((a, b) => (b.profit < a.profit ? b : a));
+  }
+
+  // weekly gross → best week + best target-beating streak in the range
+  const targets = getGrossTargets(
+    getCostBasis(periods, obligationsMonthly, loads, now).trueMonthlyCost,
+    RATE_TIERS.target,
+    WORKING_DAYS_PER_MONTH,
+  );
+  let bestWeek: number | null = null;
+  const statuses: WeekStatus[] = [];
+  const firstWeek = payWeekRange(range.start, PAY_WEEK_START_DOW).start.getTime();
+  for (let t = firstWeek; t < range.end.getTime(); t += WEEK_MS) {
+    if (t < range.start.getTime()) continue; // skip the partial leading week
+    const wg = getWeekBookedGross(loads, new Date(t), new Date(t + WEEK_MS));
+    if (bestWeek == null || wg > bestWeek) bestWeek = wg;
+    statuses.push(classify(wg, targets));
+  }
+
+  return {
+    scope,
+    label: range.label,
+    gross,
+    loadedMiles,
+    states: stateSet.size,
+    loads: mine.length,
+    bestWeek,
+    biggestLoad,
+    longestHaul,
+    bestMpg,
+    avgRpm: loadedMiles > 0 ? gross / loadedMiles : null,
+    topLane: topOf(laneRev),
+    topAgent: topOf(agentRev),
+    netProfit,
+    bestMonth,
+    hardestMonth,
+    bestStreak: bestStreakOf(statuses),
+  };
+};

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useLoads } from "@/hooks/useLoads";
 import { useTrips } from "@/hooks/useTrips";
+import { Link } from "react-router-dom";
 import { KpiCard } from "@/components/KpiCard";
 import { BREAK_EVEN_RPM, DEADHEAD_TARGET } from "@/lib/constants/targets";
 import {
@@ -129,7 +130,15 @@ const DashboardPage = () => {
     <div className="p-6 bg-iron text-light min-h-screen font-body">
       <AwardPopHost pops={awardDemo ? DEMO_AWARDS : pops} />
 
-      <h1 className="text-3xl font-condensed mb-6">Dashboard</h1>
+      <div className="flex items-center justify-between mb-6 gap-3">
+        <h1 className="text-3xl font-condensed">Dashboard</h1>
+        <Link
+          to="/recap"
+          className="text-sm text-status-info-text hover:underline whitespace-nowrap"
+        >
+          Your {new Date().getUTCFullYear()} recap →
+        </Link>
+      </div>
 
       <AlertBanners alerts={alerts} />
 

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -188,6 +188,11 @@ const DriverDetailPage = () => {
             bests={card.bests}
             trophies={card.trophies}
           />
+          <div className="text-center mt-3">
+            <Link to="/recap" className="text-sm text-status-info-text hover:underline">
+              See your full recap →
+            </Link>
+          </div>
         </div>
       ) : (
         <div className="flex flex-col md:flex-row gap-6 mt-3 mb-2 items-start">

--- a/frontend/src/pages/RecapPage.tsx
+++ b/frontend/src/pages/RecapPage.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { FuelEntry } from "@/types/fuelEntry";
+import type { ExpensePeriod } from "@/types/expense";
+import type { Obligation } from "@/types/obligation";
+import type { Truck } from "@/types/truck";
+import type { Load } from "@/types/load";
+import { useLoads } from "@/hooks/useLoads";
+import { getFuelEntries } from "@/services/fuelService";
+import { getExpensePeriods } from "@/services/expensesService";
+import { getObligations } from "@/services/obligationsService";
+import { getTrucks } from "@/services/trucksService";
+import {
+  computeRecap,
+  resolvePeriod,
+  type RecapScope,
+  type RecapRange,
+} from "@/lib/metrics/recap";
+import { careerRank } from "@/lib/metrics/playerCard";
+import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
+import { RecapPoster } from "@/components/recap/RecapPoster";
+
+const SCOPES: { key: RecapScope; label: string }[] = [
+  { key: "month", label: "Month" },
+  { key: "quarter", label: "Quarter" },
+  { key: "year", label: "Year" },
+];
+
+const hasData = (loads: Load[], r: RecapRange): boolean =>
+  loads.some((l) => {
+    if (l.load_status !== "delivered" || !l.delivery_date) return false;
+    const t = new Date(l.delivery_date.slice(0, 10) + "T00:00:00Z").getTime();
+    return t >= r.start.getTime() && t < r.end.getTime();
+  });
+
+const RecapPage = () => {
+  const { loads } = useLoads(0);
+  const [fuel, setFuel] = useState<FuelEntry[]>([]);
+  const [periods, setPeriods] = useState<ExpensePeriod[]>([]);
+  const [obligations, setObligations] = useState<Obligation[]>([]);
+  const [trucks, setTrucks] = useState<Truck[]>([]);
+  const [scope, setScope] = useState<RecapScope>("year");
+  const [ago, setAgo] = useState(0);
+
+  useEffect(() => {
+    getFuelEntries().then(setFuel).catch(() => {});
+    getExpensePeriods().then(setPeriods).catch(() => {});
+    getObligations().then(setObligations).catch(() => {});
+    getTrucks().then(setTrucks).catch(() => {});
+  }, []);
+
+  const now = new Date();
+  const range = resolvePeriod(scope, ago, now);
+  const obligationsMonthly = obligations
+    .filter((o) => o.active)
+    .reduce((s, o) => s + Number(o.amount), 0);
+
+  const stats = useMemo(
+    () => computeRecap(loads, fuel, periods, obligationsMonthly, range, scope, now),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [loads, fuel, periods, obligationsMonthly, range.label, scope],
+  );
+
+  const truckAvatarUrl = trucks.find((t) => t.avatar_url)?.avatar_url ?? null;
+  const lifetimeMiles = Math.max(
+    0,
+    ...trucks.map((t) => Number(t.current_odometer) || 0),
+    maxFuelOdometer(fuel) ?? 0,
+    ...loads.map((l) => Number(l.odometer_end) || 0),
+  );
+  const rank = careerRank(lifetimeMiles).name;
+  const canNext = ago > 0;
+  const canPrev = hasData(loads, resolvePeriod(scope, ago + 1, now));
+
+  const pick = (s: RecapScope) => {
+    setScope(s);
+    setAgo(0);
+  };
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <div className="flex items-center justify-between gap-3 mb-5 flex-wrap">
+        <h1 className="text-3xl font-condensed">Recap</h1>
+        <div className="flex gap-1 bg-plate rounded-lg p-1">
+          {SCOPES.map((s) => (
+            <button
+              key={s.key}
+              onClick={() => pick(s.key)}
+              className={`px-3 py-1 rounded text-sm font-condensed ${
+                scope === s.key ? "bg-amber text-steel" : "text-muted-text"
+              }`}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center gap-4 mb-4">
+        <button
+          onClick={() => canPrev && setAgo(ago + 1)}
+          disabled={!canPrev}
+          className="text-muted-text disabled:opacity-30 hover:text-light"
+          aria-label="Earlier"
+        >
+          <ChevronLeft size={22} />
+        </button>
+        <span className="font-condensed text-lg w-32 text-center">{range.label}</span>
+        <button
+          onClick={() => canNext && setAgo(ago - 1)}
+          disabled={!canNext}
+          className="text-muted-text disabled:opacity-30 hover:text-light"
+          aria-label="Later"
+        >
+          <ChevronRight size={22} />
+        </button>
+      </div>
+
+      {stats.loads === 0 ? (
+        <p className="text-center text-muted-text mt-10">
+          No runs logged for {range.label}.
+        </p>
+      ) : (
+        <RecapPoster
+          stats={stats}
+          rank={rank}
+          truckAvatarUrl={scope === "year" ? truckAvatarUrl : null}
+        />
+      )}
+    </div>
+  );
+};
+
+export default RecapPage;


### PR DESCRIPTION
## v1.52.0 — season recap

A `/recap` page with a **Month / Quarter / Year** toggle and prev/next period navigation. Each renders a screenshot-worthy comic poster of the period's highlights:

- gross hauled · miles · **states conquered** · loads · best week · biggest load · longest haul · best tank · avg RPM
- **net profit**, **best / hardest month**, and the period's **best grind streak** (the extra metrics)
- top lane · top agent · rank

**Year is the grand finale**: your truck's avatar as the hero image and a gold foil edge; month/quarter are the lighter amber posters.

### Engine (`recap.ts`, 4 tests)
Aggregates any date range over data we already have. Real 2026 numbers: $173.8k hauled, 30,328 mi, **25 states**, 47 loads, top lane Beech Grove → Las Vegas, top agent Mike Sorrentino.

Reachable from the **sidebar** (Recap), a **dashboard link** ("Your 2026 recap →"), and the **player card**.

Build clean; **166 tests** (+4). Frontend-only. Couldn't preview the authed page — worth a look, especially the Year poster with your truck avatar.