### PR TITLE
feat: fire a ceremony pop when a Trophy Hall trophy is earned

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.64.0",
+  "version": "1.65.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/comic/AwardPopHost.tsx
+++ b/frontend/src/components/comic/AwardPopHost.tsx
@@ -14,6 +14,7 @@ import type { Award } from "@/lib/metrics/awards";
 import { MarqueeAward } from "./MarqueeAward";
 import { BurstAward } from "./BurstAward";
 import { RecapCeremony } from "./RecapCeremony";
+import { TrophyCeremony } from "./TrophyCeremony";
 
 const ICONS: Record<string, LucideIcon> = {
   truck: Truck,
@@ -47,6 +48,7 @@ export const AwardPopHost = ({
 
   const visible = pops.filter((p) => !dismissed.has(p.id));
   const takeover =
+    visible.find((p) => p.tier === "trophy") ??
     visible.find((p) => p.tier === "recap") ??
     visible.find((p) => p.tier === "marquee");
   const bursts = takeover ? [] : visible.filter((p) => p.tier === "burst").slice(0, 4);
@@ -69,6 +71,9 @@ export const AwardPopHost = ({
             <BurstAward key={b.id} award={b} Icon={iconFor(b.icon)} onDismiss={() => dismiss(b.id)} />
           ))}
         </div>
+      )}
+      {takeover && takeover.tier === "trophy" && (
+        <TrophyCeremony award={takeover} onDismiss={() => dismiss(takeover.id)} />
       )}
       {takeover && takeover.tier === "recap" && (
         <RecapCeremony award={takeover} truckAvatarUrl={truckAvatarUrl} onDismiss={() => dismiss(takeover.id)} />

--- a/frontend/src/components/comic/TrophyCeremony.tsx
+++ b/frontend/src/components/comic/TrophyCeremony.tsx
@@ -1,0 +1,101 @@
+import { useNavigate } from "react-router-dom";
+import { Trophy, Crown } from "lucide-react";
+import type { Award } from "@/lib/metrics/awards";
+
+// The grandest celebration — a once-in-a-career Hall trophy. Full gold, a confetti
+// storm, and the approved AI art front and center; its button opens the Hall.
+const CONFETTI = [
+  { left: "12%", color: "#f5b03a", delay: ".1s" },
+  { left: "26%", color: "#4ade80", delay: ".5s" },
+  { left: "40%", color: "#60a5fa", delay: ".9s" },
+  { left: "56%", color: "#f5b03a", delay: ".3s" },
+  { left: "70%", color: "#e8940a", delay: ".7s" },
+  { left: "84%", color: "#4ade80", delay: ".2s" },
+  { left: "92%", color: "#60a5fa", delay: ".6s" },
+];
+
+export const TrophyCeremony = ({
+  award,
+  onDismiss,
+}: {
+  award: Award;
+  onDismiss: () => void;
+}) => {
+  const navigate = useNavigate();
+  const open = () => {
+    navigate("/trophy-room");
+    onDismiss();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-hidden"
+      style={{ background: "rgba(6,9,15,0.82)" }}
+    >
+      {CONFETTI.map((c, i) => (
+        <span
+          key={i}
+          className="absolute rounded-[1px]"
+          style={{
+            left: c.left,
+            top: "-10px",
+            width: 7,
+            height: 7,
+            background: c.color,
+            animation: `award-fall 2.4s linear ${c.delay} infinite`,
+          }}
+        />
+      ))}
+      <div
+        className="relative rounded-[20px] px-6 pt-5 pb-5 text-center overflow-hidden"
+        style={{
+          width: 360,
+          maxWidth: "92vw",
+          background: "#120f08",
+          border: "3px solid #f5b03a",
+          boxShadow: "inset 0 0 0 2px #7a5410",
+          animation: "award-pop .6s cubic-bezier(.2,.9,.25,1.2) both",
+        }}
+      >
+        <div className="mb-1">
+          <Crown size={24} style={{ color: "#ffd873" }} />
+        </div>
+        <div className="font-comic tracking-[3px]" style={{ color: "#ffd873", fontSize: 15 }}>
+          ★ ★ ★
+        </div>
+        <div
+          className="mx-auto mt-3 rounded-2xl overflow-hidden flex items-center justify-center"
+          style={{ width: 168, height: 168, background: "#0a0d13", border: "3px solid #f5b03a" }}
+        >
+          {award.image ? (
+            <img src={award.image} alt="" className="w-full h-full object-cover" />
+          ) : (
+            <Trophy size={72} style={{ color: "#f5b03a" }} />
+          )}
+        </div>
+        <div className="font-comic tracking-[3px] mt-3" style={{ color: "#ffd873", fontSize: 13 }}>
+          TROPHY UNLOCKED
+        </div>
+        <div className="font-comic leading-none mt-1" style={{ color: "#ffe08a", fontSize: 30 }}>
+          {award.name}
+        </div>
+        <div className="text-sm text-muted-text mt-2 px-2">{award.detail}</div>
+        <button
+          onClick={open}
+          className="mt-4 font-comic cursor-pointer"
+          style={{
+            background: "#f5b03a",
+            color: "#3a2708",
+            border: "none",
+            borderRadius: 9,
+            padding: "9px 22px",
+            fontSize: 14,
+            letterSpacing: "1px",
+          }}
+        >
+          VISIT THE TROPHY ROOM
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/hooks/useAwardPops.ts
+++ b/frontend/src/hooks/useAwardPops.ts
@@ -4,13 +4,25 @@ import type { ExpensePeriod } from "@/types/expense";
 import type { FuelEntry } from "@/types/fuelEntry";
 import type { Truck } from "@/types/truck";
 import type { Obligation } from "@/types/obligation";
+import type { Driver } from "@/types/driver";
+import type { Trophy } from "@/types/trophy";
 import { getExpensePeriods } from "@/services/expensesService";
 import { getFuelEntries } from "@/services/fuelService";
 import { getTrucks } from "@/services/trucksService";
 import { getObligations } from "@/services/obligationsService";
+import { getDrivers } from "@/services/driversService";
+import { getTrophies } from "@/services/trophyService";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { computeGrind } from "@/lib/metrics/grind";
-import { earnedAwards, newAwards, type Award } from "@/lib/metrics/awards";
+import { loadRevenue } from "@/lib/metrics/rateTargets";
+import { computeAllStatuses } from "@/lib/trophies/status";
+import { TROPHY_CATALOG } from "@/lib/trophies/catalog";
+import {
+  earnedAwards,
+  earnedTrophyAwards,
+  newAwards,
+  type Award,
+} from "@/lib/metrics/awards";
 
 // Per-device "seen" store. Earned-award facts are objective (computed from data);
 // which ones a device has already celebrated is per-device — that's what lets
@@ -50,13 +62,22 @@ export const useAwardPops = (
     fuel: FuelEntry[];
     trucks: Truck[];
     obligations: Obligation[];
+    trophies: Trophy[];
+    drivers: Driver[];
   } | null>(null);
   const [done, setDone] = useState(false);
 
   useEffect(() => {
-    Promise.all([getExpensePeriods(), getFuelEntries(), getTrucks(), getObligations()])
-      .then(([periods, fuel, trucks, obligations]) =>
-        setData({ periods, fuel, trucks, obligations }),
+    Promise.all([
+      getExpensePeriods(),
+      getFuelEntries(),
+      getTrucks(),
+      getObligations(),
+      getTrophies(),
+      getDrivers(),
+    ])
+      .then(([periods, fuel, trucks, obligations, trophies, drivers]) =>
+        setData({ periods, fuel, trucks, obligations, trophies, drivers }),
       )
       .catch(() => {});
   }, []);
@@ -80,7 +101,7 @@ export const useAwardPops = (
       .reduce((s, o) => s + Number(o.amount), 0);
     const grind = computeGrind(loads, data.periods, obligationsAllActive, now);
 
-    const earned = earnedAwards({
+    const baseAwards = earnedAwards({
       loads,
       periods: data.periods,
       fuel: data.fuel,
@@ -89,6 +110,23 @@ export const useAwardPops = (
       streak: grind.currentStreak,
       now,
     });
+
+    // Trophy Hall earns, from the same status engine the Hall renders.
+    const byKey: Record<string, Trophy> = {};
+    for (const t of data.trophies) byKey[t.trophy_key] = t;
+    const cumulativeGross = loads
+      .filter((l) => l.load_status === "delivered")
+      .reduce((s, l) => s + loadRevenue(l), 0);
+    const statuses = computeAllStatuses(TROPHY_CATALOG, byKey, {
+      lifetimeMiles,
+      driverCount: data.drivers.filter((d) => d.active).length,
+      truckCount: data.trucks.length,
+      cumulativeGross,
+    });
+    const earned = [
+      ...earnedTrophyAwards(TROPHY_CATALOG, statuses, byKey),
+      ...baseAwards,
+    ];
     const currentIds = earned.map((a) => a.id);
     const store = read();
 

--- a/frontend/src/lib/metrics/awards.test.ts
+++ b/frontend/src/lib/metrics/awards.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type { Load } from "@/types/load";
-import { earnedAwards, newAwards, type Award } from "./awards";
+import { earnedAwards, earnedTrophyAwards, newAwards, type Award } from "./awards";
+import type { TrophyDef } from "@/lib/trophies/catalog";
+import type { TrophyStatus } from "@/lib/trophies/status";
+import type { Trophy } from "@/types/trophy";
 
 const NOW = new Date("2026-07-10T12:00:00Z");
 
@@ -64,6 +67,25 @@ describe("earnedAwards", () => {
   });
 });
 
+describe("earnedTrophyAwards", () => {
+  it("emits only earned trophies, carrying the approved art", () => {
+    const catalog = [
+      { key: "owner-operator", name: "Owner Operator", form: "medallion", kind: "manual", blurb: "The origin.", promptIdea: "" },
+      { key: "second-truck", name: "Second Truck", form: "plaque", kind: "auto", blurb: "Two trucks.", promptIdea: "" },
+    ] as TrophyDef[];
+    const statuses: Record<string, TrophyStatus> = {
+      "owner-operator": { earned: true, progress: null, progressLabel: null },
+      "second-truck": { earned: false, progress: 0.5, progressLabel: "1 of 2" },
+    };
+    const records: Record<string, Trophy> = {
+      "owner-operator": { trophy_key: "owner-operator", earned: true, earned_on: null, image_url: "art.jpg", notes: null },
+    };
+    const awards = earnedTrophyAwards(catalog, statuses, records);
+    expect(awards.map((a) => a.id)).toEqual(["trophy:owner-operator"]);
+    expect(awards[0]).toMatchObject({ tier: "trophy", name: "Owner Operator", image: "art.jpg" });
+  });
+});
+
 describe("newAwards", () => {
   it("drops seen ids and orders marquee before burst", () => {
     const earned: Award[] = [
@@ -75,19 +97,23 @@ describe("newAwards", () => {
     expect(fresh.map((a) => a.id)).toEqual(["rank:road-captain", "best-week:5000"]);
   });
 
-  it("orders recap ceremonies grandest first, ahead of marquees", () => {
+  it("orders trophy → recap (grandest) → marquee → burst", () => {
     const earned: Award[] = [
+      { id: "best-week:5000", tier: "burst", name: "", detail: "", icon: "" },
       { id: "recap:month:Jun 2026", tier: "recap", scope: "month", name: "", detail: "", icon: "" },
       { id: "rank:road-captain", tier: "marquee", name: "", detail: "", icon: "" },
       { id: "recap:year:2026", tier: "recap", scope: "year", name: "", detail: "", icon: "" },
+      { id: "trophy:owner-operator", tier: "trophy", name: "", detail: "", icon: "" },
       { id: "recap:quarter:Q2 2026", tier: "recap", scope: "quarter", name: "", detail: "", icon: "" },
     ];
     const fresh = newAwards(earned, new Set());
     expect(fresh.map((a) => a.id)).toEqual([
+      "trophy:owner-operator",
       "recap:year:2026",
       "recap:quarter:Q2 2026",
       "recap:month:Jun 2026",
       "rank:road-captain",
+      "best-week:5000",
     ]);
   });
 });

--- a/frontend/src/lib/metrics/awards.ts
+++ b/frontend/src/lib/metrics/awards.ts
@@ -15,8 +15,13 @@ import {
 import { mileMilestone } from "./mileClub";
 import { resolvePeriod, loadsInRange, type RecapScope } from "./recap";
 import { loadRevenue } from "./rateTargets";
+import type { TrophyDef } from "@/lib/trophies/catalog";
+import type { TrophyStatus } from "@/lib/trophies/status";
+import type { Trophy } from "@/types/trophy";
 
-export type AwardTier = "recap" | "marquee" | "burst";
+// Grandest → smallest. trophy = once-in-a-career Hall milestone; recap = a period
+// close; marquee = a big win; burst = a frequent badge.
+export type AwardTier = "trophy" | "recap" | "marquee" | "burst";
 
 export interface Award {
   id: string;
@@ -25,6 +30,7 @@ export interface Award {
   detail: string;
   icon: string; // mapped to a lucide icon in the UI
   scope?: RecapScope; // recap tier only — drives the prestige of the ceremony
+  image?: string; // trophy tier only — the approved AI art
 }
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
@@ -154,10 +160,30 @@ export const earnedAwards = (i: AwardInputs): Award[] => {
   return out;
 };
 
+// The earned Hall trophies as awards — the grandest tier. Same earn-detection the
+// Trophy Room uses (computeAllStatuses), so a trophy pops the instant it's earned
+// and never disagrees with the Hall. Carries the approved AI art for the pop.
+export const earnedTrophyAwards = (
+  catalog: TrophyDef[],
+  statuses: Record<string, TrophyStatus>,
+  recordsByKey: Record<string, Trophy>,
+): Award[] =>
+  catalog
+    .filter((d) => statuses[d.key]?.earned)
+    .map((d) => ({
+      id: `trophy:${d.key}`,
+      tier: "trophy" as const,
+      name: d.name,
+      detail: d.blurb,
+      icon: "trophy",
+      image: recordsByKey[d.key]?.image_url ?? undefined,
+    }));
+
 // Sample awards for previewing the celebration UI (dashboard `?awarddemo`) —
 // since a real device silently baselines on first load, this is how you see the
 // pop without waiting to earn one.
 export const DEMO_AWARDS: Award[] = [
+  { id: "demo:trophy", tier: "trophy", name: "Owner Operator", detail: "The origin — you went out on your own.", icon: "trophy" },
   { id: "demo:recap-year", tier: "recap", scope: "year", name: "2026", detail: "$141k hauled · 47 loads", icon: "trophy" },
   { id: "demo:recap-quarter", tier: "recap", scope: "quarter", name: "Q2 2026", detail: "$70.4k hauled · 23 loads", icon: "trophy" },
   { id: "demo:recap-month", tier: "recap", scope: "month", name: "Jun 2026", detail: "$24.1k hauled · 8 loads", icon: "trophy" },
@@ -177,7 +203,9 @@ export const newAwards = (earned: Award[], seen: Set<string>): Award[] => {
   const recaps = fresh
     .filter((a) => a.tier === "recap")
     .sort((a, b) => (scopeRank[a.scope ?? "month"] ?? 0) - (scopeRank[b.scope ?? "month"] ?? 0));
+  // Trophies (career milestones) lead everything, then recaps, marquees, bursts.
   return [
+    ...fresh.filter((a) => a.tier === "trophy"),
     ...recaps,
     ...fresh.filter((a) => a.tier === "marquee"),
     ...fresh.filter((a) => a.tier === "burst"),


### PR DESCRIPTION
## v1.65.0 — Trophy Hall earns now pop

Earning a once-in-a-career Hall trophy was silent. Now it's the grandest celebration in the app.

- New top award tier **`trophy`** (above recap / marquee / burst). `earnedTrophyAwards` maps earned Hall trophies to awards, carrying the approved AI art.
- `useAwardPops` pulls trophies + drivers and computes earned state with the **same `computeAllStatuses` the Hall renders** — so a trophy pops the instant it's earned and can't disagree with the Hall. Fire-once via the existing per-device seen store.
- New **`TrophyCeremony`** — a full-gold screen takeover with a confetti storm, the trophy's **AI art** front and center, "TROPHY UNLOCKED," and a button into the Trophy Room. Outranks every other pop.

Note: on a device baselined before trophies existed, an already-earned trophy (e.g. Owner Operator) reads as new and pops once — a built-in first-run reveal. Preview with `?awarddemo` (trophy leads; demo has no art so it shows the trophy icon).

Frontend-only, no migration. Build clean, **183 tests**.