### PR TITLE
feat: accessorial rate editor + load-entry dropdown

### DIFF
--- a/backend/src/routes/accessorialRateRoutes.js
+++ b/backend/src/routes/accessorialRateRoutes.js
@@ -1,0 +1,52 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import {
+  getAccessorialRates,
+  upsertAccessorialRate,
+  deleteAccessorialRate,
+} from "../services/accessorialRateServices.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+const handleError = (res, err) => {
+  if (err.type === "validation")
+    return res.status(err.statusCode).json({ error: err.message });
+  if (err.type === "not_found")
+    return res.status(err.statusCode).json({ error: err.message });
+  return res
+    .status(500)
+    .json({ error: "Internal Server Error", message: err.message });
+};
+
+router.get("/", async (req, res) => {
+  try {
+    const rates = await getAccessorialRates(req.user.user_id);
+    return res.status(200).json({ rates });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.put("/", async (req, res) => {
+  try {
+    const rate = await upsertAccessorialRate(req.user.user_id, req.body);
+    return res.status(200).json({ rate });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+router.delete("/:type", async (req, res) => {
+  try {
+    const deleted = await deleteAccessorialRate(
+      req.user.user_id,
+      decodeURIComponent(req.params.type),
+    );
+    return res.status(200).json({ deleted });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -25,6 +25,7 @@ import avatarRouter from "./routes/avatarRoutes.js";
 import complianceRouter from "./routes/complianceRoutes.js";
 import trophyRouter from "./routes/trophyRoutes.js";
 import settlementScheduleRouter from "./routes/settlementScheduleRoutes.js";
+import accessorialRateRouter from "./routes/accessorialRateRoutes.js";
 
 const app = express();
 
@@ -57,6 +58,7 @@ app.use("/trophies", trophyRouter);
 app.use("/trailers", trailerRouter);
 app.use("/avatars", avatarRouter);
 app.use("/settlement-schedule", settlementScheduleRouter);
+app.use("/accessorial-rates", accessorialRateRouter);
 
 app.get("/", (req, res) => {
   res.send("Home Page");

--- a/backend/src/services/accessorialRateServices.js
+++ b/backend/src/services/accessorialRateServices.js
@@ -1,0 +1,51 @@
+import { db } from "../../db/pool.js";
+import { ValidationError, NotFoundError } from "../utils/error.js";
+
+// ---- LIST ---- (the user's accessorial types + pay rates; drives the Settings
+// editor and the load-entry dropdown)
+export async function getAccessorialRates(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const result = await db.query(
+    `SELECT accessorial_type, pay_pct
+       FROM accessorial_pay_rates
+      WHERE user_id = $1
+      ORDER BY accessorial_type`,
+    [user_id],
+  );
+  return result.rows;
+}
+
+// ---- UPSERT ---- (add a type or change its rate)
+export async function upsertAccessorialRate(user_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const accessorial_type = (data.accessorial_type ?? "").trim();
+  if (!accessorial_type) throw new ValidationError("accessorial_type is required");
+  const pct = Number(data.pay_pct);
+  if (!Number.isFinite(pct) || pct < 0 || pct > 2)
+    throw new ValidationError("pay_pct must be a fraction between 0 and 2");
+
+  const result = await db.query(
+    `INSERT INTO accessorial_pay_rates (user_id, accessorial_type, pay_pct)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (user_id, accessorial_type)
+       DO UPDATE SET pay_pct = EXCLUDED.pay_pct, updated_at = NOW()
+     RETURNING accessorial_type, pay_pct`,
+    [user_id, accessorial_type, pct],
+  );
+  return result.rows[0];
+}
+
+// ---- DELETE ---- (remove a type from the list)
+export async function deleteAccessorialRate(user_id, accessorial_type) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!accessorial_type) throw new ValidationError("Missing accessorial_type");
+  const result = await db.query(
+    `DELETE FROM accessorial_pay_rates
+      WHERE user_id = $1 AND accessorial_type = $2
+     RETURNING accessorial_type`,
+    [user_id, accessorial_type],
+  );
+  if (result.rowCount === 0)
+    throw new NotFoundError("Accessorial rate not found");
+  return result.rows[0];
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.58.3",
+  "version": "1.59.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/settings/AccessorialRatesCard.tsx
+++ b/frontend/src/components/settings/AccessorialRatesCard.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react";
+import { Trash2, Plus } from "lucide-react";
+import type { AccessorialRate } from "@/types/accessorialRate";
+import {
+  getAccessorialRates,
+  upsertAccessorialRate,
+  deleteAccessorialRate,
+} from "@/services/accessorialRateService";
+
+const errText = (e: unknown): string =>
+  (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+  "Something went wrong — try again.";
+
+export const AccessorialRatesCard = () => {
+  const [rates, setRates] = useState<AccessorialRate[] | null>(null);
+  const [newType, setNewType] = useState("");
+  const [newPct, setNewPct] = useState(73);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const load = () =>
+    getAccessorialRates()
+      .then(setRates)
+      .catch(() => setErr("Couldn't load your accessorial rates."));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const setLocalPct = (type: string, pctInt: number) =>
+    setRates((rs) =>
+      rs
+        ? rs.map((r) =>
+            r.accessorial_type === type ? { ...r, pay_pct: pctInt / 100 } : r,
+          )
+        : rs,
+    );
+
+  const commit = async (type: string, pctInt: number) => {
+    setMsg(null);
+    setErr(null);
+    try {
+      await upsertAccessorialRate(type, pctInt / 100);
+      setMsg(`Saved ${type}.`);
+    } catch (e) {
+      setErr(errText(e));
+      load();
+    }
+  };
+
+  const remove = async (type: string) => {
+    setMsg(null);
+    setErr(null);
+    try {
+      await deleteAccessorialRate(type);
+      await load();
+    } catch (e) {
+      setErr(errText(e));
+    }
+  };
+
+  const add = async () => {
+    const t = newType.trim();
+    if (!t) return;
+    setMsg(null);
+    setErr(null);
+    try {
+      await upsertAccessorialRate(t, newPct / 100);
+      setNewType("");
+      setNewPct(73);
+      await load();
+    } catch (e) {
+      setErr(errText(e));
+    }
+  };
+
+  return (
+    <div className="mt-6 max-w-[680px] bg-plate rounded-lg p-5">
+      <h2 className="text-lg font-medium text-light">Accessorial rates</h2>
+      <p className="text-sm text-muted-text mt-1">
+        What you keep of each accessorial charge. These feed your net revenue and
+        the dropdown when you add a charge to a load. Anything not listed here
+        falls back to your default accessorial rate above.
+      </p>
+
+      {!rates ? (
+        <p className="text-muted-text mt-5">Loading…</p>
+      ) : (
+        <div className="mt-4">
+          <div className="flex flex-col gap-2">
+            {rates.map((r) => (
+              <div
+                key={r.accessorial_type}
+                className="flex items-center gap-3 rounded px-3 py-2"
+                style={{ background: "#0d1119" }}
+              >
+                <span className="text-sm text-light flex-1">
+                  {r.accessorial_type}
+                </span>
+                <input
+                  type="number"
+                  min={0}
+                  max={200}
+                  step={1}
+                  value={Math.round(r.pay_pct * 100)}
+                  onChange={(e) =>
+                    setLocalPct(r.accessorial_type, Number(e.target.value))
+                  }
+                  onBlur={(e) =>
+                    commit(r.accessorial_type, Number(e.target.value))
+                  }
+                  className="w-20 bg-steel rounded px-2 py-1 text-light text-right tabular-nums"
+                />
+                <span className="text-muted-text text-sm">%</span>
+                <button
+                  onClick={() => remove(r.accessorial_type)}
+                  className="text-muted-text hover:text-destructive"
+                  aria-label={`Delete ${r.accessorial_type}`}
+                >
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-2 mt-3">
+            <input
+              type="text"
+              placeholder="New accessorial (e.g. Lumper)"
+              value={newType}
+              onChange={(e) => setNewType(e.target.value)}
+              className="flex-1 bg-steel rounded px-2 py-1.5 text-light text-sm"
+            />
+            <input
+              type="number"
+              min={0}
+              max={200}
+              step={1}
+              value={newPct}
+              onChange={(e) => setNewPct(Number(e.target.value))}
+              className="w-20 bg-steel rounded px-2 py-1.5 text-light text-right tabular-nums"
+            />
+            <span className="text-muted-text text-sm">%</span>
+            <button
+              onClick={add}
+              disabled={!newType.trim()}
+              className="bg-amber text-steel px-3 py-1.5 rounded text-sm font-semibold flex items-center gap-1 disabled:opacity-50"
+            >
+              <Plus size={14} /> Add
+            </button>
+          </div>
+
+          {msg && (
+            <p className="text-status-positive-text text-sm mt-3">{msg}</p>
+          )}
+          {err && <p className="text-destructive text-sm mt-3">{err}</p>}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -14,6 +14,7 @@ import { createAccessorial } from "@/services/createAccessorialService";
 import { deleteAccessorial } from "@/services/deleteAccessorialService";
 import { patchAccessorial } from "@/services/patchAccessorialService";
 import { deleteLoad } from "@/services/deleteLoadService";
+import { getAccessorialRates } from "@/services/accessorialRateService";
 
 import LoadForm from "@/components/LoadForm";
 import { StatusBadge } from "@/components/StatusBadge";
@@ -73,6 +74,8 @@ export const LoadDetailPage = () => {
 
   const [newType, setNewType] = useState("");
   const [newAmount, setNewAmount] = useState("");
+  const [accTypes, setAccTypes] = useState<string[]>([]);
+  const [otherMode, setOtherMode] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [statusSel, setStatusSel] = useState("");
   const [paymentSel, setPaymentSel] = useState("");
@@ -95,6 +98,12 @@ export const LoadDetailPage = () => {
       setPaymentSel(load.payment_status);
     }
   }, [load]);
+
+  useEffect(() => {
+    getAccessorialRates()
+      .then((rs) => setAccTypes(rs.map((r) => r.accessorial_type)))
+      .catch(() => {});
+  }, []);
 
   if (isLoading)
     return (
@@ -151,6 +160,7 @@ export const LoadDetailPage = () => {
     } finally {
       setNewType("");
       setNewAmount("");
+      setOtherMode(false);
     }
   };
 
@@ -657,12 +667,36 @@ export const LoadDetailPage = () => {
         )}
 
         <div className="flex flex-wrap gap-2 mt-3">
-          <input
-            className="bg-steel rounded px-2 py-1.5 text-sm flex-1 min-w-[160px] text-light placeholder:text-muted-text"
-            placeholder="Type — e.g. Layover"
-            value={newType}
-            onChange={(e) => setNewType(e.target.value)}
-          />
+          {otherMode ? (
+            <input
+              className="bg-steel rounded px-2 py-1.5 text-sm flex-1 min-w-[160px] text-light placeholder:text-muted-text"
+              placeholder="New accessorial type"
+              value={newType}
+              onChange={(e) => setNewType(e.target.value)}
+              autoFocus
+            />
+          ) : (
+            <select
+              className="bg-steel rounded px-2 py-1.5 text-sm flex-1 min-w-[160px] text-light"
+              value={newType}
+              onChange={(e) => {
+                if (e.target.value === "__other__") {
+                  setOtherMode(true);
+                  setNewType("");
+                } else {
+                  setNewType(e.target.value);
+                }
+              }}
+            >
+              <option value="">Accessorial type…</option>
+              {accTypes.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+              <option value="__other__">Other…</option>
+            </select>
+          )}
           <input
             className="bg-steel rounded px-2 py-1.5 text-sm w-28 text-light placeholder:text-muted-text"
             placeholder="0.00"

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,6 +3,7 @@ import {
   getSettlementSchedule,
   updateSettlementSchedule,
 } from "@/services/settlementScheduleService";
+import { AccessorialRatesCard } from "@/components/settings/AccessorialRatesCard";
 
 const money = (n: number) =>
   `$${n.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
@@ -180,6 +181,8 @@ const SettingsPage = () => {
           </>
         )}
       </div>
+
+      <AccessorialRatesCard />
     </div>
   );
 };

--- a/frontend/src/services/accessorialRateService.ts
+++ b/frontend/src/services/accessorialRateService.ts
@@ -1,0 +1,29 @@
+import api from "./api";
+import type { AccessorialRate } from "@/types/accessorialRate";
+
+const coerce = (r: {
+  accessorial_type: string;
+  pay_pct: unknown;
+}): AccessorialRate => ({
+  accessorial_type: r.accessorial_type,
+  pay_pct: Number(r.pay_pct),
+});
+
+export const getAccessorialRates = async (): Promise<AccessorialRate[]> => {
+  const res = await api.get("/accessorial-rates");
+  return (res.data.rates ?? []).map(coerce);
+};
+
+export const upsertAccessorialRate = async (
+  accessorial_type: string,
+  pay_pct: number,
+): Promise<AccessorialRate> => {
+  const res = await api.put("/accessorial-rates", { accessorial_type, pay_pct });
+  return coerce(res.data.rate);
+};
+
+export const deleteAccessorialRate = async (
+  accessorial_type: string,
+): Promise<void> => {
+  await api.delete(`/accessorial-rates/${encodeURIComponent(accessorial_type)}`);
+};

--- a/frontend/src/types/accessorialRate.ts
+++ b/frontend/src/types/accessorialRate.ts
@@ -1,0 +1,6 @@
+// A named accessorial charge and the fraction of it the owner-op keeps after the
+// carrier's cut (0.73 = 73%). Drives the load-entry dropdown + the Settings editor.
+export interface AccessorialRate {
+  accessorial_type: string;
+  pay_pct: number;
+}


### PR DESCRIPTION
## v1.59.0 — self-serve accessorial rates + clean entry

Follows the per-type accessorial fix (v1.58.3) with the tooling to manage it.

- **`/accessorial-rates` CRUD API** (list / upsert / delete).
- **Settings → "Accessorial rates"** card: each type with an editable %, add new, delete — Jason manages his own rates.
- **Load page dropdown**: accessorial type is now a `<select>` off the rate list, with **"Other…"** for one-offs (which fall to the schedule's default rate until given one).
- **Spelling variants consolidated** to a canonical 7: Tarp/Detention/Tolls/Loading (100%), Hazmat/Stop-Off (73%), High Value-EVC (0%).

**Prod data renamed to canonical before merge** — net-neutral (each variant already shared its canonical's rate; test loads 6723509 → $4,041.12 and 7413468 → $4,138.15 unchanged). Build clean, **176 tests**. No new migration (table shipped in v1.58.3).