### PR TITLE
feat: trailer page — metrics + its own award catalog

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.70.0",
+  "version": "1.71.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/awards/awardIcons.ts
+++ b/frontend/src/components/awards/awardIcons.ts
@@ -19,6 +19,7 @@ import {
   Feather,
   Flag,
   Droplet,
+  Weight,
   type LucideIcon,
 } from "lucide-react";
 
@@ -46,6 +47,7 @@ const MAP: Record<string, LucideIcon> = {
   feather: Feather,
   flag: Flag,
   droplet: Droplet,
+  weight: Weight,
 };
 
 export const awardIcon = (name: string): LucideIcon => MAP[name] ?? Trophy;

--- a/frontend/src/lib/awards/trailerAwards.test.ts
+++ b/frontend/src/lib/awards/trailerAwards.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { Trailer } from "@/types/trailer";
+import type { MaintenanceService } from "@/types/maintenance";
+import { computeTrailerMetrics } from "@/lib/metrics/trailerMetrics";
+import {
+  computeTrailerMedals,
+  computeTrailerPatches,
+  trailerRecords,
+} from "./trailerAwards";
+
+const L = (o: Record<string, unknown>): Load =>
+  ({
+    load_status: "delivered",
+    payment_status: "paid",
+    deadhead_miles: 0,
+    loaded_miles: 0,
+    trailer_net: "0",
+    ...o,
+  }) as unknown as Load;
+
+const svc = (unit: string, cost: number): MaintenanceService =>
+  ({ unit, cost, trailer_hub: null }) as unknown as MaintenanceService;
+
+const TRAILER = {
+  trailer_id: "t1",
+  current_hub: 48_000,
+  in_service_date: "2026-02-03",
+} as unknown as Trailer;
+
+describe("computeTrailerMetrics", () => {
+  it("earns on its 8% share and charges maintenance only (no fuel line)", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", loaded_miles: 1000, trailer_net: "100" }),
+      L({ delivery_date: "2026-05-08", loaded_miles: 1000, trailer_net: "100" }),
+    ];
+    // Only trailer/both maintenance counts; the tractor service is ignored.
+    const services = [svc("trailer", 400), svc("tractor", 9999)];
+    const m = computeTrailerMetrics(TRAILER, loads, services, new Date("2026-07-13"));
+    expect(m.earnings).toBe(200);
+    expect(m.totalMiles).toBe(2000);
+    expect(m.earningsPerMile).toBeCloseTo(0.1, 5); // 200 / 2000
+    expect(m.costToRunPerMile).toBeCloseTo(0.2, 5); // 400 / 2000, maintenance only
+  });
+
+  it("counts only delivered AND paid freight", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", loaded_miles: 500, trailer_net: "100" }),
+      L({ delivery_date: "2026-05-08", loaded_miles: 500, trailer_net: "100", payment_status: "pending" }),
+    ];
+    const m = computeTrailerMetrics(TRAILER, loads, [], new Date("2026-07-13"));
+    expect(m.earnings).toBe(100);
+    expect(m.loads).toBe(1);
+  });
+
+  it("returns null per-mile metrics with no miles", () => {
+    const m = computeTrailerMetrics(TRAILER, [], [], new Date("2026-07-13"));
+    expect(m.earningsPerMile).toBeNull();
+    expect(m.costToRunPerMile).toBeNull();
+  });
+});
+
+describe("computeTrailerMedals", () => {
+  it("tiers Hub Club and Trailer Earner, adds Debt Crusher when tracked", () => {
+    const m = computeTrailerMedals({ hubMiles: 48_000, earnings: 11_000, deliveredCount: 44, loanPaidPct: 0.03 });
+    const byKey = Object.fromEntries(m.map((x) => [x.key, x]));
+    expect(byKey["hub-club"].tier).toBe(1); // ≥25k, <50k
+    expect(byKey["trailer-earner"].tier).toBe(1); // ≥10k, <25k
+    expect(byKey["workhorse"].tier).toBe(0); // 44 < 100
+    expect(byKey["debt-crusher"].tier).toBe(0); // 3% < 25%
+  });
+
+  it("omits Debt Crusher when the loan isn't tracked", () => {
+    const keys = computeTrailerMedals({ hubMiles: 0, earnings: 0, deliveredCount: 0, loanPaidPct: null }).map((m) => m.key);
+    expect(keys).not.toContain("debt-crusher");
+  });
+});
+
+describe("computeTrailerPatches", () => {
+  it("earns Big Hauler on a heavy load against the floor", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", weight: 47_500 }),
+      L({ delivery_date: "2026-05-08", weight: 30_000 }),
+    ];
+    const p = computeTrailerPatches(loads).find((x) => x.key === "big-hauler")!;
+    expect(p.count).toBe(1); // only the 47,500-lb load clears the 46,000 floor
+    expect(p.hint).toContain("lb load");
+  });
+});
+
+describe("trailerRecords", () => {
+  it("reports the heaviest load carried", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", weight: 44_000 }),
+      L({ delivery_date: "2026-05-08", weight: 49_000 }),
+    ];
+    expect(trailerRecords(loads).heaviestLoad).toBe(49_000);
+  });
+});

--- a/frontend/src/lib/awards/trailerAwards.ts
+++ b/frontend/src/lib/awards/trailerAwards.ts
@@ -1,0 +1,115 @@
+// Trailer-flavored awards — its own catalog, distinct from the truck's. A trailer
+// has no engine, so it earns on the loads it carried: its 8% slice of net, the
+// weight it hauled, hub miles, and monthly grind. Same engines: adaptive ratcheting
+// bars for the patches, fixed tiers for the medals.
+import type { Load } from "@/types/load";
+import { loadTrailerNet } from "@/lib/metrics/rateTargets";
+import { computeStack } from "./adaptiveBar";
+import { tiered, type Medal } from "./medals";
+import type { Patch } from "./patches";
+
+const loadMiles = (l: Load): number => {
+  const odo =
+    l.odometer_end != null && l.odometer_start != null
+      ? Number(l.odometer_end) - Number(l.odometer_start)
+      : 0;
+  return odo > 0 ? odo : Number(l.loaded_miles || 0) + Number(l.deadhead_miles || 0);
+};
+const monthKey = (iso: string): string => iso.slice(0, 7);
+const num = (n: number) => Math.round(n).toLocaleString("en-US");
+
+const delivered = (loads: Load[]): Load[] =>
+  loads
+    .filter((l) => l.load_status === "delivered" && l.delivery_date)
+    .sort((a, b) => (a.delivery_date! < b.delivery_date! ? -1 : 1));
+
+// Chronological monthly series → one value per month, in time order.
+const byMonth = (loads: Load[], reduce: (ls: Load[]) => number): number[] => {
+  const map = new Map<string, Load[]>();
+  for (const l of loads) {
+    const k = monthKey(l.delivery_date!);
+    (map.get(k) ?? map.set(k, []).get(k)!).push(l);
+  }
+  return [...map.keys()].sort().map((k) => reduce(map.get(k)!));
+};
+
+export const computeTrailerPatches = (trailerLoads: Load[]): Patch[] => {
+  const dl = delivered(trailerLoads);
+  const out: Patch[] = [];
+
+  // Big Hauler — a load near the heaviest you carry.
+  const weights = dl.map((l) => Number(l.weight) || 0).filter((w) => w > 0);
+  const bh = computeStack(weights, { n: 5, floor: 46_000 });
+  out.push({ key: "big-hauler", name: "Big Hauler", icon: "weight", count: bh.count, bar: bh.bar, unit: null, hint: `${num(bh.bar)}+ lb load` });
+
+  // Marathon — one of your longest single hauls.
+  const hauls = dl.map((l) => Number(l.loaded_miles) || 0).filter((m) => m > 0);
+  const mar = computeStack(hauls, { n: 5, floor: 1200 });
+  out.push({ key: "marathon", name: "Marathon", icon: "flag", count: mar.count, bar: mar.bar, unit: "miles", hint: `${num(mar.bar)}+ mi haul` });
+
+  // Payday — a strong month for the trailer's cut.
+  const monthEarn = byMonth(dl, (ls) => ls.reduce((s, l) => s + loadTrailerNet(l), 0));
+  const pd = computeStack(monthEarn, { n: 5, floor: 1500 });
+  out.push({ key: "payday", name: "Payday", icon: "cash", count: pd.count, bar: pd.bar, unit: "money", hint: `$${num(pd.bar)}+ earnings month` });
+
+  // Road Grind — a workhorse month of miles.
+  const monthMiles = byMonth(dl, (ls) => ls.reduce((s, l) => s + loadMiles(l), 0));
+  const rg = computeStack(monthMiles, { n: 5, floor: 9000 });
+  out.push({ key: "road-grind", name: "Road Grind", icon: "road", count: rg.count, bar: rg.bar, unit: "miles", hint: `${num(rg.bar)}+ mi month` });
+
+  return out;
+};
+
+export interface TrailerMedalData {
+  hubMiles: number;
+  earnings: number; // cumulative 8% share
+  deliveredCount: number;
+  loanPaidPct: number | null; // trailer payoff
+}
+
+export const computeTrailerMedals = (d: TrailerMedalData): Medal[] => {
+  const medals: Medal[] = [
+    tiered("hub-club", "Hub Club", "medal", [25_000, 50_000, 100_000, 250_000], d.hubMiles, (n) => `${Math.round(n / 1000)}k`),
+    tiered("trailer-earner", "Trailer Earner", "coins", [10_000, 25_000, 50_000], d.earnings, (n) => `$${Math.round(n / 1000)}k`),
+    tiered("workhorse", "Workhorse", "stack-2", [100, 250, 500], d.deliveredCount, (n) => `${Math.round(n)}`),
+  ];
+  if (d.loanPaidPct != null)
+    medals.push(tiered("debt-crusher", "Debt Crusher", "lock-open", [0.25, 0.5, 0.75], d.loanPaidPct, (n) => `${Math.round(n * 100)}%`));
+  return medals;
+};
+
+// This trailer's records (improving bests) — for the Record Book.
+export interface TrailerRecords {
+  bestPayday: number | null; // best month for the trailer's cut
+  longestHaul: number | null;
+  heaviestLoad: number | null;
+  bigMonthMiles: number | null;
+}
+
+export const trailerRecords = (trailerLoads: Load[]): TrailerRecords => {
+  const dl = delivered(trailerLoads);
+  const monthEarn = byMonth(dl, (ls) => ls.reduce((s, l) => s + loadTrailerNet(l), 0));
+  const monthMiles = byMonth(dl, (ls) => ls.reduce((s, l) => s + loadMiles(l), 0));
+  const max = (xs: number[]): number | null => (xs.length ? Math.max(...xs) : null);
+  return {
+    bestPayday: max(monthEarn),
+    longestHaul: max(dl.map((l) => Number(l.loaded_miles) || 0)),
+    heaviestLoad: max(dl.map((l) => Number(l.weight) || 0)),
+    bigMonthMiles: max(monthMiles),
+  };
+};
+
+// Static catalog for the Guide's award-system reference.
+export const TRAILER_PATCH_GUIDE: { name: string; icon: string; how: string }[] = [
+  { name: "Big Hauler", icon: "weight", how: "A load near the heaviest you carry — the bar climbs as you haul heavier." },
+  { name: "Marathon", icon: "flag", how: "One of your longest single hauls." },
+  { name: "Payday", icon: "cash", how: "A strong month for the trailer's own cut of the freight." },
+  { name: "Road Grind", icon: "road", how: "A workhorse month — one of your highest for miles." },
+];
+
+export const TRAILER_MEDAL_GUIDE: { name: string; icon: string; tiers: string }[] = [
+  { name: "Hub Club", icon: "medal", tiers: "25k · 50k · 100k · 250k hub mi" },
+  { name: "Trailer Earner", icon: "coins", tiers: "$10k · $25k · $50k of its own cut" },
+  { name: "Workhorse", icon: "stack-2", tiers: "100 · 250 · 500 loads carried" },
+  { name: "Debt Crusher", icon: "lock-open", tiers: "25% · 50% · 75% paid off" },
+];

--- a/frontend/src/lib/metrics/trailerMetrics.ts
+++ b/frontend/src/lib/metrics/trailerMetrics.ts
@@ -1,0 +1,111 @@
+// Trailer-scoped metrics. A trailer has no engine, so there's no fuel line — its
+// cost to run is maintenance alone, and it earns on its own 8% slice of the loads it
+// carried. Pure; take `now` explicitly.
+import type { Load } from "@/types/load";
+import type { MaintenanceService } from "@/types/maintenance";
+import type { Trailer } from "@/types/trailer";
+import { loadTrailerNet } from "./rateTargets";
+
+export interface TrailerMetrics {
+  utilization: number | null; // active weeks ÷ weeks in service
+  earningsPerMile: number | null; // its 8% share ÷ miles carried
+  costToRunPerMile: number | null; // maintenance ÷ miles (no fuel)
+  milesPerMonth: number | null;
+  totalMiles: number;
+  earnings: number; // cumulative 8% share
+  loads: number;
+}
+
+const DAY = 86_400_000;
+
+const loadMiles = (l: Load): number => {
+  const odo =
+    l.odometer_end != null && l.odometer_start != null
+      ? Number(l.odometer_end) - Number(l.odometer_start)
+      : 0;
+  return odo > 0 ? odo : Number(l.loaded_miles || 0) + Number(l.deadhead_miles || 0);
+};
+
+const weekKey = (iso: string): string => {
+  const d = new Date(iso.slice(0, 10) + "T00:00:00Z");
+  const monday = new Date(d);
+  monday.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+  return monday.toISOString().slice(0, 10);
+};
+
+// Maintenance attributable to the trailer (trailer + both units).
+const trailerServiceSpend = (services: MaintenanceService[]): number =>
+  services
+    .filter((s) => s.unit === "trailer" || s.unit === "both")
+    .reduce((sum, s) => sum + (Number(s.cost) || 0), 0);
+
+export const computeTrailerMetrics = (
+  trailer: Trailer,
+  trailerLoads: Load[],
+  services: MaintenanceService[],
+  now: Date,
+): TrailerMetrics => {
+  const earnedLoads = trailerLoads.filter(
+    (l) => l.load_status === "delivered" && l.payment_status === "paid",
+  );
+  const earnings = earnedLoads.reduce((s, l) => s + loadTrailerNet(l), 0);
+  const totalMiles = earnedLoads.reduce((s, l) => s + loadMiles(l), 0);
+  const maintSpend = trailerServiceSpend(services);
+
+  const inService = trailer.in_service_date
+    ? new Date(trailer.in_service_date.slice(0, 10) + "T00:00:00Z")
+    : null;
+  const weeksInService = inService
+    ? Math.max(1, Math.round((now.getTime() - inService.getTime()) / (7 * DAY)))
+    : null;
+  const activeWeeks = new Set(
+    earnedLoads.filter((l) => l.delivery_date).map((l) => weekKey(l.delivery_date!)),
+  ).size;
+  const utilization =
+    weeksInService && weeksInService > 0 ? Math.min(1, activeWeeks / weeksInService) : null;
+  const monthsInService = inService
+    ? Math.max(1, (now.getTime() - inService.getTime()) / (30.44 * DAY))
+    : null;
+
+  return {
+    utilization,
+    earningsPerMile: totalMiles > 0 ? earnings / totalMiles : null,
+    costToRunPerMile: totalMiles > 0 ? maintSpend / totalMiles : null,
+    milesPerMonth: monthsInService ? totalMiles / monthsInService : null,
+    totalMiles,
+    earnings,
+    loads: earnedLoads.length,
+  };
+};
+
+export interface TrailerFleetRow {
+  trailerId: string;
+  unit: string;
+  utilization: number | null;
+  earningsPerMile: number | null;
+  milesPerMonth: number | null;
+  earnings: number;
+}
+
+export const trailerFleetSummary = (
+  trailers: Trailer[],
+  loads: Load[],
+  services: MaintenanceService[],
+  now: Date,
+): TrailerFleetRow[] =>
+  trailers.map((t) => {
+    const m = computeTrailerMetrics(
+      t,
+      loads.filter((l) => l.trailer_id === t.trailer_id),
+      services,
+      now,
+    );
+    return {
+      trailerId: t.trailer_id,
+      unit: t.unit_number,
+      utilization: m.utilization,
+      earningsPerMile: m.earningsPerMile,
+      milesPerMonth: m.milesPerMonth,
+      earnings: m.earnings,
+    };
+  });

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -7,6 +7,10 @@ import { awardIcon } from "@/components/awards/awardIcons";
 import { PATCH_GUIDE } from "@/lib/awards/patches";
 import { MEDAL_GUIDE } from "@/lib/awards/medals";
 import { TRUCK_PATCH_GUIDE, TRUCK_MEDAL_GUIDE } from "@/lib/awards/truckAwards";
+import {
+  TRAILER_PATCH_GUIDE,
+  TRAILER_MEDAL_GUIDE,
+} from "@/lib/awards/trailerAwards";
 
 const AMBER = "#e8940a";
 const AMBER_HI = "#f5b03a";
@@ -423,6 +427,21 @@ const GuidePage = () => (
             <AwardLine key={m.name} icon={m.icon} name={m.name} sub={m.tiers} />
           ))}
           {TRUCK_PATCH_GUIDE.map((p) => (
+            <AwardLine key={p.name} icon={p.icon} name={p.name} sub={p.how} />
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Trailer medals & patches — its own set">
+        <p className="text-sm text-muted-text mb-3">
+          The trailer has no engine, so it earns on the loads it carried: its 8%
+          slice of net, the weight it hauled, and hub miles.
+        </p>
+        <div className="grid sm:grid-cols-2 gap-x-6">
+          {TRAILER_MEDAL_GUIDE.map((m) => (
+            <AwardLine key={m.name} icon={m.icon} name={m.name} sub={m.tiers} />
+          ))}
+          {TRAILER_PATCH_GUIDE.map((p) => (
             <AwardLine key={p.name} icon={p.icon} name={p.name} sub={p.how} />
           ))}
         </div>

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -15,9 +15,19 @@ import {
   maxOdometer,
 } from "@/lib/metrics/maintenance";
 import { loadTrailerNet } from "@/lib/metrics/rateTargets";
+import { computeTrailerMetrics } from "@/lib/metrics/trailerMetrics";
+import {
+  computeTrailerPatches,
+  computeTrailerMedals,
+  trailerRecords,
+} from "@/lib/awards/trailerAwards";
+import { earnedMedals } from "@/lib/awards/medals";
+import { MedalBadge } from "@/components/awards/MedalBadge";
+import { RecordBook, type RecordChip } from "@/components/awards/RecordBook";
+import { PatchBoard } from "@/components/awards/PatchBoard";
 import { getObligations } from "@/services/obligationsService";
 import type { Obligation } from "@/types/obligation";
-import { isPayoffTracked } from "@/lib/metrics/payoff";
+import { isPayoffTracked, assetLoanStatus } from "@/lib/metrics/payoff";
 import { PayoffTracker } from "@/components/fleet/PayoffTracker";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
@@ -26,6 +36,28 @@ import { TRAILER_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+const num = (n: number) => Math.round(n).toLocaleString("en-US");
+
+// One tile in the trailer-metrics strip.
+const Kpi = ({
+  value,
+  label,
+  sub,
+  green,
+}: {
+  value: string;
+  label: string;
+  sub?: string;
+  green?: boolean;
+}) => (
+  <div className="flex-1 min-w-[92px] rounded-[10px] px-2 py-2.5 text-center" style={{ background: "#1c2333" }}>
+    <div className="font-comic text-[20px] leading-none" style={{ color: green ? "#4ade80" : "#f5e6c8" }}>
+      {value}
+    </div>
+    <div className="text-[9px] text-muted-text mt-1 tracking-wide">{label}</div>
+    {sub && <div className="text-[8px] text-muted-text">{sub}</div>}
+  </div>
+);
 
 const Spec = ({
   label,
@@ -141,6 +173,25 @@ const TrailerDetailPage = () => {
       </div>
     );
 
+  const now = new Date();
+  const metrics = computeTrailerMetrics(trailer, trailerLoads, services, now);
+  const trailerMedals = earnedMedals(
+    computeTrailerMedals({
+      hubMiles: hub,
+      earnings: revenue,
+      deliveredCount: earnedLoads.length,
+      loanPaidPct: assetLoanStatus(obligations, "trailer", now)?.ownedPct ?? null,
+    }),
+  );
+  const patches = computeTrailerPatches(trailerLoads);
+  const recs = trailerRecords(trailerLoads);
+  const recordChips: RecordChip[] = [
+    { icon: "cash", color: "#4ade80", value: recs.bestPayday != null ? money(recs.bestPayday) : "—", label: "BEST PAYDAY (MO)" },
+    { icon: "flag", color: "#f5b03a", value: recs.longestHaul != null ? num(recs.longestHaul) : "—", label: "LONGEST HAUL" },
+    { icon: "weight", color: "#60a5fa", value: recs.heaviestLoad != null ? num(recs.heaviestLoad) : "—", label: "HEAVIEST LOAD (LB)" },
+    { icon: "road", color: "#f5b03a", value: recs.bigMonthMiles != null ? num(recs.bigMonthMiles) : "—", label: "BIG MONTH (MI)" },
+  ];
+
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
       <Link to="/trailers" className="text-xs text-muted-text hover:text-light">
@@ -166,6 +217,13 @@ const TrailerDetailPage = () => {
                 {trailer.length_ft ? ` · ${trailer.length_ft}'` : ""} ·{" "}
                 {trailer.status}
               </p>
+              {!editing && trailerMedals.length > 0 && (
+                <div className="flex gap-1.5 flex-wrap">
+                  {trailerMedals.map((m) => (
+                    <MedalBadge key={m.key} medal={m} />
+                  ))}
+                </div>
+              )}
             </div>
             {!editing && (
               <button
@@ -223,7 +281,44 @@ const TrailerDetailPage = () => {
         </div>
       </div>
 
+      <div className="mt-1">
+        <p className="text-xs text-muted-text mb-2">
+          Trailer metrics{" "}
+          <span className="text-[11px]" style={{ color: "#5b6b82" }}>
+            · no fuel line — a trailer has no engine
+          </span>
+        </p>
+        <div className="flex gap-2 flex-wrap">
+          <div
+            className="flex-[1.4] min-w-[130px] rounded-[10px] px-3 py-2.5 text-center"
+            style={{ background: "#0f2419", border: "1px solid #2f6f52" }}
+          >
+            <div className="font-comic text-2xl leading-none" style={{ color: "#4ade80" }}>
+              {metrics.utilization != null ? `${Math.round(metrics.utilization * 100)}%` : "—"}
+            </div>
+            <div className="text-[9px] mt-1 tracking-wide" style={{ color: "#8fd6a8" }}>
+              UTILIZATION · ACTIVE WEEKS
+            </div>
+          </div>
+          <Kpi
+            value={metrics.earningsPerMile != null ? `$${metrics.earningsPerMile.toFixed(2)}` : "—"}
+            label="EARNINGS / MI"
+            sub="its 8% share"
+            green
+          />
+          <Kpi
+            value={metrics.costToRunPerMile != null ? `$${metrics.costToRunPerMile.toFixed(2)}` : "—"}
+            label="COST TO RUN / MI"
+            sub="maintenance only"
+          />
+          <Kpi value={metrics.milesPerMonth != null ? num(metrics.milesPerMonth) : "—"} label="MI / MONTH" />
+        </div>
+      </div>
+
       {trailerLoan && <PayoffTracker obligation={trailerLoan} kind="trailer" />}
+
+      <RecordBook records={recordChips} />
+      <PatchBoard patches={patches} />
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4">
         <Link

--- a/frontend/src/pages/TrailersPage.tsx
+++ b/frontend/src/pages/TrailersPage.tsx
@@ -2,11 +2,17 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Plus } from "lucide-react";
 import type { Trailer } from "@/types/trailer";
+import type { MaintenanceService } from "@/types/maintenance";
 import { getTrailers, createTrailer } from "@/services/trailersService";
+import { getMaintenanceServices } from "@/services/maintenanceService";
+import { useLoads } from "@/hooks/useLoads";
+import { trailerFleetSummary } from "@/lib/metrics/trailerMetrics";
 import { AvatarFallback } from "@/components/fleet/AvatarFallback";
 import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
 import { MilestoneBurst } from "@/components/fleet/MilestoneBurst";
 import { mileMilestone } from "@/lib/metrics/mileClub";
+
+const num = (n: number) => Math.round(n).toLocaleString("en-US");
 
 const FIELDS: FormField[] = [
   {
@@ -56,7 +62,9 @@ const FIELDS: FormField[] = [
 ];
 
 const TrailersPage = () => {
+  const { loads } = useLoads(0);
   const [trailers, setTrailers] = useState<Trailer[]>([]);
+  const [services, setServices] = useState<MaintenanceService[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -70,7 +78,18 @@ const TrailersPage = () => {
 
   useEffect(() => {
     load();
+    getMaintenanceServices().then(setServices).catch(() => {});
   }, []);
+
+  // Fleet comparison only earns its keep with more than one trailer.
+  const fleet =
+    trailers.length > 1 ? trailerFleetSummary(trailers, loads, services, new Date()) : [];
+  const best = {
+    util: Math.max(0, ...fleet.map((r) => r.utilization ?? 0)),
+    epm: Math.max(0, ...fleet.map((r) => r.earningsPerMile ?? 0)),
+    mi: Math.max(0, ...fleet.map((r) => r.milesPerMonth ?? 0)),
+    earn: Math.max(0, ...fleet.map((r) => r.earnings)),
+  };
 
   const save = async (data: Record<string, unknown>) => {
     setBusy(true);
@@ -112,6 +131,45 @@ const TrailersPage = () => {
           busy={busy}
           error={error}
         />
+      )}
+
+      {fleet.length > 1 && (
+        <div className="bg-plate rounded-lg p-4 mb-4 overflow-x-auto">
+          <p className="text-xs text-muted-text mb-2">
+            Fleet comparison{" "}
+            <span className="text-[11px]">· best per column highlighted</span>
+          </p>
+          <table className="w-full text-sm" style={{ minWidth: 380 }}>
+            <thead>
+              <tr className="text-muted-text text-right">
+                <th className="text-left font-normal pb-2">Trailer</th>
+                <th className="font-normal pb-2">Util</th>
+                <th className="font-normal pb-2">Earn/mi</th>
+                <th className="font-normal pb-2">Mi/mo</th>
+                <th className="font-normal pb-2">Earnings</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fleet.map((r) => (
+                <tr key={r.trailerId} className="border-t border-steel text-right">
+                  <td className="text-left py-1.5">Unit {r.unit}</td>
+                  <td style={r.utilization != null && r.utilization === best.util ? { color: "#4ade80" } : undefined}>
+                    {r.utilization != null ? `${Math.round(r.utilization * 100)}%` : "—"}
+                  </td>
+                  <td style={r.earningsPerMile != null && r.earningsPerMile === best.epm ? { color: "#4ade80" } : undefined}>
+                    {r.earningsPerMile != null ? `$${r.earningsPerMile.toFixed(2)}` : "—"}
+                  </td>
+                  <td style={r.milesPerMonth != null && r.milesPerMonth === best.mi ? { color: "#4ade80" } : undefined}>
+                    {r.milesPerMonth != null ? num(r.milesPerMonth) : "—"}
+                  </td>
+                  <td style={r.earnings === best.earn && r.earnings > 0 ? { color: "#4ade80" } : undefined}>
+                    {`$${num(r.earnings)}`}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
 
       {loading ? (


### PR DESCRIPTION
## v1.71.0 — Trailer page, built like the truck page

The trailer detail page gets the same treatment the truck page did — same reusable engines, its own trailer-flavored catalog. A trailer has no engine, so it earns on the loads it carried: its **8% slice of net**, the **weight** it hauled, and **hub miles**.

**Metrics** ([trailerMetrics.ts](frontend/src/lib/metrics/trailerMetrics.ts))
- Utilization (active weeks ÷ weeks in service)
- **Earnings / mi** — its 8% share ÷ miles carried
- **Cost to run / mi** — maintenance only (no fuel line)
- Mi / month, plus `trailerFleetSummary` for multi-trailer comparison

**Awards** ([trailerAwards.ts](frontend/src/lib/awards/trailerAwards.ts))
- Medals (fixed tiers): Hub Club · Trailer Earner · Workhorse · Debt Crusher
- Patches (adaptive ratcheting bars): Big Hauler · Marathon · Payday · Road Grind
- Records + Guide catalogs

**Wired in:** medals on the header, metrics strip, Record Book + Patch board ([TrailerDetailPage](frontend/src/pages/TrailerDetailPage.tsx)); fleet comparison at 2+ trailers ([TrailersPage](frontend/src/pages/TrailersPage.tsx)); "Trailer medals & patches" section in the [Guide](frontend/src/pages/GuidePage.tsx).

Frontend-only, no migration. Build clean, **212 tests** (7 new for the trailer).