### PR TITLE
feat: truck page metrics + truck-specific awards + fleet comparison

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.68.0",
+  "version": "1.69.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/awards/RecordBook.tsx
+++ b/frontend/src/components/awards/RecordBook.tsx
@@ -1,21 +1,27 @@
-import { Trophy, Gauge, Flame, Package, Layers } from "lucide-react";
 import type { PersonalBests } from "@/lib/metrics/playerCard";
+import { awardIcon } from "./awardIcons";
+
+export interface RecordChip {
+  icon: string;
+  color: string;
+  value: string;
+  label: string;
+}
 
 const kMoney = (n: number) => (n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${Math.round(n)}`);
 
-const Rec = ({ Icon, color, value, label }: { Icon: typeof Trophy; color: string; value: string; label: string }) => (
-  <div className="flex-1 min-w-[92px] rounded-[10px] px-2 py-2 text-center" style={{ background: "#1c2333" }}>
-    <Icon size={16} style={{ color }} />
-    <div className="font-comic leading-none mt-1" style={{ color: "#f5e6c8", fontSize: 19 }}>
-      {value}
-    </div>
-    <div className="text-[9px] text-muted-text mt-1 tracking-wide">{label}</div>
-  </div>
-);
+// The driver's five records → chips.
+export const driverRecordChips = (b: PersonalBests): RecordChip[] => [
+  { icon: "trophy", color: "#f5b03a", value: b.bestWeekRevenue != null ? kMoney(b.bestWeekRevenue) : "—", label: "TOP WEEK" },
+  { icon: "gauge", color: "#4ade80", value: b.lowestDeadheadPct != null ? `${(b.lowestDeadheadPct * 100).toFixed(1)}%` : "—", label: "BEST DEADHEAD" },
+  { icon: "flame", color: "#e8940a", value: b.bestMpg != null ? b.bestMpg.toFixed(1) : "—", label: "BEST TANK" },
+  { icon: "package", color: "#f5b03a", value: b.biggestLoad != null ? kMoney(b.biggestLoad) : "—", label: "BIGGEST LOAD" },
+  { icon: "stack", color: "#60a5fa", value: b.mostLoadsInWeek != null ? String(b.mostLoadsInWeek) : "—", label: "MOST / WEEK" },
+];
 
-// Your improving records — beat one and it climbs (a slide-in card announces it,
-// then the record updates). Distinct from patches, which are hard absolute bars.
-export const RecordBook = ({ bests }: { bests: PersonalBests }) => (
+// Improving records — beat one and it climbs (a slide-in announces it). Generic so
+// the driver, truck, and trailer each feed their own set.
+export const RecordBook = ({ records }: { records: RecordChip[] }) => (
   <div className="mt-6">
     <div className="flex items-baseline gap-2 mb-2">
       <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
@@ -24,11 +30,18 @@ export const RecordBook = ({ bests }: { bests: PersonalBests }) => (
       <span className="text-[11px] text-muted-text">your bests — they climb as you beat them</span>
     </div>
     <div className="flex gap-2 flex-wrap">
-      <Rec Icon={Trophy} color="#f5b03a" value={bests.bestWeekRevenue != null ? kMoney(bests.bestWeekRevenue) : "—"} label="TOP WEEK" />
-      <Rec Icon={Gauge} color="#4ade80" value={bests.lowestDeadheadPct != null ? `${(bests.lowestDeadheadPct * 100).toFixed(1)}%` : "—"} label="BEST DEADHEAD" />
-      <Rec Icon={Flame} color="#e8940a" value={bests.bestMpg != null ? bests.bestMpg.toFixed(1) : "—"} label="BEST TANK" />
-      <Rec Icon={Package} color="#f5b03a" value={bests.biggestLoad != null ? kMoney(bests.biggestLoad) : "—"} label="BIGGEST LOAD" />
-      <Rec Icon={Layers} color="#60a5fa" value={bests.mostLoadsInWeek != null ? String(bests.mostLoadsInWeek) : "—"} label="MOST / WEEK" />
+      {records.map((r) => {
+        const Icon = awardIcon(r.icon);
+        return (
+          <div key={r.label} className="flex-1 min-w-[92px] rounded-[10px] px-2 py-2 text-center" style={{ background: "#1c2333" }}>
+            <Icon size={16} style={{ color: r.color }} />
+            <div className="font-comic leading-none mt-1" style={{ color: "#f5e6c8", fontSize: 19 }}>
+              {r.value}
+            </div>
+            <div className="text-[9px] text-muted-text mt-1 tracking-wide">{r.label}</div>
+          </div>
+        );
+      })}
     </div>
   </div>
 );

--- a/frontend/src/components/awards/awardIcons.ts
+++ b/frontend/src/components/awards/awardIcons.ts
@@ -16,6 +16,9 @@ import {
   Truck,
   Package,
   Users,
+  Feather,
+  Flag,
+  Droplet,
   type LucideIcon,
 } from "lucide-react";
 
@@ -40,6 +43,9 @@ const MAP: Record<string, LucideIcon> = {
   package: Package,
   stack: Layers,
   users: Users,
+  feather: Feather,
+  flag: Flag,
+  droplet: Droplet,
 };
 
 export const awardIcon = (name: string): LucideIcon => MAP[name] ?? Trophy;

--- a/frontend/src/lib/awards/medals.ts
+++ b/frontend/src/lib/awards/medals.ts
@@ -27,7 +27,7 @@ const clamp = (n: number) => Math.max(0, Math.min(1, n));
 const kMi = (n: number) => (n >= 1_000_000 ? `${(n / 1_000_000).toFixed(0)}M` : `${Math.round(n / 1000)}k`);
 const kMoney = (n: number) => (n >= 1_000_000 ? `$${(n / 1_000_000).toFixed(0)}M` : `$${Math.round(n / 1000)}k`);
 
-const tiered = (
+export const tiered = (
   key: string,
   name: string,
   icon: string,

--- a/frontend/src/lib/awards/truckAwards.test.ts
+++ b/frontend/src/lib/awards/truckAwards.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { FuelEntry } from "@/types/fuelEntry";
+import { computeTruckPatches, computeTruckMedals, truckRecords } from "./truckAwards";
+
+const L = (o: Record<string, unknown>): Load =>
+  ({
+    load_status: "delivered",
+    fuel_surcharge: "0",
+    total_accessorials: "0",
+    deadhead_miles: 0,
+    ...o,
+  }) as unknown as Load;
+
+describe("computeTruckMedals", () => {
+  it("tiers Mile Club on the odometer and adds Fuel Miser / Debt Crusher when present", () => {
+    const m = computeTruckMedals({ odometer: 582_450, avgMpg: 7.1, deliveredCount: 47, loanPaidPct: 0.36 });
+    const byKey = Object.fromEntries(m.map((x) => [x.key, x]));
+    expect(byKey["mile-club"].tier).toBe(3); // ≥500k
+    expect(byKey["fuel-miser"].tier).toBe(2); // ≥7.0
+    expect(byKey["workhorse"].tier).toBe(0); // 47 < 100
+    expect(byKey["debt-crusher"].tier).toBe(1); // ≥25%
+  });
+
+  it("omits Fuel Miser / Debt Crusher when there's no data", () => {
+    const keys = computeTruckMedals({ odometer: 0, avgMpg: null, deliveredCount: 0, loanPaidPct: null }).map((m) => m.key);
+    expect(keys).not.toContain("fuel-miser");
+    expect(keys).not.toContain("debt-crusher");
+  });
+});
+
+describe("computeTruckPatches", () => {
+  it("earns Marathon on a long haul against the floor", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", loaded_miles: 1500 }),
+      L({ delivery_date: "2026-05-08", loaded_miles: 800 }),
+    ];
+    const p = computeTruckPatches(loads, []).find((x) => x.key === "marathon")!;
+    expect(p.count).toBe(1); // only the 1,500-mi haul clears the 1,200 floor
+    expect(p.hint).toContain("mi haul");
+  });
+});
+
+describe("truckRecords", () => {
+  it("reports the longest haul", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", loaded_miles: 1500 }),
+      L({ delivery_date: "2026-05-08", loaded_miles: 1900 }),
+    ];
+    expect(truckRecords(loads, [] as FuelEntry[]).longestHaul).toBe(1900);
+  });
+});

--- a/frontend/src/lib/awards/truckAwards.ts
+++ b/frontend/src/lib/awards/truckAwards.ts
@@ -1,0 +1,108 @@
+// Truck-flavored awards — a distinct catalog from the driver's revenue feats. The
+// truck earns on fuel economy, mileage, and per-mile efficiency. Same engines:
+// adaptive ratcheting bars for the patches, fixed tiers for the medals.
+import type { Load } from "@/types/load";
+import type { FuelEntry } from "@/types/fuelEntry";
+import { loadRevenue } from "@/lib/metrics/rateTargets";
+import { mpgWindows } from "@/lib/metrics/fuelEconomy";
+import { computeStack } from "./adaptiveBar";
+import { tiered, type Medal } from "./medals";
+import type { Patch } from "./patches";
+
+const loadMiles = (l: Load): number => {
+  const odo =
+    l.odometer_end != null && l.odometer_start != null
+      ? Number(l.odometer_end) - Number(l.odometer_start)
+      : 0;
+  return odo > 0 ? odo : Number(l.loaded_miles || 0) + Number(l.deadhead_miles || 0);
+};
+const monthKey = (iso: string): string => iso.slice(0, 7);
+const num = (n: number) => Math.round(n).toLocaleString("en-US");
+
+const delivered = (loads: Load[]): Load[] =>
+  loads
+    .filter((l) => l.load_status === "delivered" && l.delivery_date)
+    .sort((a, b) => (a.delivery_date! < b.delivery_date! ? -1 : 1));
+
+// Chronological monthly series → one value per month, in time order.
+const byMonth = (loads: Load[], reduce: (ls: Load[]) => number): number[] => {
+  const map = new Map<string, Load[]>();
+  for (const l of loads) {
+    const k = monthKey(l.delivery_date!);
+    (map.get(k) ?? map.set(k, []).get(k)!).push(l);
+  }
+  return [...map.keys()].sort().map((k) => reduce(map.get(k)!));
+};
+
+export const computeTruckPatches = (truckLoads: Load[], truckFuel: FuelEntry[]): Patch[] => {
+  const dl = delivered(truckLoads);
+  const windows = mpgWindows(truckFuel); // already chronological (by closing fill)
+  const out: Patch[] = [];
+
+  // Feather Foot — a tank clearing your top MPG bar.
+  const mpgs = windows.map((w) => w.mpg).filter((m) => m > 0);
+  const ff = computeStack(mpgs, { n: 5, floor: 6.8 });
+  out.push({ key: "feather-foot", name: "Feather Foot", icon: "feather", count: ff.count, bar: ff.bar, unit: null, hint: `tank over ${ff.bar.toFixed(1)} mpg` });
+
+  // Iron Horse — a workhorse month of miles.
+  const monthMiles = byMonth(dl, (ls) => ls.reduce((s, l) => s + loadMiles(l), 0));
+  const ih = computeStack(monthMiles, { n: 5, floor: 8000 });
+  out.push({ key: "iron-horse", name: "Iron Horse", icon: "road", count: ih.count, bar: ih.bar, unit: "miles", hint: `${num(ih.bar)}+ mi month` });
+
+  // Marathon — one of your longest single hauls.
+  const hauls = dl.map((l) => Number(l.loaded_miles) || 0).filter((m) => m > 0);
+  const mar = computeStack(hauls, { n: 5, floor: 1200 });
+  out.push({ key: "marathon", name: "Marathon", icon: "flag", count: mar.count, bar: mar.bar, unit: "miles", hint: `${num(mar.bar)}+ mi haul` });
+
+  // Thrifty — a tank under your best fuel cost per mile.
+  const costPerMi = windows.filter((w) => w.miles > 0).map((w) => w.cost / w.miles);
+  const th = computeStack(costPerMi, { n: 5, floor: 0.6, lowerIsBetter: true });
+  out.push({ key: "thrifty", name: "Thrifty", icon: "coins", count: th.count, bar: th.bar, unit: "money", hint: `tank under $${th.bar.toFixed(2)}/mi` });
+
+  return out;
+};
+
+export interface TruckMedalData {
+  odometer: number;
+  avgMpg: number | null;
+  deliveredCount: number;
+  loanPaidPct: number | null; // truck payoff
+}
+
+export const computeTruckMedals = (d: TruckMedalData): Medal[] => {
+  const medals: Medal[] = [
+    tiered("mile-club", "Mile Club", "medal", [100_000, 250_000, 500_000, 1_000_000], d.odometer, (n) => (n >= 1_000_000 ? `${(n / 1_000_000).toFixed(0)}M` : `${Math.round(n / 1000)}k`)),
+    tiered("workhorse", "Workhorse", "stack-2", [100, 250, 500], d.deliveredCount, (n) => `${Math.round(n)}`),
+  ];
+  if (d.avgMpg != null)
+    medals.push(tiered("fuel-miser", "Fuel Miser", "droplet", [6.5, 7, 7.5], d.avgMpg, (n) => `${n.toFixed(1)} mpg`));
+  if (d.loanPaidPct != null)
+    medals.push(tiered("debt-crusher", "Debt Crusher", "lock-open", [0.25, 0.5, 0.75], d.loanPaidPct, (n) => `${Math.round(n * 100)}%`));
+  return medals;
+};
+
+// This truck's records (improving bests) — for the Record Book.
+export interface TruckRecords {
+  bestTank: number | null;
+  bigMonthMiles: number | null;
+  bestRevPerMile: number | null;
+  longestHaul: number | null;
+}
+
+export const truckRecords = (truckLoads: Load[], truckFuel: FuelEntry[]): TruckRecords => {
+  const dl = delivered(truckLoads);
+  const windows = mpgWindows(truckFuel);
+  const monthMiles = byMonth(dl, (ls) => ls.reduce((s, l) => s + loadMiles(l), 0));
+  const monthRpm = byMonth(dl, (ls) => {
+    const net = ls.reduce((s, l) => s + loadRevenue(l), 0);
+    const mi = ls.reduce((s, l) => s + loadMiles(l), 0);
+    return mi > 0 ? net / mi : 0;
+  });
+  const max = (xs: number[]): number | null => (xs.length ? Math.max(...xs) : null);
+  return {
+    bestTank: max(windows.map((w) => w.mpg).filter((m) => m > 0)),
+    bigMonthMiles: max(monthMiles),
+    bestRevPerMile: max(monthRpm),
+    longestHaul: max(dl.map((l) => Number(l.loaded_miles) || 0)),
+  };
+};

--- a/frontend/src/lib/metrics/truckMetrics.ts
+++ b/frontend/src/lib/metrics/truckMetrics.ts
@@ -1,0 +1,136 @@
+// Truck-scoped operating metrics: how hard the truck runs (utilization, miles),
+// how thirsty it is (fuel economy, fuel $/mi), how much it earns per mile, and what
+// it costs to run (fuel + maintenance per mile — what the truck costs the owner, NOT
+// counting the note, which lives in the payoff tracker). Pure; take `now` explicitly.
+import type { Load } from "@/types/load";
+import type { FuelEntry } from "@/types/fuelEntry";
+import type { MaintenanceService } from "@/types/maintenance";
+import type { Truck } from "@/types/truck";
+import { loadRevenue } from "./rateTargets";
+import { fuelStats } from "./fuelEconomy";
+
+export interface TruckMetrics {
+  utilization: number | null; // active weeks ÷ weeks in service (0..1)
+  activeWeeks: number;
+  avgMpg: number | null;
+  bestTank: number | null;
+  fuelPerMile: number | null;
+  revPerMile: number | null;
+  costToRunPerMile: number | null; // (fuel + maintenance) ÷ miles
+  milesPerMonth: number | null;
+  totalMiles: number;
+  netRevenue: number;
+  loads: number;
+}
+
+const DAY = 86_400_000;
+
+// Driven miles for a load — the odometer window, else loaded + deadhead.
+const loadMiles = (l: Load): number => {
+  const odo =
+    l.odometer_end != null && l.odometer_start != null
+      ? Number(l.odometer_end) - Number(l.odometer_start)
+      : 0;
+  return odo > 0 ? odo : Number(l.loaded_miles || 0) + Number(l.deadhead_miles || 0);
+};
+
+const weekKey = (iso: string): string => {
+  const d = new Date(iso.slice(0, 10) + "T00:00:00Z");
+  const monday = new Date(d);
+  monday.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+  return monday.toISOString().slice(0, 10);
+};
+
+// Maintenance services attributable to the tractor (no per-truck link exists yet,
+// so tractor + both count; fine for a single truck).
+const truckServiceSpend = (services: MaintenanceService[]): number =>
+  services
+    .filter((s) => s.unit === "tractor" || s.unit === "both")
+    .reduce((sum, s) => sum + (Number(s.cost) || 0), 0);
+
+export const computeTruckMetrics = (
+  truck: Truck,
+  truckLoads: Load[],
+  truckFuel: FuelEntry[],
+  services: MaintenanceService[],
+  now: Date,
+): TruckMetrics => {
+  // Earned freight — delivered AND paid — matches the truck's net revenue elsewhere.
+  const earned = truckLoads.filter(
+    (l) => l.load_status === "delivered" && l.payment_status === "paid",
+  );
+  const netRevenue = earned.reduce((s, l) => s + loadRevenue(l), 0);
+  const totalMiles = earned.reduce((s, l) => s + loadMiles(l), 0);
+
+  const fs = fuelStats(truckFuel, now);
+  const fuelSpend = fs.totalSpend;
+  const maintSpend = truckServiceSpend(services);
+
+  // Utilization — share of the weeks it's been in service that it actually ran.
+  const inService = truck.in_service_date
+    ? new Date(truck.in_service_date.slice(0, 10) + "T00:00:00Z")
+    : null;
+  const weeksInService = inService
+    ? Math.max(1, Math.round((now.getTime() - inService.getTime()) / (7 * DAY)))
+    : null;
+  const activeWeeks = new Set(
+    earned.filter((l) => l.delivery_date).map((l) => weekKey(l.delivery_date!)),
+  ).size;
+  const utilization =
+    weeksInService && weeksInService > 0
+      ? Math.min(1, activeWeeks / weeksInService)
+      : null;
+
+  const monthsInService = inService
+    ? Math.max(1, (now.getTime() - inService.getTime()) / (30.44 * DAY))
+    : null;
+
+  return {
+    utilization,
+    activeWeeks,
+    avgMpg: fs.avgMpg,
+    bestTank: fs.bestMpg,
+    fuelPerMile: fs.costPerMile,
+    revPerMile: totalMiles > 0 ? netRevenue / totalMiles : null,
+    costToRunPerMile: totalMiles > 0 ? (fuelSpend + maintSpend) / totalMiles : null,
+    milesPerMonth: monthsInService ? totalMiles / monthsInService : null,
+    totalMiles,
+    netRevenue,
+    loads: earned.length,
+  };
+};
+
+// One row per truck for the fleet-comparison table (only shown at 2+ trucks).
+export interface FleetRow {
+  truckId: string;
+  unit: string;
+  utilization: number | null;
+  avgMpg: number | null;
+  revPerMile: number | null;
+  milesPerMonth: number | null;
+}
+
+export const fleetSummary = (
+  trucks: Truck[],
+  loads: Load[],
+  fuel: FuelEntry[],
+  services: MaintenanceService[],
+  now: Date,
+): FleetRow[] =>
+  trucks.map((t) => {
+    const m = computeTruckMetrics(
+      t,
+      loads.filter((l) => l.truck_id === t.truck_id),
+      fuel.filter((f) => f.truck_id === t.truck_id),
+      services,
+      now,
+    );
+    return {
+      truckId: t.truck_id,
+      unit: t.unit_number,
+      utilization: m.utilization,
+      avgMpg: m.avgMpg,
+      revPerMile: m.revPerMile,
+      milesPerMonth: m.milesPerMonth,
+    };
+  });

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -36,7 +36,7 @@ import { computePatches } from "@/lib/awards/patches";
 import { computeMedals, earnedMedals } from "@/lib/awards/medals";
 import { assetLoanStatus } from "@/lib/metrics/payoff";
 import { PlayerCard } from "@/components/playercard/PlayerCard";
-import { RecordBook } from "@/components/awards/RecordBook";
+import { RecordBook, driverRecordChips } from "@/components/awards/RecordBook";
 import { PatchBoard } from "@/components/awards/PatchBoard";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
@@ -213,7 +213,7 @@ const DriverDetailPage = () => {
             windowRpm={card.windowRpm}
             medals={card.medals}
           />
-          <RecordBook bests={card.bests} />
+          <RecordBook records={driverRecordChips(card.bests)} />
           <PatchBoard patches={card.patches} />
           <div className="flex justify-center gap-4 mt-6">
             <Link to="/trophy-room" className="text-sm text-status-info-text hover:underline">

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -20,8 +20,18 @@ import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { loadRevenue } from "@/lib/metrics/rateTargets";
 import { getObligations } from "@/services/obligationsService";
 import type { Obligation } from "@/types/obligation";
-import { isPayoffTracked } from "@/lib/metrics/payoff";
+import { isPayoffTracked, assetLoanStatus } from "@/lib/metrics/payoff";
 import { PayoffTracker } from "@/components/fleet/PayoffTracker";
+import { computeTruckMetrics } from "@/lib/metrics/truckMetrics";
+import {
+  computeTruckPatches,
+  computeTruckMedals,
+  truckRecords,
+} from "@/lib/awards/truckAwards";
+import { earnedMedals } from "@/lib/awards/medals";
+import { MedalBadge } from "@/components/awards/MedalBadge";
+import { RecordBook, type RecordChip } from "@/components/awards/RecordBook";
+import { PatchBoard } from "@/components/awards/PatchBoard";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
@@ -29,6 +39,28 @@ import { TRUCK_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+const num = (n: number) => Math.round(n).toLocaleString("en-US");
+
+// One tile in the truck-metrics strip.
+const Kpi = ({
+  value,
+  label,
+  sub,
+  green,
+}: {
+  value: string;
+  label: string;
+  sub?: string;
+  green?: boolean;
+}) => (
+  <div className="flex-1 min-w-[92px] rounded-[10px] px-2 py-2.5 text-center" style={{ background: "#1c2333" }}>
+    <div className="font-comic text-[20px] leading-none" style={{ color: green ? "#4ade80" : "#f5e6c8" }}>
+      {value}
+    </div>
+    <div className="text-[9px] text-muted-text mt-1 tracking-wide">{label}</div>
+    {sub && <div className="text-[8px] text-muted-text">{sub}</div>}
+  </div>
+);
 
 const Spec = ({
   label,
@@ -153,6 +185,25 @@ const TruckDetailPage = () => {
     );
 
   const revenue = earnedLoads.reduce((s, l) => s + loadRevenue(l), 0);
+  const now = new Date();
+  const truckFuel = fuelEntries.filter((f) => f.truck_id === id);
+  const metrics = computeTruckMetrics(truck, truckLoads, truckFuel, services, now);
+  const truckMedals = earnedMedals(
+    computeTruckMedals({
+      odometer,
+      avgMpg: metrics.avgMpg,
+      deliveredCount: earnedLoads.length,
+      loanPaidPct: assetLoanStatus(obligations, "truck", now)?.ownedPct ?? null,
+    }),
+  );
+  const patches = computeTruckPatches(truckLoads, truckFuel);
+  const recs = truckRecords(truckLoads, truckFuel);
+  const recordChips: RecordChip[] = [
+    { icon: "flame", color: "#e8940a", value: recs.bestTank != null ? recs.bestTank.toFixed(1) : "—", label: "BEST TANK" },
+    { icon: "road", color: "#f5b03a", value: recs.bigMonthMiles != null ? num(recs.bigMonthMiles) : "—", label: "BIG MONTH (MI)" },
+    { icon: "cash", color: "#4ade80", value: recs.bestRevPerMile != null ? `$${recs.bestRevPerMile.toFixed(2)}` : "—", label: "BEST REV/MI" },
+    { icon: "arrows-horizontal", color: "#60a5fa", value: recs.longestHaul != null ? num(recs.longestHaul) : "—", label: "LONGEST HAUL" },
+  ];
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -180,6 +231,13 @@ const TruckDetailPage = () => {
                   .join(" ")}{" "}
                 · {truck.status}
               </p>
+              {!editing && truckMedals.length > 0 && (
+                <div className="flex gap-1.5 flex-wrap">
+                  {truckMedals.map((m) => (
+                    <MedalBadge key={m.key} medal={m} />
+                  ))}
+                </div>
+              )}
             </div>
             {!editing && (
               <button
@@ -232,9 +290,39 @@ const TruckDetailPage = () => {
         </div>
       </div>
 
+      <div className="mt-1">
+        <p className="text-xs text-muted-text mb-2">Truck metrics</p>
+        <div className="flex gap-2 flex-wrap">
+          <div
+            className="flex-[1.4] min-w-[130px] rounded-[10px] px-3 py-2.5 text-center"
+            style={{ background: "#0f2419", border: "1px solid #2f6f52" }}
+          >
+            <div className="font-comic text-2xl leading-none" style={{ color: "#4ade80" }}>
+              {metrics.utilization != null ? `${Math.round(metrics.utilization * 100)}%` : "—"}
+            </div>
+            <div className="text-[9px] mt-1 tracking-wide" style={{ color: "#8fd6a8" }}>
+              UTILIZATION · ACTIVE WEEKS
+            </div>
+          </div>
+          <Kpi value={metrics.avgMpg != null ? metrics.avgMpg.toFixed(1) : "—"} label="AVG MPG" />
+          <Kpi value={metrics.bestTank != null ? metrics.bestTank.toFixed(1) : "—"} label="BEST TANK" />
+          <Kpi value={metrics.fuelPerMile != null ? `$${metrics.fuelPerMile.toFixed(2)}` : "—"} label="FUEL / MI" />
+          <Kpi value={metrics.revPerMile != null ? `$${metrics.revPerMile.toFixed(2)}` : "—"} label="REVENUE / MI" green />
+          <Kpi
+            value={metrics.costToRunPerMile != null ? `$${metrics.costToRunPerMile.toFixed(2)}` : "—"}
+            label="COST TO RUN / MI"
+            sub="fuel + maintenance"
+          />
+          <Kpi value={metrics.milesPerMonth != null ? num(metrics.milesPerMonth) : "—"} label="MI / MONTH" />
+        </div>
+      </div>
+
       {truckLoan && <PayoffTracker obligation={truckLoan} kind="truck" />}
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+      <RecordBook records={recordChips} />
+      <PatchBoard patches={patches} />
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
         <Link
           to="/maintenance"
           className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors"

--- a/frontend/src/pages/TrucksPage.tsx
+++ b/frontend/src/pages/TrucksPage.tsx
@@ -2,11 +2,19 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Plus } from "lucide-react";
 import type { Truck } from "@/types/truck";
+import type { FuelEntry } from "@/types/fuelEntry";
+import type { MaintenanceService } from "@/types/maintenance";
 import { getTrucks, createTruck } from "@/services/trucksService";
+import { getFuelEntries } from "@/services/fuelService";
+import { getMaintenanceServices } from "@/services/maintenanceService";
+import { useLoads } from "@/hooks/useLoads";
+import { fleetSummary } from "@/lib/metrics/truckMetrics";
 import { AvatarFallback } from "@/components/fleet/AvatarFallback";
 import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
 import { MilestoneBurst } from "@/components/fleet/MilestoneBurst";
 import { mileMilestone } from "@/lib/metrics/mileClub";
+
+const num = (n: number) => Math.round(n).toLocaleString("en-US");
 
 const FIELDS: FormField[] = [
   {
@@ -37,7 +45,10 @@ const FIELDS: FormField[] = [
 ];
 
 const TrucksPage = () => {
+  const { loads } = useLoads(0);
   const [trucks, setTrucks] = useState<Truck[]>([]);
+  const [fuel, setFuel] = useState<FuelEntry[]>([]);
+  const [services, setServices] = useState<MaintenanceService[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -51,7 +62,19 @@ const TrucksPage = () => {
 
   useEffect(() => {
     load();
+    getFuelEntries().then(setFuel).catch(() => {});
+    getMaintenanceServices().then(setServices).catch(() => {});
   }, []);
+
+  // Fleet comparison only earns its keep with more than one truck.
+  const fleet =
+    trucks.length > 1 ? fleetSummary(trucks, loads, fuel, services, new Date()) : [];
+  const best = {
+    util: Math.max(0, ...fleet.map((r) => r.utilization ?? 0)),
+    mpg: Math.max(0, ...fleet.map((r) => r.avgMpg ?? 0)),
+    rev: Math.max(0, ...fleet.map((r) => r.revPerMile ?? 0)),
+    mi: Math.max(0, ...fleet.map((r) => r.milesPerMonth ?? 0)),
+  };
 
   const save = async (data: Record<string, unknown>) => {
     setBusy(true);
@@ -93,6 +116,45 @@ const TrucksPage = () => {
           busy={busy}
           error={error}
         />
+      )}
+
+      {fleet.length > 1 && (
+        <div className="bg-plate rounded-lg p-4 mb-4 overflow-x-auto">
+          <p className="text-xs text-muted-text mb-2">
+            Fleet comparison{" "}
+            <span className="text-[11px]">· best per column highlighted</span>
+          </p>
+          <table className="w-full text-sm" style={{ minWidth: 380 }}>
+            <thead>
+              <tr className="text-muted-text text-right">
+                <th className="text-left font-normal pb-2">Truck</th>
+                <th className="font-normal pb-2">Util</th>
+                <th className="font-normal pb-2">MPG</th>
+                <th className="font-normal pb-2">Rev/mi</th>
+                <th className="font-normal pb-2">Mi/mo</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fleet.map((r) => (
+                <tr key={r.truckId} className="border-t border-steel text-right">
+                  <td className="text-left py-1.5">Unit {r.unit}</td>
+                  <td style={r.utilization != null && r.utilization === best.util ? { color: "#4ade80" } : undefined}>
+                    {r.utilization != null ? `${Math.round(r.utilization * 100)}%` : "—"}
+                  </td>
+                  <td style={r.avgMpg != null && r.avgMpg === best.mpg ? { color: "#4ade80" } : undefined}>
+                    {r.avgMpg != null ? r.avgMpg.toFixed(1) : "—"}
+                  </td>
+                  <td style={r.revPerMile != null && r.revPerMile === best.rev ? { color: "#4ade80" } : undefined}>
+                    {r.revPerMile != null ? `$${r.revPerMile.toFixed(2)}` : "—"}
+                  </td>
+                  <td style={r.milesPerMonth != null && r.milesPerMonth === best.mi ? { color: "#4ade80" } : undefined}>
+                    {r.milesPerMonth != null ? num(r.milesPerMonth) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
 
       {loading ? (


### PR DESCRIPTION
## v1.69.0 — the truck gets its own identity

Truck-scoped operating metrics, its own award catalog, and a fleet view — reusing the asset-scopeable award engine (so the trailer page later is mostly a new catalog).

### Metrics (`truckMetrics.ts`)
Utilization (**active-weeks %**), avg MPG + best tank, fuel/mi, revenue/mi, **cost to run / mi** (fuel + maintenance — the note stays in the payoff tracker, not double-counted), mi/month. Plus `fleetSummary` per truck.

### Awards (`truckAwards.ts`) — truck-flavored, not the driver's
- **Patches:** Feather Foot / Iron Horse / Marathon / Thrifty — adaptive ratcheting bars over the truck's fuel + mileage history.
- **Medals:** Mile Club (odometer) / Fuel Miser / Workhorse / Debt Crusher.
- **Records:** best tank, big month, best rev/mi, longest haul.

### UI
- **TruckDetailPage:** medals on the header, the metrics strip, Record Book + Patch board.
- **TrucksPage:** fleet-comparison table (best-per-column highlighted), appears at 2+ trucks.
- `RecordBook` generalized to `RecordChip[]` (driver + truck + trailer feed their own); `tiered` exported from medals.

Frontend-only, no migration. Build clean, **205 tests**.