### PR TITLE
feat: rate & pace card in gross booking dollars + all tiers on the bar

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.58.1",
+  "version": "1.58.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -11,24 +11,35 @@ const TRACK = "#232c3f";
 const money = (n: number | null): string =>
   n == null ? "—" : `$${Math.round(n).toLocaleString("en-US")}`;
 
-// This week's gross vs floor (break-even) + target. The solid bar is EARNED
-// (delivered) freight — what actually counts; the faded extension is COMMITTED
-// (booked/in-transit) pipeline still to haul. Color grades off earned.
+// This week's gross vs floor (break-even), target, and strong. The bar spans to
+// STRONG; solid fill is EARNED (delivered), the faded extension is COMMITTED
+// (booked/in-transit) still to haul. Floor + target are ticks. Color grades off
+// earned vs the floor/target thresholds.
 const PaceBar = ({
   earned,
   committed,
   floor,
+  minimum,
   target,
+  strong,
 }: {
   earned: number;
   committed: number;
   floor: number;
+  minimum: number;
   target: number;
+  strong: number;
 }) => {
-  const frac = (v: number) =>
-    target > 0 ? Math.max(0, Math.min(1, v / target)) : 0;
-  const floorPos = target > 0 ? Math.min(1, floor / target) : 0;
+  const max = strong > 0 ? strong : target;
+  const frac = (v: number) => (max > 0 ? Math.max(0, Math.min(1, v / max)) : 0);
   const color = earned >= target ? GREEN : earned >= floor ? AMBER : RED;
+  const tick = (v: number, title: string) => (
+    <div
+      className="absolute top-0 h-2"
+      style={{ left: `${frac(v) * 100}%`, width: 2, background: "#ebedf5" }}
+      title={title}
+    />
+  );
   return (
     <div className="relative h-2 rounded mt-2 mb-1" style={{ background: TRACK }}>
       <div
@@ -39,11 +50,9 @@ const PaceBar = ({
         className="absolute left-0 top-0 h-2 rounded"
         style={{ width: `${frac(earned) * 100}%`, background: color }}
       />
-      <div
-        className="absolute top-0 h-2"
-        style={{ left: `${floorPos * 100}%`, width: 2, background: "#ebedf5" }}
-        title="break-even floor"
-      />
+      {tick(floor, "break-even floor")}
+      {tick(minimum, "minimum")}
+      {tick(target, "target")}
     </div>
   );
 };
@@ -87,6 +96,8 @@ export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
     bookingLadder,
     grossRate,
     gross,
+    weeklyMinimum,
+    weeklyStrong,
     weekBooked,
     weekEarned,
     basis,
@@ -105,7 +116,7 @@ export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
         <p className="text-sm font-medium text-light">Rate &amp; pace targets</p>
         <p className="text-xs text-muted-text">
           {ready
-            ? `live · last ${basis.months} complete month${basis.months > 1 ? "s" : ""}`
+            ? `live · gross $ · last ${basis.months} complete month${basis.months > 1 ? "s" : ""}`
             : "needs P&L history"}
         </p>
       </div>
@@ -130,7 +141,7 @@ export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
           </div>
 
           <div>
-            <p className="text-xs text-muted-text">This week · earned</p>
+            <p className="text-xs text-muted-text">This week · earned (gross)</p>
             <div className="flex items-center gap-2">
               <p className="text-xl font-condensed mt-1">{money(weekEarned)}</p>
               {beatTarget && <TargetBurst />}
@@ -139,11 +150,13 @@ export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
               earned={weekEarned}
               committed={weekBooked}
               floor={gross.weeklyBreakEven ?? 0}
+              minimum={weeklyMinimum ?? 0}
               target={gross.weeklyTarget ?? 0}
+              strong={weeklyStrong ?? 0}
             />
             <p className="text-xs text-muted-text">
-              floor {money(gross.weeklyBreakEven)} · target{" "}
-              {money(gross.weeklyTarget)}
+              floor {money(gross.weeklyBreakEven)} · min {money(weeklyMinimum)} ·
+              target {money(gross.weeklyTarget)} · strong {money(weeklyStrong)}
             </p>
             {committedAhead > 0 && (
               <p className="text-xs mt-1 text-muted-text">

--- a/frontend/src/hooks/useRateTargets.ts
+++ b/frontend/src/hooks/useRateTargets.ts
@@ -11,9 +11,8 @@ import {
   getRateLadder,
   getGrossTargets,
   payWeekRange,
-  getWeekBookedGross,
-  getWeekEarnedGross,
-  getWeekRpm,
+  getWeekGrossCommitted,
+  getWeekGrossEarned,
   getWindowRpm,
 } from "@/lib/metrics/rateTargets";
 import {
@@ -55,41 +54,61 @@ export const useRateTargets = (loads: Load[]) => {
   return useMemo(() => {
     const now = new Date();
     const basis = getCostBasis(periods, obligationsMonthly, loads, now);
-    const ladder = getRateLadder(basis.breakEvenRpm, RATE_TIERS);
-    const gross = getGrossTargets(
-      basis.trueMonthlyCost,
-      RATE_TIERS.target,
-      WORKING_DAYS_PER_MONTH,
-    );
-    const { start, end } = payWeekRange(now, PAY_WEEK_START_DOW);
-    const weekBooked = getWeekBookedGross(loads, start, end); // committed (all non-cancelled)
-    const weekEarned = getWeekEarnedGross(loads, start, end); // delivered only
-    const weekRpm = getWeekRpm(loads, start, end);
-    const rollingRpm = getWindowRpm(loads, now);
-    // Your linehaul take (linehaul % + trailer %) grosses a net rate up to the
-    // full rate you must BOOK to clear it. 1 = no cut (own authority / unconfigured).
+    // Your linehaul take (linehaul % + trailer %). 1 = own authority / unconfigured.
     const linehaulTake = schedule
       ? Number(schedule.linehaul_pct) + Number(schedule.trailer_pct)
       : 1;
-    // The booking ladder is in Jason's terms: GROSS rate to book, per mile DRIVEN
-    // (deadhead already folded into total miles) = cost-per-total-mile ÷ your keep,
-    // then scaled by the tiers. The marker is your actual gross rate per mile.
+    const { start, end } = payWeekRange(now, PAY_WEEK_START_DOW);
+
+    // ---- The whole rate & pace card is in GROSS (booking) dollars — that's the
+    // number loads are booked at. Everything below grosses cost up by your keep. ----
+
+    // Ladder: gross rate to book per mile DRIVEN (deadhead folded into total miles)
+    // = cost-per-total-mile ÷ keep, scaled by tiers; marker = your gross rate/mile.
     const bookingBase =
       basis.costPerTotalMile != null && linehaulTake > 0
         ? basis.costPerTotalMile / linehaulTake
         : null;
     const bookingLadder = getRateLadder(bookingBase, RATE_TIERS);
+
+    // Weekly/daily GROSS to book = monthly cost grossed up by your keep, spread over
+    // the pay-week / working day, plus the target markup.
+    const bookingCost =
+      basis.trueMonthlyCost != null && linehaulTake > 0
+        ? basis.trueMonthlyCost / linehaulTake
+        : null;
+    const gross = getGrossTargets(
+      bookingCost,
+      RATE_TIERS.target,
+      WORKING_DAYS_PER_MONTH,
+    );
+    // Weekly MINIMUM (+15%) and STRONG (+60%) tiers — the extra ticks on the pace
+    // bar (floor · min · target · strong).
+    const weeklyMinimum =
+      gross.weeklyBreakEven != null
+        ? gross.weeklyBreakEven * (1 + RATE_TIERS.minimum)
+        : null;
+    const weeklyStrong =
+      gross.weeklyBreakEven != null
+        ? gross.weeklyBreakEven * (1 + RATE_TIERS.strong)
+        : null;
+
+    // This week's gross booked (committed) + gross delivered (earned).
+    const weekBooked = getWeekGrossCommitted(loads, start, end);
+    const weekEarned = getWeekGrossEarned(loads, start, end);
+
+    const rollingRpm = getWindowRpm(loads, now); // net RPM — the Avg RPM KPI
     return {
       basis,
-      ladder,
-      gross,
-      weekBooked, // committed this week — booked + in-transit + delivered
-      weekEarned, // earned this week — delivered only; drives the "hit target" win
-      weekRpm, // this week's blended rate
-      rollingRpm, // rolling 3-complete-month RPM — the Avg RPM KPI
+      gross, // weekly/daily GROSS dollars to book (break-even + target)
+      weeklyMinimum, // weekly +15% tier (gross)
+      weeklyStrong, // weekly +60% stretch tier (gross)
+      weekBooked, // this week's gross committed (booked + in-transit + delivered)
+      weekEarned, // this week's gross earned (delivered only)
+      rollingRpm,
       linehaulTake,
       bookingLadder, // gross rate to book per mile driven (walk-away/target/strong)
-      grossRate: basis.grossPerTotalMile, // your actual gross rate/mile — the marker
+      grossRate: basis.grossPerTotalMile, // your gross rate/mile — the ladder marker
       weekStart: start,
       weekEnd: end,
       ready: basis.breakEvenRpm != null,

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -233,6 +233,25 @@ export const getWeekEarnedGross = (
     .filter((l) => l.load_status === "delivered")
     .reduce((s, l) => s + loadRevenue(l), 0);
 
+// This week's GROSS dollars (full customer rate) — for the rate & pace card, which
+// tracks in gross because that's the number loads are booked at. Committed = all
+// non-cancelled in the week; earned = delivered only. (Distinct from the two above,
+// which sum NET revenue for the grind streak.)
+export const getWeekGrossCommitted = (
+  loads: Load[],
+  start: Date,
+  end: Date,
+): number => loadsInWeek(loads, start, end).reduce((s, l) => s + loadGross(l), 0);
+
+export const getWeekGrossEarned = (
+  loads: Load[],
+  start: Date,
+  end: Date,
+): number =>
+  loadsInWeek(loads, start, end)
+    .filter((l) => l.load_status === "delivered")
+    .reduce((s, l) => s + loadGross(l), 0);
+
 // This week's blended rate per loaded mile — where you're landing right now.
 export const getWeekRpm = (
   loads: Load[],

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -116,7 +116,7 @@ const DashboardPage = () => {
   // ---- threshold-based status ----
   // Live break-even (true cost ÷ loaded miles, last 3 complete months); falls
   // back to the constant until there's enough P&L history.
-  const liveBreakEven = targets.ladder.walkAway ?? BREAK_EVEN_RPM;
+  const liveBreakEven = targets.basis.breakEvenRpm ?? BREAK_EVEN_RPM;
   const rpmStatus =
     avgRpm === null ? "neutral" : avgRpm >= liveBreakEven ? "good" : "bad";
   const deadheadStatus =


### PR DESCRIPTION
## v1.58.2 — the rate & pace card, all gross, all tiers

Jason books in gross dollars, so the whole card now reads that way.

- **This week · earned / committed** → gross (`loadGross`).
- **Weekly + daily break-even / target** → grossed up by the linehaul keep (monthly cost ÷ keep, spread over the pay-week / working days). They read higher than before because they're the gross you must *book*, not the net you keep. Subtitle now says **"gross $"**.
- **Pace bar shows all four weekly tiers** — spans to **strong**, with **floor · minimum · target · strong** ticks and their dollar values, so every weekly goal is visible at a glance.
- **Net revenue + Net RPM KPIs stay net** — take-home is a separate question from what to book.

New `getWeekGrossCommitted` / `getWeekGrossEarned`; `useRateTargets` exposes `weeklyMinimum` / `weeklyStrong`. `DashboardPage`'s Net-RPM status now reads `basis.breakEvenRpm` directly (was the removed net ladder).

Verified against real data: weekly floor ~$7,462 · min ~$8,581 · target ~$10,074 · strong ~$11,939. Frontend-only, no migration. Build clean, **176 tests**.