### PR TITLE
fix: weekly target counts only earned freight; recap shows total miles

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.56.0",
+  "version": "1.56.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/GrindMeter.tsx
+++ b/frontend/src/components/dashboard/GrindMeter.tsx
@@ -22,7 +22,7 @@ const thisWeekLine = (
     case "below":
       return { text: "Below your weekly floor so far.", color: "#f87171" };
     default:
-      return { text: "No freight booked this week yet.", color: "#9daabb" };
+      return { text: "Nothing delivered yet this week.", color: "#9daabb" };
   }
 };
 

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -11,24 +11,33 @@ const TRACK = "#232c3f";
 const money = (n: number | null): string =>
   n == null ? "—" : `$${Math.round(n).toLocaleString("en-US")}`;
 
-// This week's booked gross against its floor (break-even) and target ticks.
+// This week's gross vs floor (break-even) + target. The solid bar is EARNED
+// (delivered) freight — what actually counts; the faded extension is COMMITTED
+// (booked/in-transit) pipeline still to haul. Color grades off earned.
 const PaceBar = ({
-  booked,
+  earned,
+  committed,
   floor,
   target,
 }: {
-  booked: number;
+  earned: number;
+  committed: number;
   floor: number;
   target: number;
 }) => {
-  const fill = target > 0 ? Math.max(0, Math.min(1, booked / target)) : 0;
+  const frac = (v: number) =>
+    target > 0 ? Math.max(0, Math.min(1, v / target)) : 0;
   const floorPos = target > 0 ? Math.min(1, floor / target) : 0;
-  const color = booked >= target ? GREEN : booked >= floor ? AMBER : RED;
+  const color = earned >= target ? GREEN : earned >= floor ? AMBER : RED;
   return (
     <div className="relative h-2 rounded mt-2 mb-1" style={{ background: TRACK }}>
       <div
         className="absolute left-0 top-0 h-2 rounded"
-        style={{ width: `${fill * 100}%`, background: color }}
+        style={{ width: `${frac(committed) * 100}%`, background: color, opacity: 0.3 }}
+      />
+      <div
+        className="absolute left-0 top-0 h-2 rounded"
+        style={{ width: `${frac(earned) * 100}%`, background: color }}
       />
       <div
         className="absolute top-0 h-2"
@@ -80,12 +89,13 @@ export const RateTargetsCard = ({
   targets: Targets;
   rpm?: number | null; // "your rate" marker; defaults to the recent-window rate
 }) => {
-  const { ladder, gross, weekBooked, basis, ready } = targets;
+  const { ladder, gross, weekBooked, weekEarned, basis, ready } = targets;
   const markerRpm = rpm !== undefined ? rpm : basis.windowRpm;
+  const committedAhead = Math.max(0, weekBooked - weekEarned);
   const beatTarget =
     gross.weeklyTarget != null &&
     gross.weeklyTarget > 0 &&
-    weekBooked >= gross.weeklyTarget;
+    weekEarned >= gross.weeklyTarget;
 
   return (
     <div className="bg-plate rounded-lg p-4">
@@ -113,13 +123,14 @@ export const RateTargetsCard = ({
           </div>
 
           <div>
-            <p className="text-xs text-muted-text">This week · booked</p>
+            <p className="text-xs text-muted-text">This week · earned</p>
             <div className="flex items-center gap-2">
-              <p className="text-xl font-condensed mt-1">{money(weekBooked)}</p>
+              <p className="text-xl font-condensed mt-1">{money(weekEarned)}</p>
               {beatTarget && <TargetBurst />}
             </div>
             <PaceBar
-              booked={weekBooked}
+              earned={weekEarned}
+              committed={weekBooked}
               floor={gross.weeklyBreakEven ?? 0}
               target={gross.weeklyTarget ?? 0}
             />
@@ -127,9 +138,14 @@ export const RateTargetsCard = ({
               floor {money(gross.weeklyBreakEven)} · target{" "}
               {money(gross.weeklyTarget)}
             </p>
+            {committedAhead > 0 && (
+              <p className="text-xs mt-1 text-muted-text">
+                + {money(committedAhead)} committed, still to haul
+              </p>
+            )}
             {beatTarget && (
               <p className="text-xs mt-1" style={{ color: GREEN }}>
-                Beat target by {money(weekBooked - (gross.weeklyTarget ?? 0))}
+                Beat target by {money(weekEarned - (gross.weeklyTarget ?? 0))}
               </p>
             )}
           </div>

--- a/frontend/src/components/recap/RecapPoster.tsx
+++ b/frontend/src/components/recap/RecapPoster.tsx
@@ -106,7 +106,7 @@ export const RecapPoster = ({
 
         <div className="flex gap-2 mb-2.5">
           <Hero value={kMoney(stats.gross)} label="HAULED" color="#4ade80" />
-          <Hero value={num(stats.loadedMiles)} label="MILES" color="#f5b03a" />
+          <Hero value={num(stats.totalMiles)} label="MILES" color="#f5b03a" />
           <Hero value={String(stats.states)} label="STATES" color="#60a5fa" />
         </div>
 

--- a/frontend/src/hooks/useRateTargets.ts
+++ b/frontend/src/hooks/useRateTargets.ts
@@ -10,6 +10,7 @@ import {
   getGrossTargets,
   payWeekRange,
   getWeekBookedGross,
+  getWeekEarnedGross,
   getWeekRpm,
   getWindowRpm,
 } from "@/lib/metrics/rateTargets";
@@ -56,14 +57,16 @@ export const useRateTargets = (loads: Load[]) => {
       WORKING_DAYS_PER_MONTH,
     );
     const { start, end } = payWeekRange(now, PAY_WEEK_START_DOW);
-    const weekBooked = getWeekBookedGross(loads, start, end);
+    const weekBooked = getWeekBookedGross(loads, start, end); // committed (all non-cancelled)
+    const weekEarned = getWeekEarnedGross(loads, start, end); // delivered only
     const weekRpm = getWeekRpm(loads, start, end);
     const rollingRpm = getWindowRpm(loads, now);
     return {
       basis,
       ladder,
       gross,
-      weekBooked,
+      weekBooked, // committed this week — booked + in-transit + delivered
+      weekEarned, // earned this week — delivered only; drives the "hit target" win
       weekRpm, // this week's blended rate — the ladder marker
       rollingRpm, // rolling 3-complete-month RPM — the Avg RPM KPI
       weekStart: start,

--- a/frontend/src/lib/metrics/grind.ts
+++ b/frontend/src/lib/metrics/grind.ts
@@ -1,14 +1,15 @@
 // The grind meter — a week-over-week motivation layer. Each pay-week is graded
-// on your WEEKLY GROSS PACE, the same lens the dashboard's "this week · booked"
-// card uses: did your booked/delivered freight beat your weekly target (green),
-// clear the break-even floor (amber), or fall short (red)? A week you moved no
-// freight is a home/neutral week (grey) — it doesn't count, but it doesn't break
-// your streak either. The streak is consecutive target-beating weeks.
+// on your WEEKLY GROSS PACE from freight actually HAULED (delivered/earned): did
+// it beat your weekly target (green), clear the break-even floor (amber), or fall
+// short (red)? A week you delivered no freight is a home/neutral week (grey) — it
+// doesn't count, but it doesn't break your streak either. The streak is
+// consecutive target-beating weeks. Booked-but-unhauled freight is committed
+// pipeline (shown on the rate-targets card), not a win here until it's delivered.
 import type { Load } from "@/types/load";
 import type { ExpensePeriod } from "@/types/expense";
 import {
   payWeekRange,
-  getWeekBookedGross,
+  getWeekEarnedGross,
   getGrossTargets,
   getCostBasis,
   type GrossTargets,
@@ -88,7 +89,7 @@ export const computeGrind = (
   const hasLadder = targets.weeklyTarget != null;
 
   const current = payWeekRange(now, PAY_WEEK_START_DOW);
-  const thisWeekGross = getWeekBookedGross(loads, current.start, current.end);
+  const thisWeekGross = getWeekEarnedGross(loads, current.start, current.end);
   const thisWeek: WeekStatus = hasLadder ? classify(thisWeekGross, targets) : "home";
 
   const delivered = loads.filter(
@@ -108,7 +109,7 @@ export const computeGrind = (
   const weeks: GrindWeek[] = [];
   for (let t = firstStart.getTime(); t < current.start.getTime(); t += WEEK_MS) {
     const ws = new Date(t);
-    const gross = getWeekBookedGross(loads, ws, new Date(t + WEEK_MS));
+    const gross = getWeekEarnedGross(loads, ws, new Date(t + WEEK_MS));
     weeks.push({ start: ws.toISOString().slice(0, 10), status: classify(gross, targets), gross });
     if (weeks.length > 200) break; // safety cap
   }

--- a/frontend/src/lib/metrics/rateTargets.test.ts
+++ b/frontend/src/lib/metrics/rateTargets.test.ts
@@ -8,6 +8,7 @@ import {
   getGrossTargets,
   payWeekRange,
   getWeekBookedGross,
+  getWeekEarnedGross,
   getWeekRpm,
   getWindowRpm,
 } from "./rateTargets";
@@ -167,6 +168,23 @@ describe("getWeekBookedGross", () => {
       load({ delivery_date: "2026-07-10", load_status: "cancelled", linehaul: "9999" }),
       load({ delivery_date: "2026-07-01", load_status: "delivered", linehaul: "9999" }), // before range
     ];
+    expect(getWeekBookedGross(loads, start, end)).toBeCloseTo(6000, 5);
+  });
+});
+
+describe("getWeekEarnedGross", () => {
+  const start = new Date("2026-07-08T00:00:00Z");
+  const end = new Date("2026-07-15T00:00:00Z");
+
+  it("counts only DELIVERED freight in range — booked/in-transit are committed, not earned", () => {
+    const loads = [
+      load({ delivery_date: "2026-07-08", load_status: "delivered", linehaul: "1000" }),
+      load({ delivery_date: "2026-07-10", load_status: "booked", linehaul: "2000" }), // committed, not earned
+      load({ delivery_date: "2026-07-14", load_status: "in_transit", linehaul: "3000" }), // committed, not earned
+      load({ delivery_date: "2026-07-01", load_status: "delivered", linehaul: "9999" }), // before range
+    ];
+    expect(getWeekEarnedGross(loads, start, end)).toBeCloseTo(1000, 5);
+    // committed still sees all three in range
     expect(getWeekBookedGross(loads, start, end)).toBeCloseTo(6000, 5);
   });
 });

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -192,6 +192,18 @@ export const getWeekBookedGross = (
   end: Date,
 ): number => loadsInWeek(loads, start, end).reduce((s, l) => s + loadRevenue(l), 0);
 
+// Delivered-only gross for the week — freight actually HAULED (earned). Booked
+// and in-transit are committed pipeline, not yet earned, so this is the honest
+// basis for "did I hit target this week" (committed minus this = still to haul).
+export const getWeekEarnedGross = (
+  loads: Load[],
+  start: Date,
+  end: Date,
+): number =>
+  loadsInWeek(loads, start, end)
+    .filter((l) => l.load_status === "delivered")
+    .reduce((s, l) => s + loadRevenue(l), 0);
+
 // This week's blended rate per loaded mile — where you're landing right now.
 export const getWeekRpm = (
   loads: Load[],

--- a/frontend/src/lib/metrics/recap.test.ts
+++ b/frontend/src/lib/metrics/recap.test.ts
@@ -47,6 +47,7 @@ describe("computeRecap", () => {
     const r = computeRecap(loads, [] as FuelEntry[], periods, 0, rangeFor("year", 2026, 0), "year", NOW);
     expect(r.gross).toBe(5800);
     expect(r.loadedMiles).toBe(1800);
+    expect(r.totalMiles).toBe(1800); // no odometers → falls back to loaded miles
     expect(r.states).toBe(3); // TX, GA, TN — prior-year CA/NV excluded
     expect(r.loads).toBe(2);
     expect(r.biggestLoad).toBe(3200);
@@ -54,6 +55,19 @@ describe("computeRecap", () => {
     expect(r.avgRpm).toBeCloseTo(5800 / 1800, 3);
     expect(r.topLane).toBe("Dallas → Atlanta");
     expect(r.topAgent).toBe("Redwood");
+  });
+
+  it("counts total (odometer) miles incl. deadhead, loaded only for RPM", () => {
+    const withOdo = [
+      // 700 driven (200 deadhead) on 500 loaded
+      L({ load_id: "x", delivery_date: "2026-06-05", linehaul: "1000", loaded_miles: 500, odometer_start: 1000, odometer_end: 1700 }),
+      // no odometer readings → total falls back to its 400 loaded miles
+      L({ load_id: "y", delivery_date: "2026-06-20", linehaul: "1200", loaded_miles: 400 }),
+    ];
+    const r = computeRecap(withOdo, [] as FuelEntry[], [], 0, rangeFor("year", 2026, 0), "year", NOW);
+    expect(r.totalMiles).toBe(1100); // 700 + 400
+    expect(r.loadedMiles).toBe(900); // 500 + 400
+    expect(r.avgRpm).toBeCloseTo(2200 / 900, 3); // RPM stays on loaded miles
   });
 
   it("rolls up P&L with best / hardest month", () => {

--- a/frontend/src/lib/metrics/recap.ts
+++ b/frontend/src/lib/metrics/recap.ts
@@ -80,7 +80,8 @@ export interface RecapStats {
   scope: RecapScope;
   label: string;
   gross: number;
-  loadedMiles: number;
+  totalMiles: number; // odometer miles (loaded + deadhead) — the headline "miles"
+  loadedMiles: number; // paid miles only — kept for RPM (revenue ÷ loaded)
   states: number;
   loads: number;
   bestWeek: number | null;
@@ -109,6 +110,14 @@ export const computeRecap = (
 
   const gross = mine.reduce((s, l) => s + loadRevenue(l), 0);
   const loadedMiles = mine.reduce((s, l) => s + Number(l.loaded_miles || 0), 0);
+  // Total (driven) miles = the load's odometer window (captures deadhead between
+  // loads); fall back to its loaded miles when a load has no odometer readings,
+  // so total can never read lower than loaded.
+  const totalMiles = mine.reduce((s, l) => {
+    const hasOdo = l.odometer_start != null && l.odometer_end != null;
+    const delta = hasOdo ? Number(l.odometer_end) - Number(l.odometer_start) : 0;
+    return s + (delta > 0 ? delta : Number(l.loaded_miles || 0));
+  }, 0);
 
   const stateSet = new Set<string>();
   for (const l of mine) {
@@ -180,6 +189,7 @@ export const computeRecap = (
     scope,
     label: range.label,
     gross,
+    totalMiles,
     loadedMiles,
     states: stateSet.size,
     loads: mine.length,


### PR DESCRIPTION
## v1.56.1 — two metric corrections Jason caught

### 1. Weekly target was celebrating freight you haven't hauled
The pace bar + grind meter counted **booked + in-transit** freight toward "hit target," so booking loads ahead lit the week green before a wheel turned (and evaporated if a load TONU'd).

Now the week is split into **earned** (delivered) vs **committed** (booked/in-transit):
- The green "TARGET!" burst and the grind meter grade **only on earned** (delivered) dollars.
- Committed pipeline still shows — as a faded extension on the pace bar and a `+ $X committed, still to haul` line — so you keep the forward view without it counting as a win.
- New `getWeekEarnedGross`; `computeGrind` grades every week on delivered freight (identical to before for past weeks, honest for the in-progress one).

*Live check:* this pay-week shows **$0 earned · ~$8,050 committed** (two loads deliver Mon/Tue) — no more false "target hit."

### 2. Recap miles were loaded-only, dropping deadhead
Season recap's headline **Miles** now uses the odometer window (loaded + deadhead between loads), falling back to loaded miles when a load has no readings so total can never read *below* loaded. **Avg RPM stays gross ÷ loaded** (revenue math), as intended.

Frontend-only, no migration. Build + 171 tests green (+2: earned-gross split, recap total-miles-with-deadhead).