### PR TITLE
fix: per-asset revenue attribution (earned basis + trailer's own share)

### DIFF
--- a/backend/src/services/loadServices.js
+++ b/backend/src/services/loadServices.js
@@ -51,6 +51,21 @@ export async function getLoads(user_id) {
                    AND apr.accessorial_type = a.accessorial_type
                  WHERE a.load_id = loads.load_id)
             , 2) AS net_revenue,
+            -- The trailer's cut: its % of linehaul plus its % of the base-rate
+            -- accessorials it rides on (those paid at linehaul_pct + trailer_pct).
+            -- FSC and flat-100% accessorials belong to the tractor, not the trailer.
+            ROUND(
+              linehaul * COALESCE(ss.trailer_pct, 0)
+              + COALESCE(ss.trailer_pct, 0) * (
+                  SELECT COALESCE(SUM(a.amount), 0)
+                  FROM accessorials a
+                  LEFT JOIN accessorial_pay_rates apr
+                    ON apr.user_id = loads.user_id
+                    AND apr.accessorial_type = a.accessorial_type
+                  WHERE a.load_id = loads.load_id
+                    AND COALESCE(apr.pay_pct, COALESCE(ss.accessorial_pct, 1))
+                        = COALESCE(ss.linehaul_pct, 1) + COALESCE(ss.trailer_pct, 0))
+            , 2) AS trailer_net,
             commodity,
             weight,
             dimensions,
@@ -133,6 +148,21 @@ export async function getLoad(user_id, load_id) {
                    AND apr.accessorial_type = a.accessorial_type
                  WHERE a.load_id = l.load_id)
             , 2) AS net_revenue,
+            -- The trailer's cut: its % of linehaul plus its % of the base-rate
+            -- accessorials it rides on (those paid at linehaul_pct + trailer_pct).
+            -- FSC and flat-100% accessorials belong to the tractor, not the trailer.
+            ROUND(
+              linehaul * COALESCE(ss.trailer_pct, 0)
+              + COALESCE(ss.trailer_pct, 0) * (
+                  SELECT COALESCE(SUM(a.amount), 0)
+                  FROM accessorials a
+                  LEFT JOIN accessorial_pay_rates apr
+                    ON apr.user_id = l.user_id
+                    AND apr.accessorial_type = a.accessorial_type
+                  WHERE a.load_id = l.load_id
+                    AND COALESCE(apr.pay_pct, COALESCE(ss.accessorial_pct, 1))
+                        = COALESCE(ss.linehaul_pct, 1) + COALESCE(ss.trailer_pct, 0))
+            , 2) AS trailer_net,
             commodity,
             weight,
             dimensions,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.62.0",
+  "version": "1.62.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -23,6 +23,15 @@ export const loadRevenue = (l: Load): number => {
   return Number.isFinite(net) ? net : loadGross(l);
 };
 
+// The TRAILER's slice of a load's net — its % of linehaul plus its % of the
+// base-rate accessorials it rides on (server-computed). The truck/driver earn
+// the full load net; the trailer earns only this. Absent (no schedule / fixture)
+// → 0, so a trailer with no settlement split simply shows nothing attributed.
+export const loadTrailerNet = (l: Load): number => {
+  const t = Number(l.trailer_net);
+  return Number.isFinite(t) ? t : 0;
+};
+
 // The `count` COMPLETE calendar months before now's month (excludes the
 // in-progress current month — its miles lag its cost and would inflate $/mile).
 // now = 2026-07-xx, count = 3 → [Apr, May, Jun] 2026.

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -80,6 +80,15 @@ const DriverDetailPage = () => {
     () => loads.filter((l) => l.driver_id === id),
     [loads, id],
   );
+  // Revenue/count use only earned freight — delivered AND paid — matching the
+  // dashboard. Cancelled/booked/in-transit loads haven't earned anything yet.
+  const earnedLoads = useMemo(
+    () =>
+      driverLoads.filter(
+        (l) => l.load_status === "delivered" && l.payment_status === "paid",
+      ),
+    [driverLoads],
+  );
 
   // The player card only makes sense for a driver who actually hauls; a
   // dispatch-only driver (e.g. Brandie) keeps the plain page.
@@ -149,7 +158,7 @@ const DriverDetailPage = () => {
       </div>
     );
 
-  const revenue = driverLoads.reduce((s, l) => s + loadRevenue(l), 0);
+  const revenue = earnedLoads.reduce((s, l) => s + loadRevenue(l), 0);
   const milesHauled = driverLoads.reduce(
     (s, l) =>
       l.load_status === "delivered" ? s + (Number(l.loaded_miles) || 0) : s,
@@ -263,7 +272,7 @@ const DriverDetailPage = () => {
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-4">
           <div className="bg-plate rounded-lg p-4">
             <p className="text-xs text-muted-text mb-1">Loads hauled</p>
-            <p className="text-2xl font-condensed">{driverLoads.length}</p>
+            <p className="text-2xl font-condensed">{earnedLoads.length}</p>
           </div>
           <div className="bg-plate rounded-lg p-4">
             <p className="text-xs text-muted-text mb-1">Net revenue · all time</p>
@@ -280,11 +289,11 @@ const DriverDetailPage = () => {
 
       <div className="bg-plate rounded-lg p-4 mt-4">
         <p className="text-xs text-muted-text mb-2">Recent loads</p>
-        {driverLoads.length === 0 ? (
+        {earnedLoads.length === 0 ? (
           <p className="text-sm text-muted-text">None for this driver yet.</p>
         ) : (
           <div className="text-sm divide-y divide-steel">
-            {driverLoads.slice(0, 6).map((l) => (
+            {earnedLoads.slice(0, 6).map((l) => (
               <div key={l.load_id} className="py-2 flex justify-between">
                 <span>
                   {l.origin_market} → {l.delivery_market}

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -14,7 +14,7 @@ import {
   avgMilesPerMonth,
   maxOdometer,
 } from "@/lib/metrics/maintenance";
-import { loadRevenue } from "@/lib/metrics/rateTargets";
+import { loadTrailerNet } from "@/lib/metrics/rateTargets";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
@@ -75,9 +75,19 @@ const TrailerDetailPage = () => {
     () => loads.filter((l) => l.trailer_id === id),
     [loads, id],
   );
-  const revenue = useMemo(
-    () => trailerLoads.reduce((s, l) => s + loadRevenue(l), 0),
+  // Only earned freight — delivered AND paid. The trailer earns its share of
+  // each load (loadTrailerNet: its % of linehaul + base-rate accessorials), not
+  // the full net — the tractor earns the rest.
+  const earnedLoads = useMemo(
+    () =>
+      trailerLoads.filter(
+        (l) => l.load_status === "delivered" && l.payment_status === "paid",
+      ),
     [trailerLoads],
+  );
+  const revenue = useMemo(
+    () => earnedLoads.reduce((s, l) => s + loadTrailerNet(l), 0),
+    [earnedLoads],
   );
   const due = useMemo(() => {
     let overdue = 0;
@@ -210,11 +220,14 @@ const TrailerDetailPage = () => {
         </Link>
         <div className="bg-plate rounded-lg p-4">
           <p className="text-xs text-muted-text mb-1">Loads hauled</p>
-          <p className="text-2xl font-condensed">{trailerLoads.length}</p>
+          <p className="text-2xl font-condensed">{earnedLoads.length}</p>
         </div>
         <div className="bg-plate rounded-lg p-4">
-          <p className="text-xs text-muted-text mb-1">Net revenue · all time</p>
+          <p className="text-xs text-muted-text mb-1">Trailer earnings · all time</p>
           <p className="text-2xl font-condensed">{money(revenue)}</p>
+          <p className="text-[11px] text-muted-text mt-1">
+            its cut of every load it carried
+          </p>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -72,6 +72,15 @@ const TruckDetailPage = () => {
     () => loads.filter((l) => l.truck_id === id),
     [loads, id],
   );
+  // Revenue/count use only earned freight — delivered AND paid — matching the
+  // dashboard. Cancelled/booked/in-transit loads haven't earned anything yet.
+  const earnedLoads = useMemo(
+    () =>
+      truckLoads.filter(
+        (l) => l.load_status === "delivered" && l.payment_status === "paid",
+      ),
+    [truckLoads],
+  );
 
   // Latest odometer, derived from the app: stored value + newest load + newest
   // service reading + newest fuel fill-up (fuel is usually the freshest).
@@ -127,7 +136,7 @@ const TruckDetailPage = () => {
       </div>
     );
 
-  const revenue = truckLoads.reduce((s, l) => s + loadRevenue(l), 0);
+  const revenue = earnedLoads.reduce((s, l) => s + loadRevenue(l), 0);
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -220,7 +229,7 @@ const TruckDetailPage = () => {
         </Link>
         <div className="bg-plate rounded-lg p-4">
           <p className="text-xs text-muted-text mb-1">Loads hauled</p>
-          <p className="text-2xl font-condensed">{truckLoads.length}</p>
+          <p className="text-2xl font-condensed">{earnedLoads.length}</p>
         </div>
         <div className="bg-plate rounded-lg p-4">
           <p className="text-xs text-muted-text mb-1">Net revenue · all time</p>
@@ -230,11 +239,11 @@ const TruckDetailPage = () => {
 
       <div className="bg-plate rounded-lg p-4 mt-4">
         <p className="text-xs text-muted-text mb-2">Recent loads</p>
-        {truckLoads.length === 0 ? (
+        {earnedLoads.length === 0 ? (
           <p className="text-sm text-muted-text">None on this truck yet.</p>
         ) : (
           <div className="text-sm divide-y divide-steel">
-            {truckLoads.slice(0, 6).map((l) => (
+            {earnedLoads.slice(0, 6).map((l) => (
               <div key={l.load_id} className="py-2 flex justify-between">
                 <span>
                   {l.origin_market} → {l.delivery_market}

--- a/frontend/src/types/load.ts
+++ b/frontend/src/types/load.ts
@@ -31,6 +31,9 @@ export interface Load {
   // fall back to the linehaul+FSC+accessorials sum.
   gross_revenue?: string;
   net_revenue?: string;
+  // The trailer's slice of net (its % of linehaul + its % of base-rate
+  // accessorials). Server-side; numeric → string. Absent → 0 trailer share.
+  trailer_net?: string;
   commodity: string | null;
   weight?: number | null;
   dimensions?: string | null;


### PR DESCRIPTION
## v1.62.1 — correct what each asset actually netted

The v1.62.0 sweep over-credited the truck/driver/trailer pages: they summed the full company-net of **every** load regardless of status, and gave the trailer the whole net instead of its slice.

### Fixes
- **Earned basis** — pages now count only **delivered + paid** loads. Cancelled ($18k) and booked/in-transit ($7k) drop out, so **truck and driver tie to the dashboard's net YTD ($141,356)**.
- **Trailer's own share** — new per-load `trailer_net` = `trailer_pct` × linehaul + `trailer_pct` × the base-rate accessorials it rides on (FSC + flat-100% accessorials stay with the tractor). Truck and driver keep the **full** net — they're on every load; the trailer only earns its allowance.
- **Asset-scoped** — attribution is per-load via the `truck_id`/`driver_id`/`trailer_id` filter, so a multi-truck fleet shows each truck only its own loads' revenue.
- **"Loads hauled"** counts earned loads.

### Data fix (already applied to prod)
Trailer 780991 (in service 2026-02-03) was assigned to 3 January loads from before you owned it. Unassigned — trailer drops from $12,522 to the correct **$11,066** (44 loads).

### Verified against prod
| Page | Value |
|---|---:|
| Truck | $141,356 (= dashboard) |
| Driver | $141,356 (= dashboard) |
| Trailer | $11,066 |

Backend adds `trailer_net` to getLoads/getLoad (no migration). Build clean, **177 tests**.