### PR TITLE
feat: award system rebuild — Record Book, Patches, Medals (Phase 1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.66.0",
+  "version": "1.67.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/awards/MedalBadge.tsx
+++ b/frontend/src/components/awards/MedalBadge.tsx
@@ -1,0 +1,64 @@
+import type { Medal } from "@/lib/awards/medals";
+import { awardIcon } from "./awardIcons";
+
+// Metal by tier: bronze I, silver II, gold III+.
+const METAL: Record<number, { face: string; edge: string; ink: string; r1: string; r2: string }> = {
+  1: { face: "#c9884a", edge: "#6b3f1e", ink: "#3a230e", r1: "#c9884a", r2: "#e7cfa8" },
+  2: { face: "#cdd6e3", edge: "#5a6478", ink: "#243040", r1: "#cdd6e3", r2: "#eef2f7" },
+  3: { face: "#f5b03a", edge: "#7a5410", ink: "#3a2708", r1: "#f5b03a", r2: "#f5e6c8" },
+};
+
+// A real ribboned medallion. Worn on the card header (earned tiers only).
+export const MedalBadge = ({ medal }: { medal: Medal }) => {
+  const m = METAL[Math.min(3, Math.max(1, medal.tier))];
+  const Icon = awardIcon(medal.icon);
+  return (
+    <div style={{ width: 46, textAlign: "center", position: "relative" }} title={`${medal.name} ${medal.tierLabel}`}>
+      <div
+        style={{
+          width: 22,
+          height: 15,
+          margin: "0 auto",
+          clipPath: "polygon(0 0,100% 0,100% 100%,50% 74%,0 100%)",
+          background: `repeating-linear-gradient(90deg,${m.r1} 0 4px,${m.r2} 4px 8px)`,
+        }}
+      />
+      <div
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: "50%",
+          margin: "-4px auto 0",
+          background: m.face,
+          border: `2px solid ${m.edge}`,
+          color: m.ink,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          position: "relative",
+          boxShadow: "inset 0 0 0 2px rgba(255,255,255,.22)",
+        }}
+      >
+        <Icon size={18} />
+        <span
+          className="font-comic"
+          style={{
+            position: "absolute",
+            bottom: -3,
+            right: 1,
+            fontSize: 9,
+            lineHeight: 1,
+            padding: "0 3px",
+            borderRadius: 99,
+            border: "1.5px solid #10151f",
+            background: m.face,
+            color: m.ink,
+          }}
+        >
+          {medal.tierLabel}
+        </span>
+      </div>
+      <div style={{ fontSize: 8.5, color: "#c8d0dc", marginTop: 4, lineHeight: 1.1 }}>{medal.name}</div>
+    </div>
+  );
+};

--- a/frontend/src/components/awards/PatchBoard.tsx
+++ b/frontend/src/components/awards/PatchBoard.tsx
@@ -1,0 +1,71 @@
+import type { Patch } from "@/lib/awards/patches";
+import { awardIcon } from "./awardIcons";
+
+const PatchEmblem = ({ p }: { p: Patch }) => {
+  const earned = p.count > 0;
+  const Icon = awardIcon(p.icon);
+  return (
+    <div style={{ width: 96, textAlign: "center", position: "relative", opacity: earned ? 1 : 0.5 }}>
+      <div
+        style={{
+          width: 70,
+          height: 70,
+          borderRadius: "50%",
+          margin: "0 auto",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: earned ? "#2a1e0e" : "#141a26",
+          border: `3px solid ${earned ? "#e8940a" : "#2a3550"}`,
+        }}
+      >
+        <Icon size={28} style={{ color: earned ? "#f5b03a" : "#5b6b82" }} />
+      </div>
+      {earned && (
+        <span
+          className="font-comic"
+          style={{
+            position: "absolute",
+            top: -3,
+            right: 12,
+            background: "#e8940a",
+            color: "#120f08",
+            borderRadius: 99,
+            fontSize: 11,
+            padding: "0 6px",
+            border: "2px solid #10151f",
+          }}
+        >
+          ×{p.count}
+        </span>
+      )}
+      <div style={{ fontSize: 10.5, color: earned ? "#c8d0dc" : "#7a869a", marginTop: 5, lineHeight: 1.15 }}>
+        {p.name}
+      </div>
+      <div style={{ fontSize: 8.5, color: "#9daabb" }}>{p.hint}</div>
+    </div>
+  );
+};
+
+// The patch board — hard, stackable feats. Earned (lit, with ×count) sort ahead of
+// locked (grayed, showing what it takes). Reusable for driver / truck / trailer.
+export const PatchBoard = ({ patches }: { patches: Patch[] }) => {
+  const sorted = [...patches].sort(
+    (a, b) => (b.count > 0 ? 1 : 0) - (a.count > 0 ? 1 : 0) || b.count - a.count,
+  );
+  return (
+    <div className="mt-6">
+      <div className="flex items-baseline gap-2 mb-2">
+        <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
+          PATCHES
+        </span>
+        <span className="text-[11px] text-muted-text">hard to earn · stack a ×count each time</span>
+      </div>
+      <div className="flex gap-3 flex-wrap">
+        {sorted.map((p) => (
+          <PatchEmblem key={p.key} p={p} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/awards/RecordBook.tsx
+++ b/frontend/src/components/awards/RecordBook.tsx
@@ -1,0 +1,34 @@
+import { Trophy, Gauge, Flame, Package, Layers } from "lucide-react";
+import type { PersonalBests } from "@/lib/metrics/playerCard";
+
+const kMoney = (n: number) => (n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${Math.round(n)}`);
+
+const Rec = ({ Icon, color, value, label }: { Icon: typeof Trophy; color: string; value: string; label: string }) => (
+  <div className="flex-1 min-w-[92px] rounded-[10px] px-2 py-2 text-center" style={{ background: "#1c2333" }}>
+    <Icon size={16} style={{ color }} />
+    <div className="font-comic leading-none mt-1" style={{ color: "#f5e6c8", fontSize: 19 }}>
+      {value}
+    </div>
+    <div className="text-[9px] text-muted-text mt-1 tracking-wide">{label}</div>
+  </div>
+);
+
+// Your improving records — beat one and it climbs (a slide-in card announces it,
+// then the record updates). Distinct from patches, which are hard absolute bars.
+export const RecordBook = ({ bests }: { bests: PersonalBests }) => (
+  <div className="mt-6">
+    <div className="flex items-baseline gap-2 mb-2">
+      <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
+        RECORD BOOK
+      </span>
+      <span className="text-[11px] text-muted-text">your bests — they climb as you beat them</span>
+    </div>
+    <div className="flex gap-2 flex-wrap">
+      <Rec Icon={Trophy} color="#f5b03a" value={bests.bestWeekRevenue != null ? kMoney(bests.bestWeekRevenue) : "—"} label="TOP WEEK" />
+      <Rec Icon={Gauge} color="#4ade80" value={bests.lowestDeadheadPct != null ? `${(bests.lowestDeadheadPct * 100).toFixed(1)}%` : "—"} label="BEST DEADHEAD" />
+      <Rec Icon={Flame} color="#e8940a" value={bests.bestMpg != null ? bests.bestMpg.toFixed(1) : "—"} label="BEST TANK" />
+      <Rec Icon={Package} color="#f5b03a" value={bests.biggestLoad != null ? kMoney(bests.biggestLoad) : "—"} label="BIGGEST LOAD" />
+      <Rec Icon={Layers} color="#60a5fa" value={bests.mostLoadsInWeek != null ? String(bests.mostLoadsInWeek) : "—"} label="MOST / WEEK" />
+    </div>
+  </div>
+);

--- a/frontend/src/components/awards/awardIcons.ts
+++ b/frontend/src/components/awards/awardIcons.ts
@@ -1,0 +1,38 @@
+import {
+  Banknote,
+  Route,
+  Mountain,
+  Coins,
+  Dumbbell,
+  Gauge,
+  MapPin,
+  ArrowLeftRight,
+  Layers,
+  Medal,
+  Boxes,
+  Flame,
+  Unlock,
+  Trophy,
+  type LucideIcon,
+} from "lucide-react";
+
+// The award catalogs use plain icon names; map them to lucide here so patches and
+// medals share one vocabulary.
+const MAP: Record<string, LucideIcon> = {
+  cash: Banknote,
+  road: Route,
+  mountain: Mountain,
+  coins: Coins,
+  barbell: Dumbbell,
+  gauge: Gauge,
+  "map-pin": MapPin,
+  "arrows-horizontal": ArrowLeftRight,
+  "layers-subtract": Layers,
+  medal: Medal,
+  "stack-2": Boxes,
+  flame: Flame,
+  "lock-open": Unlock,
+  trophy: Trophy,
+};
+
+export const awardIcon = (name: string): LucideIcon => MAP[name] ?? Trophy;

--- a/frontend/src/components/playercard/PlayerCard.tsx
+++ b/frontend/src/components/playercard/PlayerCard.tsx
@@ -1,21 +1,11 @@
 import type { ReactNode } from "react";
-import {
-  Truck,
-  Trophy,
-  Flame,
-  Package,
-  Layers,
-  Users,
-  Medal,
-  Gauge,
-  type LucideIcon,
-} from "lucide-react";
+import { Truck } from "lucide-react";
 import type { Grade, CareerRank, SeasonStats } from "@/lib/metrics/playerCard";
-import type { Award } from "@/lib/metrics/awards";
+import type { Medal } from "@/lib/awards/medals";
 import { fmtMiles } from "@/lib/metrics/mileClub";
 import { RANK_TIERS } from "@/lib/constants/playerCard";
 import { DEADHEAD_TARGET } from "@/lib/constants/targets";
-import { MiniTrophyCard } from "@/components/comic/MiniTrophyCard";
+import { MedalBadge } from "@/components/awards/MedalBadge";
 
 const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const pct1 = (n: number) => `${(n * 100).toFixed(1)}%`;
@@ -24,7 +14,6 @@ const GREEN = "#4ade80";
 const RED = "#f87171";
 const AMBER = "#e8940a";
 
-// Colour a metric by where it actually stands — earned, not decorative.
 const profitColor = (n: number) => (n < 0 ? RED : GREEN);
 const deadheadColor = (pct: number | null): string | undefined => {
   if (pct == null) return undefined;
@@ -40,37 +29,19 @@ const GRADE_META: Record<Grade, { label: string; fg: string; bg: string }> = {
   strong: { label: "STRONG", fg: "#fbbf24", bg: "#3a300a" },
 };
 
-// The award engine's icon strings → lucide. Shared vocabulary with the pop host,
-// so a badge here wears the same icon as the pop that announced it.
-const AWARD_ICON: Record<string, LucideIcon> = {
-  trophy: Trophy,
-  flame: Flame,
-  package: Package,
-  stack: Layers,
-  users: Users,
-  gauge: Gauge,
-  medal: Medal,
-  truck: Truck,
-};
-const iconFor = (n: string): LucideIcon => AWARD_ICON[n] ?? Trophy;
-
 const GradeChip = ({ grade, value }: { grade: Grade | null; value?: string }) => {
   if (!grade)
     return <span className="text-[11px] px-2 py-0.5 rounded-full bg-plate text-muted-text">—</span>;
   const m = GRADE_META[grade];
   return (
-    <span
-      className="text-[11px] font-semibold px-2 py-0.5 rounded-full whitespace-nowrap"
-      style={{ background: m.bg, color: m.fg }}
-    >
+    <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full whitespace-nowrap" style={{ background: m.bg, color: m.fg }}>
       {m.label}
       {value ? ` · ${value}` : ""}
     </span>
   );
 };
 
-const gradeColor = (g: Grade | null): string | undefined =>
-  g ? GRADE_META[g].fg : undefined;
+const gradeColor = (g: Grade | null): string | undefined => (g ? GRADE_META[g].fg : undefined);
 
 const Stat = ({
   label,
@@ -94,34 +65,6 @@ const Stat = ({
   </div>
 );
 
-// A small earned emblem — the persistent home for a `burst` pop. Name + the
-// record value it carries, so the achievement and its number live together.
-const Badge = ({
-  Icon,
-  name,
-  detail,
-}: {
-  Icon: LucideIcon;
-  name: string;
-  detail: string;
-}) => (
-  <div
-    className="flex items-center gap-2 rounded-[11px] px-2.5 py-2"
-    style={{ background: "#10151f", border: "1px solid #2a3347" }}
-  >
-    <div
-      className="w-8 h-8 rounded-full flex items-center justify-center shrink-0"
-      style={{ background: "#3a2a0a", color: "#f5b03a" }}
-    >
-      <Icon size={16} />
-    </div>
-    <div className="min-w-0">
-      <p className="text-[12px] font-semibold leading-tight truncate">{name}</p>
-      <p className="text-[10px] text-muted-text leading-tight truncate">{detail}</p>
-    </div>
-  </div>
-);
-
 export interface PlayerCardProps {
   name: string;
   business: string;
@@ -132,8 +75,7 @@ export interface PlayerCardProps {
   marginGrade: Grade | null;
   form: Grade | null;
   windowRpm: number | null;
-  badges: Award[]; // frequent wins (burst tier)
-  shelf: Award[]; // rarer wins (marquee tier — mile club, strong season)
+  medals: Medal[]; // earned tiers only — worn by the name
 }
 
 export const PlayerCard = ({
@@ -146,32 +88,31 @@ export const PlayerCard = ({
   marginGrade,
   form,
   windowRpm,
-  badges,
-  shelf,
+  medals,
 }: PlayerCardProps) => {
-  const stars =
-    "★".repeat(rank.index + 1) + "☆".repeat(RANK_TIERS.length - rank.index - 1);
+  const stars = "★".repeat(rank.index + 1) + "☆".repeat(RANK_TIERS.length - rank.index - 1);
 
   return (
     <div>
-      {/* ---- card header ---- */}
-      <div
-        className="relative overflow-hidden rounded-2xl border-2 p-4"
-        style={{ background: "#10151f", borderColor: "#e8940a" }}
-      >
+      <div className="relative overflow-hidden rounded-2xl border-2 p-4" style={{ background: "#10151f", borderColor: "#e8940a" }}>
         <div
           className="absolute top-0 right-0 w-32 h-32 pointer-events-none"
-          style={{
-            backgroundImage: "radial-gradient(#e8940a 1.3px, transparent 1.4px)",
-            backgroundSize: "7px 7px",
-            opacity: 0.14,
-          }}
+          style={{ backgroundImage: "radial-gradient(#e8940a 1.3px, transparent 1.4px)", backgroundSize: "7px 7px", opacity: 0.14 }}
         />
         <div className="flex gap-4 items-start relative">
           <div className="shrink-0">{avatar}</div>
           <div className="flex-1 min-w-0">
-            <h1 className="font-condensed text-3xl leading-none">{name}</h1>
-            <p className="text-xs text-muted-text mb-3">{business}</p>
+            <div className="flex justify-between items-start gap-3 flex-wrap">
+              <h1 className="font-condensed text-3xl leading-none">{name}</h1>
+              {medals.length > 0 && (
+                <div className="flex gap-1.5 flex-wrap justify-end">
+                  {medals.map((m) => (
+                    <MedalBadge key={m.key} medal={m} />
+                  ))}
+                </div>
+              )}
+            </div>
+            <p className="text-xs text-muted-text mb-3 mt-1">{business}</p>
             <div className="flex items-center gap-3">
               <div
                 className="w-11 h-11 rounded-full flex items-center justify-center shrink-0"
@@ -180,10 +121,7 @@ export const PlayerCard = ({
                 <Truck size={20} />
               </div>
               <div className="flex-1 min-w-0">
-                <div
-                  className="font-comic text-xl leading-none"
-                  style={{ color: "#f5e6c8", letterSpacing: "1px" }}
-                >
+                <div className="font-comic text-xl leading-none" style={{ color: "#f5e6c8", letterSpacing: "1px" }}>
                   {rank.name}
                 </div>
                 <div className="text-[10px] text-muted-text mt-0.5">
@@ -202,14 +140,8 @@ export const PlayerCard = ({
           </div>
         </div>
 
-        {/* season form strip */}
-        <div
-          className="flex items-center gap-2 flex-wrap mt-4 pt-3 border-t relative"
-          style={{ borderColor: "#2a3347" }}
-        >
-          <span className="font-condensed text-sm tracking-wide text-muted-text">
-            SEASON · {season.label}
-          </span>
+        <div className="flex items-center gap-2 flex-wrap mt-4 pt-3 border-t relative" style={{ borderColor: "#2a3347" }}>
+          <span className="font-condensed text-sm tracking-wide text-muted-text">SEASON · {season.label}</span>
           <span className="text-[11px] text-muted-text">Rate</span>
           <GradeChip grade={rpmGrade} value={windowRpm != null ? `$${windowRpm.toFixed(2)}` : undefined} />
           <span className="text-[11px] text-muted-text">Op margin</span>
@@ -217,10 +149,7 @@ export const PlayerCard = ({
           <span className="flex-1" />
           <span className="text-[11px] text-muted-text">Form</span>
           {form ? (
-            <span
-              className="font-comic px-2.5 py-0.5 rounded-full"
-              style={{ background: GRADE_META[form].bg, color: GRADE_META[form].fg, letterSpacing: "2px", fontSize: 14 }}
-            >
+            <span className="font-comic px-2.5 py-0.5 rounded-full" style={{ background: GRADE_META[form].bg, color: GRADE_META[form].fg, letterSpacing: "2px", fontSize: 14 }}>
               {GRADE_META[form].label}
             </span>
           ) : (
@@ -229,85 +158,22 @@ export const PlayerCard = ({
         </div>
       </div>
 
-      {/* ---- season stat line ---- */}
       <div className="flex items-baseline gap-2 mt-5 mb-2">
         <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
           LAST SEASON
         </span>
-        <span className="text-[11px] text-muted-text">
-          · {season.label} · your last 3 complete months
-        </span>
+        <span className="text-[11px] text-muted-text">· {season.label} · your last 3 complete months</span>
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
         <Stat label="Net revenue" value={money0(season.netRevenue)} sub="net of carrier cut" />
-        <Stat
-          label="Operating profit"
-          value={money0(season.netProfit)}
-          color={profitColor(season.netProfit)}
-          sub="before obligations"
-        />
-        <Stat
-          label="True net"
-          value={money0(season.trueNet)}
-          color={profitColor(season.trueNet)}
-          sub="what you keep, before draw"
-        />
+        <Stat label="Operating profit" value={money0(season.netProfit)} color={profitColor(season.netProfit)} sub="before obligations" />
+        <Stat label="True net" value={money0(season.trueNet)} color={profitColor(season.trueNet)} sub="what you keep, before draw" />
         <Stat label="Loads" value={String(season.loads)} />
         <Stat label="Miles" value={Math.round(season.totalMiles).toLocaleString("en-US")} />
-        <Stat
-          label="Deadhead"
-          value={season.deadheadPct != null ? pct1(season.deadheadPct) : "—"}
-          color={deadheadColor(season.deadheadPct)}
-        />
-        <Stat
-          label="Avg RPM"
-          value={season.avgRpm != null ? `$${season.avgRpm.toFixed(2)}` : "—"}
-          color={gradeColor(rpmGrade)}
-        />
+        <Stat label="Deadhead" value={season.deadheadPct != null ? pct1(season.deadheadPct) : "—"} color={deadheadColor(season.deadheadPct)} />
+        <Stat label="Avg RPM" value={season.avgRpm != null ? `$${season.avgRpm.toFixed(2)}` : "—"} color={gradeColor(rpmGrade)} />
         <Stat label="Best lane" value={season.bestLane?.lane ?? "—"} span2 />
       </div>
-
-      {/* ---- badges (frequent wins) ---- */}
-      <div className="flex items-baseline gap-2 mt-6">
-        <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
-          BADGES
-        </span>
-        <span className="text-[11px] text-muted-text">— earned as you run</span>
-      </div>
-      {badges.length > 0 ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2">
-          {badges.map((b) => (
-            <Badge key={b.id} Icon={iconFor(b.icon)} name={b.name} detail={b.detail} />
-          ))}
-        </div>
-      ) : (
-        <p className="text-[11px] text-muted-text mt-2">
-          Rack up best weeks, tight deadhead, and fuel records to earn badges.
-        </p>
-      )}
-
-      {/* ---- trophy shelf (rarer wins) ---- */}
-      {shelf.length > 0 && (
-        <>
-          <div className="flex items-baseline gap-2 mt-6">
-            <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
-              TROPHY SHELF
-            </span>
-            <span className="text-[11px] text-muted-text">— the bigger hauls</span>
-          </div>
-          <div className="flex flex-wrap gap-2.5 mt-2">
-            {shelf.map((t) => (
-              <MiniTrophyCard
-                key={t.id}
-                name={t.name}
-                detail={t.detail}
-                Icon={iconFor(t.icon)}
-                gold={t.id.startsWith("mileclub") || t.id.startsWith("strong-season")}
-              />
-            ))}
-          </div>
-        </>
-      )}
     </div>
   );
 };

--- a/frontend/src/lib/awards/adaptiveBar.test.ts
+++ b/frontend/src/lib/awards/adaptiveBar.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { computeStack } from "./adaptiveBar";
+
+describe("computeStack — adaptive ratcheting bar", () => {
+  it("earns against the conservative floor during cold-start", () => {
+    // floor 7000, n=5. First 5 are history; earns check against the floor throughout.
+    const s = computeStack([8000, 5000, 9000, 4000, 6000], {
+      n: 5,
+      floor: 7000,
+    });
+    // 8000 and 9000 clear the 7000 floor → 2 earns; bar still the floor (history < 5 until the end)
+    expect(s.count).toBe(2);
+    expect(s.bar).toBe(7000);
+  });
+
+  it("raises the bar as strong results stack, then a downturn can't lower it", () => {
+    // Rising then falling. Once 5 of history exist, the bar climbs to the 5th-best
+    // and holds — later weak values neither earn nor ease the bar.
+    const vals = [10000, 12000, 14000, 16000, 18000, 20000, 22000, 9000, 8000];
+    const s = computeStack(vals, { n: 5, floor: 6000, minHistory: 5 });
+    // bar ends at the 5th-best seen = 14000 (from 22,20,18,16,14,...), never eased by the 9k/8k
+    expect(s.bar).toBe(14000);
+    // the 8000/9000 at the end are below the ratcheted bar → they don't earn
+    expect(s.count).toBeGreaterThanOrEqual(6);
+  });
+
+  it("never rolls the count backward when the bar rises", () => {
+    const rising = computeStack([7000, 8000, 9000, 10000, 11000, 12000, 13000], {
+      n: 5,
+      floor: 6000,
+      minHistory: 5,
+    });
+    // every value cleared the bar in effect at its time → all 7 counted, locked in
+    expect(rising.count).toBe(7);
+  });
+
+  it("handles lower-is-better metrics (deadhead %) — the bar tightens downward", () => {
+    // Best (lowest) deadhead. Bar = 5th-lowest, ratchets DOWN. floor 0.10.
+    const dh = [0.09, 0.12, 0.08, 0.15, 0.07, 0.06, 0.2];
+    const s = computeStack(dh, { n: 5, floor: 0.1, minHistory: 5 });
+    expect(s.bar).toBeLessThanOrEqual(0.1); // tightened at/under the floor
+    expect(s.count).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/lib/awards/adaptiveBar.ts
+++ b/frontend/src/lib/awards/adaptiveBar.ts
@@ -1,0 +1,44 @@
+// Adaptive, ratcheting difficulty for the "impressive feat" awards (patches).
+// The bar is set from the user's OWN history — their ~N-th best result for the
+// metric — so it's hard but attainable, and it only ever gets HARDER (a downturn
+// can never make it easier). Earns lock in: an event that cleared the bar in
+// effect at its time stays counted forever, so the ×N count never rolls backward.
+
+export interface Stack {
+  count: number; // times earned (×N) — monotonic, never decreases
+  bar: number; // the level a NEW event must clear now
+  active: boolean; // true once there's enough history for the personal bar
+}
+
+export interface BarOpts {
+  n: number; // "top N" that sets the bar (5 → your 5th-best clears it)
+  floor: number; // conservative starter bar until history builds
+  minHistory?: number; // events before the personal bar takes over (default n)
+  lowerIsBetter?: boolean; // deadhead % etc. — a SMALLER value clears the bar
+}
+
+// Walk the metric's values in CHRONOLOGICAL order. For each value, the bar is the
+// personal bar established by everything before it (ratcheted — running hardest);
+// a value that clears the bar in effect at that moment earns, permanently.
+export const computeStack = (chrono: number[], opts: BarOpts): Stack => {
+  const { n, floor, lowerIsBetter = false } = opts;
+  const minHistory = opts.minHistory ?? n;
+  const better = (v: number, bar: number) => (lowerIsBetter ? v <= bar : v >= bar);
+  const harder = (a: number, b: number) => (lowerIsBetter ? Math.min(a, b) : Math.max(a, b));
+
+  const seen: number[] = [];
+  let bar = floor;
+  let count = 0;
+
+  for (const v of chrono) {
+    if (seen.length >= minHistory) {
+      const sorted = [...seen].sort((a, b) => (lowerIsBetter ? a - b : b - a));
+      const candidate = sorted[Math.min(n, sorted.length) - 1]; // N-th best so far
+      bar = harder(bar, candidate); // ratchet — the bar can only get tougher
+    }
+    if (better(v, bar)) count++;
+    seen.push(v);
+  }
+
+  return { count, bar, active: seen.length >= minHistory };
+};

--- a/frontend/src/lib/awards/medals.test.ts
+++ b/frontend/src/lib/awards/medals.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { computeMedals, earnedMedals } from "./medals";
+
+const base = {
+  lifetimeMiles: 0,
+  deliveredCount: 0,
+  cumulativeNet: 0,
+  streak: 0,
+  loanPaidPct: null,
+  seasonStrong: false,
+};
+
+describe("computeMedals", () => {
+  it("tiers Mile Club and reports progress to the next", () => {
+    const m = computeMedals({ ...base, lifetimeMiles: 582_450 }).find((x) => x.key === "mile-club")!;
+    expect(m.tier).toBe(3); // ≥500k, <1M
+    expect(m.tierLabel).toBe("III");
+    expect(m.next).toBe(1_000_000);
+    expect(m.progress).toBeCloseTo((582450 - 500000) / (1_000_000 - 500000), 3);
+    expect(m.hint).toBe("582k / 1M");
+  });
+
+  it("stays untiered below the first threshold", () => {
+    const m = computeMedals({ ...base, deliveredCount: 47 }).find((x) => x.key === "freight-hauler")!;
+    expect(m.tier).toBe(0);
+    expect(m.next).toBe(100);
+  });
+
+  it("adds Debt Crusher only when a loan is tracked", () => {
+    expect(computeMedals(base).find((x) => x.key === "debt-crusher")).toBeUndefined();
+    const m = computeMedals({ ...base, loanPaidPct: 0.36 }).find((x) => x.key === "debt-crusher")!;
+    expect(m.tier).toBe(1); // ≥25%
+    expect(m.hint).toBe("36% / 50%");
+  });
+
+  it("earnedMedals keeps only earned, most prestigious first", () => {
+    const all = computeMedals({
+      ...base,
+      lifetimeMiles: 582_450, // Mile Club III
+      streak: 5, // Iron Streak I
+      loanPaidPct: 0.36, // Debt Crusher I
+    });
+    const earned = earnedMedals(all).map((m) => m.key);
+    expect(earned[0]).toBe("mile-club"); // tier III leads
+    expect(earned).toContain("iron-streak");
+    expect(earned).not.toContain("freight-hauler"); // 0 loads → untiered
+  });
+});

--- a/frontend/src/lib/awards/medals.ts
+++ b/frontend/src/lib/awards/medals.ts
@@ -1,0 +1,77 @@
+// Medals: tiered, FIXED universal milestones (a million miles is a million miles for
+// everyone) — the aspirational career ladder, each line ending in a Trophy. Derived
+// from the driver's real totals, but the thresholds don't move. Pure.
+
+export interface Medal {
+  key: string;
+  name: string;
+  icon: string;
+  tier: number; // 0 = none yet, 1..N = current tier
+  tierLabel: string; // "", "I", "II", "III"
+  next: number | null; // next threshold (null = topped out / trophy next)
+  progress: number; // 0..1 toward the next tier
+  hint: string; // "582k / 1M"
+}
+
+export interface MedalData {
+  lifetimeMiles: number;
+  deliveredCount: number;
+  cumulativeNet: number; // Σ delivered net
+  streak: number; // grind streak, weeks
+  loanPaidPct: number | null; // best % paid across tracked loans (0..1)
+  seasonStrong: boolean; // season margin graded "strong"
+}
+
+const ROMAN = ["", "I", "II", "III", "IV"];
+const clamp = (n: number) => Math.max(0, Math.min(1, n));
+const kMi = (n: number) => (n >= 1_000_000 ? `${(n / 1_000_000).toFixed(0)}M` : `${Math.round(n / 1000)}k`);
+const kMoney = (n: number) => (n >= 1_000_000 ? `$${(n / 1_000_000).toFixed(0)}M` : `$${Math.round(n / 1000)}k`);
+
+const tiered = (
+  key: string,
+  name: string,
+  icon: string,
+  tiers: number[],
+  current: number,
+  fmt: (n: number) => string,
+): Medal => {
+  let tier = 0;
+  for (let i = 0; i < tiers.length; i++) if (current >= tiers[i]) tier = i + 1;
+  const next = tier < tiers.length ? tiers[tier] : null;
+  const prev = tier > 0 ? tiers[tier - 1] : 0;
+  const progress = next != null ? clamp((current - prev) / (next - prev)) : 1;
+  const hint = next != null ? `${fmt(current)} / ${fmt(next)}` : `${fmt(current)} · maxed`;
+  return { key, name, icon, tier, tierLabel: ROMAN[tier], next, progress, hint };
+};
+
+export const computeMedals = (d: MedalData): Medal[] => {
+  const medals: Medal[] = [
+    tiered("mile-club", "Mile Club", "medal", [100_000, 250_000, 500_000, 1_000_000], d.lifetimeMiles, kMi),
+    tiered("freight-hauler", "Freight Hauler", "stack-2", [100, 250, 500], d.deliveredCount, (n) => `${Math.round(n)}`),
+    tiered("big-earner", "Big Earner", "coins", [250_000, 500_000, 750_000], d.cumulativeNet, kMoney),
+    tiered("iron-streak", "Iron Streak", "flame", [4, 8, 12], d.streak, (n) => `${Math.round(n)} wk`),
+  ];
+
+  if (d.loanPaidPct != null)
+    medals.push(
+      tiered("debt-crusher", "Debt Crusher", "lock-open", [0.25, 0.5, 0.75], d.loanPaidPct, (n) => `${Math.round(n * 100)}%`),
+    );
+
+  // Strong Season — a single-tier honor (this season's margin graded strong).
+  medals.push({
+    key: "strong-season",
+    name: "Strong Season",
+    icon: "trophy",
+    tier: d.seasonStrong ? 1 : 0,
+    tierLabel: d.seasonStrong ? "I" : "",
+    next: null,
+    progress: d.seasonStrong ? 1 : 0,
+    hint: d.seasonStrong ? "earned this season" : "grade a strong margin season",
+  });
+
+  return medals;
+};
+
+// Earned medals only, most prestigious first — for the card header.
+export const earnedMedals = (medals: Medal[]): Medal[] =>
+  medals.filter((m) => m.tier > 0).sort((a, b) => b.tier - a.tier);

--- a/frontend/src/lib/awards/patches.test.ts
+++ b/frontend/src/lib/awards/patches.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { FuelEntry } from "@/types/fuelEntry";
+import { computePatches } from "./patches";
+
+const L = (o: Record<string, unknown>): Load =>
+  ({
+    load_status: "delivered",
+    fuel_surcharge: "0",
+    total_accessorials: "0",
+    loaded_miles: 500,
+    deadhead_miles: 0,
+    ...o,
+  }) as unknown as Load;
+
+const find = (loads: Load[], key: string) =>
+  computePatches(loads, [] as FuelEntry[]).find((p) => p.key === key)!;
+
+describe("computePatches", () => {
+  it("Trailblazer counts distinct states touched", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", origin_state: "TX", destination_state: "GA", linehaul: "2000" }),
+      L({ delivery_date: "2026-05-08", origin_state: "GA", destination_state: "FL", linehaul: "2000" }),
+      L({ delivery_date: "2026-05-15", origin_state: "TX", destination_state: "FL", linehaul: "2000" }),
+    ];
+    expect(find(loads, "trailblazer").count).toBe(3); // TX, GA, FL
+    expect(find(loads, "trailblazer").hint).toBe("3 / 48 states");
+  });
+
+  it("Doubleheader counts days with 2+ deliveries", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", linehaul: "1000" }),
+      L({ delivery_date: "2026-05-01", linehaul: "1000" }),
+      L({ delivery_date: "2026-05-02", linehaul: "1000" }),
+    ];
+    expect(find(loads, "doubleheader").count).toBe(1); // only 05-01
+  });
+
+  it("Big Ticket earns against the floor and exposes the current bar", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", linehaul: "9000" }), // clears $7k floor
+      L({ delivery_date: "2026-05-02", linehaul: "3000" }),
+      L({ delivery_date: "2026-05-03", linehaul: "8000" }), // clears
+    ];
+    const bt = find(loads, "big-ticket");
+    expect(bt.count).toBe(2);
+    expect(bt.bar).toBe(7000);
+    expect(bt.unit).toBe("money");
+  });
+
+  it("Coast to Coast spots a West↔East run", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", origin_state: "CA", destination_state: "FL", linehaul: "5000" }),
+      L({ delivery_date: "2026-05-08", origin_state: "TX", destination_state: "OK", linehaul: "1000" }),
+    ];
+    expect(find(loads, "coast-to-coast").count).toBe(1);
+  });
+});

--- a/frontend/src/lib/awards/patches.ts
+++ b/frontend/src/lib/awards/patches.ts
@@ -1,0 +1,125 @@
+// Patches: hard, stackable feats. The "impressive" ones use an adaptive ratcheting
+// bar set from the driver's own history (computeStack); the "structural" ones have a
+// fixed definition (a new state, a cross-country run, two deliveries in a day). Every
+// patch is derived from load data and takes the loads pre-filtered, so the same
+// function scopes to a driver, a truck, or a trailer just by what you pass in.
+import type { Load } from "@/types/load";
+import type { FuelEntry } from "@/types/fuelEntry";
+import { loadGross, loadRevenue } from "@/lib/metrics/rateTargets";
+import { computeStack, type BarOpts } from "./adaptiveBar";
+
+export interface Patch {
+  key: string;
+  name: string;
+  icon: string;
+  count: number; // ×N earned (0 = not yet)
+  bar: number | null; // current threshold to clear now (null = structural)
+  unit: "money" | "miles" | "pct" | "weight" | null;
+  hint: string; // one-liner requirement / progress
+}
+
+const delivered = (loads: Load[]): Load[] =>
+  loads
+    .filter((l) => l.load_status === "delivered" && l.delivery_date)
+    .sort((a, b) => (a.delivery_date! < b.delivery_date! ? -1 : 1));
+
+const weekKey = (iso: string): string => {
+  const d = new Date(iso.slice(0, 10) + "T00:00:00Z");
+  const monday = new Date(d);
+  monday.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+  return monday.toISOString().slice(0, 10);
+};
+const monthKey = (iso: string): string => iso.slice(0, 7);
+
+// Chronological buckets → a value per bucket, in time order.
+const bucketed = <T>(
+  loads: Load[],
+  keyOf: (l: Load) => string,
+  reduce: (ls: Load[]) => T,
+): T[] => {
+  const map = new Map<string, Load[]>();
+  for (const l of loads) {
+    const k = keyOf(l);
+    (map.get(k) ?? map.set(k, []).get(k)!).push(l);
+  }
+  return [...map.keys()].sort().map((k) => reduce(map.get(k)!));
+};
+
+const WEST = new Set(["WA", "OR", "CA", "NV", "ID", "UT", "AZ", "MT", "WY", "CO", "NM", "AK", "HI"]);
+const EAST = new Set(["ME", "NH", "VT", "MA", "RI", "CT", "NY", "NJ", "PA", "DE", "MD", "VA", "WV", "NC", "SC", "GA", "FL"]);
+const spansCoasts = (a: string | null, b: string | null): boolean =>
+  !!a && !!b && ((WEST.has(a) && EAST.has(b)) || (EAST.has(a) && WEST.has(b)));
+
+const ADAPTIVE: {
+  key: string;
+  name: string;
+  icon: string;
+  unit: Patch["unit"];
+  opts: BarOpts;
+  value: (l: Load) => number;
+  bucket?: "week" | "month"; // adaptive over per-week/per-month values, else per-load
+  weekMetric?: (ls: Load[]) => number; // for bucketed metrics
+}[] = [
+  { key: "big-ticket", name: "Big Ticket", icon: "cash", unit: "money", opts: { n: 5, floor: 7000 }, value: (l) => loadGross(l) },
+  { key: "long-hauler", name: "Long Hauler", icon: "road", unit: "miles", opts: { n: 5, floor: 1200 }, value: (l) => Number(l.loaded_miles) || 0 },
+  { key: "mountain-mover", name: "Mountain Mover", icon: "mountain", unit: "weight", opts: { n: 5, floor: 46000 }, value: (l) => Number(l.weight) || 0 },
+];
+
+const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+
+export const computePatches = (loads: Load[], _fuel: FuelEntry[]): Patch[] => {
+  const dl = delivered(loads);
+  const out: Patch[] = [];
+
+  // ---- per-load adaptive feats ----
+  for (const d of ADAPTIVE) {
+    const chrono = dl.map(d.value).filter((v) => v > 0);
+    const s = computeStack(chrono, d.opts);
+    const barText =
+      d.unit === "money" ? money(s.bar) : d.unit === "miles" ? `${Math.round(s.bar).toLocaleString("en-US")} mi` : `${Math.round(s.bar).toLocaleString("en-US")} lb`;
+    out.push({ key: d.key, name: d.name, icon: d.icon, count: s.count, bar: s.bar, unit: d.unit, hint: `clear ${barText}` });
+  }
+
+  // ---- Rainmaker: adaptive over per-month net ----
+  const monthlyNet = bucketed(dl, (l) => monthKey(l.delivery_date!), (ls) => ls.reduce((s, l) => s + loadRevenue(l), 0));
+  const rain = computeStack(monthlyNet, { n: 5, floor: 12000 });
+  out.push({ key: "rainmaker", name: "Rainmaker", icon: "coins", count: rain.count, bar: rain.bar, unit: "money", hint: `${money(rain.bar)} net in a month` });
+
+  // ---- Iron Week: adaptive over loads-per-week ----
+  const weeklyLoads = bucketed(dl, (l) => weekKey(l.delivery_date!), (ls) => ls.length);
+  const iron = computeStack(weeklyLoads, { n: 5, floor: 5 });
+  out.push({ key: "iron-week", name: "Iron Week", icon: "barbell", count: iron.count, bar: iron.bar, unit: null, hint: `${Math.round(iron.bar)}+ loads in a week` });
+
+  // ---- Clean Run: adaptive over weekly deadhead %, lower is better ----
+  const weeklyDeadhead = bucketed(
+    dl,
+    (l) => weekKey(l.delivery_date!),
+    (ls) => {
+      const loaded = ls.reduce((s, l) => s + (Number(l.loaded_miles) || 0), 0);
+      const dead = ls.reduce((s, l) => s + (Number(l.deadhead_miles) || 0), 0);
+      return loaded + dead > 0 ? dead / (loaded + dead) : 1;
+    },
+  );
+  const clean = computeStack(weeklyDeadhead, { n: 5, floor: 0.1, lowerIsBetter: true });
+  out.push({ key: "clean-run", name: "Clean Run", icon: "gauge", count: clean.count, bar: clean.bar, unit: "pct", hint: `a week under ${(clean.bar * 100).toFixed(0)}% deadhead` });
+
+  // ---- Trailblazer (structural): distinct states touched — the count IS the map ----
+  const states = new Set<string>();
+  for (const l of dl) {
+    if (l.origin_state) states.add(l.origin_state);
+    if (l.destination_state) states.add(l.destination_state);
+  }
+  out.push({ key: "trailblazer", name: "Trailblazer", icon: "map-pin", count: states.size, bar: null, unit: null, hint: `${states.size} / 48 states` });
+
+  // ---- Coast to Coast (structural): a single run spanning West ↔ East ----
+  const coast = dl.filter((l) => spansCoasts(l.origin_state, l.destination_state)).length;
+  out.push({ key: "coast-to-coast", name: "Coast to Coast", icon: "arrows-horizontal", count: coast, bar: null, unit: null, hint: "a cross-country run" });
+
+  // ---- Doubleheader (structural): days with 2+ deliveries ----
+  const perDay = new Map<string, number>();
+  for (const l of dl) perDay.set(l.delivery_date!.slice(0, 10), (perDay.get(l.delivery_date!.slice(0, 10)) ?? 0) + 1);
+  const doubles = [...perDay.values()].filter((c) => c >= 2).length;
+  out.push({ key: "doubleheader", name: "Doubleheader", icon: "layers-subtract", count: doubles, bar: null, unit: null, hint: "2+ delivered in a day" });
+
+  return out;
+};

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -29,10 +29,15 @@ import {
   marginGrade,
   rpmGrade,
   worseGrade,
+  personalBests,
 } from "@/lib/metrics/playerCard";
-import { earnedAwards } from "@/lib/metrics/awards";
 import { computeGrind } from "@/lib/metrics/grind";
+import { computePatches } from "@/lib/awards/patches";
+import { computeMedals, earnedMedals } from "@/lib/awards/medals";
+import { assetLoanStatus } from "@/lib/metrics/payoff";
 import { PlayerCard } from "@/components/playercard/PlayerCard";
+import { RecordBook } from "@/components/awards/RecordBook";
+import { PatchBoard } from "@/components/awards/PatchBoard";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 
@@ -114,18 +119,22 @@ const DriverDetailPage = () => {
     const season = getSeasonStats(periods, driverLoads, now, 3, obligationsDebt);
     const rpmG = rpmGrade(basis.windowRpm, ladder);
     const marginG = marginGrade(season.netMargin);
-    // One award engine drives both the pops and the card, so a badge here matches
-    // the pop that announced it. Split by tier: burst = badges, marquee = shelf
-    // (rank lives in the header, so it's kept off the shelf).
     const grind = computeGrind(driverLoads, periods, obligationsTotal, now);
-    const awards = earnedAwards({
-      loads: driverLoads,
-      periods,
-      fuel,
+    // Medals (fixed tiers), records (improving bests), patches (hard stackable feats).
+    const del = driverLoads.filter((l) => l.load_status === "delivered");
+    const paidPcts = [
+      assetLoanStatus(obligations, "truck", now),
+      assetLoanStatus(obligations, "trailer", now),
+    ]
+      .map((s) => s?.ownedPct)
+      .filter((x): x is number => x != null);
+    const medals = computeMedals({
       lifetimeMiles,
-      obligationsDebtMonthly: obligationsDebt,
+      deliveredCount: del.length,
+      cumulativeNet: del.reduce((s, l) => s + loadRevenue(l), 0),
       streak: grind.currentStreak,
-      now,
+      loanPaidPct: paidPcts.length ? Math.max(...paidPcts) : null,
+      seasonStrong: marginG === "strong",
     });
     return {
       rank: careerRank(lifetimeMiles),
@@ -134,8 +143,9 @@ const DriverDetailPage = () => {
       marginGrade: marginG,
       form: worseGrade(rpmG, marginG),
       windowRpm: basis.windowRpm,
-      badges: awards.filter((a) => a.tier === "burst"),
-      shelf: awards.filter((a) => a.tier === "marquee" && !a.id.startsWith("rank:")),
+      medals: earnedMedals(medals),
+      bests: personalBests(driverLoads, fuel, now),
+      patches: computePatches(driverLoads, fuel),
     };
   }, [driverLoads, periods, obligations, fuel, trucks]);
 
@@ -201,10 +211,11 @@ const DriverDetailPage = () => {
             marginGrade={card.marginGrade}
             form={card.form}
             windowRpm={card.windowRpm}
-            badges={card.badges}
-            shelf={card.shelf}
+            medals={card.medals}
           />
-          <div className="flex justify-center gap-4 mt-3">
+          <RecordBook bests={card.bests} />
+          <PatchBoard patches={card.patches} />
+          <div className="flex justify-center gap-4 mt-6">
             <Link to="/trophy-room" className="text-sm text-status-info-text hover:underline">
               Trophy Room →
             </Link>


### PR DESCRIPTION
## v1.67.0 — awards rebuilt into four tiers (Phase 1)

Splits the old conflated "badges" into distinct tiers, each with its own mechanic, and rebuilds the driver page around them.

### Engine (pure + tested)
- **adaptiveBar** — the ratcheting personal-difficulty bar: a patch's bar sits at your ~Nth-best-ever for its metric, **only ever gets harder**, and earns **lock in** so ×N counts never roll backward. A downturn can't ease it.
- **patches** — Big Ticket, Long Hauler, Mountain Mover, Rainmaker, Iron Week, Clean Run (adaptive) + Trailblazer, Coast to Coast, Doubleheader (structural). Hard, stackable ×N, all derived from load data, asset-scopeable.
- **medals** — Mile Club, Freight Hauler, Big Earner, Iron Streak, Debt Crusher, Strong Season — **fixed universal tiers**.

### UI
- **Medals** worn on the card header, right of the name (earned tiers only — ribboned bronze/silver/gold).
- **Record Book** back as its own section (improving bests).
- **Patch board** — earned lit with ×N, locked grayed with the requirement.
- Removed the old Badges / Trophy Shelf.

### Phase 2 (next)
The Guide's "Award System" catalog + the pop restyle (record beat → slide-in → record ticks up; patch/medal pops).

Frontend-only, no migration. Build clean, **201 tests**.