### PR TITLE
feat: driver badges area, tiered awards, and avatar cleanup

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.63.1",
+  "version": "1.64.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/fleet/EntityAvatar.tsx
+++ b/frontend/src/components/fleet/EntityAvatar.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { Sparkles, Upload } from "lucide-react";
+import { Sparkles, Upload, Pencil } from "lucide-react";
 import {
   generateAvatar,
   uploadAvatar,
@@ -28,7 +28,11 @@ export const EntityAvatar = ({
   const [busy, setBusy] = useState<null | "gen" | "up">(null);
   const [variant, setVariant] = useState("male");
   const [err, setErr] = useState<string | null>(null);
+  // Once an avatar exists the generation controls collapse behind a "Change"
+  // affordance — a finished avatar shouldn't carry a toolbar. Editing reopens them.
+  const [editing, setEditing] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
+  const showControls = !url || editing;
 
   // Storage path is fixed per entity, so a fresh image reuses the URL — bust
   // the browser cache so the new one shows.
@@ -81,47 +85,67 @@ export const EntityAvatar = ({
             {busy === "gen" ? "Generating…" : "Uploading…"}
           </div>
         )}
+        {url && !editing && !busy && (
+          <button
+            onClick={() => setEditing(true)}
+            aria-label="Change avatar"
+            className="absolute top-1.5 right-1.5 bg-black/55 hover:bg-black/75 text-light rounded-md p-1"
+          >
+            <Pencil size={13} />
+          </button>
+        )}
       </div>
 
-      {allowVariant && (
-        <div className="flex gap-1 text-xs">
-          {["male", "female"].map((v) => (
+      {showControls && (
+        <>
+          {allowVariant && (
+            <div className="flex gap-1 text-xs">
+              {["male", "female"].map((v) => (
+                <button
+                  key={v}
+                  onClick={() => setVariant(v)}
+                  className={`px-2 py-0.5 rounded capitalize ${
+                    variant === v ? "bg-amber text-steel" : "bg-steel text-muted-text"
+                  }`}
+                >
+                  {v}
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="flex gap-2">
             <button
-              key={v}
-              onClick={() => setVariant(v)}
-              className={`px-2 py-0.5 rounded capitalize ${
-                variant === v ? "bg-amber text-steel" : "bg-steel text-muted-text"
-              }`}
+              onClick={gen}
+              disabled={!!busy}
+              className="bg-amber text-steel px-2 py-1 rounded text-xs font-semibold flex items-center gap-1 disabled:opacity-50"
             >
-              {v}
+              <Sparkles size={13} /> Generate
             </button>
-          ))}
-        </div>
+            <button
+              onClick={() => fileRef.current?.click()}
+              disabled={!!busy}
+              className="bg-steel text-light px-2 py-1 rounded text-xs flex items-center gap-1 disabled:opacity-50"
+            >
+              <Upload size={13} /> Upload
+            </button>
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              className="hidden"
+              onChange={onFile}
+            />
+          </div>
+          {url && (
+            <button
+              onClick={() => setEditing(false)}
+              className="text-[11px] text-muted-text hover:text-light"
+            >
+              Done
+            </button>
+          )}
+        </>
       )}
-
-      <div className="flex gap-2">
-        <button
-          onClick={gen}
-          disabled={!!busy}
-          className="bg-amber text-steel px-2 py-1 rounded text-xs font-semibold flex items-center gap-1 disabled:opacity-50"
-        >
-          <Sparkles size={13} /> Generate
-        </button>
-        <button
-          onClick={() => fileRef.current?.click()}
-          disabled={!!busy}
-          className="bg-steel text-light px-2 py-1 rounded text-xs flex items-center gap-1 disabled:opacity-50"
-        >
-          <Upload size={13} /> Upload
-        </button>
-        <input
-          ref={fileRef}
-          type="file"
-          accept="image/jpeg,image/png,image/webp"
-          className="hidden"
-          onChange={onFile}
-        />
-      </div>
       {err && <p className="text-destructive text-xs">{err}</p>}
     </div>
   );

--- a/frontend/src/components/playercard/PlayerCard.tsx
+++ b/frontend/src/components/playercard/PlayerCard.tsx
@@ -7,16 +7,11 @@ import {
   Layers,
   Users,
   Medal,
-  TrendingDown,
+  Gauge,
   type LucideIcon,
 } from "lucide-react";
-import type {
-  Grade,
-  CareerRank,
-  SeasonStats,
-  PersonalBests,
-  Trophy as TrophyData,
-} from "@/lib/metrics/playerCard";
+import type { Grade, CareerRank, SeasonStats } from "@/lib/metrics/playerCard";
+import type { Award } from "@/lib/metrics/awards";
 import { fmtMiles } from "@/lib/metrics/mileClub";
 import { RANK_TIERS } from "@/lib/constants/playerCard";
 import { DEADHEAD_TARGET } from "@/lib/constants/targets";
@@ -45,13 +40,19 @@ const GRADE_META: Record<Grade, { label: string; fg: string; bg: string }> = {
   strong: { label: "STRONG", fg: "#fbbf24", bg: "#3a300a" },
 };
 
-const TROPHY_ICON: Record<string, LucideIcon> = {
-  medal: Medal,
-  users: Users,
-  stack: Layers,
+// The award engine's icon strings → lucide. Shared vocabulary with the pop host,
+// so a badge here wears the same icon as the pop that announced it.
+const AWARD_ICON: Record<string, LucideIcon> = {
   trophy: Trophy,
   flame: Flame,
+  package: Package,
+  stack: Layers,
+  users: Users,
+  gauge: Gauge,
+  medal: Medal,
+  truck: Truck,
 };
+const iconFor = (n: string): LucideIcon => AWARD_ICON[n] ?? Trophy;
 
 const GradeChip = ({ grade, value }: { grade: Grade | null; value?: string }) => {
   if (!grade)
@@ -93,25 +94,31 @@ const Stat = ({
   </div>
 );
 
-const Record = ({
+// A small earned emblem — the persistent home for a `burst` pop. Name + the
+// record value it carries, so the achievement and its number live together.
+const Badge = ({
   Icon,
-  label,
-  value,
-  color,
+  name,
+  detail,
 }: {
   Icon: LucideIcon;
-  label: string;
-  value: string;
-  color: string;
+  name: string;
+  detail: string;
 }) => (
-  <div className="rounded-[11px] border border-plate px-3 py-2.5" style={{ background: "#10151f" }}>
-    <p className="text-[11px] text-muted-text flex items-center gap-1.5">
-      <Icon size={13} style={{ color }} />
-      {label}
-    </p>
-    <p className="text-lg font-condensed mt-0.5" style={{ color: value === "—" ? undefined : "#4ade80" }}>
-      {value}
-    </p>
+  <div
+    className="flex items-center gap-2 rounded-[11px] px-2.5 py-2"
+    style={{ background: "#10151f", border: "1px solid #2a3347" }}
+  >
+    <div
+      className="w-8 h-8 rounded-full flex items-center justify-center shrink-0"
+      style={{ background: "#3a2a0a", color: "#f5b03a" }}
+    >
+      <Icon size={16} />
+    </div>
+    <div className="min-w-0">
+      <p className="text-[12px] font-semibold leading-tight truncate">{name}</p>
+      <p className="text-[10px] text-muted-text leading-tight truncate">{detail}</p>
+    </div>
   </div>
 );
 
@@ -125,8 +132,8 @@ export interface PlayerCardProps {
   marginGrade: Grade | null;
   form: Grade | null;
   windowRpm: number | null;
-  bests: PersonalBests;
-  trophies: TrophyData[];
+  badges: Award[]; // frequent wins (burst tier)
+  shelf: Award[]; // rarer wins (marquee tier — mile club, strong season)
 }
 
 export const PlayerCard = ({
@@ -139,8 +146,8 @@ export const PlayerCard = ({
   marginGrade,
   form,
   windowRpm,
-  bests,
-  trophies,
+  badges,
+  shelf,
 }: PlayerCardProps) => {
   const stars =
     "★".repeat(rank.index + 1) + "☆".repeat(RANK_TIERS.length - rank.index - 1);
@@ -225,7 +232,7 @@ export const PlayerCard = ({
       {/* ---- season stat line ---- */}
       <div className="flex items-baseline gap-2 mt-5 mb-2">
         <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
-          THIS SEASON
+          LAST SEASON
         </span>
         <span className="text-[11px] text-muted-text">
           · {season.label} · your last 3 complete months
@@ -260,35 +267,42 @@ export const PlayerCard = ({
         <Stat label="Best lane" value={season.bestLane?.lane ?? "—"} span2 />
       </div>
 
-      {/* ---- personal bests ---- */}
+      {/* ---- badges (frequent wins) ---- */}
       <div className="flex items-baseline gap-2 mt-6">
         <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
-          PERSONAL BESTS
+          BADGES
         </span>
-        <span className="text-[11px] text-muted-text">— top one and it re-earns</span>
+        <span className="text-[11px] text-muted-text">— earned as you run</span>
       </div>
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2">
-        <Record Icon={Trophy} label="Top week" color="#f5b03a" value={bests.bestWeekRevenue != null ? money0(bests.bestWeekRevenue) : "—"} />
-        <Record Icon={TrendingDown} label="Best deadhead" color="#4ade80" value={bests.lowestDeadheadPct != null ? pct1(bests.lowestDeadheadPct) : "—"} />
-        <Record Icon={Flame} label="Best tank" color="#e8940a" value={bests.bestMpg != null ? `${bests.bestMpg.toFixed(1)} mpg` : "—"} />
-        <Record Icon={Package} label="Biggest load" color="#f5b03a" value={bests.biggestLoad != null ? money0(bests.biggestLoad) : "—"} />
-        <Record Icon={Layers} label="Most loads / wk" color="#60a5fa" value={bests.mostLoadsInWeek != null ? String(bests.mostLoadsInWeek) : "—"} />
-      </div>
+      {badges.length > 0 ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2">
+          {badges.map((b) => (
+            <Badge key={b.id} Icon={iconFor(b.icon)} name={b.name} detail={b.detail} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-[11px] text-muted-text mt-2">
+          Rack up best weeks, tight deadhead, and fuel records to earn badges.
+        </p>
+      )}
 
-      {/* ---- trophy shelf ---- */}
-      {trophies.length > 0 && (
+      {/* ---- trophy shelf (rarer wins) ---- */}
+      {shelf.length > 0 && (
         <>
-          <div className="font-comic text-lg mt-6" style={{ color: "#f5b03a" }}>
-            TROPHY SHELF
+          <div className="flex items-baseline gap-2 mt-6">
+            <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
+              TROPHY SHELF
+            </span>
+            <span className="text-[11px] text-muted-text">— the bigger hauls</span>
           </div>
           <div className="flex flex-wrap gap-2.5 mt-2">
-            {trophies.map((t) => (
+            {shelf.map((t) => (
               <MiniTrophyCard
-                key={t.key}
+                key={t.id}
                 name={t.name}
                 detail={t.detail}
-                Icon={TROPHY_ICON[t.icon] ?? Trophy}
-                gold={t.key === "mileclub" || t.key === "strong-season"}
+                Icon={iconFor(t.icon)}
+                gold={t.id.startsWith("mileclub") || t.id.startsWith("strong-season")}
               />
             ))}
           </div>

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -29,9 +29,9 @@ import {
   marginGrade,
   rpmGrade,
   worseGrade,
-  personalBests,
-  earnedTrophies,
 } from "@/lib/metrics/playerCard";
+import { earnedAwards } from "@/lib/metrics/awards";
+import { computeGrind } from "@/lib/metrics/grind";
 import { PlayerCard } from "@/components/playercard/PlayerCard";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
@@ -114,12 +114,18 @@ const DriverDetailPage = () => {
     const season = getSeasonStats(periods, driverLoads, now, 3, obligationsDebt);
     const rpmG = rpmGrade(basis.windowRpm, ladder);
     const marginG = marginGrade(season.netMargin);
-    const bests = personalBests(driverLoads, fuel, now);
-    const trophies = earnedTrophies({
-      lifetimeMiles,
+    // One award engine drives both the pops and the card, so a badge here matches
+    // the pop that announced it. Split by tier: burst = badges, marquee = shelf
+    // (rank lives in the header, so it's kept off the shelf).
+    const grind = computeGrind(driverLoads, periods, obligationsTotal, now);
+    const awards = earnedAwards({
       loads: driverLoads,
-      bestMpg: bests.bestMpg,
-      seasonMargin: marginG,
+      periods,
+      fuel,
+      lifetimeMiles,
+      obligationsDebtMonthly: obligationsDebt,
+      streak: grind.currentStreak,
+      now,
     });
     return {
       rank: careerRank(lifetimeMiles),
@@ -128,8 +134,8 @@ const DriverDetailPage = () => {
       marginGrade: marginG,
       form: worseGrade(rpmG, marginG),
       windowRpm: basis.windowRpm,
-      bests,
-      trophies,
+      badges: awards.filter((a) => a.tier === "burst"),
+      shelf: awards.filter((a) => a.tier === "marquee" && !a.id.startsWith("rank:")),
     };
   }, [driverLoads, periods, obligations, fuel, trucks]);
 
@@ -171,7 +177,7 @@ const DriverDetailPage = () => {
       kind="driver"
       id={driver.driver_id}
       avatarUrl={driver.avatar_url}
-      size={118}
+      size={150}
       allowVariant
       onUpdated={(u) => setDriver({ ...driver, avatar_url: u })}
     />
@@ -195,12 +201,15 @@ const DriverDetailPage = () => {
             marginGrade={card.marginGrade}
             form={card.form}
             windowRpm={card.windowRpm}
-            bests={card.bests}
-            trophies={card.trophies}
+            badges={card.badges}
+            shelf={card.shelf}
           />
-          <div className="text-center mt-3">
+          <div className="flex justify-center gap-4 mt-3">
+            <Link to="/trophy-room" className="text-sm text-status-info-text hover:underline">
+              Trophy Room →
+            </Link>
             <Link to="/recap" className="text-sm text-status-info-text hover:underline">
-              See your full recap →
+              Full recap →
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## v1.64.0 — badges / shelf / room, plus avatar polish

Reworks the driver page around the three award tiers, all driven by the same engine that fires the pops — so a pop always has a matching persistent home.

- **Badges** — the frequent `burst` wins get a permanent area on the player card, record numbers folded in as detail (**Tight Lines · 7.2% deadhead**, **Feather Foot · 6.9 mpg**). Same name/icon as the pop. Replaces the old "Personal Bests" strip.
- **Trophy shelf** — `marquee` only now (Mile Club, Strong Season). Century / Relationship / Feather-Foot moved down to Badges; rank stays in the header.
- **Trophy Room** — link added from under the card (the once-in-a-career Hall).
- **"This season" → "Last season"** (last 3 complete months).
- **Avatar** — once one exists, the male/female toggle + Generate/Upload collapse behind a corner pencil ("Change"); enlarged 118 → 150 to fill the card header. Truck/trailer avatars get the same collapse.

Both badges and shelf now come from `earnedAwards` filtered by tier, killing the parallel `earnedTrophies`/`personalBests` divergence.

Frontend-only, no migration. Build clean, **182 tests**.