### PR TITLE
feat: trophy room backend + locked catalog

### DIFF
--- a/backend/db/migrations/032_trophies.sql
+++ b/backend/db/migrations/032_trophies.sql
@@ -1,0 +1,19 @@
+-- Trophy room. One row per (user, trophy_key). `earned_on` is null while a
+-- trophy is locked and set when it's won — manually for the milestones the app
+-- can't detect (owner-operator, own authority, truck/trailer paid off) and
+-- stamped automatically for the data-driven ones (mile clubs, fleet size,
+-- lifetime hauled). `image_url` holds the AI-generated trophy art once approved.
+CREATE TABLE IF NOT EXISTS trophies (
+  trophy_id  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  trophy_key text NOT NULL,
+  earned     boolean NOT NULL DEFAULT false, -- won or not (auto ones are also computed live)
+  earned_on  date,        -- when it was won, if known (null even when earned)
+  image_url  text,        -- AI-generated art, null until generated + approved
+  notes      text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT unique_trophy_per_user UNIQUE (user_id, trophy_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trophies_user ON trophies(user_id);

--- a/backend/src/routes/trophyRoutes.js
+++ b/backend/src/routes/trophyRoutes.js
@@ -1,0 +1,50 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import {
+  getTrophies,
+  upsertTrophy,
+  deleteTrophy,
+} from "../services/trophyServices.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+const handle = (err, res) => {
+  if (err.type === "validation")
+    return res.status(err.statusCode).json({ error: err.message, details: err.details });
+  if (err.type === "not_found")
+    return res.status(err.statusCode).json({ error: err.message });
+  return res.status(500).json({ error: "Internal Server Error", message: err.message });
+};
+
+// ---- LIST ----
+router.get("/", async (req, res) => {
+  try {
+    const trophies = await getTrophies(req.user.user_id);
+    return res.status(200).json({ message: "Trophies retrieved", trophies });
+  } catch (err) {
+    return handle(err, res);
+  }
+});
+
+// ---- UPSERT one trophy (mark earned / set date / attach art) ----
+router.put("/:trophy_key", async (req, res) => {
+  try {
+    const trophy = await upsertTrophy(req.user.user_id, req.params.trophy_key, req.body);
+    return res.status(200).json({ message: "Trophy saved", trophy });
+  } catch (err) {
+    return handle(err, res);
+  }
+});
+
+// ---- DELETE ----
+router.delete("/:trophy_key", async (req, res) => {
+  try {
+    const trophy = await deleteTrophy(req.user.user_id, req.params.trophy_key);
+    return res.status(200).json({ message: "Trophy removed", trophy });
+  } catch (err) {
+    return handle(err, res);
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -23,6 +23,7 @@ import maintenanceRouter from "./routes/maintenanceRoutes.js";
 import trailerRouter from "./routes/trailerRoutes.js";
 import avatarRouter from "./routes/avatarRoutes.js";
 import complianceRouter from "./routes/complianceRoutes.js";
+import trophyRouter from "./routes/trophyRoutes.js";
 
 const app = express();
 
@@ -51,6 +52,7 @@ app.use("/expenses", expenseRouter);
 app.use("/obligations", obligationRouter);
 app.use("/maintenance", maintenanceRouter);
 app.use("/compliance", complianceRouter);
+app.use("/trophies", trophyRouter);
 app.use("/trailers", trailerRouter);
 app.use("/avatars", avatarRouter);
 

--- a/backend/src/services/trophyServices.js
+++ b/backend/src/services/trophyServices.js
@@ -1,0 +1,64 @@
+import { db } from "../../db/pool.js";
+import { validateTrophy, isTrophyKey } from "../utils/validation/trophyValidation.js";
+import { ValidationError, NotFoundError } from "../utils/error.js";
+
+const COLUMNS = "trophy_key, earned, earned_on, image_url, notes, created_at, updated_at";
+const WRITABLE = ["earned", "earned_on", "image_url", "notes"];
+
+export async function getTrophies(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const r = await db.query(
+    `SELECT ${COLUMNS} FROM trophies WHERE user_id = $1 ORDER BY trophy_key`,
+    [user_id],
+  );
+  return r.rows;
+}
+
+// Create or update one trophy row (mark earned, set earned_on, attach art).
+export async function upsertTrophy(user_id, trophy_key, body) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!isTrophyKey(trophy_key)) throw new ValidationError("Unknown trophy_key");
+
+  for (const f in body)
+    if (!WRITABLE.includes(f)) throw new ValidationError(`${f} not allowed`);
+  const errors = validateTrophy(body);
+  if (errors.length > 0) throw new ValidationError("Validation failed", errors);
+
+  const fields = ["user_id", "trophy_key"];
+  const values = [user_id, trophy_key];
+  const placeholders = ["$1", "$2"];
+  const setParts = [];
+  let i = 3;
+  for (const f of WRITABLE) {
+    if (body[f] !== undefined) {
+      fields.push(f);
+      values.push(body[f]);
+      placeholders.push(`$${i}`);
+      setParts.push(`${f} = EXCLUDED.${f}`);
+      i++;
+    }
+  }
+  const setClause = setParts.length
+    ? `${setParts.join(", ")}, updated_at = NOW()`
+    : "updated_at = NOW()";
+
+  const r = await db.query(
+    `INSERT INTO trophies (${fields.join(", ")})
+     VALUES (${placeholders.join(", ")})
+     ON CONFLICT (user_id, trophy_key) DO UPDATE SET ${setClause}
+     RETURNING ${COLUMNS}`,
+    values,
+  );
+  return r.rows[0];
+}
+
+export async function deleteTrophy(user_id, trophy_key) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!trophy_key) throw new ValidationError("Missing trophy_key");
+  const r = await db.query(
+    `DELETE FROM trophies WHERE user_id = $1 AND trophy_key = $2 RETURNING trophy_key`,
+    [user_id, trophy_key],
+  );
+  if (r.rowCount === 0) throw new NotFoundError("Trophy not found");
+  return r.rows[0];
+}

--- a/backend/src/utils/validation/trophyValidation.js
+++ b/backend/src/utils/validation/trophyValidation.js
@@ -1,0 +1,45 @@
+import { isValidType, isDateValid } from "../helper.js";
+
+// The locked catalog of major trophies. The backend only validates the key set;
+// the frontend catalog carries the display metadata + earn conditions.
+export const TROPHY_KEYS = [
+  "owner-operator",
+  "highway-legend",
+  "million-mile-club",
+  "free-and-clear",
+  "trailer-paid-off",
+  "own-authority",
+  "second-driver",
+  "second-truck",
+  "five-truck-fleet",
+  "one-million-hauled",
+];
+
+export const isTrophyKey = (k) => TROPHY_KEYS.includes(k);
+
+const rules = {
+  earned: (v, errors) => {
+    if (v !== undefined && typeof v !== "boolean") errors.push("earned must be a boolean");
+  },
+  earned_on: (v, errors) => {
+    if (v === null || v === undefined) return;
+    if (!isValidType("string", v) || v.trim().length !== 10 || !isDateValid(v.trim()))
+      errors.push("earned_on must be yyyy-mm-dd");
+  },
+  image_url: (v, errors) => {
+    if (v === null || v === undefined) return;
+    if (!isValidType("string", v)) errors.push("image_url must be a string");
+    else if (v.trim().length > 2000) errors.push("image_url too long");
+  },
+  notes: (v, errors) => {
+    if (v === null || v === undefined) return;
+    if (!isValidType("string", v)) errors.push("notes must be a string");
+    else if (v.trim().length > 500) errors.push("notes too long");
+  },
+};
+
+export const validateTrophy = (data) => {
+  const errors = [];
+  for (const f in data) if (rules[f]) rules[f](data[f], errors);
+  return errors;
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.52.0",
+  "version": "1.53.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/trophies/catalog.ts
+++ b/frontend/src/lib/trophies/catalog.ts
@@ -1,0 +1,98 @@
+// The locked catalog of the Trophy Room — the major, once-in-a-career milestones.
+// `kind` = how it's earned: manual (you mark it — the app can't detect it),
+// auto (computed from data), capstone (Highway Legend, derived from the others).
+// `promptIdea` seeds the AI art we generate + sign off on per trophy.
+export type TrophyForm = "medallion" | "plaque" | "cup" | "belt" | "star";
+export type TrophyKind = "manual" | "auto" | "capstone";
+
+export interface TrophyDef {
+  key: string;
+  name: string;
+  form: TrophyForm;
+  kind: TrophyKind;
+  blurb: string;
+  promptIdea: string;
+}
+
+export const TROPHY_CATALOG: TrophyDef[] = [
+  {
+    key: "owner-operator",
+    name: "Owner Operator",
+    form: "medallion",
+    kind: "manual",
+    blurb: "The origin — you went out on your own.",
+    promptIdea: "keys to your first rig; a lone flatbed pulling out of the yard at dawn",
+  },
+  {
+    key: "own-authority",
+    name: "Own Authority",
+    form: "star",
+    kind: "manual",
+    blurb: "Your own MC/DOT — off the lease.",
+    promptIdea: "your name on the door; an MC certificate sealed in gold",
+  },
+  {
+    key: "free-and-clear",
+    name: "Free & Clear",
+    form: "belt",
+    kind: "manual",
+    blurb: "The truck note, paid off.",
+    promptIdea: "a semi with a snapped chain; PAID stamped across the title",
+  },
+  {
+    key: "trailer-paid-off",
+    name: "Trailer Paid Off",
+    form: "belt",
+    kind: "manual",
+    blurb: "The trailer, paid off.",
+    promptIdea: "a flatbed trailer wrapped in a gold 'paid' ribbon",
+  },
+  {
+    key: "second-driver",
+    name: "Second Driver",
+    form: "plaque",
+    kind: "auto",
+    blurb: "A second driver joins the outfit.",
+    promptIdea: "two drivers shoulder to shoulder at the truck",
+  },
+  {
+    key: "second-truck",
+    name: "Second Truck",
+    form: "plaque",
+    kind: "auto",
+    blurb: "A second truck in the fleet.",
+    promptIdea: "two rigs parked side by side under the lights",
+  },
+  {
+    key: "five-truck-fleet",
+    name: "Five-Truck Fleet",
+    form: "plaque",
+    kind: "auto",
+    blurb: "Five trucks rolling.",
+    promptIdea: "a lineup of five rigs, headlights on",
+  },
+  {
+    key: "million-mile-club",
+    name: "Million Mile Club",
+    form: "plaque",
+    kind: "auto",
+    blurb: "1,000,000 lifetime miles.",
+    promptIdea: "an odometer rolling past 1,000,000 on a brass plaque",
+  },
+  {
+    key: "one-million-hauled",
+    name: "One Million Hauled",
+    form: "cup",
+    kind: "auto",
+    blurb: "$1,000,000 gross hauled.",
+    promptIdea: "a gold vault door with $1,000,000 across it",
+  },
+  {
+    key: "highway-legend",
+    name: "Highway Legend",
+    form: "cup",
+    kind: "capstone",
+    blurb: "The capstone — own authority, truck free-and-clear, and the million miles.",
+    promptIdea: "a chromed-out legend rig in golden-hour light, a halo of road behind it",
+  },
+];

--- a/frontend/src/services/trophyService.ts
+++ b/frontend/src/services/trophyService.ts
@@ -1,0 +1,20 @@
+import api from "./api";
+import type { Trophy, TrophyInput } from "@/types/trophy";
+
+export const getTrophies = async (): Promise<Trophy[]> => {
+  const res = await api.get("/trophies");
+  return res.data.trophies;
+};
+
+// Mark earned, set the earned-on date, or attach approved AI art.
+export const upsertTrophy = async (
+  key: string,
+  data: TrophyInput,
+): Promise<Trophy> => {
+  const res = await api.put(`/trophies/${key}`, data);
+  return res.data.trophy;
+};
+
+export const deleteTrophy = async (key: string): Promise<void> => {
+  await api.delete(`/trophies/${key}`);
+};

--- a/frontend/src/types/trophy.ts
+++ b/frontend/src/types/trophy.ts
@@ -1,0 +1,14 @@
+export interface Trophy {
+  trophy_key: string;
+  earned: boolean;
+  earned_on: string | null; // 'YYYY-MM-DD'
+  image_url: string | null; // AI-generated art
+  notes: string | null;
+}
+
+export interface TrophyInput {
+  earned?: boolean;
+  earned_on?: string | null;
+  image_url?: string | null;
+  notes?: string | null;
+}


### PR DESCRIPTION
## v1.53.0 — trophy room backend (the foundation)

The "backend problem" for the AI-generated trophy hall, taken care of.

### Table (`032_trophies.sql`, applied dev + prod)
One row per (user, trophy_key): **earned** flag + **earned_on** date + **image_url** (the AI art) + notes. It remembers the **manual** milestones the app can't detect (owner-operator, own authority, truck/trailer paid off) and holds art for every trophy. Owner Operator seeded **earned** on prod — the origin.

### API (`/trophies`)
GET · **PUT /:key** (upsert — mark earned, set date, attach art; partial upserts don't clobber other fields) · DELETE. Key whitelist in validation.

### Locked catalog (`lib/trophies/catalog.ts`)
The 10 majors: Owner Operator, Own Authority, Free & Clear, Trailer Paid Off, Second Driver, Second Truck, Five-Truck Fleet, Million Mile Club, One Million Hauled, and **Highway Legend as the capstone** (own authority + free-and-clear + million miles — not a dupe of the mile club). Each carries a form + kind (manual/auto/capstone) + an art-prompt idea.

### Verified
Router/service/validation import clean; upsert + partial-upsert + delete SQL exercised on dev (test rows cleaned up). Migration idempotent, applied both DBs. Build + 166 tests green.

Next phases (separate): house style prompt, the fal generate-and-approve tool (you sign off each), auto earn-detection, and the immersive hall page.