### PR TITLE
feat: immersive trophy hall page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.54.1",
+  "version": "1.55.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,7 +25,8 @@ import SignupPage from "@/pages/SignupPage";
 import GuidePage from "@/pages/GuidePage";
 import CompliancePage from "@/pages/CompliancePage";
 import RecapPage from "@/pages/RecapPage";
-import TrophyRoomPage from "@/pages/TrophyRoomPage";
+import TrophyHallPage from "@/pages/TrophyHallPage";
+import TrophyStudioPage from "@/pages/TrophyStudioPage";
 
 // Code-split Lanes — it bundles the US map topology (~600KB), so it should only
 // load when the page is actually visited, not on every app start.
@@ -62,7 +63,8 @@ const App = () => {
           <Route path="/maintenance" element={<MaintenancePage />} />
           <Route path="/compliance" element={<CompliancePage />} />
           <Route path="/recap" element={<RecapPage />} />
-          <Route path="/trophy-room" element={<TrophyRoomPage />} />
+          <Route path="/trophy-room" element={<TrophyHallPage />} />
+          <Route path="/trophy-studio" element={<TrophyStudioPage />} />
           <Route path="/agents" element={<AgentsPage />} />
           <Route path="/agents/:agent_id" element={<AgentDetailPage />} />
           <Route path="/fuel-entries" element={<FuelEntriesPage />} />

--- a/frontend/src/lib/trophies/status.test.ts
+++ b/frontend/src/lib/trophies/status.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import type { Trophy } from "@/types/trophy";
+import { TROPHY_CATALOG } from "./catalog";
+import { computeAllStatuses } from "./status";
+
+const rec = (key: string, earned: boolean): Trophy => ({
+  trophy_key: key,
+  earned,
+  earned_on: null,
+  image_url: null,
+  notes: null,
+});
+
+describe("computeAllStatuses", () => {
+  it("computes data-driven progress and earned", () => {
+    const s = computeAllStatuses(TROPHY_CATALOG, {}, {
+      lifetimeMiles: 582_450,
+      driverCount: 1,
+      truckCount: 1,
+      cumulativeGross: 174_000,
+    });
+    expect(s["million-mile-club"].earned).toBe(false);
+    expect(s["million-mile-club"].progress).toBeCloseTo(0.582, 2);
+    expect(s["second-truck"].earned).toBe(false);
+    expect(s["five-truck-fleet"].progress).toBeCloseTo(0.2, 2);
+    expect(s["one-million-hauled"].earned).toBe(false);
+    expect(s["one-million-hauled"].progress).toBeCloseTo(0.174, 2);
+  });
+
+  it("reads manual trophies from the record", () => {
+    const s = computeAllStatuses(TROPHY_CATALOG, { "owner-operator": rec("owner-operator", true) }, {
+      lifetimeMiles: 0,
+      driverCount: 1,
+      truckCount: 1,
+      cumulativeGross: 0,
+    });
+    expect(s["owner-operator"].earned).toBe(true);
+    expect(s["own-authority"].earned).toBe(false);
+  });
+
+  it("Highway Legend is the capstone of authority + free-and-clear + million miles", () => {
+    const base = {
+      "own-authority": rec("own-authority", true),
+      "free-and-clear": rec("free-and-clear", true),
+    };
+    const notYet = computeAllStatuses(TROPHY_CATALOG, base, {
+      lifetimeMiles: 900_000,
+      driverCount: 1,
+      truckCount: 1,
+      cumulativeGross: 0,
+    });
+    expect(notYet["highway-legend"].earned).toBe(false); // miles short
+    expect(notYet["highway-legend"].progress).toBeCloseTo(2 / 3, 2);
+
+    const done = computeAllStatuses(TROPHY_CATALOG, base, {
+      lifetimeMiles: 1_000_000,
+      driverCount: 1,
+      truckCount: 1,
+      cumulativeGross: 0,
+    });
+    expect(done["highway-legend"].earned).toBe(true);
+  });
+});

--- a/frontend/src/lib/trophies/status.ts
+++ b/frontend/src/lib/trophies/status.ts
@@ -1,0 +1,86 @@
+// Earn-detection for the trophy hall. Manual trophies come straight from the
+// stored record's `earned` flag; the data-driven ones compute from lifetime
+// miles / fleet size / cumulative gross; Highway Legend is the capstone —
+// earned only when own authority, free-and-clear, and the million miles are all
+// done.
+import type { TrophyDef } from "./catalog";
+import type { Trophy } from "@/types/trophy";
+
+export interface TrophyStatus {
+  earned: boolean;
+  progress: number | null; // 0..1 for the data-driven ones; null for yes/no
+  progressLabel: string | null;
+}
+
+export interface TrophyStatusData {
+  lifetimeMiles: number;
+  driverCount: number;
+  truckCount: number;
+  cumulativeGross: number;
+}
+
+const MI = (n: number) => `${Math.round(n / 1000)}K`;
+const K = (n: number) => `$${Math.round(n / 1000)}k`;
+const clamp = (n: number) => Math.max(0, Math.min(1, n));
+
+const one = (
+  def: TrophyDef,
+  record: Trophy | undefined,
+  d: TrophyStatusData,
+  earnedByKey: Record<string, boolean>,
+): TrophyStatus => {
+  switch (def.key) {
+    case "million-mile-club":
+      return {
+        earned: d.lifetimeMiles >= 1_000_000,
+        progress: clamp(d.lifetimeMiles / 1_000_000),
+        progressLabel: `${MI(d.lifetimeMiles)} / 1M mi`,
+      };
+    case "second-driver":
+      return { earned: d.driverCount >= 2, progress: clamp(d.driverCount / 2), progressLabel: `${d.driverCount} of 2 drivers` };
+    case "second-truck":
+      return { earned: d.truckCount >= 2, progress: clamp(d.truckCount / 2), progressLabel: `${d.truckCount} of 2 trucks` };
+    case "five-truck-fleet":
+      return { earned: d.truckCount >= 5, progress: clamp(d.truckCount / 5), progressLabel: `${d.truckCount} of 5 trucks` };
+    case "one-million-hauled":
+      return {
+        earned: d.cumulativeGross >= 1_000_000,
+        progress: clamp(d.cumulativeGross / 1_000_000),
+        progressLabel: `${K(d.cumulativeGross)} / $1M`,
+      };
+    case "highway-legend": {
+      const done = [
+        earnedByKey["own-authority"],
+        earnedByKey["free-and-clear"],
+        earnedByKey["million-mile-club"],
+      ].filter(Boolean).length;
+      return { earned: done === 3, progress: done / 3, progressLabel: `${done} of 3 milestones` };
+    }
+    default:
+      // manual: owner-operator, own-authority, free-and-clear, trailer-paid-off
+      return { earned: record?.earned ?? false, progress: null, progressLabel: null };
+  }
+};
+
+export const computeAllStatuses = (
+  catalog: TrophyDef[],
+  recordsByKey: Record<string, Trophy>,
+  data: TrophyStatusData,
+): Record<string, TrophyStatus> => {
+  const out: Record<string, TrophyStatus> = {};
+  const earnedByKey: Record<string, boolean> = {};
+
+  // Pass 1: everything except the capstone (which depends on the others).
+  for (const def of catalog)
+    if (def.kind !== "capstone") {
+      const s = one(def, recordsByKey[def.key], data, {});
+      out[def.key] = s;
+      earnedByKey[def.key] = s.earned;
+    }
+  // Pass 2: the capstone.
+  for (const def of catalog)
+    if (def.kind === "capstone")
+      out[def.key] = one(def, recordsByKey[def.key], data, earnedByKey);
+
+  return out;
+};

--- a/frontend/src/pages/TrophyHallPage.tsx
+++ b/frontend/src/pages/TrophyHallPage.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { Lock, Trophy, Sparkles } from "lucide-react";
+import type { Trophy as TrophyRecord } from "@/types/trophy";
+import type { Driver } from "@/types/driver";
+import type { Truck } from "@/types/truck";
+import type { FuelEntry } from "@/types/fuelEntry";
+import { useLoads } from "@/hooks/useLoads";
+import { getTrophies } from "@/services/trophyService";
+import { getDrivers } from "@/services/driversService";
+import { getTrucks } from "@/services/trucksService";
+import { getFuelEntries } from "@/services/fuelService";
+import { loadRevenue } from "@/lib/metrics/rateTargets";
+import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
+import { TROPHY_CATALOG } from "@/lib/trophies/catalog";
+import { computeAllStatuses, type TrophyStatus } from "@/lib/trophies/status";
+
+const fmtDate = (d: string) =>
+  new Date(d.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+// A framed avatar portrait hung on the hall wall.
+const Portrait = ({ url, name }: { url: string | null; name: string }) => (
+  <div className="w-[104px]">
+    <div
+      className="aspect-square rounded overflow-hidden"
+      style={{ border: "4px double #e8940a", background: "#0d1119" }}
+    >
+      {url ? (
+        <img src={url} alt={name} className="w-full h-full object-cover" />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center text-[#3b4660]">
+          <Trophy size={28} />
+        </div>
+      )}
+    </div>
+    <div
+      className="text-center font-comic text-[11px] mt-0.5"
+      style={{ color: "#f5e6c8", letterSpacing: "1px" }}
+    >
+      {name}
+    </div>
+  </div>
+);
+
+const Pedestal = ({
+  name,
+  art,
+  status,
+  earnedOn,
+}: {
+  name: string;
+  art: string | null;
+  status: TrophyStatus;
+  earnedOn: string | null;
+}) => {
+  const earned = status.earned;
+  return (
+    <div className="text-center">
+      <div
+        className="relative rounded-xl overflow-hidden border-2 aspect-square"
+        style={{ background: "#0d1119", borderColor: earned ? "#e8940a" : "#232c3f" }}
+      >
+        {earned && (
+          <div
+            className="absolute inset-0 pointer-events-none"
+            style={{ background: "radial-gradient(circle at 50% 38%, rgba(232,148,10,0.22), transparent 70%)" }}
+          />
+        )}
+        {art ? (
+          <img
+            src={art}
+            alt={name}
+            className="w-full h-full object-cover"
+            style={earned ? undefined : { filter: "grayscale(1)", opacity: 0.4 }}
+          />
+        ) : (
+          <div
+            className="absolute inset-0 flex items-center justify-center"
+            style={{ color: earned ? "#f5b03a" : "#3b4660" }}
+          >
+            <Trophy size={40} />
+          </div>
+        )}
+        {!earned && (
+          <span className="absolute top-2 right-2 text-muted-text">
+            <Lock size={15} />
+          </span>
+        )}
+      </div>
+      <div
+        className="font-comic text-sm mt-1.5 leading-tight"
+        style={{ color: earned ? "#f5e6c8" : "#9daabb" }}
+      >
+        {name}
+      </div>
+      {earned ? (
+        <div className="text-[11px] text-status-positive-text">
+          ★ {earnedOn ? fmtDate(earnedOn) : "Earned"}
+        </div>
+      ) : status.progress != null ? (
+        <>
+          <div className="h-1.5 rounded bg-plate overflow-hidden mt-1">
+            <div className="h-full" style={{ width: `${status.progress * 100}%`, background: "#e8940a" }} />
+          </div>
+          <div className="text-[10px] text-muted-text mt-0.5">{status.progressLabel}</div>
+        </>
+      ) : (
+        <div className="text-[10px] text-muted-text">Locked</div>
+      )}
+    </div>
+  );
+};
+
+const TrophyHallPage = () => {
+  const { loads } = useLoads(0);
+  const [records, setRecords] = useState<TrophyRecord[]>([]);
+  const [drivers, setDrivers] = useState<Driver[]>([]);
+  const [trucks, setTrucks] = useState<Truck[]>([]);
+  const [fuel, setFuel] = useState<FuelEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([getTrophies(), getDrivers(), getTrucks(), getFuelEntries()])
+      .then(([tr, dr, tk, fu]) => {
+        setRecords(tr);
+        setDrivers(dr);
+        setTrucks(tk);
+        setFuel(fu);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const byKey = useMemo(() => {
+    const m: Record<string, TrophyRecord> = {};
+    for (const t of records) m[t.trophy_key] = t;
+    return m;
+  }, [records]);
+
+  const statuses = useMemo(() => {
+    const lifetimeMiles = Math.max(
+      0,
+      ...trucks.map((t) => Number(t.current_odometer) || 0),
+      maxFuelOdometer(fuel) ?? 0,
+      ...loads.map((l) => Number(l.odometer_end) || 0),
+    );
+    const cumulativeGross = loads
+      .filter((l) => l.load_status === "delivered")
+      .reduce((s, l) => s + loadRevenue(l), 0);
+    return computeAllStatuses(TROPHY_CATALOG, byKey, {
+      lifetimeMiles,
+      driverCount: drivers.filter((d) => d.active).length,
+      truckCount: trucks.length,
+      cumulativeGross,
+    });
+  }, [byKey, drivers, trucks, fuel, loads]);
+
+  const hallBg = byKey["hall-background"]?.image_url ?? null;
+  const driverAvatar = drivers.find((d) => d.avatar_url)?.avatar_url ?? null;
+  const truck = trucks.find((t) => t.avatar_url) ?? trucks[0];
+  const earnedCount = TROPHY_CATALOG.filter((d) => statuses[d.key]?.earned).length;
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <div className="flex items-center justify-between gap-3 mb-4">
+        <h1 className="text-3xl font-condensed">Trophy Room</h1>
+        <Link
+          to="/trophy-studio"
+          className="text-sm text-status-info-text hover:underline flex items-center gap-1"
+        >
+          <Sparkles size={14} /> Studio
+        </Link>
+      </div>
+
+      {loading ? (
+        <p className="text-muted-text">Loading…</p>
+      ) : (
+        <>
+          {/* ---- hall hero ---- */}
+          <div
+            className="relative rounded-2xl overflow-hidden border-2 mb-6"
+            style={{ borderColor: "#e8940a", background: "#0d1119", minHeight: 260 }}
+          >
+            {hallBg && (
+              <div
+                className="absolute inset-0 bg-cover bg-center"
+                style={{ backgroundImage: `url(${hallBg})` }}
+              />
+            )}
+            <div
+              className="absolute inset-0"
+              style={{ background: "linear-gradient(to bottom, rgba(10,13,19,0.35), rgba(10,13,19,0.75))" }}
+            />
+            <div className="relative flex items-center justify-between gap-3 p-5 min-h-[260px]">
+              <Portrait url={driverAvatar} name={drivers[0] ? drivers[0].first_name : "Driver"} />
+              <div className="text-center">
+                <div className="font-comic text-[13px] tracking-[3px]" style={{ color: "#9daabb" }}>
+                  DELGADO TRUCKING
+                </div>
+                <div className="font-comic text-4xl sm:text-5xl leading-none" style={{ color: "#f5b03a" }}>
+                  HALL OF FAME
+                </div>
+                <div className="text-xs text-muted-text mt-2">
+                  {earnedCount} of {TROPHY_CATALOG.length} trophies earned
+                </div>
+                {!hallBg && (
+                  <Link to="/trophy-studio" className="text-xs text-status-info-text hover:underline mt-2 inline-block">
+                    Generate your hall in the Studio →
+                  </Link>
+                )}
+              </div>
+              <Portrait url={truck?.avatar_url ?? null} name={truck ? `Unit ${truck.unit_number}` : "Truck"} />
+            </div>
+          </div>
+
+          {/* ---- the collection ---- */}
+          <div className="font-comic text-lg mb-3" style={{ color: "#f5b03a" }}>
+            THE COLLECTION
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+            {TROPHY_CATALOG.map((def) => (
+              <Pedestal
+                key={def.key}
+                name={def.name}
+                art={byKey[def.key]?.image_url ?? null}
+                status={statuses[def.key]}
+                earnedOn={byKey[def.key]?.earned_on ?? null}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default TrophyHallPage;

--- a/frontend/src/pages/TrophyStudioPage.tsx
+++ b/frontend/src/pages/TrophyStudioPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
 import { Sparkles, Check, RefreshCw, X } from "lucide-react";
 import type { Trophy } from "@/types/trophy";
 import {
@@ -112,7 +113,7 @@ const StudioItem = ({
   );
 };
 
-const TrophyRoomPage = () => {
+const TrophyStudioPage = () => {
   const [byKey, setByKey] = useState<Record<string, Trophy>>({});
   const [preview, setPreview] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState<string | null>(null);
@@ -186,7 +187,10 @@ const TrophyRoomPage = () => {
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
-      <h1 className="text-3xl font-condensed">Trophy Studio</h1>
+      <Link to="/trophy-room" className="text-xs text-muted-text hover:text-light">
+        ← Trophy Room
+      </Link>
+      <h1 className="text-3xl font-condensed mt-2">Trophy Studio</h1>
       <p className="text-sm text-muted-text mb-5">
         Generate each trophy and the hall background, regenerate until it's worthy,
         then approve — only approved art gets hung in the hall.
@@ -275,4 +279,4 @@ const TrophyRoomPage = () => {
   );
 };
 
-export default TrophyRoomPage;
+export default TrophyStudioPage;


### PR DESCRIPTION
## v1.55.0 — the immersive trophy hall

`/trophy-room` becomes the **hall of fame**:
- The approved AI **hall background** as the hero, with your **driver and truck avatars framed** on the walls and a "HALL OF FAME" title.
- The **ten trophies** as a grid: **earned** ones lit with their art + earned date; **locked** ones dimmed with a lock and a **live progress bar**.

### Earn-detection (`lib/trophies/status.ts`, 3 tests)
Data-driven trophies compute from lifetime miles / fleet size / cumulative gross (Million Mile 58%, $1M Hauled 17%, fleet counts); manual ones read their stored `earned` flag; **Highway Legend** is the capstone (own authority + free-and-clear + million miles).

### Structure
The generate/approve **studio moves to `/trophy-studio`** (linked from the hall). Sidebar "Trophy Room" → the hall.

Verified against prod: every trophy has art, hall bg approved, Owner Operator earned (Jun 2025) — so the hall renders fully populated. Build + 169 tests green; frontend-only.