### PR TITLE
feat: truck/trailer payoff trackers with auto-earning trophies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Jason is the **learner**. My job is to **teach**, not to do the work for him. He
 
 **Mode is set per track (changed 2026-07-08):**
 
-- **dash (Track A) → issue-driven BUILD mode.** Jason writes a GitHub issue (the spec); we align on scope + design/formula decisions; **I build it**; we verify together that it matches intent AND that the formulas compute correctly; test on dev; ship (PR → merge) and bump the version only if warranted. I still surface design/formula decisions one at a time before building, and I never rubber-stamp my own math — the verify gate is the whole point.
+- **dash (Track A) → issue-driven BUILD mode.** Jason writes a GitHub issue (the spec); we align on scope + design/formula decisions; **I build it**; we verify together that it matches intent AND that the formulas compute correctly; test on dev; ship (PR → merge) and bump the version only if warranted. I still surface design/formula decisions one at a time before building, and I never rubber-stamp my own math — the verify gate is the whole point. **Design-first gate (added 2026-07-13, Jason's rule): for any feature with a visual/UI surface, I present a design mockup (a rendered widget/artifact Jason can see) and get his approval BEFORE writing code. Show the design, get the nod, then build — this is a hard gate, like the verify gate.**
 - **dts-tools (Track B) → TEACHING mode.** It's a structured learning course, so the teaching loop below governs there.
 
 **Teaching loop (Track B, and any genuinely new concept):** concept → pseudocode/plan → **Jason writes the code** → I review and nudge.

--- a/backend/db/migrations/036_obligation_payoff.sql
+++ b/backend/db/migrations/036_obligation_payoff.sql
@@ -1,0 +1,14 @@
+-- Payoff tracking. A debt obligation (Truck Note, Trailer Payment) can carry a
+-- loan/lease balance so the asset pages show an "own it outright" tracker, and the
+-- Free & Clear / Trailer Paid Off trophies auto-earn when the balance reaches $0.
+-- Nullable throughout — a plain obligation (owner draw, personal loan) just leaves
+-- them empty. `payoff_date` is the contract end/maturity (exact projection); when
+-- null the tracker estimates the payoff at the current payment pace. `asset_id`
+-- has no FK because it may point at either trucks or trailers.
+ALTER TABLE obligations
+  ADD COLUMN IF NOT EXISTS original_balance NUMERIC(12, 2),
+  ADD COLUMN IF NOT EXISTS current_balance  NUMERIC(12, 2),
+  ADD COLUMN IF NOT EXISTS balance_as_of    DATE,
+  ADD COLUMN IF NOT EXISTS payoff_date      DATE,
+  ADD COLUMN IF NOT EXISTS asset_type       VARCHAR(10),
+  ADD COLUMN IF NOT EXISTS asset_id         UUID;

--- a/backend/src/services/obligationServices.js
+++ b/backend/src/services/obligationServices.js
@@ -5,7 +5,9 @@ import { ValidationError, NotFoundError } from "../utils/error.js";
 export async function getObligations(user_id) {
   if (!user_id) throw new ValidationError("Missing user_id");
   const result = await db.query(
-    `SELECT obligation_id, label, amount, active, is_draw
+    `SELECT obligation_id, label, amount, active, is_draw,
+            original_balance, current_balance, balance_as_of, payoff_date,
+            asset_type, asset_id
      FROM obligations
      WHERE user_id = $1
      ORDER BY created_at`,
@@ -17,15 +19,40 @@ export async function getObligations(user_id) {
 // ---- CREATE ----
 export async function createObligation(user_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
-  const { label, amount, is_draw } = data;
+  const {
+    label,
+    amount,
+    is_draw,
+    original_balance,
+    current_balance,
+    balance_as_of,
+    payoff_date,
+    asset_type,
+    asset_id,
+  } = data;
   if (!label || amount == null)
     throw new ValidationError("label and amount are required");
 
   const result = await db.query(
-    `INSERT INTO obligations (user_id, label, amount, is_draw)
-     VALUES ($1, $2, $3, $4)
-     RETURNING obligation_id, label, amount, active, is_draw`,
-    [user_id, label, amount, is_draw === true],
+    `INSERT INTO obligations
+       (user_id, label, amount, is_draw, original_balance, current_balance,
+        balance_as_of, payoff_date, asset_type, asset_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     RETURNING obligation_id, label, amount, active, is_draw,
+               original_balance, current_balance, balance_as_of, payoff_date,
+               asset_type, asset_id`,
+    [
+      user_id,
+      label,
+      amount,
+      is_draw === true,
+      original_balance ?? null,
+      current_balance ?? null,
+      balance_as_of || null,
+      payoff_date || null,
+      asset_type || null,
+      asset_id || null,
+    ],
   );
   return result.rows[0];
 }
@@ -35,7 +62,18 @@ export async function patchObligation(user_id, obligation_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
   if (!obligation_id) throw new ValidationError("Missing obligation_id");
 
-  const allowedFields = ["label", "amount", "active", "is_draw"];
+  const allowedFields = [
+    "label",
+    "amount",
+    "active",
+    "is_draw",
+    "original_balance",
+    "current_balance",
+    "balance_as_of",
+    "payoff_date",
+    "asset_type",
+    "asset_id",
+  ];
   const updates = [];
   const values = [];
   let index = 1;
@@ -56,7 +94,9 @@ export async function patchObligation(user_id, obligation_id, data) {
     `UPDATE obligations
        SET ${updates.join(", ")}
      WHERE obligation_id = $${index} AND user_id = $${index + 1}
-     RETURNING obligation_id, label, amount, active, is_draw`,
+     RETURNING obligation_id, label, amount, active, is_draw,
+               original_balance, current_balance, balance_as_of, payoff_date,
+               asset_type, asset_id`,
     values,
   );
   if (result.rowCount === 0) throw new NotFoundError("Obligation not found");

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.65.0",
+  "version": "1.66.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/expenses/ObligationsCard.tsx
+++ b/frontend/src/components/expenses/ObligationsCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { Pencil, Trash2, Check, X, Plus, Eye, EyeOff, HandCoins } from "lucide-react";
 import type { Obligation } from "@/types/obligation";
 import {
@@ -25,6 +25,11 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
   const [editing, setEditing] = useState<string | null>(null);
   const [editLabel, setEditLabel] = useState("");
   const [editAmt, setEditAmt] = useState("");
+  // Payoff / loan tracking on the obligation being edited.
+  const [editOrig, setEditOrig] = useState("");
+  const [editBal, setEditBal] = useState("");
+  const [editPayoff, setEditPayoff] = useState("");
+  const [editAsset, setEditAsset] = useState("");
   const [showAdd, setShowAdd] = useState(false);
   const [newLabel, setNewLabel] = useState("");
   const [newAmt, setNewAmt] = useState("");
@@ -68,7 +73,8 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
       <table className="w-full text-sm">
         <tbody>
           {items.map((o) => (
-            <tr key={o.obligation_id} className="border-t border-steel">
+            <Fragment key={o.obligation_id}>
+            <tr className="border-t border-steel">
               <td className="py-2">
                 {editing === o.obligation_id ? (
                   <input
@@ -112,6 +118,10 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
                           await patchObligation(o.obligation_id, {
                             label: editLabel,
                             amount: Number(editAmt),
+                            original_balance: editOrig ? Number(editOrig) : null,
+                            current_balance: editBal ? Number(editBal) : null,
+                            payoff_date: editPayoff || null,
+                            asset_type: editAsset || null,
                           });
                           setEditing(null);
                         })
@@ -169,6 +179,14 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
                           setEditing(o.obligation_id);
                           setEditLabel(o.label);
                           setEditAmt(String(o.amount));
+                          setEditOrig(
+                            o.original_balance != null ? String(o.original_balance) : "",
+                          );
+                          setEditBal(
+                            o.current_balance != null ? String(o.current_balance) : "",
+                          );
+                          setEditPayoff(o.payoff_date ? o.payoff_date.slice(0, 10) : "");
+                          setEditAsset(o.asset_type ?? "");
                         }}
                       />
                     </>
@@ -184,6 +202,58 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
                 </div>
               </td>
             </tr>
+            {editing === o.obligation_id && !o.is_draw && (
+              <tr>
+                <td colSpan={3} className="pb-3">
+                  <div className="rounded bg-steel/50 p-3 grid grid-cols-2 sm:grid-cols-4 gap-2">
+                    <label className="text-[11px] text-muted-text">
+                      Original $
+                      <input
+                        className="bg-steel rounded px-2 py-1 w-full mt-0.5 text-light"
+                        value={editOrig}
+                        onChange={(e) => setEditOrig(e.target.value)}
+                        placeholder="0"
+                      />
+                    </label>
+                    <label className="text-[11px] text-muted-text">
+                      Current balance $
+                      <input
+                        className="bg-steel rounded px-2 py-1 w-full mt-0.5 text-light"
+                        value={editBal}
+                        onChange={(e) => setEditBal(e.target.value)}
+                        placeholder="0"
+                      />
+                    </label>
+                    <label className="text-[11px] text-muted-text">
+                      Payoff / end date
+                      <input
+                        type="date"
+                        className="bg-steel rounded px-2 py-1 w-full mt-0.5 text-light"
+                        value={editPayoff}
+                        onChange={(e) => setEditPayoff(e.target.value)}
+                      />
+                    </label>
+                    <label className="text-[11px] text-muted-text">
+                      Tracks asset
+                      <select
+                        className="bg-steel rounded px-2 py-1 w-full mt-0.5 text-light"
+                        value={editAsset}
+                        onChange={(e) => setEditAsset(e.target.value)}
+                      >
+                        <option value="">Not tracked</option>
+                        <option value="truck">Truck</option>
+                        <option value="trailer">Trailer</option>
+                      </select>
+                    </label>
+                  </div>
+                  <p className="text-[10px] text-muted-text mt-1.5">
+                    Fill these to show a payoff tracker on the asset's page. Leave the
+                    date blank to estimate at your payment pace; $0 auto-earns the trophy.
+                  </p>
+                </td>
+              </tr>
+            )}
+            </Fragment>
           ))}
           {showAdd ? (
             <tr className="border-t border-steel">

--- a/frontend/src/components/fleet/PayoffTracker.tsx
+++ b/frontend/src/components/fleet/PayoffTracker.tsx
@@ -1,0 +1,109 @@
+import { Truck, Container, Flag } from "lucide-react";
+import type { Obligation } from "@/types/obligation";
+import { computePayoff } from "@/lib/metrics/payoff";
+
+const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const monthYear = (iso: string) => {
+  const d = new Date(iso.slice(0, 10) + "T00:00:00Z");
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+};
+
+const Stat = ({ value, label }: { value: string; label: string }) => (
+  <div className="flex-1 rounded-[9px] px-1.5 py-2 text-center" style={{ background: "#1c2333" }}>
+    <div className="font-comic text-[17px] leading-none" style={{ color: "#f5e6c8" }}>
+      {value}
+    </div>
+    <div className="text-[9px] text-muted-text mt-1 tracking-wide">{label}</div>
+  </div>
+);
+
+// The "own it outright" tracker on an asset page — a road the truck/trailer rides
+// toward a FREE & CLEAR flag as the loan balance drops. Fills gold + stamps PAID
+// OFF at $0 (which is also when the Free & Clear / Trailer Paid Off trophy earns).
+export const PayoffTracker = ({
+  obligation,
+  kind,
+}: {
+  obligation: Obligation;
+  kind: "truck" | "trailer";
+}) => {
+  const p = computePayoff(obligation, new Date());
+  const Icon = kind === "truck" ? Truck : Container;
+  const metal = p.isPaidOff ? "#f5b03a" : kind === "truck" ? "#e8940a" : "#aab4c4";
+  const label = kind === "truck" ? "TRUCK" : "TRAILER";
+  // Keep at least a sliver filled so the vehicle stays on the road.
+  const fillPct = p.isPaidOff ? 100 : Math.max(4, Math.round((p.paidPct ?? 0) * 100));
+
+  return (
+    <div
+      className="rounded-2xl p-4 mt-4"
+      style={{
+        background: p.isPaidOff ? "#120f08" : "#10151f",
+        border: `2px solid ${metal}`,
+        boxShadow: p.isPaidOff ? "inset 0 0 0 2px #7a5410" : undefined,
+      }}
+    >
+      <p className="font-comic tracking-[3px] text-[12px]" style={{ color: "#9daabb" }}>
+        OWN THE {label} OUTRIGHT
+      </p>
+
+      {p.isPaidOff ? (
+        <div className="flex items-center gap-3 mt-1 mb-3">
+          <div className="font-comic text-3xl" style={{ color: "#ffe08a" }}>
+            FREE &amp; CLEAR
+          </div>
+          <span
+            className="font-comic inline-block"
+            style={{ border: "2px solid #4ade80", color: "#4ade80", borderRadius: 8, padding: "1px 10px", transform: "rotate(-4deg)" }}
+          >
+            PAID OFF
+          </span>
+        </div>
+      ) : (
+        <div className="flex items-baseline gap-2 mt-1 mb-3">
+          <div className="font-comic text-3xl" style={{ color: metal }}>
+            {money(p.owed)}
+          </div>
+          <div className="text-xs text-muted-text">to free &amp; clear</div>
+        </div>
+      )}
+
+      <div className="relative rounded-lg overflow-hidden" style={{ height: 34, background: "#0a0d13", border: "1px solid #22304a" }}>
+        <div className="absolute left-0 top-0 bottom-0" style={{ width: `${fillPct}%`, background: metal, borderRadius: "7px 0 0 7px" }} />
+        <div className="absolute left-2 right-2 top-1/2" style={{ height: 2, transform: "translateY(-50%)", background: "repeating-linear-gradient(90deg,#2a3550 0 12px,transparent 12px 24px)" }} />
+        <Icon size={20} style={{ position: "absolute", top: "50%", left: `${fillPct}%`, transform: "translate(-50%,-50%)", color: "#120f08" }} />
+        <Flag size={16} style={{ position: "absolute", top: "50%", right: 8, transform: "translateY(-50%)", color: metal }} />
+      </div>
+
+      {p.paidPct != null && !p.isPaidOff && (
+        <div className="flex justify-between text-[11px] text-muted-text mt-1">
+          <span>{Math.round(p.paidPct * 100)}% owned</span>
+          <span>{p.exact ? "payoff from contract" : "at current pace"}</span>
+        </div>
+      )}
+
+      {p.isPaidOff ? (
+        <p className="text-center mt-3 text-[12px]" style={{ color: "#f5b03a" }}>
+          Free &amp; Clear trophy earned
+        </p>
+      ) : (
+        <>
+          <div className="flex gap-2 mt-3">
+            <Stat value={money(p.monthlyPayment)} label="PER MONTH" />
+            <Stat
+              value={p.payoffDate ? monthYear(p.payoffDate) : "—"}
+              label={p.exact ? "PAYOFF DATE" : "PAYOFF AT PACE"}
+            />
+            <Stat value={p.paymentsLeft != null ? String(p.paymentsLeft) : "—"} label="PAYMENTS LEFT" />
+          </div>
+          {p.paymentsLeft != null && (
+            <p className="font-comic text-center mt-3 text-[13px]" style={{ color: metal, letterSpacing: "1px" }}>
+              ≈ {p.paymentsLeft} MORE PAYMENT{p.paymentsLeft === 1 ? "" : "S"} TO FREE &amp; CLEAR
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useAwardPops.ts
+++ b/frontend/src/hooks/useAwardPops.ts
@@ -15,6 +15,7 @@ import { getTrophies } from "@/services/trophyService";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { computeGrind } from "@/lib/metrics/grind";
 import { loadRevenue } from "@/lib/metrics/rateTargets";
+import { assetLoanStatus } from "@/lib/metrics/payoff";
 import { computeAllStatuses } from "@/lib/trophies/status";
 import { TROPHY_CATALOG } from "@/lib/trophies/catalog";
 import {
@@ -122,6 +123,8 @@ export const useAwardPops = (
       driverCount: data.drivers.filter((d) => d.active).length,
       truckCount: data.trucks.length,
       cumulativeGross,
+      truckLoan: assetLoanStatus(data.obligations, "truck", now),
+      trailerLoan: assetLoanStatus(data.obligations, "trailer", now),
     });
     const earned = [
       ...earnedTrophyAwards(TROPHY_CATALOG, statuses, byKey),

--- a/frontend/src/lib/metrics/payoff.test.ts
+++ b/frontend/src/lib/metrics/payoff.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import type { Obligation } from "@/types/obligation";
+import { computePayoff, isPayoffTracked } from "./payoff";
+
+const NOW = new Date("2026-07-13T12:00:00Z");
+
+const O = (o: Partial<Obligation>): Obligation =>
+  ({
+    obligation_id: "x",
+    label: "L",
+    amount: 0,
+    active: true,
+    is_draw: false,
+    original_balance: null,
+    current_balance: null,
+    balance_as_of: null,
+    payoff_date: null,
+    asset_type: null,
+    asset_id: null,
+    ...o,
+  }) as Obligation;
+
+describe("isPayoffTracked", () => {
+  it("is tracked once a current balance exists", () => {
+    expect(isPayoffTracked(O({ current_balance: 44100 }))).toBe(true);
+    expect(isPayoffTracked(O({}))).toBe(false);
+  });
+});
+
+describe("computePayoff", () => {
+  it("estimates at pace when there's no end date (the truck lease)", () => {
+    const p = computePayoff(
+      O({ amount: 1575, current_balance: 44100, original_balance: 69000 }),
+      NOW,
+    );
+    expect(p.owed).toBe(44100);
+    expect(p.paidPct).toBeCloseTo((69000 - 44100) / 69000, 4); // ~36% owned
+    expect(p.paymentsLeft).toBe(28); // 44100 / 1575
+    expect(p.exact).toBe(false);
+    expect(p.payoffDate).toBe("2028-11-13"); // 28 months out
+    expect(p.isPaidOff).toBe(false);
+  });
+
+  it("uses the contract date exactly when present (the trailer loan)", () => {
+    const p = computePayoff(
+      O({
+        amount: 475.19,
+        current_balance: 38298.61,
+        original_balance: 39408.09,
+        payoff_date: "2036-01-27",
+      }),
+      NOW,
+    );
+    expect(p.paidPct).toBeCloseTo((39408.09 - 38298.61) / 39408.09, 4); // ~2.8%
+    expect(p.exact).toBe(true);
+    expect(p.payoffDate).toBe("2036-01-27");
+    expect(p.paymentsLeft).toBe(114); // full months to maturity
+  });
+
+  it("is paid off at zero", () => {
+    const p = computePayoff(
+      O({ amount: 1575, current_balance: 0, original_balance: 69000 }),
+      NOW,
+    );
+    expect(p.isPaidOff).toBe(true);
+    expect(p.paidPct).toBe(1);
+    expect(p.paymentsLeft).toBe(0);
+  });
+});

--- a/frontend/src/lib/metrics/payoff.ts
+++ b/frontend/src/lib/metrics/payoff.ts
@@ -1,0 +1,85 @@
+// Turns a loan/lease obligation into the "own it outright" tracker: how much is
+// left, how far along, and when it's free-and-clear. Where the contract gives a
+// real end date (payoff_date) the payoff is exact; otherwise it's estimated at
+// the current payment pace. Pure; take `now` explicitly so it's testable.
+import type { Obligation } from "@/types/obligation";
+
+export interface Payoff {
+  owed: number; // current balance
+  original: number | null; // starting balance (for the % owned)
+  paidPct: number | null; // 0..1 owned so far; null when no original recorded
+  monthlyPayment: number;
+  paymentsLeft: number | null; // months to $0
+  payoffDate: string | null; // 'YYYY-MM-DD'
+  isPaidOff: boolean;
+  exact: boolean; // true when payoffDate came from the contract, not an estimate
+}
+
+// A debt obligation is "trackable" for payoff once it carries a current balance.
+export const isPayoffTracked = (o: Obligation): boolean =>
+  o.current_balance != null;
+
+// The paid-off state of the loan tracked against an asset type — feeds the
+// Free & Clear / Trailer Paid Off trophy engine. null when nothing is tracked.
+export const assetLoanStatus = (
+  obligations: Obligation[],
+  assetType: "truck" | "trailer",
+  now: Date,
+): { paidOff: boolean; ownedPct: number | null; owed: number } | null => {
+  const o = obligations.find((x) => x.asset_type === assetType && isPayoffTracked(x));
+  if (!o) return null;
+  const p = computePayoff(o, now);
+  return { paidOff: p.isPaidOff, ownedPct: p.paidPct, owed: p.owed };
+};
+
+const parseUTC = (d: string): Date => new Date(d.slice(0, 10) + "T00:00:00Z");
+
+const addMonths = (from: Date, n: number): Date =>
+  new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth() + n, from.getUTCDate()));
+
+const monthsBetween = (from: Date, to: Date): number =>
+  Math.max(
+    0,
+    (to.getUTCFullYear() - from.getUTCFullYear()) * 12 +
+      (to.getUTCMonth() - from.getUTCMonth()),
+  );
+
+export const computePayoff = (o: Obligation, now: Date): Payoff => {
+  const owed = Math.max(0, Number(o.current_balance ?? 0));
+  const original = o.original_balance != null ? Number(o.original_balance) : null;
+  const monthlyPayment = Number(o.amount) || 0;
+  const isPaidOff = owed <= 0;
+
+  const paidPct =
+    original && original > 0
+      ? Math.max(0, Math.min(1, (original - owed) / original))
+      : null;
+
+  let payoffDate: string | null = null;
+  let paymentsLeft: number | null = null;
+  let exact = false;
+
+  if (isPaidOff) {
+    paymentsLeft = 0;
+  } else if (o.payoff_date) {
+    // Contract end / maturity — the real date, no interest math needed.
+    payoffDate = o.payoff_date.slice(0, 10);
+    paymentsLeft = monthsBetween(now, parseUTC(o.payoff_date));
+    exact = true;
+  } else if (monthlyPayment > 0) {
+    // No end date on file — estimate at the current payment pace.
+    paymentsLeft = Math.ceil(owed / monthlyPayment);
+    payoffDate = addMonths(now, paymentsLeft).toISOString().slice(0, 10);
+  }
+
+  return {
+    owed,
+    original,
+    paidPct,
+    monthlyPayment,
+    paymentsLeft,
+    payoffDate,
+    isPaidOff,
+    exact,
+  };
+};

--- a/frontend/src/lib/trophies/status.test.ts
+++ b/frontend/src/lib/trophies/status.test.ts
@@ -38,6 +38,41 @@ describe("computeAllStatuses", () => {
     expect(s["own-authority"].earned).toBe(false);
   });
 
+  it("free-and-clear auto-earns when the truck loan hits $0, and cascades to the capstone", () => {
+    const base = {
+      lifetimeMiles: 1_000_000,
+      driverCount: 1,
+      truckCount: 1,
+      cumulativeGross: 0,
+    };
+    const open = computeAllStatuses(
+      TROPHY_CATALOG,
+      { "own-authority": rec("own-authority", true) },
+      { ...base, truckLoan: { paidOff: false, ownedPct: 0.36, owed: 44100 } },
+    );
+    expect(open["free-and-clear"].earned).toBe(false);
+    expect(open["free-and-clear"].progress).toBeCloseTo(0.36, 2);
+
+    const paid = computeAllStatuses(
+      TROPHY_CATALOG,
+      { "own-authority": rec("own-authority", true) },
+      { ...base, truckLoan: { paidOff: true, ownedPct: 1, owed: 0 } },
+    );
+    expect(paid["free-and-clear"].earned).toBe(true);
+    expect(paid["highway-legend"].earned).toBe(true); // authority + free&clear + 1M mi
+  });
+
+  it("trailer-paid-off auto-earns from the trailer loan", () => {
+    const s = computeAllStatuses(TROPHY_CATALOG, {}, {
+      lifetimeMiles: 0,
+      driverCount: 1,
+      truckCount: 1,
+      cumulativeGross: 0,
+      trailerLoan: { paidOff: true, ownedPct: 1, owed: 0 },
+    });
+    expect(s["trailer-paid-off"].earned).toBe(true);
+  });
+
   it("Highway Legend is the capstone of authority + free-and-clear + million miles", () => {
     const base = {
       "own-authority": rec("own-authority", true),

--- a/frontend/src/lib/trophies/status.ts
+++ b/frontend/src/lib/trophies/status.ts
@@ -12,16 +12,41 @@ export interface TrophyStatus {
   progressLabel: string | null;
 }
 
+// A tracked loan/lease against an asset — drives the paid-off trophies.
+export interface LoanStatus {
+  paidOff: boolean;
+  ownedPct: number | null; // 0..1 owned so far
+  owed: number;
+}
+
 export interface TrophyStatusData {
   lifetimeMiles: number;
   driverCount: number;
   truckCount: number;
   cumulativeGross: number;
+  truckLoan?: LoanStatus | null; // null/absent = no truck loan tracked
+  trailerLoan?: LoanStatus | null;
 }
 
 const MI = (n: number) => `${Math.round(n / 1000)}K`;
 const K = (n: number) => `$${Math.round(n / 1000)}k`;
 const clamp = (n: number) => Math.max(0, Math.min(1, n));
+
+// Paid-off trophies earn either manually (owned outright, no loan tracked) OR the
+// moment the tracked loan balance reaches $0. When a loan IS tracked, its balance
+// drives the progress bar toward free-and-clear.
+const loanTrophy = (
+  record: Trophy | undefined,
+  loan: LoanStatus | null | undefined,
+): TrophyStatus => {
+  if (record?.earned) return { earned: true, progress: null, progressLabel: null };
+  if (!loan) return { earned: false, progress: null, progressLabel: null };
+  return {
+    earned: loan.paidOff,
+    progress: loan.ownedPct,
+    progressLabel: loan.paidOff ? "Paid off" : `${K(loan.owed)} to go`,
+  };
+};
 
 const one = (
   def: TrophyDef,
@@ -48,6 +73,10 @@ const one = (
         progress: clamp(d.cumulativeGross / 1_000_000),
         progressLabel: `${K(d.cumulativeGross)} / $1M`,
       };
+    case "free-and-clear":
+      return loanTrophy(record, d.truckLoan);
+    case "trailer-paid-off":
+      return loanTrophy(record, d.trailerLoan);
     case "highway-legend": {
       const done = [
         earnedByKey["own-authority"],

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -15,6 +15,10 @@ import {
   maxOdometer,
 } from "@/lib/metrics/maintenance";
 import { loadTrailerNet } from "@/lib/metrics/rateTargets";
+import { getObligations } from "@/services/obligationsService";
+import type { Obligation } from "@/types/obligation";
+import { isPayoffTracked } from "@/lib/metrics/payoff";
+import { PayoffTracker } from "@/components/fleet/PayoffTracker";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
@@ -44,6 +48,7 @@ const TrailerDetailPage = () => {
   const [trailer, setTrailer] = useState<Trailer | null>(null);
   const [items, setItems] = useState<MaintenanceItem[]>([]);
   const [services, setServices] = useState<MaintenanceService[]>([]);
+  const [obligations, setObligations] = useState<Obligation[]>([]);
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -59,7 +64,18 @@ const TrailerDetailPage = () => {
     getMaintenanceServices()
       .then(setServices)
       .catch(() => {});
+    getObligations()
+      .then(setObligations)
+      .catch(() => {});
   }, [id]);
+
+  // The loan tracked against this trailer, if any.
+  const trailerLoan = obligations.find(
+    (o) =>
+      o.asset_type === "trailer" &&
+      (o.asset_id === id || o.asset_id == null) &&
+      isPayoffTracked(o),
+  );
 
   // Latest hub reading, derived from the app: stored + newest trailer service.
   const hub = useMemo(() => {
@@ -207,7 +223,9 @@ const TrailerDetailPage = () => {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      {trailerLoan && <PayoffTracker obligation={trailerLoan} kind="trailer" />}
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4">
         <Link
           to="/maintenance"
           className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors block"

--- a/frontend/src/pages/TrophyHallPage.tsx
+++ b/frontend/src/pages/TrophyHallPage.tsx
@@ -5,12 +5,15 @@ import type { Trophy as TrophyRecord } from "@/types/trophy";
 import type { Driver } from "@/types/driver";
 import type { Truck } from "@/types/truck";
 import type { FuelEntry } from "@/types/fuelEntry";
+import type { Obligation } from "@/types/obligation";
 import { useLoads } from "@/hooks/useLoads";
 import { getTrophies } from "@/services/trophyService";
 import { getDrivers } from "@/services/driversService";
 import { getTrucks } from "@/services/trucksService";
 import { getFuelEntries } from "@/services/fuelService";
+import { getObligations } from "@/services/obligationsService";
 import { loadRevenue } from "@/lib/metrics/rateTargets";
+import { assetLoanStatus } from "@/lib/metrics/payoff";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { TROPHY_CATALOG } from "@/lib/trophies/catalog";
 import { computeAllStatuses, type TrophyStatus } from "@/lib/trophies/status";
@@ -195,15 +198,23 @@ const TrophyHallPage = () => {
   const [drivers, setDrivers] = useState<Driver[]>([]);
   const [trucks, setTrucks] = useState<Truck[]>([]);
   const [fuel, setFuel] = useState<FuelEntry[]>([]);
+  const [obligations, setObligations] = useState<Obligation[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    Promise.all([getTrophies(), getDrivers(), getTrucks(), getFuelEntries()])
-      .then(([tr, dr, tk, fu]) => {
+    Promise.all([
+      getTrophies(),
+      getDrivers(),
+      getTrucks(),
+      getFuelEntries(),
+      getObligations(),
+    ])
+      .then(([tr, dr, tk, fu, ob]) => {
         setRecords(tr);
         setDrivers(dr);
         setTrucks(tk);
         setFuel(fu);
+        setObligations(ob);
       })
       .catch(() => {})
       .finally(() => setLoading(false));
@@ -225,13 +236,16 @@ const TrophyHallPage = () => {
     const cumulativeGross = loads
       .filter((l) => l.load_status === "delivered")
       .reduce((s, l) => s + loadRevenue(l), 0);
+    const now = new Date();
     return computeAllStatuses(TROPHY_CATALOG, byKey, {
       lifetimeMiles,
       driverCount: drivers.filter((d) => d.active).length,
       truckCount: trucks.length,
       cumulativeGross,
+      truckLoan: assetLoanStatus(obligations, "truck", now),
+      trailerLoan: assetLoanStatus(obligations, "trailer", now),
     });
-  }, [byKey, drivers, trucks, fuel, loads]);
+  }, [byKey, drivers, trucks, fuel, loads, obligations]);
 
   const hallBg = byKey["hall-background"]?.image_url ?? null;
   const driver = drivers.find((d) => d.avatar_url) ?? drivers[0];

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -18,6 +18,10 @@ import {
 } from "@/lib/metrics/maintenance";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { loadRevenue } from "@/lib/metrics/rateTargets";
+import { getObligations } from "@/services/obligationsService";
+import type { Obligation } from "@/types/obligation";
+import { isPayoffTracked } from "@/lib/metrics/payoff";
+import { PayoffTracker } from "@/components/fleet/PayoffTracker";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
@@ -48,6 +52,7 @@ const TruckDetailPage = () => {
   const [items, setItems] = useState<MaintenanceItem[]>([]);
   const [services, setServices] = useState<MaintenanceService[]>([]);
   const [fuelEntries, setFuelEntries] = useState<FuelEntry[]>([]);
+  const [obligations, setObligations] = useState<Obligation[]>([]);
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -66,7 +71,18 @@ const TruckDetailPage = () => {
     getFuelEntries()
       .then(setFuelEntries)
       .catch(() => {});
+    getObligations()
+      .then(setObligations)
+      .catch(() => {});
   }, [id]);
+
+  // The loan/lease tracked against this truck, if any.
+  const truckLoan = obligations.find(
+    (o) =>
+      o.asset_type === "truck" &&
+      (o.asset_id === id || o.asset_id == null) &&
+      isPayoffTracked(o),
+  );
 
   const truckLoads = useMemo(
     () => loads.filter((l) => l.truck_id === id),
@@ -216,7 +232,9 @@ const TruckDetailPage = () => {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {truckLoan && <PayoffTracker obligation={truckLoan} kind="truck" />}
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
         <Link
           to="/maintenance"
           className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors"

--- a/frontend/src/services/obligationsService.ts
+++ b/frontend/src/services/obligationsService.ts
@@ -8,7 +8,23 @@ const coerce = (o: any): Obligation => ({
   amount: Number(o.amount),
   active: o.active,
   is_draw: o.is_draw ?? false,
+  original_balance: o.original_balance != null ? Number(o.original_balance) : null,
+  current_balance: o.current_balance != null ? Number(o.current_balance) : null,
+  balance_as_of: o.balance_as_of ?? null,
+  payoff_date: o.payoff_date ?? null,
+  asset_type: o.asset_type ?? null,
+  asset_id: o.asset_id ?? null,
 });
+
+// The payoff fields a create/patch may set on a loan-type obligation.
+export interface PayoffInput {
+  original_balance: number | null;
+  current_balance: number | null;
+  balance_as_of: string | null;
+  payoff_date: string | null;
+  asset_type: string | null;
+  asset_id: string | null;
+}
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 export const getObligations = async (): Promise<Obligation[]> => {
@@ -35,7 +51,9 @@ export const createObligation = async (data: {
 
 export const patchObligation = async (
   id: string,
-  data: Partial<{ label: string; amount: number; active: boolean; is_draw: boolean }>,
+  data: Partial<
+    { label: string; amount: number; active: boolean; is_draw: boolean } & PayoffInput
+  >,
 ): Promise<void> => {
   try {
     await api.patch(`/obligations/${id}`, data);

--- a/frontend/src/types/obligation.ts
+++ b/frontend/src/types/obligation.ts
@@ -4,4 +4,12 @@ export interface Obligation {
   amount: number;
   active: boolean;
   is_draw: boolean; // owner draw (distribution) — excluded from True Net
+  // Payoff tracking — a loan/lease balance on a debt obligation (null on plain
+  // obligations and draws). Balances are numbers; dates are ISO strings.
+  original_balance: number | null;
+  current_balance: number | null;
+  balance_as_of: string | null;
+  payoff_date: string | null; // contract end/maturity; null → estimate at pace
+  asset_type: string | null; // 'truck' | 'trailer'
+  asset_id: string | null; // the specific truck/trailer this loan is against
 }


### PR DESCRIPTION
## v1.66.0 — own it outright

An "own it outright" tracker on each asset page, fed by a loan/lease balance carried on the obligation, that auto-earns the paid-off trophies.

### Data + input
- **Migration 036** adds `original_balance`, `current_balance`, `balance_as_of`, `payoff_date`, `asset_type`, `asset_id` to obligations (all nullable). Applied to dev + prod.
- The **Truck Note / Trailer Payment editors** on the Expenses page expand to capture original, current balance, payoff date, and which asset it tracks.

### Tracker
- **Payoff engine** (`lib/metrics/payoff.ts`): % owned, payments left, payoff date — exact from the contract's `payoff_date`, else estimated at the current payment pace. Fits a bank loan (trailer) **and** a lease-purchase (truck).
- **PayoffTracker** card on the truck/trailer detail pages — the road-to-own with the vehicle riding toward the FREE & CLEAR flag; gold **PAID OFF** state at $0.

### Auto-earn
- **Free & Clear** (truck) and **Trailer Paid Off** (trailer) compute from the loan balance (hybrid with the manual flag): a live "$X to go" bar in the Trophy Room, and the instant a balance hits $0 they **auto-earn and fire the ceremony pop** — cascading into the **Highway Legend** capstone.

### Seed (prod, from Jason's contracts)
- Truck: $69,000 → **$44,100** (lease, ~28 payments at pace). Trailer: $39,408.09 → **$38,298.63**, matures **Jan 2036**. Trailer payment corrected to **$475.19** (was $478).

Also: **CLAUDE.md** gains the design-first gate (show a mockup before building UI).

Backend + frontend. Build clean, **189 tests**.