### PR TITLE
fix: rate ladder in booking terms (gross rate per mile driven)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.58.0",
+  "version": "1.58.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/RateLadder.tsx
+++ b/frontend/src/components/dashboard/RateLadder.tsx
@@ -1,10 +1,8 @@
 import type { RateLadder as Ladder } from "@/lib/metrics/rateTargets";
-import { bookedRate } from "@/lib/metrics/rateTargets";
 
 interface Props {
   ladder: Ladder;
-  rpm: number | null; // your current rate — the marker (net)
-  take?: number; // linehaul take (linehaul % + trailer %); < 1 adds the "book" line
+  rpm: number | null; // your current rate — the marker
 }
 
 const RED = "#e24b4a";
@@ -14,16 +12,12 @@ const TRACK = "#232c3f";
 
 const rate = (n: number | null): string => (n == null ? "—" : `$${n.toFixed(2)}`);
 
-// Horizontal ladder from walk-away → strong, split at the target tier. The marker
-// shows where the current NET rate lands: red at/below walk-away (losing money),
-// amber below target, green at/above. When a settlement cut applies (take < 1),
-// each rung also shows the full rate you must BOOK to clear it after the cut.
-export const RateLadder = ({ ladder, rpm, take = 1 }: Props) => {
+// Horizontal ladder from walk-away → strong, split at the target tier. A marker
+// shows where the current rate lands: red at/below walk-away (losing money),
+// amber below target, green at/above target.
+export const RateLadder = ({ ladder, rpm }: Props) => {
   const { walkAway, target, strong } = ladder;
   if (walkAway == null || target == null || strong == null) return null;
-
-  const showBook = take > 0 && take < 1;
-  const book = (n: number | null): string => rate(bookedRate(n, take));
 
   const span = strong - walkAway;
   const targetPos = span > 0 ? ((target - walkAway) / span) * 100 : 58;
@@ -33,20 +27,6 @@ export const RateLadder = ({ ladder, rpm, take = 1 }: Props) => {
       : Math.max(0, Math.min(1, (rpm - walkAway) / span)) * 100;
   const markerColor =
     rpm == null ? AMBER : rpm >= target ? GREEN : rpm <= walkAway ? RED : AMBER;
-
-  const rung = (label: string, net: number | null) => (
-    <>
-      {label}
-      <br />
-      <span className="text-light">{rate(net)}</span>
-      {showBook && (
-        <>
-          <br />
-          <span style={{ color: AMBER }}>book {book(net)}</span>
-        </>
-      )}
-    </>
-  );
 
   return (
     <div>
@@ -73,18 +53,24 @@ export const RateLadder = ({ ladder, rpm, take = 1 }: Props) => {
         <div style={{ flex: 1, background: GREEN, opacity: 0.55 }} />
       </div>
 
-      <div
-        className={`relative ${showBook ? "h-12" : "h-8"} mt-1 text-xs text-muted-text`}
-      >
-        <span className="absolute left-0">{rung("walk-away", walkAway)}</span>
+      <div className="relative h-8 mt-1 text-xs text-muted-text">
+        <span className="absolute left-0">
+          walk-away
+          <br />
+          <span className="text-light">{rate(walkAway)}</span>
+        </span>
         <span
           className="absolute text-center"
           style={{ left: `${targetPos}%`, transform: "translateX(-50%)" }}
         >
-          {rung("target", target)}
+          target
+          <br />
+          <span className="text-light">{rate(target)}</span>
         </span>
         <span className="absolute right-0 text-right">
-          {rung("strong", strong)}
+          strong
+          <br />
+          <span className="text-light">{rate(strong)}</span>
         </span>
       </div>
     </div>

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -82,16 +82,17 @@ const TargetBurst = () => (
   </span>
 );
 
-export const RateTargetsCard = ({
-  targets,
-  rpm,
-}: {
-  targets: Targets;
-  rpm?: number | null; // "your rate" marker; defaults to the recent-window rate
-}) => {
-  const { ladder, gross, weekBooked, weekEarned, basis, ready, linehaulTake } =
-    targets;
-  const markerRpm = rpm !== undefined ? rpm : basis.windowRpm;
+export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
+  const {
+    bookingLadder,
+    grossRate,
+    gross,
+    weekBooked,
+    weekEarned,
+    basis,
+    ready,
+    linehaulTake,
+  } = targets;
   const committedAhead = Math.max(0, weekBooked - weekEarned);
   const beatTarget =
     gross.weeklyTarget != null &&
@@ -118,17 +119,14 @@ export const RateTargetsCard = ({
         <div className="grid grid-cols-1 md:grid-cols-[1.6fr_1fr_1fr] gap-6">
           <div>
             <p className="text-xs text-muted-text mb-3">
-              Net rate per loaded mile · marker = this week
+              Rate to book · gross $/mile driven · marker = your rate
             </p>
-            <RateLadder ladder={ladder} rpm={markerRpm} take={linehaulTake} />
-            {linehaulTake < 1 && (
-              <p className="text-[11px] text-muted-text mt-2">
-                <span style={{ color: "#e8940a" }}>book</span> = full linehaul
-                rate to quote to clear each tier (you keep{" "}
-                {Math.round(linehaulTake * 100)}% of the linehaul; fuel surcharge
-                is on top)
-              </p>
-            )}
+            <RateLadder ladder={bookingLadder} rpm={grossRate} />
+            <p className="text-[11px] text-muted-text mt-2">
+              walk-away = your cost/mile ÷ your{" "}
+              {Math.round(linehaulTake * 100)}% keep. Book above it — with your
+              deadhead in the miles — and you clear cost.
+            </p>
           </div>
 
           <div>

--- a/frontend/src/hooks/useRateTargets.ts
+++ b/frontend/src/hooks/useRateTargets.ts
@@ -71,15 +71,25 @@ export const useRateTargets = (loads: Load[]) => {
     const linehaulTake = schedule
       ? Number(schedule.linehaul_pct) + Number(schedule.trailer_pct)
       : 1;
+    // The booking ladder is in Jason's terms: GROSS rate to book, per mile DRIVEN
+    // (deadhead already folded into total miles) = cost-per-total-mile ÷ your keep,
+    // then scaled by the tiers. The marker is your actual gross rate per mile.
+    const bookingBase =
+      basis.costPerTotalMile != null && linehaulTake > 0
+        ? basis.costPerTotalMile / linehaulTake
+        : null;
+    const bookingLadder = getRateLadder(bookingBase, RATE_TIERS);
     return {
       basis,
       ladder,
       gross,
       weekBooked, // committed this week — booked + in-transit + delivered
       weekEarned, // earned this week — delivered only; drives the "hit target" win
-      weekRpm, // this week's blended rate — the ladder marker
+      weekRpm, // this week's blended rate
       rollingRpm, // rolling 3-complete-month RPM — the Avg RPM KPI
-      linehaulTake, // net-rate → booked-rate gross-up factor
+      linehaulTake,
+      bookingLadder, // gross rate to book per mile driven (walk-away/target/strong)
+      grossRate: basis.grossPerTotalMile, // your actual gross rate/mile — the marker
       weekStart: start,
       weekEnd: end,
       ready: basis.breakEvenRpm != null,

--- a/frontend/src/lib/metrics/rateTargets.test.ts
+++ b/frontend/src/lib/metrics/rateTargets.test.ts
@@ -106,6 +106,10 @@ describe("getCostBasis", () => {
     expect(b.breakEvenRpm).toBeCloseTo(6.0, 5);
     // your rate = revenue (24k) / loaded (6000) = 4.00
     expect(b.windowRpm).toBeCloseTo(4.0, 5);
+    // cost per TOTAL mile (deadhead included) = 36k / 7500 = 4.80
+    expect(b.costPerTotalMile).toBeCloseTo(4.8, 5);
+    // your gross rate per total mile = gross (24k) / 7500 = 3.20
+    expect(b.grossPerTotalMile).toBeCloseTo(3.2, 5);
   });
 
   it("skips months with no P&L, keeping cost and miles aligned", () => {
@@ -125,6 +129,17 @@ describe("getCostBasis", () => {
     expect(b.months).toBe(0);
     expect(b.trueMonthlyCost).toBeNull();
     expect(b.breakEvenRpm).toBeNull();
+  });
+});
+
+describe("booking ladder (gross rate to book per mile driven)", () => {
+  it("walk-away = cost per total mile ÷ keep; tiers scale from there", () => {
+    // Jason: $3.17 cost/total mile ÷ 0.73 keep = $4.34 gross to book
+    const walkAway = 3.165 / 0.73;
+    const l = getRateLadder(walkAway, { minimum: 0.15, target: 0.35, strong: 0.6 });
+    expect(l.walkAway).toBeCloseTo(4.34, 2);
+    expect(l.target).toBeCloseTo(4.34 * 1.35, 1);
+    expect(l.strong).toBeCloseTo(4.34 * 1.6, 1);
   });
 });
 

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -59,16 +59,19 @@ const monthMiles = (loads: Load[], year: number, month: number) => {
     0,
   );
   const loaded = inMonth.reduce((s, l) => s + Number(l.loaded_miles || 0), 0);
-  const revenue = inMonth.reduce((s, l) => s + loadRevenue(l), 0);
-  return { total, loaded, revenue };
+  const revenue = inMonth.reduce((s, l) => s + loadRevenue(l), 0); // net
+  const gross = inMonth.reduce((s, l) => s + loadGross(l), 0); // full customer rate
+  return { total, loaded, revenue, gross };
 };
 
 export interface CostBasis {
   trueMonthlyCost: number | null; // avg monthly true cost over included months
   loadedMiles: number; // summed over included months
   totalMiles: number;
-  breakEvenRpm: number | null; // true cost ÷ loaded miles = the walk-away rate
-  windowRpm: number | null; // revenue ÷ loaded miles over the window (your rate)
+  breakEvenRpm: number | null; // true cost ÷ LOADED miles (net break-even/mile)
+  windowRpm: number | null; // net revenue ÷ loaded miles over the window
+  costPerTotalMile: number | null; // true cost ÷ TOTAL miles — cost per mile driven
+  grossPerTotalMile: number | null; // full gross ÷ TOTAL miles — your booked rate/mile
   months: number; // months with a P&L that were actually included
 }
 
@@ -92,6 +95,7 @@ export const getCostBasis = (
   let loaded = 0;
   let total = 0;
   let revenue = 0;
+  let grossRev = 0;
   let n = 0;
   for (const { year, month } of completeMonthsBefore(now, monthsBack)) {
     const p = byKey.get(`${year}-${month}`);
@@ -102,6 +106,7 @@ export const getCostBasis = (
     loaded += m.loaded;
     total += m.total;
     revenue += m.revenue;
+    grossRev += m.gross;
   }
 
   return {
@@ -110,6 +115,8 @@ export const getCostBasis = (
     totalMiles: total,
     breakEvenRpm: loaded > 0 ? cost / loaded : null,
     windowRpm: loaded > 0 ? revenue / loaded : null,
+    costPerTotalMile: total > 0 ? cost / total : null,
+    grossPerTotalMile: total > 0 ? grossRev / total : null,
     months: n,
   };
 };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -175,7 +175,7 @@ const DashboardPage = () => {
 
       {/* Rate & pace targets */}
       <div className="mt-6">
-        <RateTargetsCard targets={targets} rpm={targets.weekRpm} />
+        <RateTargetsCard targets={targets} />
       </div>
 
       {/* The grind — weekly target-beating streak */}

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -181,10 +181,16 @@ const ExpensesPage = () => {
     () => getCostBasis(periods, obligationsTotal, loads, new Date()),
     [periods, obligationsTotal, loads],
   );
-  const rateLadder = getRateLadder(rateBasis.breakEvenRpm, RATE_TIERS);
   const linehaulTake = schedule
     ? Number(schedule.linehaul_pct) + Number(schedule.trailer_pct)
     : 1;
+  // Booking ladder in Jason's terms: gross rate to book per mile driven =
+  // cost-per-total-mile ÷ keep, scaled by tiers. Marker = actual gross rate/mile.
+  const bookingBase =
+    rateBasis.costPerTotalMile != null && linehaulTake > 0
+      ? rateBasis.costPerTotalMile / linehaulTake
+      : null;
+  const rateLadder = getRateLadder(bookingBase, RATE_TIERS);
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -274,21 +280,15 @@ const ExpensesPage = () => {
           {rateLadder.walkAway != null && (
             <div className="bg-plate rounded-lg p-4 mb-6">
               <p className="text-xs text-muted-text mb-3">
-                Net rate per loaded mile · last {rateBasis.months} complete month
-                {rateBasis.months > 1 ? "s" : ""}
+                Rate to book · gross $/mile driven · last {rateBasis.months}{" "}
+                complete month{rateBasis.months > 1 ? "s" : ""}
               </p>
-              <RateLadder
-                ladder={rateLadder}
-                rpm={rateBasis.windowRpm}
-                take={linehaulTake}
-              />
-              {linehaulTake < 1 && (
-                <p className="text-[11px] text-muted-text mt-2">
-                  <span style={{ color: "#e8940a" }}>book</span> = full linehaul
-                  rate to quote to clear each tier (you keep{" "}
-                  {Math.round(linehaulTake * 100)}% of the linehaul)
-                </p>
-              )}
+              <RateLadder ladder={rateLadder} rpm={rateBasis.grossPerTotalMile} />
+              <p className="text-[11px] text-muted-text mt-2">
+                walk-away = your cost/mile ÷ your{" "}
+                {Math.round(linehaulTake * 100)}% keep. Book above it with your
+                deadhead folded into the miles and you clear cost.
+              </p>
             </div>
           )}
 


### PR DESCRIPTION
## v1.58.1 — the rate ladder in Jason's booking terms

The ladder was reading in net $/loaded mile. Jason books in **gross $/mile driven** — he folds his deadhead into the miles himself, so his floor is per mile *driven*. This makes the ladder match that.

- **Walk-away = cost-per-total-mile ÷ your linehaul keep.** His $3.17 ÷ 0.73 = **$4.34**, scaling through the 15/35/60% tiers. Marker = your actual gross rate per mile (gross ÷ total miles = **$4.52**).
- **`getCostBasis`** gains `costPerTotalMile` + `grossPerTotalMile`; `useRateTargets` builds the booking ladder off them.
- **Reverts the v1.58.0 "book $X" per-rung annotation** — plotting a net marker next to gross rungs is what set off the whole confusion.
- Same treatment on the Expenses ladder.
- Conservative by design: FSC + accessorials come 100% on top of the 73%, so the real cushion exceeds the $4.34→$4.52 gap.

Verified against real data: cost/total $3.17, walk-away $4.34, marker $4.52. Frontend-only, no migration. Build clean, **176 tests**.