### PR TITLE
feat: net-revenue sweep across asset pages + trailer revenue

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.61.1",
+  "version": "1.62.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/loads.test.ts
+++ b/frontend/src/lib/metrics/loads.test.ts
@@ -115,7 +115,7 @@ describe("outstandingLoads", () => {
 describe("loadsKpis", () => {
   const now = new Date("2026-06-15T00:00:00.000Z");
 
-  it("aggregates delivered gross, RPM, AR, and pipeline", () => {
+  it("aggregates delivered net, RPM, AR, and pipeline", () => {
     const loads = [
       {
         load_status: "delivered",
@@ -141,13 +141,33 @@ describe("loadsKpis", () => {
 
     const k = loadsKpis(loads as any, now);
     expect(k.deliveredCount).toBe(2);
-    expect(k.deliveredGross).toBe(3000);
+    expect(k.deliveredNet).toBe(3000);
     expect(k.loadedMiles).toBe(1500);
     expect(k.rpm).toBeCloseTo(2); // 3000 / 1500
     expect(k.arTotal).toBe(1000); // the delivered+unpaid one
     expect(k.arCount).toBe(1);
     expect(k.bookedCount).toBe(1);
     expect(k.inTransitCount).toBe(1);
+  });
+
+  it("reports net dollars but a gross rate/mile", () => {
+    const loads = [
+      {
+        load_status: "delivered",
+        delivery_date: "2026-06-05T04:00:00.000Z",
+        payment_status: "unpaid", // also counts toward AR
+        linehaul: "2000",
+        fuel_surcharge: "0",
+        total_accessorials: "0",
+        gross_revenue: "2000",
+        net_revenue: "1460", // 73% carrier take
+        loaded_miles: 1000,
+      },
+    ];
+    const k = loadsKpis(loads as any, now);
+    expect(k.deliveredNet).toBe(1460); // dollars kept = net
+    expect(k.arTotal).toBe(1460); // owed = net
+    expect(k.rpm).toBeCloseTo(2); // rate/mile = gross (2000 / 1000)
   });
 
   it("returns null RPM when there are no loaded miles", () => {

--- a/frontend/src/lib/metrics/loads.ts
+++ b/frontend/src/lib/metrics/loads.ts
@@ -1,4 +1,7 @@
 import type { Load } from "@/types/load";
+// The canonical NET revenue helper (server-computed, after the carrier's cut).
+// Aliased so the money KPIs below report what the company actually keeps.
+import { loadRevenue as loadNet } from "./rateTargets";
 
 // Total revenue for a load = linehaul + fuel surcharge + accessorials.
 // Postgres numerics arrive as strings, so coerce before adding.
@@ -56,8 +59,8 @@ export const deliveredThisMonth = (
 
 export interface LoadsKpis {
   deliveredCount: number;
-  deliveredGross: number;
-  rpm: number | null; // revenue per loaded mile this month; null when no miles
+  deliveredNet: number; // this month's delivered revenue, NET (what the company keeps)
+  rpm: number | null; // GROSS rate per loaded mile this month; null when no miles
   loadedMiles: number;
   arTotal: number;
   arCount: number;
@@ -69,6 +72,8 @@ export interface LoadsKpis {
 // what's owed, and what's in the pipeline.
 export const loadsKpis = (loads: Array<Load>, now: Date): LoadsKpis => {
   const delivered = deliveredThisMonth(loads, now);
+  // Dollars the company keeps (net); rate/mile stays gross (the booking lens).
+  const deliveredNet = delivered.reduce((s, l) => s + loadNet(l), 0);
   const deliveredGross = delivered.reduce((s, l) => s + loadRevenue(l), 0);
   const loadedMiles = delivered.reduce(
     (s, l) => s + (Number(l.loaded_miles) || 0),
@@ -77,10 +82,10 @@ export const loadsKpis = (loads: Array<Load>, now: Date): LoadsKpis => {
   const ar = outstandingLoads(loads);
   return {
     deliveredCount: delivered.length,
-    deliveredGross,
+    deliveredNet,
     rpm: loadedMiles > 0 ? deliveredGross / loadedMiles : null,
     loadedMiles,
-    arTotal: ar.reduce((s, l) => s + loadRevenue(l), 0),
+    arTotal: ar.reduce((s, l) => s + loadNet(l), 0),
     arCount: ar.length,
     bookedCount: getBookedCount(loads),
     inTransitCount: getInTransitCount(loads),

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Pencil } from "lucide-react";
 import type { Driver } from "@/types/driver";
-import type { Load } from "@/types/load";
 import type { ExpensePeriod } from "@/types/expense";
 import type { FuelEntry } from "@/types/fuelEntry";
 import type { Truck } from "@/types/truck";
@@ -17,7 +16,11 @@ import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { DRIVER_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
-import { getCostBasis, getRateLadder } from "@/lib/metrics/rateTargets";
+import {
+  getCostBasis,
+  getRateLadder,
+  loadRevenue,
+} from "@/lib/metrics/rateTargets";
 import { RATE_TIERS } from "@/lib/constants/targets";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import {
@@ -32,8 +35,6 @@ import {
 import { PlayerCard } from "@/components/playercard/PlayerCard";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
-const loadRev = (l: Load) =>
-  Number(l.linehaul) + Number(l.fuel_surcharge) + Number(l.total_accessorials);
 
 const Spec = ({
   label,
@@ -148,7 +149,7 @@ const DriverDetailPage = () => {
       </div>
     );
 
-  const revenue = driverLoads.reduce((s, l) => s + loadRev(l), 0);
+  const revenue = driverLoads.reduce((s, l) => s + loadRevenue(l), 0);
   const milesHauled = driverLoads.reduce(
     (s, l) =>
       l.load_status === "delivered" ? s + (Number(l.loaded_miles) || 0) : s,
@@ -265,7 +266,7 @@ const DriverDetailPage = () => {
             <p className="text-2xl font-condensed">{driverLoads.length}</p>
           </div>
           <div className="bg-plate rounded-lg p-4">
-            <p className="text-xs text-muted-text mb-1">Revenue · all time</p>
+            <p className="text-xs text-muted-text mb-1">Net revenue · all time</p>
             <p className="text-2xl font-condensed">{money(revenue)}</p>
           </div>
           <div className="bg-plate rounded-lg p-4">
@@ -288,7 +289,7 @@ const DriverDetailPage = () => {
                 <span>
                   {l.origin_market} → {l.delivery_market}
                 </span>
-                <span className="text-muted-text">{money(loadRev(l))}</span>
+                <span className="text-muted-text">{money(loadRevenue(l))}</span>
               </div>
             ))}
           </div>

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -126,6 +126,11 @@ export const LoadDetailPage = () => {
       .join(" ");
 
   const revenue = loadRevenue(load);
+  // What the company actually keeps after the carrier's cut. Falls back to the
+  // full rate for own-authority users (no settlement schedule → net == gross).
+  const net = Number.isFinite(Number(load.net_revenue))
+    ? Number(load.net_revenue)
+    : revenue;
   const rpm = loadRpm(load);
   const dh = deadheadShare(load);
   const fuel = estimateLoadFuel(load);
@@ -424,9 +429,22 @@ export const LoadDetailPage = () => {
             value={money2(Number(load.total_accessorials))}
           />
           <div className="flex justify-between border-t border-steel mt-1.5 pt-1.5 text-sm">
-            <span>Total</span>
+            <span>Total rate</span>
             <span className="font-condensed text-base">{money2(revenue)}</span>
           </div>
+          {Math.abs(net - revenue) > 0.005 && (
+            <>
+              <div className="flex justify-between mt-1 text-sm">
+                <span className="text-status-positive-text">Your net</span>
+                <span className="font-condensed text-base text-status-positive-text">
+                  {money2(net)}
+                </span>
+              </div>
+              <p className="text-[11px] text-muted-text mt-1">
+                After your carrier's cut — what your company keeps.
+              </p>
+            </>
+          )}
         </div>
 
         <div className="bg-plate rounded-lg p-4">

--- a/frontend/src/pages/LoadsPage.tsx
+++ b/frontend/src/pages/LoadsPage.tsx
@@ -133,8 +133,8 @@ const LoadsPage = () => {
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Kpi
-          label="This month"
-          value={money(kpis.deliveredGross)}
+          label="This month · net"
+          value={money(kpis.deliveredNet)}
           sub={`${kpis.deliveredCount} load${plural(kpis.deliveredCount)} delivered`}
         />
         <Kpi

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -14,11 +14,14 @@ import {
   avgMilesPerMonth,
   maxOdometer,
 } from "@/lib/metrics/maintenance";
+import { loadRevenue } from "@/lib/metrics/rateTargets";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
 import { TRAILER_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
+
+const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 
 const Spec = ({
   label,
@@ -68,6 +71,14 @@ const TrailerDetailPage = () => {
   }, [trailer, services]);
 
   const mpm = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
+  const trailerLoads = useMemo(
+    () => loads.filter((l) => l.trailer_id === id),
+    [loads, id],
+  );
+  const revenue = useMemo(
+    () => trailerLoads.reduce((s, l) => s + loadRevenue(l), 0),
+    [trailerLoads],
+  );
   const due = useMemo(() => {
     let overdue = 0;
     let soon = 0;
@@ -186,16 +197,26 @@ const TrailerDetailPage = () => {
         </div>
       </div>
 
-      <Link
-        to="/maintenance"
-        className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors block max-w-xs"
-      >
-        <p className="text-xs text-muted-text mb-2">Maintenance</p>
-        <div className="flex gap-3 text-sm">
-          <span style={{ color: "#e24b4a" }}>{due.overdue} overdue</span>
-          <span style={{ color: "#e8940a" }}>{due.soon} due soon</span>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Link
+          to="/maintenance"
+          className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors block"
+        >
+          <p className="text-xs text-muted-text mb-2">Maintenance</p>
+          <div className="flex gap-3 text-sm">
+            <span style={{ color: "#e24b4a" }}>{due.overdue} overdue</span>
+            <span style={{ color: "#e8940a" }}>{due.soon} due soon</span>
+          </div>
+        </Link>
+        <div className="bg-plate rounded-lg p-4">
+          <p className="text-xs text-muted-text mb-1">Loads hauled</p>
+          <p className="text-2xl font-condensed">{trailerLoads.length}</p>
         </div>
-      </Link>
+        <div className="bg-plate rounded-lg p-4">
+          <p className="text-xs text-muted-text mb-1">Net revenue · all time</p>
+          <p className="text-2xl font-condensed">{money(revenue)}</p>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Pencil } from "lucide-react";
 import type { Truck } from "@/types/truck";
-import type { Load } from "@/types/load";
 import type { FuelEntry } from "@/types/fuelEntry";
 import type { MaintenanceItem, MaintenanceService } from "@/types/maintenance";
 import { getTruck, patchTruck } from "@/services/trucksService";
@@ -18,6 +17,7 @@ import {
   maxOdometer,
 } from "@/lib/metrics/maintenance";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
+import { loadRevenue } from "@/lib/metrics/rateTargets";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
@@ -25,8 +25,6 @@ import { TRUCK_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
-const loadRev = (l: Load) =>
-  Number(l.linehaul) + Number(l.fuel_surcharge) + Number(l.total_accessorials);
 
 const Spec = ({
   label,
@@ -129,7 +127,7 @@ const TruckDetailPage = () => {
       </div>
     );
 
-  const revenue = truckLoads.reduce((s, l) => s + loadRev(l), 0);
+  const revenue = truckLoads.reduce((s, l) => s + loadRevenue(l), 0);
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -225,7 +223,7 @@ const TruckDetailPage = () => {
           <p className="text-2xl font-condensed">{truckLoads.length}</p>
         </div>
         <div className="bg-plate rounded-lg p-4">
-          <p className="text-xs text-muted-text mb-1">Revenue · all time</p>
+          <p className="text-xs text-muted-text mb-1">Net revenue · all time</p>
           <p className="text-2xl font-condensed">{money(revenue)}</p>
         </div>
       </div>
@@ -241,7 +239,7 @@ const TruckDetailPage = () => {
                 <span>
                   {l.origin_market} → {l.delivery_market}
                 </span>
-                <span className="text-muted-text">{money(loadRev(l))}</span>
+                <span className="text-muted-text">{money(loadRevenue(l))}</span>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## v1.62.0 — Phase 3 of the net-revenue arc

Every "what the company keeps" figure now routes through the one canonical net helper; market-economics and pricing figures stay gross.

### Net (your earnings from the asset/person)
- **Truck** & **Driver** pages — "Net revenue · all time" (recent-load amounts net too)
- **Trailer** page — **new** "Net revenue · all time" + "Loads hauled" (track what the trailer has made you)
- **Load detail** — **new** "Your net" line under the rate breakdown (appears when net ≠ gross)
- **Loads list** — "This month · **net**" and "Outstanding AR" now net

### Gross (on purpose)
- **Agent** & **Lane** pages — the market rate, independent of the driver's cut
- Loads-list **"Gross"** column + load-detail headline — the deal size / booked rate
- Every **rate / mile** (rate card, load detail, loads-page avg) — the pricing lens
- **Pipeline** — a count

### Under the hood
- `loads.ts` reuses `rateTargets`' net helper, removing a duplicate gross helper (the one flagged in memory).
- New test pins the **net-dollars / gross-rate-per-mile** split so it can't silently regress.

Frontend-only, no migration. Build clean, **177 tests**.