### PR TITLE
fix: subsume smaller recap ceremonies into the period that closes with them

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.63.0",
+  "version": "1.63.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/awards.test.ts
+++ b/frontend/src/lib/metrics/awards.test.ts
@@ -37,6 +37,23 @@ describe("earnedAwards", () => {
     expect(ids.some((x) => x.startsWith("best-week:"))).toBe(true);
   });
 
+  it("subsumes the closing month of a quarter — quarter pops, month doesn't", () => {
+    // NOW is July, so June (last complete month) closes the same day as Q2.
+    const loads = [L({ load_id: "j", delivery_date: "2026-06-15" })];
+    const ids = earnedAwards({ loads, periods: [], fuel: [], lifetimeMiles: 0, obligationsDebtMonthly: 0, now: NOW }).map((a) => a.id);
+    expect(ids).toContain("recap:quarter:Q2 2026");
+    expect(ids).not.toContain("recap:month:Jun 2026");
+  });
+
+  it("a mid-quarter month still pops its own recap", () => {
+    // NOW is mid-June: last complete month = May, last complete quarter = Q1 —
+    // different close dates, so May is not subsumed.
+    const NOW_JUN = new Date("2026-06-10T12:00:00Z");
+    const loads = [L({ load_id: "m", delivery_date: "2026-05-12" })];
+    const ids = earnedAwards({ loads, periods: [], fuel: [], lifetimeMiles: 0, obligationsDebtMonthly: 0, now: NOW_JUN }).map((a) => a.id);
+    expect(ids).toContain("recap:month:May 2026");
+  });
+
   it("re-earns: a bigger best week yields a new id so it pops again", () => {
     const base = { periods: [], fuel: [], lifetimeMiles: 0, obligationsDebtMonthly: 0, now: NOW };
     const a = earnedAwards({ ...base, loads: [L({ load_id: "1", linehaul: "4000" })] });
@@ -56,5 +73,21 @@ describe("newAwards", () => {
     ];
     const fresh = newAwards(earned, new Set(["seen-one"]));
     expect(fresh.map((a) => a.id)).toEqual(["rank:road-captain", "best-week:5000"]);
+  });
+
+  it("orders recap ceremonies grandest first, ahead of marquees", () => {
+    const earned: Award[] = [
+      { id: "recap:month:Jun 2026", tier: "recap", scope: "month", name: "", detail: "", icon: "" },
+      { id: "rank:road-captain", tier: "marquee", name: "", detail: "", icon: "" },
+      { id: "recap:year:2026", tier: "recap", scope: "year", name: "", detail: "", icon: "" },
+      { id: "recap:quarter:Q2 2026", tier: "recap", scope: "quarter", name: "", detail: "", icon: "" },
+    ];
+    const fresh = newAwards(earned, new Set());
+    expect(fresh.map((a) => a.id)).toEqual([
+      "recap:year:2026",
+      "recap:quarter:Q2 2026",
+      "recap:month:Jun 2026",
+      "rank:road-captain",
+    ]);
   });
 });

--- a/frontend/src/lib/metrics/awards.ts
+++ b/frontend/src/lib/metrics/awards.ts
@@ -48,11 +48,24 @@ const STREAK_MARKS = [12, 8, 4];
 export const earnedAwards = (i: AwardInputs): Award[] => {
   const out: Award[] = [];
 
-  // ---- Recap ceremony: each COMPLETED period (month/quarter/year) that has
-  // earned freight. The id carries the period label, so a given month only ever
-  // fires once; the next month's recap is a new id. Prestige rises by scope.
-  for (const scope of ["month", "quarter", "year"] as RecapScope[]) {
-    const r = resolvePeriod(scope, 0, i.now);
+  // ---- Recap ceremony: each COMPLETED period (month/quarter/year) with earned
+  // freight. A smaller period that closes on the SAME day as a larger one is
+  // SUBSUMED — only the grandest ceremony fires (the last month of a quarter
+  // hands the moment to the quarter; the last quarter of a year, to the year).
+  // The subsumed period is still fully browsable on the recap page. The id carries
+  // the label so each period only ever fires once.
+  const monthR = resolvePeriod("month", 0, i.now);
+  const quarterR = resolvePeriod("quarter", 0, i.now);
+  const yearR = resolvePeriod("year", 0, i.now);
+  const sameClose = (a: typeof monthR, b: typeof monthR) =>
+    a.end.getTime() === b.end.getTime();
+  const recapPeriods = [
+    { scope: "month" as RecapScope, r: monthR, subsumed: sameClose(monthR, quarterR) },
+    { scope: "quarter" as RecapScope, r: quarterR, subsumed: sameClose(quarterR, yearR) },
+    { scope: "year" as RecapScope, r: yearR, subsumed: false },
+  ];
+  for (const { scope, r, subsumed } of recapPeriods) {
+    if (subsumed) continue;
     const inR = loadsInRange(i.loads, r);
     if (inR.length === 0) continue;
     const gross = inR.reduce((s, l) => s + loadRevenue(l), 0);
@@ -145,9 +158,9 @@ export const earnedAwards = (i: AwardInputs): Award[] => {
 // since a real device silently baselines on first load, this is how you see the
 // pop without waiting to earn one.
 export const DEMO_AWARDS: Award[] = [
-  { id: "demo:recap-month", tier: "recap", scope: "month", name: "Jun 2026", detail: "$24.1k hauled · 8 loads", icon: "trophy" },
-  { id: "demo:recap-quarter", tier: "recap", scope: "quarter", name: "Q2 2026", detail: "$70.4k hauled · 23 loads", icon: "trophy" },
   { id: "demo:recap-year", tier: "recap", scope: "year", name: "2026", detail: "$141k hauled · 47 loads", icon: "trophy" },
+  { id: "demo:recap-quarter", tier: "recap", scope: "quarter", name: "Q2 2026", detail: "$70.4k hauled · 23 loads", icon: "trophy" },
+  { id: "demo:recap-month", tier: "recap", scope: "month", name: "Jun 2026", detail: "$24.1k hauled · 8 loads", icon: "trophy" },
   { id: "demo:rank", tier: "marquee", name: "Rank up — Road Captain", detail: "582,450 lifetime miles and climbing.", icon: "truck" },
   { id: "demo:tightlines", tier: "burst", name: "Tight Lines", detail: "Deadhead down to 7.2%", icon: "gauge" },
   { id: "demo:feather", tier: "burst", name: "Feather Foot", detail: "New best tank — 6.9 mpg", icon: "flame" },
@@ -157,9 +170,10 @@ export const DEMO_AWARDS: Award[] = [
 // the screen), then bursts.
 export const newAwards = (earned: Award[], seen: Set<string>): Award[] => {
   const fresh = earned.filter((a) => !seen.has(a.id));
-  const scopeRank: Record<string, number> = { month: 0, quarter: 1, year: 2 };
-  // Recap ceremonies lead, played smallest → grandest (month → quarter → year)
-  // so a period-boundary crescendos; then any marquee, then bursts.
+  const scopeRank: Record<string, number> = { year: 0, quarter: 1, month: 2 };
+  // Recap ceremonies lead, grandest first (year → quarter → month) so the biggest
+  // milestone is the primary pop and smaller ones queue behind it; then any
+  // marquee, then bursts.
   const recaps = fresh
     .filter((a) => a.tier === "recap")
     .sort((a, b) => (scopeRank[a.scope ?? "month"] ?? 0) - (scopeRank[b.scope ?? "month"] ?? 0));


### PR DESCRIPTION
## v1.63.1 — the last month of a quarter hands the moment to the quarter

On production, the June ceremony fired and masked the Q2 ceremony. The fix:

- **Subsumption** — when a smaller period closes on the *same day* as a bigger one, only the grandest pops. June ends when Q2 ends → **Q2 pops, June is suppressed**; December hands off to Q4 and the year. The subsumed period stays fully browsable on the recap page.
- **Grandest-first** — if several ceremonies are ever pending together, the biggest is the primary pop; smaller ones queue behind it.

Note: on a device that already fired the June pop, Q2 was marked seen at the same moment, so it won't re-pop there — this corrects every future boundary. Preview the look with `?awarddemo`.

Frontend-only, no migration. Build clean, **182 tests** (added subsumption + ordering coverage).