### PR TITLE
feat: rate ladder shows the booking rate (net + full rate to quote)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.57.0",
+  "version": "1.58.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/RateLadder.tsx
+++ b/frontend/src/components/dashboard/RateLadder.tsx
@@ -1,8 +1,10 @@
 import type { RateLadder as Ladder } from "@/lib/metrics/rateTargets";
+import { bookedRate } from "@/lib/metrics/rateTargets";
 
 interface Props {
   ladder: Ladder;
-  rpm: number | null; // your current rate — the marker
+  rpm: number | null; // your current rate — the marker (net)
+  take?: number; // linehaul take (linehaul % + trailer %); < 1 adds the "book" line
 }
 
 const RED = "#e24b4a";
@@ -12,12 +14,16 @@ const TRACK = "#232c3f";
 
 const rate = (n: number | null): string => (n == null ? "—" : `$${n.toFixed(2)}`);
 
-// Horizontal ladder from walk-away → strong, split at the target tier. A marker
-// shows where the current rate lands: red at/below walk-away (losing money),
-// amber below target, green at/above target.
-export const RateLadder = ({ ladder, rpm }: Props) => {
+// Horizontal ladder from walk-away → strong, split at the target tier. The marker
+// shows where the current NET rate lands: red at/below walk-away (losing money),
+// amber below target, green at/above. When a settlement cut applies (take < 1),
+// each rung also shows the full rate you must BOOK to clear it after the cut.
+export const RateLadder = ({ ladder, rpm, take = 1 }: Props) => {
   const { walkAway, target, strong } = ladder;
   if (walkAway == null || target == null || strong == null) return null;
+
+  const showBook = take > 0 && take < 1;
+  const book = (n: number | null): string => rate(bookedRate(n, take));
 
   const span = strong - walkAway;
   const targetPos = span > 0 ? ((target - walkAway) / span) * 100 : 58;
@@ -27,6 +33,20 @@ export const RateLadder = ({ ladder, rpm }: Props) => {
       : Math.max(0, Math.min(1, (rpm - walkAway) / span)) * 100;
   const markerColor =
     rpm == null ? AMBER : rpm >= target ? GREEN : rpm <= walkAway ? RED : AMBER;
+
+  const rung = (label: string, net: number | null) => (
+    <>
+      {label}
+      <br />
+      <span className="text-light">{rate(net)}</span>
+      {showBook && (
+        <>
+          <br />
+          <span style={{ color: AMBER }}>book {book(net)}</span>
+        </>
+      )}
+    </>
+  );
 
   return (
     <div>
@@ -53,24 +73,18 @@ export const RateLadder = ({ ladder, rpm }: Props) => {
         <div style={{ flex: 1, background: GREEN, opacity: 0.55 }} />
       </div>
 
-      <div className="relative h-8 mt-1 text-xs text-muted-text">
-        <span className="absolute left-0">
-          walk-away
-          <br />
-          <span className="text-light">{rate(walkAway)}</span>
-        </span>
+      <div
+        className={`relative ${showBook ? "h-12" : "h-8"} mt-1 text-xs text-muted-text`}
+      >
+        <span className="absolute left-0">{rung("walk-away", walkAway)}</span>
         <span
           className="absolute text-center"
           style={{ left: `${targetPos}%`, transform: "translateX(-50%)" }}
         >
-          target
-          <br />
-          <span className="text-light">{rate(target)}</span>
+          {rung("target", target)}
         </span>
         <span className="absolute right-0 text-right">
-          strong
-          <br />
-          <span className="text-light">{rate(strong)}</span>
+          {rung("strong", strong)}
         </span>
       </div>
     </div>

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -89,7 +89,8 @@ export const RateTargetsCard = ({
   targets: Targets;
   rpm?: number | null; // "your rate" marker; defaults to the recent-window rate
 }) => {
-  const { ladder, gross, weekBooked, weekEarned, basis, ready } = targets;
+  const { ladder, gross, weekBooked, weekEarned, basis, ready, linehaulTake } =
+    targets;
   const markerRpm = rpm !== undefined ? rpm : basis.windowRpm;
   const committedAhead = Math.max(0, weekBooked - weekEarned);
   const beatTarget =
@@ -119,7 +120,15 @@ export const RateTargetsCard = ({
             <p className="text-xs text-muted-text mb-3">
               Net rate per loaded mile · marker = this week
             </p>
-            <RateLadder ladder={ladder} rpm={markerRpm} />
+            <RateLadder ladder={ladder} rpm={markerRpm} take={linehaulTake} />
+            {linehaulTake < 1 && (
+              <p className="text-[11px] text-muted-text mt-2">
+                <span style={{ color: "#e8940a" }}>book</span> = full linehaul
+                rate to quote to clear each tier (you keep{" "}
+                {Math.round(linehaulTake * 100)}% of the linehaul; fuel surcharge
+                is on top)
+              </p>
+            )}
           </div>
 
           <div>

--- a/frontend/src/hooks/useRateTargets.ts
+++ b/frontend/src/hooks/useRateTargets.ts
@@ -4,6 +4,8 @@ import type { ExpensePeriod } from "@/types/expense";
 import type { Obligation } from "@/types/obligation";
 import { getExpensePeriods } from "@/services/expensesService";
 import { getObligations } from "@/services/obligationsService";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import type { SettlementSchedule } from "@/types/settlementSchedule";
 import {
   getCostBasis,
   getRateLadder,
@@ -26,16 +28,19 @@ import {
 export const useRateTargets = (loads: Load[]) => {
   const [periods, setPeriods] = useState<ExpensePeriod[]>([]);
   const [obligations, setObligations] = useState<Obligation[]>([]);
+  const [schedule, setSchedule] = useState<SettlementSchedule | null>(null);
 
   useEffect(() => {
     let active = true;
     Promise.all([
       getExpensePeriods().catch(() => [] as ExpensePeriod[]),
       getObligations().catch(() => [] as Obligation[]),
-    ]).then(([ps, obs]) => {
+      getSettlementSchedule().catch(() => null),
+    ]).then(([ps, obs, sch]) => {
       if (!active) return;
       setPeriods(ps);
       setObligations(obs);
+      setSchedule(sch);
     });
     return () => {
       active = false;
@@ -61,6 +66,11 @@ export const useRateTargets = (loads: Load[]) => {
     const weekEarned = getWeekEarnedGross(loads, start, end); // delivered only
     const weekRpm = getWeekRpm(loads, start, end);
     const rollingRpm = getWindowRpm(loads, now);
+    // Your linehaul take (linehaul % + trailer %) grosses a net rate up to the
+    // full rate you must BOOK to clear it. 1 = no cut (own authority / unconfigured).
+    const linehaulTake = schedule
+      ? Number(schedule.linehaul_pct) + Number(schedule.trailer_pct)
+      : 1;
     return {
       basis,
       ladder,
@@ -69,9 +79,10 @@ export const useRateTargets = (loads: Load[]) => {
       weekEarned, // earned this week — delivered only; drives the "hit target" win
       weekRpm, // this week's blended rate — the ladder marker
       rollingRpm, // rolling 3-complete-month RPM — the Avg RPM KPI
+      linehaulTake, // net-rate → booked-rate gross-up factor
       weekStart: start,
       weekEnd: end,
       ready: basis.breakEvenRpm != null,
     };
-  }, [periods, obligationsMonthly, loads]);
+  }, [periods, obligationsMonthly, loads, schedule]);
 };

--- a/frontend/src/lib/metrics/rateTargets.test.ts
+++ b/frontend/src/lib/metrics/rateTargets.test.ts
@@ -7,6 +7,7 @@ import {
   completeMonthsBefore,
   getCostBasis,
   getRateLadder,
+  bookedRate,
   getGrossTargets,
   payWeekRange,
   getWeekBookedGross,
@@ -140,6 +141,18 @@ describe("getRateLadder", () => {
     const l = getRateLadder(null, { minimum: 0.15, target: 0.35, strong: 0.6 });
     expect(l.walkAway).toBeNull();
     expect(l.target).toBeNull();
+  });
+});
+
+describe("bookedRate", () => {
+  it("grosses a net rate up to the full booking rate by the linehaul take", () => {
+    expect(bookedRate(5.4, 0.73)).toBeCloseTo(7.397, 2); // 5.40 / 0.73
+    expect(bookedRate(4.1, 0.73)).toBeCloseTo(5.616, 2);
+  });
+  it("no gross-up at 100% take (own authority); null when net absent or take 0", () => {
+    expect(bookedRate(5, 1)).toBe(5);
+    expect(bookedRate(null, 0.73)).toBeNull();
+    expect(bookedRate(5, 0)).toBeNull();
   });
 });
 

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -142,6 +142,13 @@ export const getRateLadder = (
   };
 };
 
+// The full rate per loaded mile you must BOOK to net a given (net) rate, given
+// your linehaul take = linehaul % + trailer % (e.g. 0.73). Fuel surcharge and
+// accessorials come on top, so this is the conservative linehaul price to quote.
+// take >= 1 (own authority / unconfigured) → returns the net rate unchanged.
+export const bookedRate = (net: number | null, take: number): number | null =>
+  net == null || take <= 0 ? null : take >= 1 ? net : net / take;
+
 const WEEKS_PER_MONTH = 52 / 12;
 
 export interface GrossTargets {

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -16,6 +16,8 @@ import {
 import { getCostBasis, getRateLadder } from "@/lib/metrics/rateTargets";
 import { RATE_TIERS } from "@/lib/constants/targets";
 import { RateLadder } from "@/components/dashboard/RateLadder";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import type { SettlementSchedule } from "@/types/settlementSchedule";
 import { ExpenseUpload } from "@/components/expenses/ExpenseUpload";
 import { ExpenseLedger } from "@/components/expenses/ExpenseLedger";
 import { ExpenseYtdChart } from "@/components/expenses/ExpenseYtdChart";
@@ -64,11 +66,16 @@ const ExpensesPage = () => {
   const [showUpload, setShowUpload] = useState(false);
   const [loading, setLoading] = useState(true);
   const [obligations, setObligations] = useState<Obligation[]>([]);
+  const [schedule, setSchedule] = useState<SettlementSchedule | null>(null);
 
   // Obligations live at the page level so the headline KPIs + chart can fold
   // them into true cost; the card just edits the list and calls this back.
   const reloadObligations = () =>
     getObligations().then(setObligations).catch(() => {});
+
+  useEffect(() => {
+    getSettlementSchedule().then(setSchedule).catch(() => {});
+  }, []);
   useEffect(() => {
     reloadObligations();
   }, []);
@@ -175,6 +182,9 @@ const ExpensesPage = () => {
     [periods, obligationsTotal, loads],
   );
   const rateLadder = getRateLadder(rateBasis.breakEvenRpm, RATE_TIERS);
+  const linehaulTake = schedule
+    ? Number(schedule.linehaul_pct) + Number(schedule.trailer_pct)
+    : 1;
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -264,10 +274,21 @@ const ExpensesPage = () => {
           {rateLadder.walkAway != null && (
             <div className="bg-plate rounded-lg p-4 mb-6">
               <p className="text-xs text-muted-text mb-3">
-                Rate targets · per loaded mile · last {rateBasis.months} complete
-                month{rateBasis.months > 1 ? "s" : ""}
+                Net rate per loaded mile · last {rateBasis.months} complete month
+                {rateBasis.months > 1 ? "s" : ""}
               </p>
-              <RateLadder ladder={rateLadder} rpm={rateBasis.windowRpm} />
+              <RateLadder
+                ladder={rateLadder}
+                rpm={rateBasis.windowRpm}
+                take={linehaulTake}
+              />
+              {linehaulTake < 1 && (
+                <p className="text-[11px] text-muted-text mt-2">
+                  <span style={{ color: "#e8940a" }}>book</span> = full linehaul
+                  rate to quote to clear each tier (you keep{" "}
+                  {Math.round(linehaulTake * 100)}% of the linehaul)
+                </p>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## v1.58.0 — Phase 2: the ladder is a pricing tool again

After Phase 1 made everything net, the rate ladder read in net rate/mile — honest, but you *book* the full rate. This adds the booking rate back.

Each rung now shows **both**:
- **net** — your take-home per loaded mile vs. your cost (the "you $X ▼" marker rides this)
- **book** (amber) — the full linehaul rate you must quote to clear that tier after the cut = `net ÷ your linehaul take` (65% + 8% = 73%). Fuel surcharge rides on top, so it's the conservative floor.

A one-line explainer shows only when a cut applies; someone on their own authority (100% take) sees the clean net ladder with no book line. Wired on the dashboard card **and** the Expenses ladder so they match.

New pure `bookedRate(net, take)` (tested); `useRateTargets` pulls the settlement schedule for the take. Frontend-only, no migration. Build clean, **175 tests** (+2).