### PR TITLE
feat: prestige-tiered recaps + period-close ceremony pops

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.62.1",
+  "version": "1.63.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/comic/AwardPopHost.tsx
+++ b/frontend/src/components/comic/AwardPopHost.tsx
@@ -13,6 +13,7 @@ import {
 import type { Award } from "@/lib/metrics/awards";
 import { MarqueeAward } from "./MarqueeAward";
 import { BurstAward } from "./BurstAward";
+import { RecapCeremony } from "./RecapCeremony";
 
 const ICONS: Record<string, LucideIcon> = {
   truck: Truck,
@@ -26,9 +27,16 @@ const ICONS: Record<string, LucideIcon> = {
 };
 const iconFor = (n: string): LucideIcon => ICONS[n] ?? Trophy;
 
-// Orchestrates the celebration: a marquee takes over the screen (one at a time);
-// bursts stack in the corner and auto-fade. Marquees block bursts until dismissed.
-export const AwardPopHost = ({ pops }: { pops: Award[] }) => {
+// Orchestrates the celebration: a takeover (recap ceremony or marquee) owns the
+// screen one at a time; bursts stack in the corner and auto-fade. A takeover
+// blocks bursts until dismissed. Recap ceremonies outrank marquees.
+export const AwardPopHost = ({
+  pops,
+  truckAvatarUrl,
+}: {
+  pops: Award[];
+  truckAvatarUrl?: string | null;
+}) => {
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
   const dismiss = (id: string) =>
     setDismissed((d) => {
@@ -38,8 +46,10 @@ export const AwardPopHost = ({ pops }: { pops: Award[] }) => {
     });
 
   const visible = pops.filter((p) => !dismissed.has(p.id));
-  const marquee = visible.find((p) => p.tier === "marquee");
-  const bursts = marquee ? [] : visible.filter((p) => p.tier === "burst").slice(0, 4);
+  const takeover =
+    visible.find((p) => p.tier === "recap") ??
+    visible.find((p) => p.tier === "marquee");
+  const bursts = takeover ? [] : visible.filter((p) => p.tier === "burst").slice(0, 4);
 
   const burstKey = bursts.map((b) => b.id).join(",");
   useEffect(() => {
@@ -49,7 +59,7 @@ export const AwardPopHost = ({ pops }: { pops: Award[] }) => {
     return () => timers.forEach(clearTimeout);
   }, [burstKey]);
 
-  if (!marquee && bursts.length === 0) return null;
+  if (!takeover && bursts.length === 0) return null;
 
   return (
     <>
@@ -60,8 +70,11 @@ export const AwardPopHost = ({ pops }: { pops: Award[] }) => {
           ))}
         </div>
       )}
-      {marquee && (
-        <MarqueeAward award={marquee} Icon={iconFor(marquee.icon)} onDismiss={() => dismiss(marquee.id)} />
+      {takeover && takeover.tier === "recap" && (
+        <RecapCeremony award={takeover} truckAvatarUrl={truckAvatarUrl} onDismiss={() => dismiss(takeover.id)} />
+      )}
+      {takeover && takeover.tier === "marquee" && (
+        <MarqueeAward award={takeover} Icon={iconFor(takeover.icon)} onDismiss={() => dismiss(takeover.id)} />
       )}
     </>
   );

--- a/frontend/src/components/comic/RecapCeremony.tsx
+++ b/frontend/src/components/comic/RecapCeremony.tsx
@@ -1,0 +1,141 @@
+import { useNavigate } from "react-router-dom";
+import { Truck, Crown, CalendarCheck, Award as AwardIcon } from "lucide-react";
+import type { Award } from "@/lib/metrics/awards";
+import type { RecapScope } from "@/lib/metrics/recap";
+import { RECAP_TIERS } from "@/lib/constants/recapTiers";
+
+// Confetti scales with the occasion: a couple of flecks for a month, a full
+// multi-color burst for the year.
+const CONFETTI: Record<RecapScope, { left: string; color: string; delay: string }[]> = {
+  month: [
+    { left: "30%", color: "#b3763f", delay: ".1s" },
+    { left: "64%", color: "#c9884a", delay: ".5s" },
+  ],
+  quarter: [
+    { left: "20%", color: "#aab4c4", delay: ".1s" },
+    { left: "42%", color: "#cdd6e3", delay: ".5s" },
+    { left: "60%", color: "#e8940a", delay: ".3s" },
+    { left: "80%", color: "#cdd6e3", delay: ".7s" },
+  ],
+  year: [
+    { left: "16%", color: "#f5b03a", delay: ".1s" },
+    { left: "30%", color: "#4ade80", delay: ".5s" },
+    { left: "46%", color: "#60a5fa", delay: ".9s" },
+    { left: "62%", color: "#f5b03a", delay: ".3s" },
+    { left: "78%", color: "#e8940a", delay: ".7s" },
+    { left: "90%", color: "#4ade80", delay: ".2s" },
+  ],
+};
+
+const POP_KICKER: Record<RecapScope, string> = {
+  month: "MONTH IN THE BOOKS",
+  quarter: "QUARTER COMPLETE",
+  year: "GRAND FINALE",
+};
+
+const SIZE: Record<RecapScope, { card: number; medal: number; title: number }> = {
+  month: { card: 300, medal: 64, title: 26 },
+  quarter: { card: 322, medal: 74, title: 30 },
+  year: { card: 344, medal: 84, title: 34 },
+};
+
+export const RecapCeremony = ({
+  award,
+  truckAvatarUrl,
+  onDismiss,
+}: {
+  award: Award;
+  truckAvatarUrl?: string | null;
+  onDismiss: () => void;
+}) => {
+  const navigate = useNavigate();
+  const scope = award.scope ?? "month";
+  const t = RECAP_TIERS[scope];
+  const s = SIZE[scope];
+
+  const open = () => {
+    navigate("/recap", { state: { scope } });
+    onDismiss();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-hidden"
+      style={{ background: "rgba(6,9,15,0.78)" }}
+    >
+      {CONFETTI[scope].map((c, i) => (
+        <span
+          key={i}
+          className="absolute rounded-[1px]"
+          style={{
+            left: c.left,
+            top: "-10px",
+            width: 7,
+            height: 7,
+            background: c.color,
+            animation: `award-fall 2.4s linear ${c.delay} infinite`,
+          }}
+        />
+      ))}
+      <div
+        className="relative rounded-[18px] px-6 pt-5 pb-4 text-center overflow-hidden"
+        style={{
+          width: s.card,
+          maxWidth: "92vw",
+          background: t.cardBg,
+          border: `${t.border}px solid ${t.metal}`,
+          boxShadow: t.inner ? `inset 0 0 0 2px ${t.inner}` : undefined,
+          animation: "award-pop .6s cubic-bezier(.2,.9,.25,1.2) both",
+        }}
+      >
+        {t.crown && (
+          <div className="mb-1">
+            <Crown size={22} style={{ color: t.metal }} />
+          </div>
+        )}
+        <div className="font-comic tracking-[3px]" style={{ color: t.title, fontSize: 14 }}>
+          {"★ ".repeat(t.stars).trim()}
+        </div>
+
+        <div
+          className="relative mx-auto mt-2 rounded-full flex items-center justify-center overflow-hidden"
+          style={{ width: s.medal, height: s.medal, background: t.medalBg, border: `3px solid ${t.metal}`, color: t.medalInk }}
+        >
+          {t.banner && truckAvatarUrl ? (
+            <img src={truckAvatarUrl} alt="Your truck" className="w-full h-full object-cover" />
+          ) : t.banner ? (
+            <Truck size={s.medal * 0.42} />
+          ) : scope === "quarter" ? (
+            <AwardIcon size={s.medal * 0.5} />
+          ) : (
+            <CalendarCheck size={s.medal * 0.42} />
+          )}
+        </div>
+
+        <div className="font-comic tracking-[2px] mt-2.5" style={{ color: t.title, fontSize: 12 }}>
+          {POP_KICKER[scope]}
+        </div>
+        <div className="font-comic leading-none mt-0.5" style={{ color: t.title, fontSize: s.title }}>
+          {award.name}
+        </div>
+        <div className="text-sm text-muted-text mt-2">{award.detail}</div>
+
+        <button
+          onClick={open}
+          className="mt-4 font-comic cursor-pointer"
+          style={{
+            background: t.metal,
+            color: "#10151f",
+            border: "none",
+            borderRadius: 9,
+            padding: "9px 22px",
+            fontSize: 14,
+            letterSpacing: "1px",
+          }}
+        >
+          {scope === "year" ? "OPEN YOUR SEASON" : "SEE YOUR RECAP"}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/recap/RecapPoster.tsx
+++ b/frontend/src/components/recap/RecapPoster.tsx
@@ -1,10 +1,17 @@
-import { Truck, MapPin, Star } from "lucide-react";
+import { Truck, MapPin, Star, Crown, Leaf } from "lucide-react";
 import type { RecapStats } from "@/lib/metrics/recap";
+import { RECAP_TIERS } from "@/lib/constants/recapTiers";
 
 const kMoney = (n: number) =>
   n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${Math.round(n)}`;
 const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const num = (n: number) => Math.round(n).toLocaleString("en-US");
+
+const Pips = ({ n, color }: { n: number; color: string }) => (
+  <span className="font-comic tracking-[3px]" style={{ color }}>
+    {"★ ".repeat(n).trim()}
+  </span>
+);
 
 const Tile = ({
   value,
@@ -15,11 +22,11 @@ const Tile = ({
   label: string;
   color?: string;
 }) => (
-  <div className="rounded-[10px] px-3 py-2.5 text-center" style={{ background: "#1c2333" }}>
-    <div className="font-comic text-[22px] leading-none" style={{ color }}>
+  <div className="flex-1 rounded-[9px] px-1 py-2 text-center" style={{ background: "#1c2333" }}>
+    <div className="font-comic text-[19px] leading-none" style={{ color }}>
       {value}
     </div>
-    <div className="text-[10px] text-muted-text mt-1 tracking-wide">{label}</div>
+    <div className="text-[9px] text-muted-text mt-1 tracking-wide">{label}</div>
   </div>
 );
 
@@ -27,16 +34,57 @@ const Hero = ({
   value,
   label,
   color,
+  big,
 }: {
   value: string;
   label: string;
   color: string;
+  big: boolean;
 }) => (
-  <div className="flex-1 rounded-xl px-2 py-3 text-center" style={{ background: "#0a0d13" }}>
-    <div className="font-comic text-3xl leading-none" style={{ color }}>
+  <div className="flex-1 rounded-xl text-center" style={{ background: "#0a0d13", padding: big ? "11px 4px" : "9px 4px" }}>
+    <div className="font-comic leading-none" style={{ color, fontSize: big ? 30 : 26 }}>
       {value}
     </div>
-    <div className="text-[11px] text-muted-text mt-1 tracking-wider">{label}</div>
+    <div className="text-[10px] text-muted-text mt-1 tracking-wider">{label}</div>
+  </div>
+);
+
+const MonthStrip = ({
+  data,
+  color,
+}: {
+  data: { label: string; gross: number }[];
+  color: string;
+}) => {
+  const max = Math.max(1, ...data.map((d) => d.gross));
+  return (
+    <div className="rounded-[10px] px-3 py-2.5" style={{ background: "#0a0d13" }}>
+      <div className="text-[10px] text-muted-text tracking-wide mb-1.5">
+        MONTHLY HAUL · {data[0].label} → {data[data.length - 1].label}
+      </div>
+      <div className="flex gap-1 items-end" style={{ height: 38 }}>
+        {data.map((d, i) => (
+          <div
+            key={i}
+            className="flex-1 rounded-t-[2px]"
+            style={{ height: `${Math.max(6, (d.gross / max) * 100)}%`, minWidth: 5, background: color }}
+            title={`${d.label}: ${kMoney(d.gross)}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const RankChip = ({ rank, t }: { rank: string; t: (typeof RECAP_TIERS)[keyof typeof RECAP_TIERS] }) => (
+  <div
+    className="inline-flex items-center gap-1.5 mt-2 rounded-full px-3 py-0.5"
+    style={{ background: t.chipBg, border: `1px solid ${t.chipBorder}` }}
+  >
+    <Truck size={13} style={{ color: t.chipInk }} />
+    <span className="font-comic tracking-wide text-[13px] uppercase" style={{ color: t.chipInk }}>
+      {rank}
+    </span>
   </div>
 );
 
@@ -49,36 +97,35 @@ export const RecapPoster = ({
   rank: string;
   truckAvatarUrl?: string | null;
 }) => {
-  const isYear = stats.scope === "year";
-  const edge = isYear ? "#f5b03a" : "#e8940a";
-  const kicker = isYear ? "GRAND FINALE · THE" : "RECAP ·";
-  const title = isYear ? `${stats.label} SEASON` : stats.label;
+  const t = RECAP_TIERS[stats.scope];
+  const rich = stats.scope !== "month"; // quarter + year carry the extra data
+  const titleSize = stats.scope === "year" ? 44 : stats.scope === "quarter" ? 38 : 30;
 
   return (
     <div
-      className="relative overflow-hidden rounded-2xl border-2 max-w-[600px] mx-auto"
-      style={{ background: "#10151f", borderColor: edge }}
+      className="relative overflow-hidden rounded-2xl max-w-[600px] mx-auto"
+      style={{
+        background: t.cardBg,
+        border: `${t.border}px solid ${t.metal}`,
+        boxShadow: t.inner ? `inset 0 0 0 ${stats.scope === "year" ? 2 : 1}px ${t.inner}` : undefined,
+      }}
     >
       <div
         className="absolute top-0 right-0 w-40 h-40 pointer-events-none"
         style={{
-          backgroundImage: "radial-gradient(#e8940a 1.3px, transparent 1.4px)",
+          backgroundImage: `radial-gradient(${t.metal} 1.3px, transparent 1.4px)`,
           backgroundSize: "8px 8px",
-          opacity: 0.13,
+          opacity: 0.14,
         }}
       />
 
-      {isYear && (
+      {t.banner && (
         <div
-          className="relative h-44 sm:h-52 border-b-2 flex items-center justify-center overflow-hidden"
-          style={{ borderColor: edge, background: "#0a0d13" }}
+          className="relative h-44 sm:h-52 flex items-center justify-center overflow-hidden"
+          style={{ borderBottom: `${t.border}px solid ${t.metal}`, background: "#0a0d13" }}
         >
           {truckAvatarUrl ? (
-            <img
-              src={truckAvatarUrl}
-              alt="Your truck"
-              className="w-full h-full object-cover"
-            />
+            <img src={truckAvatarUrl} alt="Your truck" className="w-full h-full object-cover" />
           ) : (
             <Truck size={72} style={{ color: "#2a3347" }} />
           )}
@@ -87,68 +134,73 @@ export const RecapPoster = ({
 
       <div className="relative p-5 sm:p-6">
         <div className="text-center mb-5">
-          <div className="font-comic tracking-[4px] text-xs" style={{ color: "#9daabb" }}>
-            DELGADO TRUCKING · {kicker}
+          <div className="font-comic tracking-[3px] text-[11px] flex items-center justify-center gap-1.5" style={{ color: "#9daabb" }}>
+            {t.crown && <Crown size={14} style={{ color: t.metal }} />}
+            DELGADO TRUCKING · {t.kicker} · <Pips n={t.stars} color={t.title} />
           </div>
-          <div className="font-comic leading-none" style={{ color: edge, fontSize: isYear ? 44 : 34 }}>
-            {title}
+          <div className="flex items-center justify-center gap-2.5 mt-0.5">
+            {t.laurels && <Leaf size={titleSize * 0.5} style={{ color: t.metal, transform: "scaleX(-1)" }} />}
+            <div className="font-comic leading-none" style={{ color: t.title, fontSize: titleSize }}>
+              {stats.label}
+            </div>
+            {t.laurels && <Leaf size={titleSize * 0.5} style={{ color: t.metal }} />}
           </div>
-          <div
-            className="inline-flex items-center gap-1.5 mt-2.5 rounded-full px-3 py-0.5"
-            style={{ background: "#3a2a0a", border: "1px solid #e8940a" }}
-          >
-            <Truck size={14} style={{ color: "#f5b03a" }} />
-            <span className="font-comic tracking-wide text-[14px] uppercase" style={{ color: "#f5e6c8" }}>
-              {rank}
-            </span>
-          </div>
+          <RankChip rank={rank} t={t} />
         </div>
 
-        <div className="flex gap-2 mb-2.5">
-          <Hero value={kMoney(stats.gross)} label="HAULED" color="#4ade80" />
-          <Hero value={num(stats.totalMiles)} label="MILES" color="#f5b03a" />
-          <Hero value={String(stats.states)} label="STATES" color="#60a5fa" />
+        <div className="flex gap-2 mb-2">
+          <Hero value={kMoney(stats.gross)} label="HAULED" color="#4ade80" big={stats.scope === "year"} />
+          <Hero value={num(stats.totalMiles)} label="MILES" color={t.metal === "#b3763f" ? "#f5b03a" : t.metal} big={stats.scope === "year"} />
+          <Hero value={String(stats.states)} label="STATES" color="#60a5fa" big={stats.scope === "year"} />
         </div>
 
-        <div className="grid grid-cols-3 gap-2">
+        <div className="flex gap-2 mb-2">
           <Tile value={String(stats.loads)} label="LOADS" />
           <Tile value={stats.bestWeek != null ? kMoney(stats.bestWeek) : "—"} label="BEST WEEK" />
-          <Tile value={stats.biggestLoad != null ? kMoney(stats.biggestLoad) : "—"} label="BIGGEST LOAD" />
-          <Tile value={stats.longestHaul != null ? num(stats.longestHaul) : "—"} label="LONGEST HAUL (MI)" />
-          <Tile value={stats.bestMpg != null ? stats.bestMpg.toFixed(1) : "—"} label="BEST TANK (MPG)" />
-          <Tile value={stats.avgRpm != null ? `$${stats.avgRpm.toFixed(2)}` : "—"} label="AVG RPM" />
+          {rich && <Tile value={stats.biggestLoad != null ? kMoney(stats.biggestLoad) : "—"} label="BIGGEST" />}
+          {rich && <Tile value={stats.longestHaul != null ? num(stats.longestHaul) : "—"} label="LONGEST MI" />}
+          <Tile value={stats.bestMpg != null ? stats.bestMpg.toFixed(1) : "—"} label="BEST TANK" />
+          {rich && <Tile value={stats.avgRpm != null ? `$${stats.avgRpm.toFixed(2)}` : "—"} label="AVG RPM" />}
         </div>
 
-        {stats.netProfit != null && (
-          <div className="grid grid-cols-3 gap-2 mt-2">
+        {rich && stats.netProfit != null && (
+          <div className="flex gap-2 mb-2">
             <Tile value={money0(stats.netProfit)} label="NET PROFIT" color="#4ade80" />
             {stats.bestMonth && <Tile value={stats.bestMonth.label.split(" ")[0]} label="BEST MONTH" color="#4ade80" />}
-            {stats.hardestMonth && <Tile value={stats.hardestMonth.label.split(" ")[0]} label="HARDEST MONTH" color="#f87171" />}
+            {stats.hardestMonth && <Tile value={stats.hardestMonth.label.split(" ")[0]} label="HARDEST" color="#f87171" />}
           </div>
         )}
 
-        <div className="flex gap-2 flex-wrap mt-2.5">
-          <div className="flex-1 min-w-[180px] rounded-[10px] px-3 py-2.5" style={{ background: "#1c2333" }}>
-            <div className="text-[10px] text-muted-text tracking-wide">
-              <MapPin size={12} className="inline -mt-0.5" style={{ color: "#e8940a" }} /> TOP LANE
-            </div>
-            <div className="font-comic text-[17px] mt-0.5" style={{ color: "#f5b03a" }}>
-              {stats.topLane ?? "—"}
-            </div>
+        {rich && stats.monthlyGross.length > 1 && (
+          <div className="mb-2">
+            <MonthStrip data={stats.monthlyGross} color={t.metal} />
           </div>
-          <div className="flex-1 min-w-[150px] rounded-[10px] px-3 py-2.5" style={{ background: "#1c2333" }}>
-            <div className="text-[10px] text-muted-text tracking-wide">
-              <Star size={12} className="inline -mt-0.5" style={{ color: "#e8940a" }} /> TOP AGENT
-            </div>
-            <div className="font-comic text-[17px] mt-0.5" style={{ color: "#f5b03a" }}>
-              {stats.topAgent ?? "—"}
-            </div>
-          </div>
-        </div>
+        )}
 
-        <div className="text-center mt-4 border-t border-plate pt-3">
-          <span className="font-comic tracking-[2px] text-[13px]" style={{ color: "#9daabb" }}>
-            {stats.states} OF 48 STATES · BEST STREAK {stats.bestStreak} WK · KEEP ROLLING
+        {rich && (
+          <div className="flex gap-2">
+            <div className="flex-1 min-w-[150px] rounded-[10px] px-3 py-2.5" style={{ background: "#1c2333" }}>
+              <div className="text-[10px] text-muted-text tracking-wide">
+                <MapPin size={12} className="inline -mt-0.5" style={{ color: "#e8940a" }} /> TOP LANE
+              </div>
+              <div className="font-comic text-[16px] mt-0.5" style={{ color: "#f5b03a" }}>
+                {stats.topLane ?? "—"}
+              </div>
+            </div>
+            <div className="flex-1 min-w-[130px] rounded-[10px] px-3 py-2.5" style={{ background: "#1c2333" }}>
+              <div className="text-[10px] text-muted-text tracking-wide">
+                <Star size={12} className="inline -mt-0.5" style={{ color: "#e8940a" }} /> TOP AGENT
+              </div>
+              <div className="font-comic text-[16px] mt-0.5" style={{ color: "#f5b03a" }}>
+                {stats.topAgent ?? "—"}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="text-center mt-4 border-t pt-3" style={{ borderColor: stats.scope === "year" ? "#2a2010" : "#1c2333" }}>
+          <span className="font-comic tracking-[2px] text-[12px]" style={{ color: "#9daabb" }}>
+            {rich ? `${stats.states} OF 48 STATES · ` : ""}BEST STREAK {stats.bestStreak} WK · KEEP ROLLING
           </span>
         </div>
       </div>

--- a/frontend/src/hooks/useAwardPops.ts
+++ b/frontend/src/hooks/useAwardPops.ts
@@ -41,7 +41,9 @@ const write = (s: Store) => {
 // Computes the awards newly earned since this device last looked. On a device's
 // first-ever load it silently baselines the current set (no day-one flood), so
 // only things earned AFTER that fire a celebration.
-export const useAwardPops = (loads: Load[]): { pops: Award[] } => {
+export const useAwardPops = (
+  loads: Load[],
+): { pops: Award[]; truckAvatarUrl: string | null } => {
   const [pops, setPops] = useState<Award[]>([]);
   const [data, setData] = useState<{
     periods: ExpensePeriod[];
@@ -101,5 +103,6 @@ export const useAwardPops = (loads: Load[]): { pops: Award[] } => {
     }
   }, [data, loads, done]);
 
-  return { pops };
+  const truckAvatarUrl = data?.trucks.find((t) => t.avatar_url)?.avatar_url ?? null;
+  return { pops, truckAvatarUrl };
 };

--- a/frontend/src/lib/constants/recapTiers.ts
+++ b/frontend/src/lib/constants/recapTiers.ts
@@ -1,0 +1,77 @@
+import type { RecapScope } from "@/lib/metrics/recap";
+
+// Bronze → silver → gold. One source of truth for the prestige look so the recap
+// CARD and the ceremony POP always match. Colors are the dash comic palette.
+export interface RecapTier {
+  metal: string; // border + primary accent
+  inner: string | null; // inner foil line (quarter/year)
+  title: string; // big title text
+  medalBg: string; // medallion disc bg
+  medalInk: string; // medallion icon color
+  chipBg: string;
+  chipBorder: string;
+  chipInk: string;
+  kicker: string; // "MONTH RECAP" / "QUARTER RECAP" / "GRAND FINALE"
+  stars: number; // rank pips: 1 / 2 / 3
+  crown: boolean; // year only
+  laurels: boolean; // quarter + year (flank the title)
+  banner: boolean; // year only — the truck-avatar hero
+  border: number; // border weight px
+  cardBg: string;
+}
+
+export const RECAP_TIERS: Record<RecapScope, RecapTier> = {
+  month: {
+    metal: "#b3763f",
+    inner: null,
+    title: "#c9884a",
+    medalBg: "#2a1d0e",
+    medalInk: "#d9a05c",
+    chipBg: "#2a1d0e",
+    chipBorder: "#b3763f",
+    chipInk: "#e7cfa8",
+    kicker: "MONTH RECAP",
+    stars: 1,
+    crown: false,
+    laurels: false,
+    banner: false,
+    border: 2,
+    cardBg: "#10151f",
+  },
+  quarter: {
+    metal: "#aab4c4",
+    inner: "#5a6478",
+    title: "#dfe6f0",
+    medalBg: "#1a2130",
+    medalInk: "#dfe6f0",
+    chipBg: "#1a2130",
+    chipBorder: "#cdd6e3",
+    chipInk: "#dfe6f0",
+    kicker: "QUARTER RECAP",
+    stars: 2,
+    crown: false,
+    laurels: true,
+    banner: false,
+    border: 3,
+    cardBg: "#10151f",
+  },
+  year: {
+    metal: "#f5b03a",
+    inner: "#7a5410",
+    title: "#ffe08a",
+    medalBg: "#0a0d13",
+    medalInk: "#f5b03a",
+    chipBg: "#3a2a0a",
+    chipBorder: "#f5b03a",
+    chipInk: "#ffe08a",
+    kicker: "GRAND FINALE",
+    stars: 3,
+    crown: true,
+    laurels: true,
+    banner: true,
+    border: 3,
+    cardBg: "#120f08",
+  },
+};
+
+export const stars = (n: number): string => "★ ".repeat(n).trim();

--- a/frontend/src/lib/metrics/awards.ts
+++ b/frontend/src/lib/metrics/awards.ts
@@ -13,8 +13,10 @@ import {
   personalBests,
 } from "./playerCard";
 import { mileMilestone } from "./mileClub";
+import { resolvePeriod, loadsInRange, type RecapScope } from "./recap";
+import { loadRevenue } from "./rateTargets";
 
-export type AwardTier = "marquee" | "burst";
+export type AwardTier = "recap" | "marquee" | "burst";
 
 export interface Award {
   id: string;
@@ -22,9 +24,12 @@ export interface Award {
   name: string;
   detail: string;
   icon: string; // mapped to a lucide icon in the UI
+  scope?: RecapScope; // recap tier only — drives the prestige of the ceremony
 }
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+const kMoney = (n: number) =>
+  n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${Math.round(n)}`;
 
 export interface AwardInputs {
   loads: Load[];
@@ -42,6 +47,24 @@ const STREAK_MARKS = [12, 8, 4];
 
 export const earnedAwards = (i: AwardInputs): Award[] => {
   const out: Award[] = [];
+
+  // ---- Recap ceremony: each COMPLETED period (month/quarter/year) that has
+  // earned freight. The id carries the period label, so a given month only ever
+  // fires once; the next month's recap is a new id. Prestige rises by scope.
+  for (const scope of ["month", "quarter", "year"] as RecapScope[]) {
+    const r = resolvePeriod(scope, 0, i.now);
+    const inR = loadsInRange(i.loads, r);
+    if (inR.length === 0) continue;
+    const gross = inR.reduce((s, l) => s + loadRevenue(l), 0);
+    out.push({
+      id: `recap:${scope}:${r.label}`,
+      tier: "recap",
+      scope,
+      name: r.label,
+      detail: `${kMoney(gross)} hauled · ${inR.length} load${inR.length === 1 ? "" : "s"}`,
+      icon: "trophy",
+    });
+  }
 
   // ---- Marquee: career rank ----
   const rank = careerRank(i.lifetimeMiles);
@@ -122,6 +145,9 @@ export const earnedAwards = (i: AwardInputs): Award[] => {
 // since a real device silently baselines on first load, this is how you see the
 // pop without waiting to earn one.
 export const DEMO_AWARDS: Award[] = [
+  { id: "demo:recap-month", tier: "recap", scope: "month", name: "Jun 2026", detail: "$24.1k hauled · 8 loads", icon: "trophy" },
+  { id: "demo:recap-quarter", tier: "recap", scope: "quarter", name: "Q2 2026", detail: "$70.4k hauled · 23 loads", icon: "trophy" },
+  { id: "demo:recap-year", tier: "recap", scope: "year", name: "2026", detail: "$141k hauled · 47 loads", icon: "trophy" },
   { id: "demo:rank", tier: "marquee", name: "Rank up — Road Captain", detail: "582,450 lifetime miles and climbing.", icon: "truck" },
   { id: "demo:tightlines", tier: "burst", name: "Tight Lines", detail: "Deadhead down to 7.2%", icon: "gauge" },
   { id: "demo:feather", tier: "burst", name: "Feather Foot", detail: "New best tank — 6.9 mpg", icon: "flame" },
@@ -131,7 +157,14 @@ export const DEMO_AWARDS: Award[] = [
 // the screen), then bursts.
 export const newAwards = (earned: Award[], seen: Set<string>): Award[] => {
   const fresh = earned.filter((a) => !seen.has(a.id));
+  const scopeRank: Record<string, number> = { month: 0, quarter: 1, year: 2 };
+  // Recap ceremonies lead, played smallest → grandest (month → quarter → year)
+  // so a period-boundary crescendos; then any marquee, then bursts.
+  const recaps = fresh
+    .filter((a) => a.tier === "recap")
+    .sort((a, b) => (scopeRank[a.scope ?? "month"] ?? 0) - (scopeRank[b.scope ?? "month"] ?? 0));
   return [
+    ...recaps,
     ...fresh.filter((a) => a.tier === "marquee"),
     ...fresh.filter((a) => a.tier === "burst"),
   ];

--- a/frontend/src/lib/metrics/recap.test.ts
+++ b/frontend/src/lib/metrics/recap.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from "vitest";
 import type { Load } from "@/types/load";
 import type { ExpensePeriod } from "@/types/expense";
 import type { FuelEntry } from "@/types/fuelEntry";
-import { rangeFor, resolvePeriod, computeRecap } from "./recap";
+import {
+  rangeFor,
+  resolvePeriod,
+  computeRecap,
+  latestRecapWithData,
+} from "./recap";
 
 const NOW = new Date("2026-07-11T12:00:00Z");
 
@@ -24,11 +29,29 @@ describe("rangeFor / resolvePeriod", () => {
     expect(rangeFor("quarter", 2026, 1).label).toBe("Q2 2026");
     expect(rangeFor("month", 2026, 5).label).toBe("Jun 2026");
   });
-  it("resolves the most recent complete period", () => {
+  it("resolves the most recent complete period — never the in-progress one", () => {
     expect(resolvePeriod("month", 0, NOW).label).toBe("Jun 2026");
     expect(resolvePeriod("quarter", 0, NOW).label).toBe("Q2 2026");
-    expect(resolvePeriod("year", 0, NOW).label).toBe("2026");
+    expect(resolvePeriod("year", 0, NOW).label).toBe("2025"); // NOT 2026 — it isn't done
     expect(resolvePeriod("month", 1, NOW).label).toBe("May 2026");
+    expect(resolvePeriod("year", 1, NOW).label).toBe("2024");
+  });
+});
+
+describe("latestRecapWithData", () => {
+  it("prefers the grandest finished period that has data", () => {
+    // A June-2026 delivery: the last complete year (2025) is empty, so it falls
+    // back to the quarter (Q2 2026), which has the load.
+    const loads = [
+      { load_status: "delivered", delivery_date: "2026-06-15" },
+    ] as unknown as Load[];
+    expect(latestRecapWithData(loads, NOW)).toEqual({ scope: "quarter", label: "Q2 2026" });
+  });
+  it("returns null when nothing is finished yet", () => {
+    const loads = [
+      { load_status: "delivered", delivery_date: "2026-07-05" }, // current month only
+    ] as unknown as Load[];
+    expect(latestRecapWithData(loads, NOW)).toBeNull();
   });
 });
 
@@ -55,6 +78,10 @@ describe("computeRecap", () => {
     expect(r.avgRpm).toBeCloseTo(5800 / 1800, 3);
     expect(r.topLane).toBe("Dallas → Atlanta");
     expect(r.topAgent).toBe("Redwood");
+    // 12 months for a year, with only May + Jun carrying gross
+    expect(r.monthlyGross).toHaveLength(12);
+    expect(r.monthlyGross[4]).toEqual({ label: "May", gross: 3200 });
+    expect(r.monthlyGross[5]).toEqual({ label: "Jun", gross: 2600 });
   });
 
   it("counts total (odometer) miles incl. deadhead, loaded only for RPM", () => {

--- a/frontend/src/lib/metrics/recap.ts
+++ b/frontend/src/lib/metrics/recap.ts
@@ -54,6 +54,8 @@ export const rangeFor = (scope: RecapScope, year: number, unit: number): RecapRa
 };
 
 // The period `periodsAgo` complete periods before now (0 = most recent complete).
+// Every scope looks BACKWARD at finished periods — you never recap the current,
+// in-progress month/quarter/year. So year 0 = last year, not this one.
 export const resolvePeriod = (
   scope: RecapScope,
   periodsAgo: number,
@@ -61,7 +63,7 @@ export const resolvePeriod = (
 ): RecapRange => {
   const y = now.getUTCFullYear();
   const m = now.getUTCMonth();
-  if (scope === "year") return rangeFor("year", y - periodsAgo, 0);
+  if (scope === "year") return rangeFor("year", y - 1 - periodsAgo, 0);
   if (scope === "quarter") {
     const totalQ = y * 4 + Math.floor(m / 3) - 1 - periodsAgo;
     return rangeFor("quarter", Math.floor(totalQ / 4), ((totalQ % 4) + 4) % 4);
@@ -74,6 +76,29 @@ const inRange = (d: string | null | undefined, r: RecapRange): boolean => {
   if (!d) return false;
   const t = new Date(d.slice(0, 10) + "T00:00:00Z").getTime();
   return t >= r.start.getTime() && t < r.end.getTime();
+};
+
+// The delivered loads that fall inside a range.
+export const loadsInRange = (loads: Load[], r: RecapRange): Load[] =>
+  loads.filter((l) => l.load_status === "delivered" && inRange(l.delivery_date, r));
+
+// Does the range contain any earned (delivered) freight? Drives both the recap
+// page's empty state and which completed periods are worth celebrating.
+export const rangeHasData = (loads: Load[], r: RecapRange): boolean =>
+  loadsInRange(loads, r).length > 0;
+
+// The grandest completed period that actually has data — year, else quarter, else
+// month. Used to land the recap page (and the dashboard link) on a real, finished
+// recap instead of an empty in-progress one. null when there's no history yet.
+export const latestRecapWithData = (
+  loads: Load[],
+  now: Date,
+): { scope: RecapScope; label: string } | null => {
+  for (const scope of ["year", "quarter", "month"] as RecapScope[]) {
+    const r = resolvePeriod(scope, 0, now);
+    if (rangeHasData(loads, r)) return { scope, label: r.label };
+  }
+  return null;
 };
 
 export interface RecapStats {
@@ -95,6 +120,7 @@ export interface RecapStats {
   bestMonth: { label: string; profit: number } | null;
   hardestMonth: { label: string; profit: number } | null;
   bestStreak: number;
+  monthlyGross: { label: string; gross: number }[]; // 1/3/12 bars for the strip
 }
 
 export const computeRecap = (
@@ -185,6 +211,28 @@ export const computeRecap = (
     statuses.push(classify(wg, targets));
   }
 
+  // Gross per month across the range (1 for a month, 3 for a quarter, 12 for a
+  // year) — feeds the recap's monthly bar strip. Empty months read as 0.
+  const monthGrossMap = new Map<number, number>();
+  for (const l of mine) {
+    if (!l.delivery_date) continue;
+    const d = new Date(l.delivery_date.slice(0, 10) + "T00:00:00Z");
+    const key = d.getUTCFullYear() * 12 + d.getUTCMonth();
+    monthGrossMap.set(key, (monthGrossMap.get(key) ?? 0) + loadRevenue(l));
+  }
+  const monthlyGross: { label: string; gross: number }[] = [];
+  for (
+    let d = new Date(range.start);
+    d.getTime() < range.end.getTime();
+    d = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1))
+  ) {
+    const key = d.getUTCFullYear() * 12 + d.getUTCMonth();
+    monthlyGross.push({
+      label: MONTHS[d.getUTCMonth()],
+      gross: monthGrossMap.get(key) ?? 0,
+    });
+  }
+
   return {
     scope,
     label: range.label,
@@ -204,5 +252,6 @@ export const computeRecap = (
     bestMonth,
     hardestMonth,
     bestStreak: bestStreakOf(statuses),
+    monthlyGross,
   };
 };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -27,6 +27,7 @@ import { useComplianceAlerts } from "@/hooks/useComplianceAlerts";
 import { useAwardPops } from "@/hooks/useAwardPops";
 import { AwardPopHost } from "@/components/comic/AwardPopHost";
 import { DEMO_AWARDS } from "@/lib/metrics/awards";
+import { latestRecapWithData } from "@/lib/metrics/recap";
 import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
 import { GrindMeter } from "@/components/dashboard/GrindMeter";
 import { RevenueChart } from "@/components/RevenueChart";
@@ -72,7 +73,9 @@ const DashboardPage = () => {
   } = useTrips(refreshKey);
   const targets = useRateTargets(loads);
   const alerts = [...useMaintenanceAlerts(loads), ...useComplianceAlerts()];
-  const { pops } = useAwardPops(loads);
+  const { pops, truckAvatarUrl } = useAwardPops(loads);
+  // The latest FINISHED recap that actually has data — never the in-progress one.
+  const latestRecap = latestRecapWithData(loads, new Date());
   // `?awarddemo` on the dashboard previews the celebration UI on demand.
   const awardDemo = window.location.search.includes("awarddemo");
 
@@ -128,7 +131,7 @@ const DashboardPage = () => {
 
   return (
     <div className="p-6 bg-iron text-light min-h-screen font-body">
-      <AwardPopHost pops={awardDemo ? DEMO_AWARDS : pops} />
+      <AwardPopHost pops={awardDemo ? DEMO_AWARDS : pops} truckAvatarUrl={truckAvatarUrl} />
 
       <div className="flex items-center justify-between mb-6 gap-3">
         <h1 className="text-3xl font-condensed">Dashboard</h1>
@@ -136,7 +139,7 @@ const DashboardPage = () => {
           to="/recap"
           className="text-sm text-status-info-text hover:underline whitespace-nowrap"
         >
-          Your {new Date().getUTCFullYear()} recap →
+          Your {latestRecap ? `${latestRecap.label} ` : ""}recap →
         </Link>
       </div>
 

--- a/frontend/src/pages/RecapPage.tsx
+++ b/frontend/src/pages/RecapPage.tsx
@@ -10,9 +10,11 @@ import { getFuelEntries } from "@/services/fuelService";
 import { getExpensePeriods } from "@/services/expensesService";
 import { getObligations } from "@/services/obligationsService";
 import { getTrucks } from "@/services/trucksService";
+import { useLocation } from "react-router-dom";
 import {
   computeRecap,
   resolvePeriod,
+  latestRecapWithData,
   type RecapScope,
   type RecapRange,
 } from "@/lib/metrics/recap";
@@ -39,8 +41,14 @@ const RecapPage = () => {
   const [periods, setPeriods] = useState<ExpensePeriod[]>([]);
   const [obligations, setObligations] = useState<Obligation[]>([]);
   const [trucks, setTrucks] = useState<Truck[]>([]);
-  const [scope, setScope] = useState<RecapScope>("year");
+  const location = useLocation();
+  const navScope = (location.state as { scope?: RecapScope } | null)?.scope;
+  const [scope, setScope] = useState<RecapScope>(navScope ?? "month");
   const [ago, setAgo] = useState(0);
+  // Once loads arrive, land on the grandest FINISHED period that has data (unless
+  // a ceremony pop already told us which scope to open). Set-once, then the user
+  // is free to switch scopes.
+  const [autoScoped, setAutoScoped] = useState(!!navScope);
 
   useEffect(() => {
     getFuelEntries().then(setFuel).catch(() => {});
@@ -48,6 +56,13 @@ const RecapPage = () => {
     getObligations().then(setObligations).catch(() => {});
     getTrucks().then(setTrucks).catch(() => {});
   }, []);
+
+  useEffect(() => {
+    if (autoScoped || loads.length === 0) return;
+    const latest = latestRecapWithData(loads, new Date());
+    if (latest) setScope(latest.scope);
+    setAutoScoped(true);
+  }, [loads, autoScoped]);
 
   const now = new Date();
   const range = resolvePeriod(scope, ago, now);


### PR DESCRIPTION
## v1.63.0 — recaps look backward and celebrate, scaled by prestige

### Look-back fix
`resolvePeriod` for **year** resolved to the current, in-progress year (month/quarter already subtracted 1). Now every scope looks back to the last *complete* period — no 2026 recap until 2026 ends. The recap page and the dashboard link land on the latest *finished* period that has data, not an empty current one.

### Prestige cards
`RecapPoster` reworked into **bronze (month) → silver (quarter) → gold (year)**, with data density scaling to the period:
- **Month** — core 6 stats
- **Quarter** — detail tiles + a 3-bar P&L strip
- **Year** — the full poster + a 12-month haul strip + the truck-avatar banner

A shared `recapTiers` token file keeps the card and the pop in lockstep; a new `monthlyGross` series feeds the bar strips.

### Ceremony pops
A new `RecapCeremony` screen-takeover fires **once per period-close** (per-device "seen" store, same as existing award pops), escalating month → quarter → year. The year medallion uses your truck avatar and its button opens the full season poster. Added as a new `recap` award tier ranked above marquees. Preview any time with `?awarddemo`.

Frontend-only, no migration. Build clean, **179 tests**.