### PR TITLE
fix: per-type accessorial pay rates in net revenue

### DIFF
--- a/backend/db/migrations/034_accessorial_pay_rates.sql
+++ b/backend/db/migrations/034_accessorial_pay_rates.sql
@@ -1,0 +1,17 @@
+-- Per-user, per-type accessorial pay rate. A load's accessorials aren't all paid
+-- at the same percentage: for Jason's Landstar flatbed, tarp/fuel-surcharge/
+-- detention/tolls/loading pay 100%, hazmat/stop-offs and anything unlisted pay
+-- 73% (his 65% tractor + 8% trailer, same as linehaul), and excess-value (EVC)
+-- pays 0% (Landstar keeps it). Verified against his actual settlement statements.
+--
+-- Net computation looks up each accessorial's rate here by exact type string; a
+-- type with no row falls back to settlement_schedules.accessorial_pct (the user's
+-- default). Empty table (or default schedule) keeps net = gross, as before.
+CREATE TABLE IF NOT EXISTS accessorial_pay_rates (
+  user_id          uuid NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  accessorial_type text NOT NULL,
+  pay_pct          numeric NOT NULL DEFAULT 1.0 CHECK (pay_pct >= 0 AND pay_pct <= 2),
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, accessorial_type)
+);

--- a/backend/src/services/loadServices.js
+++ b/backend/src/services/loadServices.js
@@ -42,8 +42,14 @@ export async function getLoads(user_id) {
             ROUND(
               linehaul * (COALESCE(ss.linehaul_pct, 1) + COALESCE(ss.trailer_pct, 0))
               + fuel_surcharge * COALESCE(ss.fuel_surcharge_pct, 1)
-              + (SELECT COALESCE(SUM(amount), 0) FROM accessorials WHERE load_id = loads.load_id)
-                * COALESCE(ss.accessorial_pct, 1)
+              + (SELECT COALESCE(SUM(
+                     a.amount * COALESCE(apr.pay_pct, COALESCE(ss.accessorial_pct, 1))
+                   ), 0)
+                 FROM accessorials a
+                 LEFT JOIN accessorial_pay_rates apr
+                   ON apr.user_id = loads.user_id
+                   AND apr.accessorial_type = a.accessorial_type
+                 WHERE a.load_id = loads.load_id)
             , 2) AS net_revenue,
             commodity,
             weight,
@@ -118,8 +124,14 @@ export async function getLoad(user_id, load_id) {
             ROUND(
               linehaul * (COALESCE(ss.linehaul_pct, 1) + COALESCE(ss.trailer_pct, 0))
               + fuel_surcharge * COALESCE(ss.fuel_surcharge_pct, 1)
-              + (SELECT COALESCE(SUM(amount), 0) FROM accessorials WHERE load_id = l.load_id)
-                * COALESCE(ss.accessorial_pct, 1)
+              + (SELECT COALESCE(SUM(
+                     a.amount * COALESCE(apr.pay_pct, COALESCE(ss.accessorial_pct, 1))
+                   ), 0)
+                 FROM accessorials a
+                 LEFT JOIN accessorial_pay_rates apr
+                   ON apr.user_id = l.user_id
+                   AND apr.accessorial_type = a.accessorial_type
+                 WHERE a.load_id = l.load_id)
             , 2) AS net_revenue,
             commodity,
             weight,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.58.2",
+  "version": "1.58.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.58.3 — accessorials paid at their real per-type rate

The settlement schedule paid every accessorial at a flat 100%. But Jason's Landstar settlements show they're not equal:

| Accessorial | Rate | Source |
|---|---|---|
| Tarp, Fuel Surcharge, Detention, Tolls, Loading | **100%** | ICOA Appendix A-1 |
| Hazmat, Stop-Offs, unlisted | **73%** | 65% tractor + 8% trailer — verified on settlement 05-27 |
| High Value / EVC | **0%** | Landstar keeps it — verified (no line on settlement 04-29) |

The trailer 8% rides on accessorials just like linehaul, so the honest unlisted default is 73%, not 65%. EVC is excess-value insurance Landstar retains entirely.

- Migration `034` — `accessorial_pay_rates` (per-user, per-type).
- `getLoads`/`getLoad` net looks up each accessorial's rate, falling back to `settlement_schedules.accessorial_pct` (his default = 73%).
- **Prod seeded** with his 12 actual line-item names before merge, so the backend deploy lands on a ready table.

**Verified on prod:** hazmat load 6723509 → $4,041.12 (hazmat + stop drop to 73%, detention stays 100%); EVC load 7413468 → $4,138.15 (EVC $582.80 fully excluded, tarp stays 100%). Both match the settlements.

Deferred: accessorial-entry dropdown, spelling consolidation, Settings editor. Backend-only.