### PR TITLE
feat: trophy generate-and-approve studio

### DIFF
--- a/backend/src/routes/trophyRoutes.js
+++ b/backend/src/routes/trophyRoutes.js
@@ -5,6 +5,7 @@ import {
   upsertTrophy,
   deleteTrophy,
 } from "../services/trophyServices.js";
+import { generateTrophyImage } from "../services/trophyImageService.js";
 
 const router = express.Router();
 router.use(requireAuth);
@@ -32,6 +33,21 @@ router.put("/:trophy_key", async (req, res) => {
   try {
     const trophy = await upsertTrophy(req.user.user_id, req.params.trophy_key, req.body);
     return res.status(200).json({ message: "Trophy saved", trophy });
+  } catch (err) {
+    return handle(err, res);
+  }
+});
+
+// ---- GENERATE a preview image (fal) ----
+router.post("/:trophy_key/generate", async (req, res) => {
+  try {
+    const result = await generateTrophyImage(
+      req.user.user_id,
+      req.params.trophy_key,
+      req.body.prompt,
+      req.body.wide === true,
+    );
+    return res.status(200).json({ message: "Generated", ...result });
   } catch (err) {
     return handle(err, res);
   }

--- a/backend/src/services/avatarService.js
+++ b/backend/src/services/avatarService.js
@@ -49,7 +49,7 @@ const buildPrompt = (kind, row, variant) => {
   );
 };
 
-const falGenerate = async (prompt) => {
+export const falGenerate = async (prompt, image_size = "square_hd") => {
   if (!FAL_API_KEY) throw new ValidationError("FAL_API_KEY is not configured");
   const res = await fetch(`https://fal.run/${FAL_MODEL}`, {
     method: "POST",
@@ -57,7 +57,7 @@ const falGenerate = async (prompt) => {
       Authorization: `Key ${FAL_API_KEY}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ prompt, image_size: "square_hd", num_images: 1 }),
+    body: JSON.stringify({ prompt, image_size, num_images: 1 }),
   });
   if (!res.ok)
     throw new Error(`Image generation failed (${res.status})`);
@@ -67,7 +67,7 @@ const falGenerate = async (prompt) => {
   return url;
 };
 
-const uploadToStorage = async (path, buffer, contentType) => {
+export const uploadToStorage = async (path, buffer, contentType) => {
   if (!SUPABASE_URL || !SERVICE_KEY)
     throw new ValidationError(
       "Avatar storage is not configured (set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY)",

--- a/backend/src/services/trophyImageService.js
+++ b/backend/src/services/trophyImageService.js
@@ -1,0 +1,21 @@
+import { falGenerate, uploadToStorage } from "./avatarService.js";
+import { isTrophyKey } from "../utils/validation/trophyValidation.js";
+import { ValidationError } from "../utils/error.js";
+
+// Generate a PREVIEW image for a trophy (or the hall background) from a prompt,
+// store it to Supabase, and return its URL. This is not attached to the trophy
+// yet — the user reviews it and, if they like it, approves it via the trophy
+// upsert (which sets image_url). Each generation gets a unique path so previews
+// never overwrite an already-approved image.
+export async function generateTrophyImage(user_id, key, prompt, wide) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!isTrophyKey(key)) throw new ValidationError("Unknown trophy_key");
+  if (!prompt || typeof prompt !== "string" || prompt.trim().length === 0)
+    throw new ValidationError("Missing prompt");
+
+  const imageUrl = await falGenerate(prompt, wide ? "landscape_16_9" : "square_hd");
+  const buffer = Buffer.from(await (await fetch(imageUrl)).arrayBuffer());
+  const path = `trophies/${user_id}/${key}-${Date.now()}.jpg`;
+  const publicUrl = await uploadToStorage(path, buffer, "image/jpeg");
+  return { image_url: publicUrl };
+}

--- a/backend/src/utils/validation/trophyValidation.js
+++ b/backend/src/utils/validation/trophyValidation.js
@@ -13,6 +13,7 @@ export const TROPHY_KEYS = [
   "second-truck",
   "five-truck-fleet",
   "one-million-hauled",
+  "hall-background", // not a trophy — stores the generated hall backdrop
 ];
 
 export const isTrophyKey = (k) => TROPHY_KEYS.includes(k);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.53.1",
+  "version": "1.54.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import SignupPage from "@/pages/SignupPage";
 import GuidePage from "@/pages/GuidePage";
 import CompliancePage from "@/pages/CompliancePage";
 import RecapPage from "@/pages/RecapPage";
+import TrophyRoomPage from "@/pages/TrophyRoomPage";
 
 // Code-split Lanes — it bundles the US map topology (~600KB), so it should only
 // load when the page is actually visited, not on every app start.
@@ -61,6 +62,7 @@ const App = () => {
           <Route path="/maintenance" element={<MaintenancePage />} />
           <Route path="/compliance" element={<CompliancePage />} />
           <Route path="/recap" element={<RecapPage />} />
+          <Route path="/trophy-room" element={<TrophyRoomPage />} />
           <Route path="/agents" element={<AgentsPage />} />
           <Route path="/agents/:agent_id" element={<AgentDetailPage />} />
           <Route path="/fuel-entries" element={<FuelEntriesPage />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -44,6 +44,7 @@ const nav: Entry[] = [
   { to: "/compliance", label: "Compliance" },
   { to: "/expenses", label: "Expenses" },
   { to: "/recap", label: "Recap" },
+  { to: "/trophy-room", label: "Trophy Room" },
   { to: "/guide", label: "Guide" },
 ];
 

--- a/frontend/src/pages/TrophyRoomPage.tsx
+++ b/frontend/src/pages/TrophyRoomPage.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Sparkles, Check, RefreshCw, X } from "lucide-react";
+import type { Trophy } from "@/types/trophy";
+import {
+  getTrophies,
+  upsertTrophy,
+  generateTrophyImage,
+} from "@/services/trophyService";
+import { TROPHY_CATALOG } from "@/lib/trophies/catalog";
+import { trophyPrompt, HALL_PROMPT } from "@/lib/trophies/style";
+
+const errText = (e: unknown): string =>
+  (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+  "Something went wrong — generation can take a few seconds, try again.";
+
+const StudioItem = ({
+  title,
+  subtitle,
+  current,
+  preview,
+  wide,
+  busy,
+  onGenerate,
+  onApprove,
+  onDiscard,
+  footer,
+}: {
+  title: string;
+  subtitle: string;
+  current: string | null;
+  preview: string | null;
+  wide?: boolean;
+  busy: boolean;
+  onGenerate: () => void;
+  onApprove: () => void;
+  onDiscard: () => void;
+  footer?: ReactNode;
+}) => {
+  const show = preview ?? current;
+  return (
+    <div
+      className="rounded-xl border overflow-hidden"
+      style={{ background: "#10151f", borderColor: preview ? "#e8940a" : "#2a3347" }}
+    >
+      <div className="flex items-baseline justify-between gap-2 px-3 pt-2.5">
+        <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
+          {title}
+        </span>
+        <span className="text-[11px] text-muted-text truncate">{subtitle}</span>
+      </div>
+
+      <div
+        className={`relative m-3 rounded-lg overflow-hidden bg-steel ${wide ? "aspect-video" : "aspect-square"}`}
+      >
+        {busy ? (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-muted-text">
+            <Sparkles size={22} className="animate-pulse text-amber" />
+            <span className="text-xs">Generating…</span>
+          </div>
+        ) : show ? (
+          <img src={show} alt={title} className="w-full h-full object-cover" />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-muted-text text-xs">
+            Not generated yet
+          </div>
+        )}
+        {preview && !busy && (
+          <span className="absolute top-2 left-2 text-[10px] font-comic tracking-wider bg-amber text-steel px-2 py-0.5 rounded">
+            PREVIEW
+          </span>
+        )}
+      </div>
+
+      <div className="px-3 pb-3 flex flex-wrap gap-2">
+        {preview ? (
+          <>
+            <button
+              onClick={onApprove}
+              disabled={busy}
+              className="bg-amber text-steel px-3 py-1.5 rounded text-sm font-semibold flex items-center gap-1 disabled:opacity-50"
+            >
+              <Check size={14} /> Approve
+            </button>
+            <button
+              onClick={onGenerate}
+              disabled={busy}
+              className="bg-plate text-light px-3 py-1.5 rounded text-sm flex items-center gap-1 disabled:opacity-50"
+            >
+              <RefreshCw size={14} /> Regenerate
+            </button>
+            <button
+              onClick={onDiscard}
+              disabled={busy}
+              className="text-muted-text px-2 py-1.5 rounded text-sm flex items-center gap-1"
+            >
+              <X size={14} /> Discard
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={onGenerate}
+            disabled={busy}
+            className="bg-plate text-light px-3 py-1.5 rounded text-sm flex items-center gap-1 disabled:opacity-50"
+          >
+            <Sparkles size={14} /> {current ? "Regenerate" : "Generate"}
+          </button>
+        )}
+      </div>
+
+      {footer && <div className="px-3 pb-3 border-t border-plate pt-2.5">{footer}</div>}
+    </div>
+  );
+};
+
+const TrophyRoomPage = () => {
+  const [byKey, setByKey] = useState<Record<string, Trophy>>({});
+  const [preview, setPreview] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = () =>
+    getTrophies()
+      .then((list) => {
+        const m: Record<string, Trophy> = {};
+        for (const t of list) m[t.trophy_key] = t;
+        setByKey(m);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const gen = async (key: string, prompt: string, wide: boolean) => {
+    setBusy(key);
+    setError(null);
+    try {
+      const url = await generateTrophyImage(key, prompt, wide);
+      setPreview((p) => ({ ...p, [key]: url }));
+    } catch (e) {
+      setError(errText(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const approve = async (key: string) => {
+    setBusy(key);
+    setError(null);
+    try {
+      await upsertTrophy(key, { image_url: preview[key] });
+      setPreview((p) => {
+        const n = { ...p };
+        delete n[key];
+        return n;
+      });
+      await load();
+    } catch (e) {
+      setError(errText(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const discard = (key: string) =>
+    setPreview((p) => {
+      const n = { ...p };
+      delete n[key];
+      return n;
+    });
+
+  const setEarned = async (key: string, earned: boolean, earned_on?: string) => {
+    setBusy(key);
+    setError(null);
+    try {
+      await upsertTrophy(key, { earned, earned_on: earned_on || null });
+      await load();
+    } catch (e) {
+      setError(errText(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <h1 className="text-3xl font-condensed">Trophy Studio</h1>
+      <p className="text-sm text-muted-text mb-5">
+        Generate each trophy and the hall background, regenerate until it's worthy,
+        then approve — only approved art gets hung in the hall.
+      </p>
+
+      {error && <p className="text-destructive text-sm mb-4">{error}</p>}
+
+      {loading ? (
+        <p className="text-muted-text">Loading…</p>
+      ) : (
+        <>
+          <div className="max-w-[640px] mb-6">
+            <StudioItem
+              title="HALL BACKGROUND"
+              subtitle="the room · your avatars hang in the frames"
+              current={byKey["hall-background"]?.image_url ?? null}
+              preview={preview["hall-background"] ?? null}
+              wide
+              busy={busy === "hall-background"}
+              onGenerate={() => gen("hall-background", HALL_PROMPT, true)}
+              onApprove={() => approve("hall-background")}
+              onDiscard={() => discard("hall-background")}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {TROPHY_CATALOG.map((def) => {
+              const t = byKey[def.key];
+              const manual = def.kind === "manual";
+              return (
+                <StudioItem
+                  key={def.key}
+                  title={def.name}
+                  subtitle={def.blurb}
+                  current={t?.image_url ?? null}
+                  preview={preview[def.key] ?? null}
+                  busy={busy === def.key}
+                  onGenerate={() => gen(def.key, trophyPrompt(def.promptIdea), false)}
+                  onApprove={() => approve(def.key)}
+                  onDiscard={() => discard(def.key)}
+                  footer={
+                    manual ? (
+                      <div className="flex items-center gap-2 flex-wrap">
+                        {t?.earned ? (
+                          <>
+                            <span className="text-[11px] text-status-positive-text font-semibold">
+                              ★ Earned
+                            </span>
+                            <input
+                              type="date"
+                              value={t.earned_on?.slice(0, 10) ?? ""}
+                              onChange={(e) => setEarned(def.key, true, e.target.value)}
+                              className="bg-steel rounded px-2 py-1 text-xs text-light"
+                            />
+                            <button
+                              onClick={() => setEarned(def.key, false)}
+                              className="text-[11px] text-muted-text hover:text-destructive"
+                            >
+                              unmark
+                            </button>
+                          </>
+                        ) : (
+                          <button
+                            onClick={() => setEarned(def.key, true)}
+                            className="text-xs bg-steel text-light px-2 py-1 rounded"
+                          >
+                            Mark earned
+                          </button>
+                        )}
+                      </div>
+                    ) : (
+                      <span className="text-[11px] text-muted-text">
+                        {def.kind === "capstone"
+                          ? "The capstone — earns when authority, free-and-clear, and the million miles are all done."
+                          : "Earns automatically from your data."}
+                      </span>
+                    )
+                  }
+                />
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default TrophyRoomPage;

--- a/frontend/src/services/trophyService.ts
+++ b/frontend/src/services/trophyService.ts
@@ -18,3 +18,14 @@ export const upsertTrophy = async (
 export const deleteTrophy = async (key: string): Promise<void> => {
   await api.delete(`/trophies/${key}`);
 };
+
+// Generate a preview image (fal) for a trophy or the hall background. Returns the
+// stored preview URL — not attached until you approve it via upsertTrophy.
+export const generateTrophyImage = async (
+  key: string,
+  prompt: string,
+  wide = false,
+): Promise<string> => {
+  const res = await api.post(`/trophies/${key}/generate`, { prompt, wide });
+  return res.data.image_url;
+};


### PR DESCRIPTION
## v1.54.0 — the generate-and-approve tool

The **Trophy Studio** (`/trophy-room`, sidebar): generate the hall background and each of the 10 trophies from the locked style, **preview → regenerate → approve** — only approved art attaches. Manual milestones (owner-operator, authority, truck/trailer paid off) get a **Mark earned** + date; the auto/capstone ones note they earn from data.

### Backend
Reuses your fal image pipeline — `avatarService.falGenerate` (now takes an `image_size`, exported) + `uploadToStorage`. New `trophyImageService.generateTrophyImage` generates a **unique-path preview**, stores it to the avatars bucket under `trophies/`, returns the URL; approving attaches it via the existing trophy upsert (so previews never clobber an approved image). `POST /trophies/:key/generate`. `hall-background` added to the key whitelist.

### Note
Generation runs on the deployed backend (your fal key) — I can't run it from here, so this is the one **you** drive. Each image costs a few cents on fal and it's an iterative loop. Build + 166 tests green; no migration (table already live).