### PR TITLE
feat: settlement schedule → net revenue everywhere

### DIFF
--- a/backend/db/migrations/033_settlement_schedule.sql
+++ b/backend/db/migrations/033_settlement_schedule.sql
@@ -1,0 +1,22 @@
+-- Per-user SETTLEMENT SCHEDULE: the carrier's pay % per revenue component, which
+-- turns a load's full customer rate (what the shipper pays) into the owner-op's
+-- NET — i.e. what their own company grosses after the carrier's cut.
+--
+-- net = linehaul*(linehaul_pct + trailer_pct) + fuel_surcharge*fuel_surcharge_pct
+--       + accessorials*accessorial_pct
+--
+-- Defaults are 100% / 0% / 100% / 100%, so a user with no row (or one on their own
+-- authority) nets the full rate = today's behavior. Nothing changes until a
+-- schedule is configured.
+--
+-- Jason's Landstar BCO split: 65% linehaul + 8% flatbed trailer = 73%, 100% fuel
+-- surcharge (seeded separately, per the signed ICOA Appendix A / A-1).
+CREATE TABLE IF NOT EXISTS settlement_schedules (
+  user_id            uuid PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
+  linehaul_pct       numeric NOT NULL DEFAULT 1.0 CHECK (linehaul_pct       >= 0 AND linehaul_pct       <= 2),
+  trailer_pct        numeric NOT NULL DEFAULT 0.0 CHECK (trailer_pct        >= 0 AND trailer_pct        <= 2),
+  fuel_surcharge_pct numeric NOT NULL DEFAULT 1.0 CHECK (fuel_surcharge_pct >= 0 AND fuel_surcharge_pct <= 2),
+  accessorial_pct    numeric NOT NULL DEFAULT 1.0 CHECK (accessorial_pct    >= 0 AND accessorial_pct    <= 2),
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);

--- a/backend/src/routes/settlementScheduleRoutes.js
+++ b/backend/src/routes/settlementScheduleRoutes.js
@@ -1,0 +1,37 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import {
+  getSettlementSchedule,
+  upsertSettlementSchedule,
+} from "../services/settlementScheduleServices.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+const handleError = (res, err) => {
+  if (err.type === "validation")
+    return res.status(err.statusCode).json({ error: err.message });
+  return res
+    .status(500)
+    .json({ error: "Internal Server Error", message: err.message });
+};
+
+router.get("/", async (req, res) => {
+  try {
+    const schedule = await getSettlementSchedule(req.user.user_id);
+    return res.status(200).json({ schedule });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.put("/", async (req, res) => {
+  try {
+    const schedule = await upsertSettlementSchedule(req.user.user_id, req.body);
+    return res.status(200).json({ schedule });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -24,6 +24,7 @@ import trailerRouter from "./routes/trailerRoutes.js";
 import avatarRouter from "./routes/avatarRoutes.js";
 import complianceRouter from "./routes/complianceRoutes.js";
 import trophyRouter from "./routes/trophyRoutes.js";
+import settlementScheduleRouter from "./routes/settlementScheduleRoutes.js";
 
 const app = express();
 
@@ -55,6 +56,7 @@ app.use("/compliance", complianceRouter);
 app.use("/trophies", trophyRouter);
 app.use("/trailers", trailerRouter);
 app.use("/avatars", avatarRouter);
+app.use("/settlement-schedule", settlementScheduleRouter);
 
 app.get("/", (req, res) => {
   res.send("Home Page");

--- a/backend/src/services/loadServices.js
+++ b/backend/src/services/loadServices.js
@@ -36,6 +36,15 @@ export async function getLoads(user_id) {
               FROM accessorials
               WHERE load_id = loads.load_id
             ) AS total_accessorials,
+            linehaul + fuel_surcharge
+              + (SELECT COALESCE(SUM(amount), 0) FROM accessorials WHERE load_id = loads.load_id)
+              AS gross_revenue,
+            ROUND(
+              linehaul * (COALESCE(ss.linehaul_pct, 1) + COALESCE(ss.trailer_pct, 0))
+              + fuel_surcharge * COALESCE(ss.fuel_surcharge_pct, 1)
+              + (SELECT COALESCE(SUM(amount), 0) FROM accessorials WHERE load_id = loads.load_id)
+                * COALESCE(ss.accessorial_pct, 1)
+            , 2) AS net_revenue,
             commodity,
             weight,
             dimensions,
@@ -56,6 +65,8 @@ export async function getLoads(user_id) {
         ON loads.origin_market_id = origin_market.market_id
         JOIN markets AS destination_market
         ON loads.destination_market_id = destination_market.market_id
+        LEFT JOIN settlement_schedules AS ss
+        ON ss.user_id = loads.user_id
         WHERE loads.user_id = $1
         ORDER BY pickup_date DESC;
     `;
@@ -101,6 +112,15 @@ export async function getLoad(user_id, load_id) {
               FROM accessorials
               WHERE load_id = l.load_id
             ) AS total_accessorials,
+            linehaul + fuel_surcharge
+              + (SELECT COALESCE(SUM(amount), 0) FROM accessorials WHERE load_id = l.load_id)
+              AS gross_revenue,
+            ROUND(
+              linehaul * (COALESCE(ss.linehaul_pct, 1) + COALESCE(ss.trailer_pct, 0))
+              + fuel_surcharge * COALESCE(ss.fuel_surcharge_pct, 1)
+              + (SELECT COALESCE(SUM(amount), 0) FROM accessorials WHERE load_id = l.load_id)
+                * COALESCE(ss.accessorial_pct, 1)
+            , 2) AS net_revenue,
             commodity,
             weight,
             dimensions,
@@ -130,6 +150,8 @@ export async function getLoad(user_id, load_id) {
         ON l.driver_id = drv.driver_id
         LEFT JOIN trailers AS trl
         ON l.trailer_id = trl.trailer_id
+        LEFT JOIN settlement_schedules AS ss
+        ON ss.user_id = l.user_id
         WHERE l.user_id = $1
         AND load_id = $2;
     `;

--- a/backend/src/services/settlementScheduleServices.js
+++ b/backend/src/services/settlementScheduleServices.js
@@ -1,0 +1,65 @@
+import { db } from "../../db/pool.js";
+import { ValidationError } from "../utils/error.js";
+
+// The identity schedule — net = gross. Returned when a user hasn't configured one
+// so the app (and the Settings form) always has values to work with.
+const DEFAULTS = {
+  linehaul_pct: 1,
+  trailer_pct: 0,
+  fuel_surcharge_pct: 1,
+  accessorial_pct: 1,
+};
+
+const FIELDS = [
+  "linehaul_pct",
+  "trailer_pct",
+  "fuel_surcharge_pct",
+  "accessorial_pct",
+];
+
+// ---- GET ---- (always returns a schedule; defaults if none saved yet)
+export async function getSettlementSchedule(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const result = await db.query(
+    `SELECT ${FIELDS.join(", ")}
+       FROM settlement_schedules
+      WHERE user_id = $1`,
+    [user_id],
+  );
+  return result.rows[0] ?? { ...DEFAULTS };
+}
+
+// ---- UPSERT ---- (partial: only provided fields change, the rest are kept)
+export async function upsertSettlementSchedule(user_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+
+  const provided = {};
+  for (const f of FIELDS) {
+    if (data[f] === undefined) continue;
+    const n = Number(data[f]);
+    if (!Number.isFinite(n) || n < 0 || n > 2)
+      throw new ValidationError(`${f} must be a fraction between 0 and 2`);
+    provided[f] = n;
+  }
+  if (Object.keys(provided).length === 0)
+    throw new ValidationError("No valid fields to update");
+
+  // Merge onto the current (or default) schedule so a partial save is safe.
+  const current = await getSettlementSchedule(user_id);
+  const m = { ...current, ...provided };
+
+  const result = await db.query(
+    `INSERT INTO settlement_schedules
+       (user_id, linehaul_pct, trailer_pct, fuel_surcharge_pct, accessorial_pct)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (user_id) DO UPDATE SET
+       linehaul_pct       = EXCLUDED.linehaul_pct,
+       trailer_pct        = EXCLUDED.trailer_pct,
+       fuel_surcharge_pct = EXCLUDED.fuel_surcharge_pct,
+       accessorial_pct    = EXCLUDED.accessorial_pct,
+       updated_at         = NOW()
+     RETURNING ${FIELDS.join(", ")}`,
+    [user_id, m.linehaul_pct, m.trailer_pct, m.fuel_surcharge_pct, m.accessorial_pct],
+  );
+  return result.rows[0];
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.56.1",
+  "version": "1.57.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import CompliancePage from "@/pages/CompliancePage";
 import RecapPage from "@/pages/RecapPage";
 import TrophyHallPage from "@/pages/TrophyHallPage";
 import TrophyStudioPage from "@/pages/TrophyStudioPage";
+import SettingsPage from "@/pages/SettingsPage";
 
 // Code-split Lanes — it bundles the US map topology (~600KB), so it should only
 // load when the page is actually visited, not on every app start.
@@ -75,6 +76,7 @@ const App = () => {
           <Route path="/trailers" element={<TrailersPage />} />
           <Route path="/trailers/:id" element={<TrailerDetailPage />} />
           <Route path="/guide" element={<GuidePage />} />
+          <Route path="/settings" element={<SettingsPage />} />
         </Route>
       </Route>
 

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -134,7 +134,14 @@ const AppSidebar = () => {
       </SidebarContent>
 
       <SidebarFooter>
-        <div className="p-4 text-sm text-muted-foreground">v{__APP_VERSION__}</div>
+        <div className="px-4 pt-2">
+          <Link to="/settings" className={`text-sm ${linkCls("/settings")}`}>
+            Settings
+          </Link>
+        </div>
+        <div className="px-4 pb-4 pt-1 text-sm text-muted-foreground">
+          v{__APP_VERSION__}
+        </div>
       </SidebarFooter>
     </Sidebar>
   );

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -117,7 +117,7 @@ export const RateTargetsCard = ({
         <div className="grid grid-cols-1 md:grid-cols-[1.6fr_1fr_1fr] gap-6">
           <div>
             <p className="text-xs text-muted-text mb-3">
-              Rate per loaded mile · marker = this week
+              Net rate per loaded mile · marker = this week
             </p>
             <RateLadder ladder={ladder} rpm={markerRpm} />
           </div>

--- a/frontend/src/lib/metrics/dashboard.ts
+++ b/frontend/src/lib/metrics/dashboard.ts
@@ -1,17 +1,12 @@
 import type { Load } from "@/types/load";
 import type { Trip } from "@/types/trip";
+import { loadRevenue } from "./rateTargets";
 
+// Revenue = the owner-op's NET take (their company gross), via loadRevenue —
+// so every dashboard tile reflects money kept, not the full pre-cut rate.
 const getLoadRevenue = (loads: Load[] | null): number | null => {
   if (!loads) return null;
-
-  return loads.reduce((total, load) => {
-    return (
-      total +
-      Number(load.linehaul) +
-      Number(load.fuel_surcharge) +
-      Number(load.total_accessorials)
-    );
-  }, 0);
+  return loads.reduce((total, load) => total + loadRevenue(load), 0);
 };
 
 // ---- GET REVENUE MTD ----

--- a/frontend/src/lib/metrics/rateTargets.test.ts
+++ b/frontend/src/lib/metrics/rateTargets.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import type { Load } from "@/types/load";
 import type { ExpensePeriod } from "@/types/expense";
 import {
+  loadRevenue,
+  loadGross,
   completeMonthsBefore,
   getCostBasis,
   getRateLadder,
@@ -35,6 +37,26 @@ const period = (month: string, cogs: number, expense: number): ExpensePeriod => 
   income_total: null,
   cogs_total: cogs,
   expense_total: expense,
+});
+
+describe("loadRevenue / loadGross", () => {
+  it("revenue = net_revenue (the owner-op's take); gross = gross_revenue (full rate)", () => {
+    const l = load({
+      linehaul: "5000",
+      fuel_surcharge: "500",
+      total_accessorials: "0",
+      gross_revenue: "5500",
+      net_revenue: "4150", // 5000*0.73 + 500
+    });
+    expect(loadRevenue(l)).toBe(4150);
+    expect(loadGross(l)).toBe(5500);
+  });
+
+  it("falls back to the component sum when net/gross are absent (no schedule)", () => {
+    const l = load({ linehaul: "5000", fuel_surcharge: "500", total_accessorials: "0" });
+    expect(loadRevenue(l)).toBe(5500);
+    expect(loadGross(l)).toBe(5500);
+  });
 });
 
 describe("completeMonthsBefore", () => {

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -4,9 +4,24 @@ import type { ExpensePeriod } from "@/types/expense";
 // Rate & pace targets, all derived live from the P&L + loads. Pure functions
 // take `now` explicitly so they're testable without touching the clock.
 
-// Load gross revenue = linehaul + fuel surcharge + accessorials (NUMERIC strings).
-export const loadRevenue = (l: Load): number =>
-  Number(l.linehaul) + Number(l.fuel_surcharge) + Number(l.total_accessorials);
+// The full customer rate (gross) = linehaul + fuel surcharge + accessorials. Used
+// for pricing guidance, where the rate you actually book is what matters.
+export const loadGross = (l: Load): number => {
+  const gross = Number(l.gross_revenue);
+  return Number.isFinite(gross)
+    ? gross
+    : Number(l.linehaul) + Number(l.fuel_surcharge) + Number(l.total_accessorials);
+};
+
+// A load's revenue = the owner-op's NET (their company gross after the carrier's
+// settlement cut), computed server-side from the settlement schedule. Falls back
+// to gross when net_revenue is absent (a user with no schedule, or a test fixture).
+// This is THE revenue used everywhere — reporting, RPM, pace, and targets — so
+// every number reflects what the company actually keeps.
+export const loadRevenue = (l: Load): number => {
+  const net = Number(l.net_revenue);
+  return Number.isFinite(net) ? net : loadGross(l);
+};
 
 // The `count` COMPLETE calendar months before now's month (excludes the
 // in-progress current month — its miles lag its cost and would inflate $/mile).

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -145,13 +145,13 @@ const DashboardPage = () => {
       {/* KPI STRIP */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
         <KpiCard
-          label="Revenue · MTD"
+          label="Net revenue · MTD"
           value={formatCurrency(revenueMTD)}
           delta={mtdDelta}
         />
-        <KpiCard label="Revenue · YTD" value={formatCurrency(revenueYTD)} />
+        <KpiCard label="Net revenue · YTD" value={formatCurrency(revenueYTD)} />
         <KpiCard
-          label="Avg RPM · 3mo"
+          label="Net RPM · 3mo"
           value={formatRpm(avgRpm)}
           status={rpmStatus}
           subtext={

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from "react";
+import {
+  getSettlementSchedule,
+  updateSettlementSchedule,
+} from "@/services/settlementScheduleService";
+
+const money = (n: number) =>
+  `$${n.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+
+// A sample load for the live preview, so the effect of the percentages is visible.
+const SAMPLE_LINEHAUL = 2000;
+const SAMPLE_FSC = 300;
+
+type Pcts = {
+  linehaul: number;
+  trailer: number;
+  fsc: number;
+  accessorial: number;
+};
+
+const Field = ({
+  label,
+  help,
+  value,
+  onChange,
+}: {
+  label: string;
+  help: string;
+  value: number;
+  onChange: (v: number) => void;
+}) => (
+  <label className="block">
+    <span className="text-sm text-light">{label}</span>
+    <div className="flex items-center gap-2 mt-1">
+      <input
+        type="number"
+        min={0}
+        max={200}
+        step={0.5}
+        value={Number.isFinite(value) ? value : ""}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-24 bg-steel rounded px-2 py-1.5 text-light text-right tabular-nums"
+      />
+      <span className="text-muted-text">%</span>
+    </div>
+    <span className="text-xs text-muted-text mt-1 block">{help}</span>
+  </label>
+);
+
+const SettingsPage = () => {
+  const [pcts, setPcts] = useState<Pcts | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    getSettlementSchedule()
+      .then((s) =>
+        setPcts({
+          linehaul: s.linehaul_pct * 100,
+          trailer: s.trailer_pct * 100,
+          fsc: s.fuel_surcharge_pct * 100,
+          accessorial: s.accessorial_pct * 100,
+        }),
+      )
+      .catch(() => setErr("Couldn't load your settlement schedule."));
+  }, []);
+
+  const set = (k: keyof Pcts) => (v: number) => {
+    setMsg(null);
+    setPcts((p) => (p ? { ...p, [k]: v } : p));
+  };
+
+  const save = async () => {
+    if (!pcts) return;
+    setSaving(true);
+    setErr(null);
+    setMsg(null);
+    try {
+      await updateSettlementSchedule({
+        linehaul_pct: pcts.linehaul / 100,
+        trailer_pct: pcts.trailer / 100,
+        fuel_surcharge_pct: pcts.fsc / 100,
+        accessorial_pct: pcts.accessorial / 100,
+      });
+      setMsg("Saved. Your revenue and targets now use this split.");
+    } catch (e) {
+      setErr(
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Couldn't save — check the values and try again.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const gross = SAMPLE_LINEHAUL + SAMPLE_FSC;
+  const net = pcts
+    ? SAMPLE_LINEHAUL * ((pcts.linehaul + pcts.trailer) / 100) +
+      SAMPLE_FSC * (pcts.fsc / 100)
+    : gross;
+  const effLinehaul = pcts ? pcts.linehaul + pcts.trailer : 100;
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <h1 className="text-3xl font-condensed">Settings</h1>
+
+      <div className="mt-6 max-w-[680px] bg-plate rounded-lg p-5">
+        <h2 className="text-lg font-medium text-light">Settlement schedule</h2>
+        <p className="text-sm text-muted-text mt-1">
+          Your carrier's pay split. You keep entering each load's full customer
+          rate — this turns it into what your company actually grosses after the
+          carrier's cut. Revenue, RPM, and your rate targets all use it. Leave
+          everything at 100% if you run under your own authority.
+        </p>
+
+        {!pcts ? (
+          <p className="text-muted-text mt-5">Loading…</p>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-5 mt-5">
+              <Field
+                label="Linehaul"
+                help="Your base cut of the linehaul (Landstar BCO: 65%)."
+                value={pcts.linehaul}
+                onChange={set("linehaul")}
+              />
+              <Field
+                label="Trailer"
+                help="Extra % of linehaul for furnishing your trailer (flatbed: 8%)."
+                value={pcts.trailer}
+                onChange={set("trailer")}
+              />
+              <Field
+                label="Fuel surcharge"
+                help="Share of the fuel surcharge you keep (usually 100%)."
+                value={pcts.fsc}
+                onChange={set("fsc")}
+              />
+              <Field
+                label="Accessorials"
+                help="Default share of accessorial charges (tarp, detention, etc.)."
+                value={pcts.accessorial}
+                onChange={set("accessorial")}
+              />
+            </div>
+
+            <div
+              className="mt-5 rounded-lg p-4 flex flex-wrap items-center gap-x-6 gap-y-2"
+              style={{ background: "#0d1119" }}
+            >
+              <div className="text-sm text-muted-text">
+                Effective linehaul take{" "}
+                <span className="text-amber font-semibold">
+                  {effLinehaul.toFixed(0)}%
+                </span>
+              </div>
+              <div className="text-sm text-muted-text">
+                Sample: {money(SAMPLE_LINEHAUL)} linehaul + {money(SAMPLE_FSC)}{" "}
+                FSC ={" "}
+                <span className="line-through">{money(gross)}</span>{" "}
+                <span className="text-status-positive-text font-semibold">
+                  {money(net)} net
+                </span>
+              </div>
+            </div>
+
+            {msg && (
+              <p className="text-status-positive-text text-sm mt-4">{msg}</p>
+            )}
+            {err && <p className="text-destructive text-sm mt-4">{err}</p>}
+
+            <button
+              onClick={save}
+              disabled={saving}
+              className="mt-4 bg-amber text-steel px-4 py-2 rounded font-semibold disabled:opacity-50"
+            >
+              {saving ? "Saving…" : "Save schedule"}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/frontend/src/services/settlementScheduleService.ts
+++ b/frontend/src/services/settlementScheduleService.ts
@@ -1,0 +1,21 @@
+import api from "./api";
+import type { SettlementSchedule } from "@/types/settlementSchedule";
+
+const coerce = (s: Record<string, unknown>): SettlementSchedule => ({
+  linehaul_pct: Number(s.linehaul_pct),
+  trailer_pct: Number(s.trailer_pct),
+  fuel_surcharge_pct: Number(s.fuel_surcharge_pct),
+  accessorial_pct: Number(s.accessorial_pct),
+});
+
+export const getSettlementSchedule = async (): Promise<SettlementSchedule> => {
+  const res = await api.get("/settlement-schedule");
+  return coerce(res.data.schedule);
+};
+
+export const updateSettlementSchedule = async (
+  data: SettlementSchedule,
+): Promise<SettlementSchedule> => {
+  const res = await api.put("/settlement-schedule", data);
+  return coerce(res.data.schedule);
+};

--- a/frontend/src/types/load.ts
+++ b/frontend/src/types/load.ts
@@ -25,6 +25,12 @@ export interface Load {
   linehaul: string;
   fuel_surcharge: string;
   total_accessorials: string;
+  // Full customer rate (gross) and the owner-op's take after the settlement
+  // schedule (net = their company gross). Both computed server-side; numeric →
+  // string. Optional: absent on locally-built loads / fixtures, where the metrics
+  // fall back to the linehaul+FSC+accessorials sum.
+  gross_revenue?: string;
+  net_revenue?: string;
   commodity: string | null;
   weight?: number | null;
   dimensions?: string | null;

--- a/frontend/src/types/settlementSchedule.ts
+++ b/frontend/src/types/settlementSchedule.ts
@@ -1,0 +1,9 @@
+// The carrier pay fractions that turn a load's full customer rate into the
+// owner-op's net (their company gross). 0.65 = 65%. Coerced to numbers in the
+// service so the UI works in plain fractions.
+export interface SettlementSchedule {
+  linehaul_pct: number;
+  trailer_pct: number;
+  fuel_surcharge_pct: number;
+  accessorial_pct: number;
+}


### PR DESCRIPTION
## v1.57.0 — Phase 1: the app finally shows *your* money

A Landstar BCO enters the full customer rate but only keeps ~73% of the linehaul + 100% of the fuel surcharge. The app was reporting the full pre-cut rate as "revenue" — 14–27% high. This fixes it.

### Settlement schedule
- Per-user `settlement_schedules` (migration `033`): linehaul %, trailer %, fuel-surcharge %, accessorial %.
- Every load now carries **`gross_revenue`** (full rate) and **`net_revenue`** (computed server-side from the schedule). Defaults are 100/0/100/100, so net = gross for anyone unconfigured — nothing changes until a schedule is set, and it productizes.
- **New Settings page** to view/edit the schedule with a live "$2,000 + $300 FSC → $X net" preview.

### Net everywhere
`loadRevenue` now returns net, so YTD/MTD (relabeled **Net revenue**), the revenue chart, recap, top-agents, outstanding, Avg RPM (**Net RPM**), and the pace/grind targets all reflect money kept. The targets **self-correct**: because pace/grind compare net take to cost, "hit target" now means netting your cost + margin (they were ~27% too low before). `loadGross` is exposed for **Phase 2** (the booking-rate line on the rate ladder).

### Verified against real books
Schedule-computed net lands **within 0.9% of Jason's actual P&L income over Q2** (monthly ±8% is settlement-timing that washes out). A $1,000 + $500 load → $1,230; his in-transit load $6,703.80 gross → $5,124.30 net, confirmed on prod.

**Prod already migrated + seeded** (Jason's 65/8/100/100) before this merge, so the backend deploy is safe. Build clean, 173 tests (+2). Dev-tested by Jason.