### PR TITLE
feat: immersive trophy hall + text-free trophy art

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.55.0",
+  "version": "1.56.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/trophies/catalog.ts
+++ b/frontend/src/lib/trophies/catalog.ts
@@ -1,7 +1,8 @@
 // The locked catalog of the Trophy Room — the major, once-in-a-career milestones.
 // `kind` = how it's earned: manual (you mark it — the app can't detect it),
 // auto (computed from data), capstone (Highway Legend, derived from the others).
-// `promptIdea` seeds the AI art we generate + sign off on per trophy.
+// `promptIdea` seeds the AI art we generate + sign off on per trophy — kept as a
+// wordless SYMBOL (no text/numbers, which image models mangle); the app draws all text.
 export type TrophyForm = "medallion" | "plaque" | "cup" | "belt" | "star";
 export type TrophyKind = "manual" | "auto" | "capstone";
 
@@ -21,7 +22,8 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     form: "medallion",
     kind: "manual",
     blurb: "The origin — you went out on your own.",
-    promptIdea: "keys to your first rig; a lone flatbed pulling out of the yard at dawn",
+    promptIdea:
+      "a lone flatbed semi truck pulling out of an empty yard at first light, the long open road ahead",
   },
   {
     key: "own-authority",
@@ -29,7 +31,8 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     form: "star",
     kind: "manual",
     blurb: "Your own MC/DOT — off the lease.",
-    promptIdea: "your name on the door; an MC certificate sealed in gold",
+    promptIdea:
+      "a bold heraldic eagle spreading its wings over a gleaming shield badge, forged in gold and steel",
   },
   {
     key: "free-and-clear",
@@ -37,7 +40,8 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     form: "belt",
     kind: "manual",
     blurb: "The truck note, paid off.",
-    promptIdea: "a semi with a snapped chain; PAID stamped across the title",
+    promptIdea:
+      "a heavy iron chain snapping apart in a shower of sparks across the grille of a proud semi truck",
   },
   {
     key: "trailer-paid-off",
@@ -45,7 +49,8 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     form: "belt",
     kind: "manual",
     blurb: "The trailer, paid off.",
-    promptIdea: "a flatbed trailer wrapped in a gold 'paid' ribbon",
+    promptIdea:
+      "a massive golden padlock bursting open with a broken shackle, resting on a flatbed trailer in warm light",
   },
   {
     key: "second-driver",
@@ -53,7 +58,8 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     form: "plaque",
     kind: "auto",
     blurb: "A second driver joins the outfit.",
-    promptIdea: "two drivers shoulder to shoulder at the truck",
+    promptIdea:
+      "two rugged truck drivers clasping hands shoulder to shoulder in front of a rig, headlights glowing behind them",
   },
   {
     key: "second-truck",
@@ -61,7 +67,8 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     form: "plaque",
     kind: "auto",
     blurb: "A second truck in the fleet.",
-    promptIdea: "two rigs parked side by side under the lights",
+    promptIdea:
+      "two heavy flatbed rigs parked nose to nose under the lot lights at night, chrome gleaming",
   },
   {
     key: "five-truck-fleet",
@@ -69,7 +76,8 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     form: "plaque",
     kind: "auto",
     blurb: "Five trucks rolling.",
-    promptIdea: "a lineup of five rigs, headlights on",
+    promptIdea:
+      "a heroic low-angle lineup of five heavy rigs in a row, headlights blazing into the dark",
   },
   {
     key: "million-mile-club",
@@ -77,7 +85,8 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     form: "plaque",
     kind: "auto",
     blurb: "1,000,000 lifetime miles.",
-    promptIdea: "an odometer rolling past 1,000,000 on a brass plaque",
+    promptIdea:
+      "a lone highway stretching straight to a fiery sunset horizon, endless worn asphalt and centerline",
   },
   {
     key: "one-million-hauled",
@@ -85,7 +94,8 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     form: "cup",
     kind: "auto",
     blurb: "$1,000,000 gross hauled.",
-    promptIdea: "a gold vault door with $1,000,000 across it",
+    promptIdea:
+      "a towering golden mountain of stacked freight crates and cargo on a flatbed, gleaming like treasure",
   },
   {
     key: "highway-legend",

--- a/frontend/src/lib/trophies/style.ts
+++ b/frontend/src/lib/trophies/style.ts
@@ -12,22 +12,24 @@ const CORE =
   "tone (noir, not cartoonish)";
 
 // Per-trophy suffix — prefix each catalog subject with this for the full prompt.
+// Image models can't spell, so every subject is a wordless SYMBOL and this style
+// hard-forbids lettering — the app renders all text (names, numbers) over the art.
 export const TROPHY_STYLE =
-  `${CORE}, gleaming gold, brass and amber, a single heroic trophy centered and ` +
-  "isolated on a plain near-black background, museum trophy product shot, no text, no watermark";
+  `${CORE}, gleaming gold, brass, chrome and amber, a bold emblematic hero symbol ` +
+  "centered and isolated on a plain near-black background, dramatic single-spotlight " +
+  "insignia, rich and iconic — absolutely no text, no words, no letters, no numbers, " +
+  "no lettering, no typography, no signage, no watermark, no captions";
 
 export const trophyPrompt = (subject: string): string => `${subject} — ${TROPHY_STYLE}`;
 
-// The hall background is just the ROOM — the trophies stand on pedestals the page
-// places over the open foreground floor, so all of them stay visible at full size.
-// A wide, front-on view (not a deep receding corridor) keeps that floor open. It
-// includes the two empty forward-facing frames the page composites the driver
-// (left) and truck (right) avatars into.
+// The hall background is just the empty ROOM. The page hangs the driver + truck
+// portraits in its own gold frames on the walls (always aligned), and stands the
+// trophies over the floor — so the AI must NOT draw its own frames or pedestals.
+// A wide, front-on view with a low horizon keeps the walls and floor open.
 export const HALL_PROMPT =
   "An empty grand trucking hall of fame gallery, wide eye-level frontal view with a " +
-  "low horizon and a broad open polished stone floor across the foreground, deep " +
+  "low horizon and a broad open polished stone floor across the foreground, tall deep " +
   "steel-blue walls with subtle oversize-freight motifs (chains, flatbed silhouettes), " +
-  "warm amber spotlights washing down the walls, a large emblem centered on the back " +
-  "wall, two large ornate empty gold picture frames mounted flat and facing forward — " +
-  `one on the left wall, one on the right wall, at eye level — ${CORE}, moody cinematic ` +
-  "rim lighting, no pedestals, no people, no text";
+  "warm amber spotlights washing down the walls, a large emblem centered high on the " +
+  `back wall — ${CORE}, moody cinematic rim lighting, no picture frames, no pedestals, ` +
+  "no people, no text";

--- a/frontend/src/pages/TrophyHallPage.tsx
+++ b/frontend/src/pages/TrophyHallPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { Lock, Trophy, Sparkles } from "lucide-react";
 import type { Trophy as TrophyRecord } from "@/types/trophy";
@@ -22,31 +22,66 @@ const fmtDate = (d: string) =>
     timeZone: "UTC",
   });
 
-// A framed avatar portrait hung on the hall wall.
-const Portrait = ({ url, name }: { url: string | null; name: string }) => (
-  <div className="w-[104px]">
-    <div
-      className="aspect-square rounded overflow-hidden"
-      style={{ border: "4px double #e8940a", background: "#0d1119" }}
-    >
-      {url ? (
-        <img src={url} alt={name} className="w-full h-full object-cover" />
-      ) : (
-        <div className="w-full h-full flex items-center justify-center text-[#3b4660]">
-          <Trophy size={28} />
+// A framed portrait hung on the hall wall — the page draws the gold frame so it's
+// always aligned (the AI background is a frameless room). Links to the entity page.
+const Portrait = ({
+  url,
+  name,
+  to,
+}: {
+  url: string | null;
+  name: string;
+  to?: string;
+}) => {
+  const inner: ReactNode = (
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className="relative rounded-[5px] p-2.5"
+        style={{
+          background:
+            "linear-gradient(135deg,#f6d98a,#b5700a 38%,#7a4e08 62%,#f6d98a)",
+          boxShadow:
+            "0 14px 30px rgba(0,0,0,.6),0 0 0 2px #4a3305,0 0 26px rgba(232,148,10,.22)",
+        }}
+      >
+        <div
+          className="w-[124px] h-[124px] rounded-[2px] overflow-hidden"
+          style={{ background: "#0a0d13", border: "2px solid #3a2a08" }}
+        >
+          {url ? (
+            <img src={url} alt={name} className="w-full h-full object-cover" />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-[#3b4660]">
+              <Trophy size={30} />
+            </div>
+          )}
         </div>
-      )}
+      </div>
+      <div
+        className="font-comic text-[13px] uppercase px-4 py-0.5 rounded-[3px]"
+        style={{
+          color: "#2a1d04",
+          letterSpacing: "1px",
+          background: "linear-gradient(180deg,#f6d98a,#b5700a)",
+          boxShadow: "0 3px 8px rgba(0,0,0,.5),inset 0 0 0 1px rgba(0,0,0,.25)",
+        }}
+      >
+        {name}
+      </div>
     </div>
-    <div
-      className="text-center font-comic text-[11px] mt-0.5"
-      style={{ color: "#f5e6c8", letterSpacing: "1px" }}
-    >
-      {name}
-    </div>
-  </div>
-);
+  );
+  return to ? (
+    <Link to={to} className="shrink-0 transition-transform hover:-translate-y-0.5">
+      {inner}
+    </Link>
+  ) : (
+    <div className="shrink-0">{inner}</div>
+  );
+};
 
-const Pedestal = ({
+// One trophy standing on the hall floor: a spotlit medallion (earned = lit gold,
+// locked = grayed with a lock + live progress) over its light pool.
+const TrophyStand = ({
   name,
   art,
   status,
@@ -59,59 +94,98 @@ const Pedestal = ({
 }) => {
   const earned = status.earned;
   return (
-    <div className="text-center">
-      <div
-        className="relative rounded-xl overflow-hidden border-2 aspect-square"
-        style={{ background: "#0d1119", borderColor: earned ? "#e8940a" : "#232c3f" }}
-      >
-        {earned && (
-          <div
-            className="absolute inset-0 pointer-events-none"
-            style={{ background: "radial-gradient(circle at 50% 38%, rgba(232,148,10,0.22), transparent 70%)" }}
-          />
-        )}
-        {art ? (
-          <img
-            src={art}
-            alt={name}
-            className="w-full h-full object-cover"
-            style={earned ? undefined : { filter: "grayscale(1)", opacity: 0.4 }}
-          />
-        ) : (
-          <div
-            className="absolute inset-0 flex items-center justify-center"
-            style={{ color: earned ? "#f5b03a" : "#3b4660" }}
-          >
-            <Trophy size={40} />
-          </div>
-        )}
-        {!earned && (
-          <span className="absolute top-2 right-2 text-muted-text">
-            <Lock size={15} />
-          </span>
-        )}
+    <figure className="relative flex flex-col items-center text-center">
+      <div className="relative w-full">
+        {/* light pool on the floor */}
+        <div
+          className="absolute left-1/2 -translate-x-1/2 pointer-events-none rounded-[50%]"
+          style={{
+            bottom: -13,
+            width: "78%",
+            height: 30,
+            background: earned
+              ? "radial-gradient(ellipse at center,rgba(232,148,10,.20),transparent 70%)"
+              : "radial-gradient(ellipse at center,rgba(120,140,170,.09),transparent 70%)",
+          }}
+        />
+        <div
+          className="relative rounded-full overflow-hidden"
+          style={{
+            aspectRatio: "1 / 1",
+            background: "#0a0d13",
+            border: earned ? "3px solid #e8940a" : "3px solid #2a3550",
+            boxShadow: earned
+              ? "0 0 0 4px rgba(232,148,10,.12),0 0 30px rgba(232,148,10,.35)"
+              : "none",
+          }}
+        >
+          {art ? (
+            <img
+              src={art}
+              alt={name}
+              className="w-full h-full object-cover"
+              style={earned ? undefined : { filter: "grayscale(1)", opacity: 0.45 }}
+            />
+          ) : (
+            <div
+              className="absolute inset-0 flex items-center justify-center"
+              style={{ color: earned ? "#f5b03a" : "#3b4660" }}
+            >
+              <Trophy size={40} />
+            </div>
+          )}
+          {earned && (
+            <div
+              className="absolute inset-0 pointer-events-none"
+              style={{
+                background:
+                  "radial-gradient(circle at 50% 32%,rgba(232,148,10,.18),transparent 68%)",
+              }}
+            />
+          )}
+          {!earned && (
+            <span
+              className="absolute top-2 right-2 w-6 h-6 rounded-full flex items-center justify-center"
+              style={{ background: "rgba(10,13,19,.8)", color: "#8b98ad" }}
+            >
+              <Lock size={13} />
+            </span>
+          )}
+        </div>
       </div>
-      <div
-        className="font-comic text-sm mt-1.5 leading-tight"
+
+      <figcaption
+        className="font-comic text-[15px] mt-3.5 leading-tight"
         style={{ color: earned ? "#f5e6c8" : "#9daabb" }}
       >
         {name}
-      </div>
+      </figcaption>
       {earned ? (
-        <div className="text-[11px] text-status-positive-text">
+        <div className="text-[11.5px] mt-1" style={{ color: "#5fb87a" }}>
           ★ {earnedOn ? fmtDate(earnedOn) : "Earned"}
         </div>
       ) : status.progress != null ? (
         <>
-          <div className="h-1.5 rounded bg-plate overflow-hidden mt-1">
-            <div className="h-full" style={{ width: `${status.progress * 100}%`, background: "#e8940a" }} />
+          <div
+            className="h-1.5 rounded overflow-hidden mt-2"
+            style={{ width: 104, background: "#1a2338" }}
+          >
+            <div
+              className="h-full"
+              style={{
+                width: `${status.progress * 100}%`,
+                background: "linear-gradient(to right,#b5700a,#f5b03a)",
+              }}
+            />
           </div>
-          <div className="text-[10px] text-muted-text mt-0.5">{status.progressLabel}</div>
+          <div className="text-[10.5px] text-muted-text mt-1">
+            {status.progressLabel}
+          </div>
         </>
       ) : (
-        <div className="text-[10px] text-muted-text">Locked</div>
+        <div className="text-[11px] text-muted-text mt-1">Locked</div>
       )}
-    </div>
+    </figure>
   );
 };
 
@@ -160,80 +234,151 @@ const TrophyHallPage = () => {
   }, [byKey, drivers, trucks, fuel, loads]);
 
   const hallBg = byKey["hall-background"]?.image_url ?? null;
-  const driverAvatar = drivers.find((d) => d.avatar_url)?.avatar_url ?? null;
+  const driver = drivers.find((d) => d.avatar_url) ?? drivers[0];
   const truck = trucks.find((t) => t.avatar_url) ?? trucks[0];
   const earnedCount = TROPHY_CATALOG.filter((d) => statuses[d.key]?.earned).length;
 
-  return (
-    <div className="p-6 bg-iron text-light font-body min-h-screen">
-      <div className="flex items-center justify-between gap-3 mb-4">
-        <h1 className="text-3xl font-condensed">Trophy Room</h1>
-        <Link
-          to="/trophy-studio"
-          className="text-sm text-status-info-text hover:underline flex items-center gap-1"
-        >
-          <Sparkles size={14} /> Studio
-        </Link>
-      </div>
+  const roomStyle = hallBg
+    ? {
+        backgroundImage: `linear-gradient(to bottom, rgba(9,12,18,.5), rgba(9,12,18,.8)), url(${hallBg})`,
+        backgroundSize: "cover, cover",
+        backgroundPosition: "center, center",
+        backgroundRepeat: "no-repeat, no-repeat",
+        backgroundAttachment: "fixed, fixed",
+      }
+    : undefined;
 
-      {loading ? (
-        <p className="text-muted-text">Loading…</p>
-      ) : (
-        <>
-          {/* ---- hall hero ---- */}
-          <div
-            className="relative rounded-2xl overflow-hidden border-2 mb-6"
-            style={{ borderColor: "#e8940a", background: "#0d1119", minHeight: 260 }}
+  return (
+    <div
+      className={`relative min-h-screen text-light font-body ${hallBg ? "" : "bg-iron"}`}
+      style={roomStyle}
+    >
+      <div className="max-w-[1120px] mx-auto px-5 pb-20">
+        <div className="flex justify-end pt-4">
+          <Link
+            to="/trophy-studio"
+            className="text-sm text-cream/80 hover:text-cream flex items-center gap-1.5"
+            style={{ textShadow: "0 1px 4px rgba(0,0,0,.8)" }}
           >
-            {hallBg && (
-              <div
-                className="absolute inset-0 bg-cover bg-center"
-                style={{ backgroundImage: `url(${hallBg})` }}
-              />
-            )}
-            <div
-              className="absolute inset-0"
-              style={{ background: "linear-gradient(to bottom, rgba(10,13,19,0.35), rgba(10,13,19,0.75))" }}
-            />
-            <div className="relative flex items-center justify-between gap-3 p-5 min-h-[260px]">
-              <Portrait url={driverAvatar} name={drivers[0] ? drivers[0].first_name : "Driver"} />
-              <div className="text-center">
-                <div className="font-comic text-[13px] tracking-[3px]" style={{ color: "#9daabb" }}>
+            <Sparkles size={14} /> Studio
+          </Link>
+        </div>
+
+        {loading ? (
+          <p className="text-muted-text text-center py-24">Entering the hall…</p>
+        ) : (
+          <>
+            {/* ---- marquee: portraits framed on the walls + title ---- */}
+            <header className="grid grid-cols-1 sm:grid-cols-[auto_1fr_auto] items-center gap-6 py-10 sm:py-14 min-h-[300px]">
+              <div className="hidden sm:block order-1">
+                <Portrait
+                  url={driver?.avatar_url ?? null}
+                  name={driver ? driver.first_name : "Driver"}
+                  to={driver ? `/drivers/${driver.driver_id}` : undefined}
+                />
+              </div>
+
+              <div className="text-center order-first sm:order-2">
+                <div
+                  className="font-comic text-[13px]"
+                  style={{ color: "#9daabb", letterSpacing: "4px" }}
+                >
                   DELGADO TRUCKING
                 </div>
-                <div className="font-comic text-4xl sm:text-5xl leading-none" style={{ color: "#f5b03a" }}>
+                <h1
+                  className="font-comic leading-[0.86] my-2"
+                  style={{
+                    fontSize: "clamp(44px,7vw,84px)",
+                    color: "#f5b03a",
+                    textShadow:
+                      "3px 4px 0 #0a0d13, 0 0 34px rgba(232,148,10,.5)",
+                  }}
+                >
                   HALL OF FAME
-                </div>
-                <div className="text-xs text-muted-text mt-2">
-                  {earnedCount} of {TROPHY_CATALOG.length} trophies earned
+                </h1>
+                <div
+                  className="inline-flex items-center gap-2 text-[12.5px] uppercase rounded-full px-4 py-1.5"
+                  style={{
+                    letterSpacing: "1.5px",
+                    color: "#f5e6c8",
+                    background: "rgba(10,13,19,.55)",
+                    border: "1px solid #22304a",
+                  }}
+                >
+                  <span
+                    className="w-[7px] h-[7px] rounded-full"
+                    style={{ background: "#5fb87a", boxShadow: "0 0 9px #5fb87a" }}
+                  />
+                  <b style={{ color: "#f5b03a" }}>{earnedCount}</b> of{" "}
+                  <b style={{ color: "#f5b03a" }}>{TROPHY_CATALOG.length}</b>{" "}
+                  enshrined
                 </div>
                 {!hallBg && (
-                  <Link to="/trophy-studio" className="text-xs text-status-info-text hover:underline mt-2 inline-block">
-                    Generate your hall in the Studio →
-                  </Link>
+                  <div className="mt-3">
+                    <Link
+                      to="/trophy-studio"
+                      className="text-xs text-status-info-text hover:underline"
+                    >
+                      Generate your hall background in the Studio →
+                    </Link>
+                  </div>
                 )}
               </div>
-              <Portrait url={truck?.avatar_url ?? null} name={truck ? `Unit ${truck.unit_number}` : "Truck"} />
-            </div>
-          </div>
 
-          {/* ---- the collection ---- */}
-          <div className="font-comic text-lg mb-3" style={{ color: "#f5b03a" }}>
-            THE COLLECTION
-          </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-            {TROPHY_CATALOG.map((def) => (
-              <Pedestal
-                key={def.key}
-                name={def.name}
-                art={byKey[def.key]?.image_url ?? null}
-                status={statuses[def.key]}
-                earnedOn={byKey[def.key]?.earned_on ?? null}
+              <div className="hidden sm:block order-3">
+                <Portrait
+                  url={truck?.avatar_url ?? null}
+                  name={truck ? `Unit ${truck.unit_number}` : "Truck"}
+                  to={truck ? `/trucks/${truck.truck_id}` : undefined}
+                />
+              </div>
+
+              {/* mobile: portraits below the title, side by side */}
+              <div className="flex sm:hidden justify-center gap-8 order-last">
+                <Portrait
+                  url={driver?.avatar_url ?? null}
+                  name={driver ? driver.first_name : "Driver"}
+                  to={driver ? `/drivers/${driver.driver_id}` : undefined}
+                />
+                <Portrait
+                  url={truck?.avatar_url ?? null}
+                  name={truck ? `Unit ${truck.unit_number}` : "Truck"}
+                  to={truck ? `/trucks/${truck.truck_id}` : undefined}
+                />
+              </div>
+            </header>
+
+            {/* ---- the collection, standing on the floor ---- */}
+            <div className="flex items-center gap-3.5 mt-2 mb-9">
+              <span
+                className="font-comic text-[19px] whitespace-nowrap"
+                style={{ color: "#f5b03a" }}
+              >
+                THE COLLECTION
+              </span>
+              <span
+                className="h-px flex-1"
+                style={{
+                  background:
+                    "linear-gradient(to right,rgba(232,148,10,.5),transparent)",
+                }}
               />
-            ))}
-          </div>
-        </>
-      )}
+            </div>
+
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-x-5 gap-y-9">
+              {TROPHY_CATALOG.map((def) => (
+                <TrophyStand
+                  key={def.key}
+                  name={def.name}
+                  art={byKey[def.key]?.image_url ?? null}
+                  status={statuses[def.key]}
+                  earnedOn={byKey[def.key]?.earned_on ?? null}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## v1.56.0 — the hall becomes the page, and the art goes wordless

Two things, both from Jason's review of the shipped hall.

### The hall is the whole page
- The approved AI **hall background** is now a **fixed full-bleed backdrop** (`background-attachment: fixed`) — it holds in place as you scroll, so the trophies read as *standing inside the same room*, not on a separate slab below. It clips to the content area, so it never bleeds behind the sidebar.
- Your **driver + truck avatars hang in page-drawn gold frames** on the walls, always aligned — so the background no longer draws its own (empty, mis-aligned) frames.
- The ten trophies **stand over the floor** as spotlit medallions with light pools: earned = lit gold with date, locked = grayed with a lock + live progress bar.
- Framed portraits are **drill-down links** to the truck/driver pages.

### Trophy art is wordless by design
Image models can't spell — that's why the first pass came back with garbled "1,000,000" and MC gibberish. So:
- Every `promptIdea` is now a **symbol**, not a trophy-with-text: Own Authority = eagle + shield, Million Mile Club = highway to the horizon, One Million Hauled = a mountain of freight, Free & Clear = a snapping chain, etc.
- `TROPHY_STYLE` **hard-forbids** all text/numbers/lettering.
- The **app draws every label and figure** on the card, so the art never has to spell anything.
- `HALL_PROMPT` drops its baked frames to match the page-drawn ones.

Frontend-only, no migration. Build + 169 tests green. **Jason regenerates the hall background + the ten trophies in the Studio against the new text-free style after this deploys.**