### PR TITLE
fix: unambiguous cost-per-mile labels on the Expenses page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.61.0",
+  "version": "1.61.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -249,11 +249,11 @@ const ExpensesPage = () => {
             <Kpi label="Monthly cost" value={money(trueMonthly.trueMonthlyCost)} />
             <Kpi label="Weekly cost" value={money(trueMonthly.trueWeeklyCost)} />
             <Kpi
-              label={`Cost / mile · ${trailing.months}mo`}
+              label={`Cost / total mile · ${trailing.months}mo`}
               value={cash.trueCpm == null ? "—" : `$${cash.trueCpm.toFixed(2)}`}
             />
             <Kpi
-              label={`Break-even RPM · ${trailing.months}mo`}
+              label={`Break-even / loaded mi · ${trailing.months}mo`}
               value={
                 cash.trueBreakEvenRpm == null
                   ? "—"
@@ -269,13 +269,15 @@ const ExpensesPage = () => {
               }
             />
           </div>
-          {obligationsTotal > 0 && (
-            <p className="text-[11px] text-muted-text -mt-4 mb-6">
-              Includes {money(obligationsTotal)}/mo of obligations (loan principal
-              + draws). Dollar figures are this month; per-mile figures blend the
-              last {trailing.months} month{trailing.months > 1 ? "s" : ""}.
-            </p>
-          )}
+          <p className="text-[11px] text-muted-text -mt-4 mb-6">
+            <span className="text-light">Cost / total mile</span> is over every mile
+            you drive; <span className="text-light">break-even / loaded mile</span>{" "}
+            spreads that same cost over only the paid miles — the gap is your
+            deadhead. Per-mile figures blend the last {trailing.months} month
+            {trailing.months > 1 ? "s" : ""}.
+            {obligationsTotal > 0 &&
+              ` Cost includes ${money(obligationsTotal)}/mo of obligations (loan principal + draws).`}
+          </p>
 
           {rateLadder.walkAway != null && (
             <div className="bg-plate rounded-lg p-4 mb-6">
@@ -283,6 +285,34 @@ const ExpensesPage = () => {
                 Rate to book · gross $/mile driven · last {rateBasis.months}{" "}
                 complete month{rateBasis.months > 1 ? "s" : ""}
               </p>
+              <div className="flex items-center gap-2 flex-wrap mb-3 text-[11px]">
+                <span
+                  className="rounded px-2 py-1"
+                  style={{ background: "#0d1119", border: "1px solid #22304a" }}
+                >
+                  <span className="text-light font-condensed">
+                    {`$${rateBasis.costPerTotalMile?.toFixed(2)}`}
+                  </span>{" "}
+                  <span className="text-muted-text">/ total mi</span>
+                </span>
+                <span className="text-muted-text">→</span>
+                <span
+                  className="rounded px-2 py-1 text-muted-text"
+                  style={{ background: "#0d1119", border: "1px solid #22304a" }}
+                >
+                  ÷ {Math.round(linehaulTake * 100)}% keep
+                </span>
+                <span className="text-muted-text">→</span>
+                <span
+                  className="rounded px-2 py-1"
+                  style={{ background: "#0d1119", border: "1px solid #22304a" }}
+                >
+                  <span className="font-condensed" style={{ color: "#f5b03a" }}>
+                    {`$${rateLadder.walkAway?.toFixed(2)}`}
+                  </span>{" "}
+                  <span className="text-muted-text">to book</span>
+                </span>
+              </div>
               <RateLadder ladder={rateLadder} rpm={rateBasis.grossPerTotalMile} />
               <p className="text-[11px] text-muted-text mt-2">
                 walk-away = your cost/mile ÷ your{" "}


### PR DESCRIPTION
## v1.61.1 — defuse the three-numbers confusion on Expenses

The page showed **Cost / mile ($3.17, per total mile)** and **Break-even RPM ($4.72, per loaded mile)** — same word "mile," different denominator, neither said which — plus the ladder's $4.34. That ambiguity cost us several turns.

- Relabeled to **"Cost / total mile"** and **"Break-even / loaded mi"**.
- Clarifier line: cost is over all miles; break-even spreads it over only the paid miles — the gap is your deadhead.
- Live **cost → book chain** above the booking ladder: `$3.17 / total mi → ÷ 73% keep → $4.34 to book`.

Frontend-only, no migration. Build clean, **176 tests**.