### PR TITLE
feat: configurable carrier name

### DIFF
--- a/backend/db/migrations/035_carrier_name.sql
+++ b/backend/db/migrations/035_carrier_name.sql
@@ -1,0 +1,4 @@
+-- The user's carrier name (e.g. "Landstar"), shown on agent labels and anywhere
+-- the carrier is named. NULL for owner-operators on their own authority (no
+-- leased carrier), where the app just omits the label.
+ALTER TABLE settlement_schedules ADD COLUMN IF NOT EXISTS carrier_name text;

--- a/backend/src/services/settlementScheduleServices.js
+++ b/backend/src/services/settlementScheduleServices.js
@@ -1,27 +1,30 @@
 import { db } from "../../db/pool.js";
 import { ValidationError } from "../utils/error.js";
 
-// The identity schedule — net = gross. Returned when a user hasn't configured one
-// so the app (and the Settings form) always has values to work with.
+// The identity schedule — net = gross, no carrier. Returned when a user hasn't
+// configured one so the app (and the Settings form) always has values to work with.
 const DEFAULTS = {
   linehaul_pct: 1,
   trailer_pct: 0,
   fuel_surcharge_pct: 1,
   accessorial_pct: 1,
+  carrier_name: null,
 };
 
-const FIELDS = [
+const PCT_FIELDS = [
   "linehaul_pct",
   "trailer_pct",
   "fuel_surcharge_pct",
   "accessorial_pct",
 ];
 
+const COLUMNS = [...PCT_FIELDS, "carrier_name"];
+
 // ---- GET ---- (always returns a schedule; defaults if none saved yet)
 export async function getSettlementSchedule(user_id) {
   if (!user_id) throw new ValidationError("Missing user_id");
   const result = await db.query(
-    `SELECT ${FIELDS.join(", ")}
+    `SELECT ${COLUMNS.join(", ")}
        FROM settlement_schedules
       WHERE user_id = $1`,
     [user_id],
@@ -34,13 +37,17 @@ export async function upsertSettlementSchedule(user_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
 
   const provided = {};
-  for (const f of FIELDS) {
+  for (const f of PCT_FIELDS) {
     if (data[f] === undefined) continue;
     const n = Number(data[f]);
     if (!Number.isFinite(n) || n < 0 || n > 2)
       throw new ValidationError(`${f} must be a fraction between 0 and 2`);
     provided[f] = n;
   }
+  const carrierProvided = data.carrier_name !== undefined;
+  if (carrierProvided)
+    provided.carrier_name = (data.carrier_name ?? "").trim() || null;
+
   if (Object.keys(provided).length === 0)
     throw new ValidationError("No valid fields to update");
 
@@ -50,16 +57,24 @@ export async function upsertSettlementSchedule(user_id, data) {
 
   const result = await db.query(
     `INSERT INTO settlement_schedules
-       (user_id, linehaul_pct, trailer_pct, fuel_surcharge_pct, accessorial_pct)
-     VALUES ($1, $2, $3, $4, $5)
+       (user_id, linehaul_pct, trailer_pct, fuel_surcharge_pct, accessorial_pct, carrier_name)
+     VALUES ($1, $2, $3, $4, $5, $6)
      ON CONFLICT (user_id) DO UPDATE SET
        linehaul_pct       = EXCLUDED.linehaul_pct,
        trailer_pct        = EXCLUDED.trailer_pct,
        fuel_surcharge_pct = EXCLUDED.fuel_surcharge_pct,
        accessorial_pct    = EXCLUDED.accessorial_pct,
+       carrier_name       = EXCLUDED.carrier_name,
        updated_at         = NOW()
-     RETURNING ${FIELDS.join(", ")}`,
-    [user_id, m.linehaul_pct, m.trailer_pct, m.fuel_surcharge_pct, m.accessorial_pct],
+     RETURNING ${COLUMNS.join(", ")}`,
+    [
+      user_id,
+      m.linehaul_pct,
+      m.trailer_pct,
+      m.fuel_surcharge_pct,
+      m.accessorial_pct,
+      m.carrier_name,
+    ],
   );
   return result.rows[0];
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.60.0",
+  "version": "1.61.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/agents/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard.tsx
@@ -40,11 +40,13 @@ export const AgentCard = ({
   stats,
   honors,
   live,
+  carrierName,
 }: {
   agent: Agent;
   stats?: AgentStat;
   honors?: AgentHonors;
   live?: LiveStanding | null;
+  carrierName?: string;
 }) => {
   const tier = agentPrestige(honors);
   const prestige = PRESTIGE_META[tier];
@@ -67,7 +69,8 @@ export const AgentCard = ({
             {agent.first_name} {agent.last_name}
           </p>
           <p className="text-xs text-muted-text truncate">
-            {agent.broker_name} · Landstar
+            {agent.broker_name}
+            {carrierName ? ` · ${carrierName}` : ""}
           </p>
         </div>
       </div>

--- a/frontend/src/hooks/useCarrierName.ts
+++ b/frontend/src/hooks/useCarrierName.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+
+// The user's carrier name (e.g. "Landstar"), or "" when unset / on own authority.
+// Used to label agents by the carrier they run under instead of a hardcoded name.
+export const useCarrierName = (): string => {
+  const [name, setName] = useState("");
+  useEffect(() => {
+    getSettlementSchedule()
+      .then((s) => setName(s.carrier_name ?? ""))
+      .catch(() => {});
+  }, []);
+  return name;
+};

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -4,6 +4,7 @@ import { Mail, Phone, StickyNote, Star } from "lucide-react";
 
 import { useAgent } from "@/hooks/useAgent";
 import { useLoads } from "@/hooks/useLoads";
+import { useCarrierName } from "@/hooks/useCarrierName";
 import { createAgentNote } from "@/services/createAgentNoteService";
 
 import RatingForm from "@/components/RatingForm";
@@ -48,6 +49,7 @@ const fmtDate = (d?: string | null) =>
 const AgentDetailPage = () => {
   const [refreshKey, setRefreshKey] = useState(0);
   const [showRatingForm, setShowRatingForm] = useState(false);
+  const carrierName = useCarrierName();
   const { agent, loads, notes, ratingHistory, isLoading, error } =
     useAgent(refreshKey);
   const { loads: allLoads } = useLoads(0);
@@ -159,7 +161,8 @@ const AgentDetailPage = () => {
               {agent.first_name} {agent.last_name}
             </h1>
             <p className="text-sm text-muted-text mt-1">
-              {agent.broker_name} · Landstar Agent
+              {agent.broker_name}
+              {carrierName ? ` · ${carrierName} Agent` : ""}
             </p>
             {prestige.label && (
               <p

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -4,6 +4,7 @@ import { useAgents } from "@/hooks/useAgents";
 import { useLoads } from "@/hooks/useLoads";
 import { Kpi } from "@/components/Kpi";
 import { AgentCard } from "@/components/agents/AgentCard";
+import { useCarrierName } from "@/hooks/useCarrierName";
 import {
   computeHonors,
   perAgentStats,
@@ -33,6 +34,7 @@ const AgentsPage = () => {
 
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<SortKey>("rating");
+  const carrierName = useCarrierName();
 
   const honors = useMemo(() => computeHonors(loads ?? [], new Date()), [loads]);
   const stats = useMemo(() => perAgentStats(loads ?? []), [loads]);
@@ -173,6 +175,7 @@ const AgentsPage = () => {
               stats={stats.get(agent.agent_id)}
               honors={honors.get(agent.agent_id)}
               live={standings.get(agent.agent_id)}
+              carrierName={carrierName}
             />
           ))}
         </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -50,20 +50,22 @@ const Field = ({
 
 const SettingsPage = () => {
   const [pcts, setPcts] = useState<Pcts | null>(null);
+  const [carrier, setCarrier] = useState("");
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
     getSettlementSchedule()
-      .then((s) =>
+      .then((s) => {
         setPcts({
           linehaul: s.linehaul_pct * 100,
           trailer: s.trailer_pct * 100,
           fsc: s.fuel_surcharge_pct * 100,
           accessorial: s.accessorial_pct * 100,
-        }),
-      )
+        });
+        setCarrier(s.carrier_name ?? "");
+      })
       .catch(() => setErr("Couldn't load your settlement schedule."));
   }, []);
 
@@ -83,6 +85,7 @@ const SettingsPage = () => {
         trailer_pct: pcts.trailer / 100,
         fuel_surcharge_pct: pcts.fsc / 100,
         accessorial_pct: pcts.accessorial / 100,
+        carrier_name: carrier.trim() || null,
       });
       setMsg("Saved. Your revenue and targets now use this split.");
     } catch (e) {
@@ -114,6 +117,23 @@ const SettingsPage = () => {
           carrier's cut. Revenue, RPM, and your rate targets all use it. Leave
           everything at 100% if you run under your own authority.
         </p>
+
+        <label className="block mt-4">
+          <span className="text-sm text-light">Carrier name</span>
+          <input
+            type="text"
+            placeholder="e.g. Landstar"
+            value={carrier}
+            onChange={(e) => {
+              setMsg(null);
+              setCarrier(e.target.value);
+            }}
+            className="w-full max-w-xs mt-1 bg-steel rounded px-2 py-1.5 text-light text-sm block"
+          />
+          <span className="text-xs text-muted-text mt-1 block">
+            Shown on your agents. Leave blank if you run on your own authority.
+          </span>
+        </label>
 
         {!pcts ? (
           <p className="text-muted-text mt-5">Loading…</p>

--- a/frontend/src/services/settlementScheduleService.ts
+++ b/frontend/src/services/settlementScheduleService.ts
@@ -6,6 +6,7 @@ const coerce = (s: Record<string, unknown>): SettlementSchedule => ({
   trailer_pct: Number(s.trailer_pct),
   fuel_surcharge_pct: Number(s.fuel_surcharge_pct),
   accessorial_pct: Number(s.accessorial_pct),
+  carrier_name: (s.carrier_name as string | null) ?? null,
 });
 
 export const getSettlementSchedule = async (): Promise<SettlementSchedule> => {

--- a/frontend/src/types/settlementSchedule.ts
+++ b/frontend/src/types/settlementSchedule.ts
@@ -6,4 +6,5 @@ export interface SettlementSchedule {
   trailer_pct: number;
   fuel_surcharge_pct: number;
   accessorial_pct: number;
+  carrier_name: string | null; // e.g. "Landstar"; null on own authority
 }


### PR DESCRIPTION
## v1.61.0 — carrier name is a setting

The last hardcoded "Landstar". Now productize-ready.

- **`carrier_name`** on the settlement schedule (migration `035`), returned + saved with the pay split.
- **Settings → Carrier name** field (blank = own authority).
- **Agent card + agent detail** show the configured carrier via a `useCarrierName` hook; when blank, no carrier label at all.

**Prod migrated + carrier set to "Landstar" before merge** — display unchanged for Jason, and any productized user sets their own (or leaves it blank on their own authority). Build clean, **176 tests**.