### PR TITLE
fix: use median over mean where outliers skew the metric (#235)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.71.0",
+  "version": "1.72.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/OutstandingLoadsList.tsx
+++ b/frontend/src/components/OutstandingLoadsList.tsx
@@ -23,7 +23,8 @@ const ageColor = (days: number): string => {
 };
 
 export const OutstandingLoadsList = ({ loads }: Props) => {
-  const { total, avgDaysOutstanding } = getOutstandingSummary(loads);
+  const { total, medianDaysOutstanding, oldestDaysOutstanding } =
+    getOutstandingSummary(loads);
 
   return (
     <div className="bg-plate rounded-lg p-4">
@@ -31,12 +32,20 @@ export const OutstandingLoadsList = ({ loads }: Props) => {
         <h3 className="text-sm font-medium text-light">Outstanding loads</h3>
         <span className="text-sm text-status-aware-text font-medium">
           {formatCurrency(total)} owed
-          {avgDaysOutstanding !== null && (
+          {medianDaysOutstanding !== null && (
             <span className="text-muted-text font-normal">
               {" "}
-              · avg {Math.round(avgDaysOutstanding)}d out
+              · median {Math.round(medianDaysOutstanding)}d
             </span>
           )}
+          {oldestDaysOutstanding !== null &&
+            medianDaysOutstanding !== null &&
+            oldestDaysOutstanding > Math.round(medianDaysOutstanding) && (
+              <span className={`font-normal ${ageColor(oldestDaysOutstanding)}`}>
+                {" "}
+                · oldest {oldestDaysOutstanding}d
+              </span>
+            )}
         </span>
       </div>
 

--- a/frontend/src/components/lanes/LanesKpis.tsx
+++ b/frontend/src/components/lanes/LanesKpis.tsx
@@ -12,12 +12,14 @@ const Card = ({
   icon,
   title,
   rpm,
+  blended,
   loads,
 }: {
   label: string;
   icon: ReactNode;
   title: string;
-  rpm: number | null;
+  rpm: number | null; // typical (median) — the headline
+  blended: number | null; // revenue-weighted — the quiet sub-line
   loads: number;
 }) => (
   <div className="bg-plate rounded-lg p-4">
@@ -28,8 +30,14 @@ const Card = ({
     <p className="text-base font-condensed text-light mt-1">{title}</p>
     <p className="text-sm mt-1">
       <span className={`font-semibold ${rpmTextClass(rpm)}`}>{fmtRpm(rpm)}</span>
+      <span className="text-muted-text text-xs"> typical</span>
       <span className="text-muted-text"> · {loads} loads</span>
     </p>
+    {blended !== null && (
+      <p className="text-[11px] mt-0.5" style={{ color: "#5b6b82" }}>
+        blended {fmtRpm(blended)}
+      </p>
+    )}
   </div>
 );
 
@@ -58,7 +66,8 @@ export const LanesKpis = ({ summary }: Props) => {
           label="Top RPM lane"
           icon={FLAME}
           title={topRpmLane.lane}
-          rpm={topRpmLane.avgRpm}
+          rpm={topRpmLane.medianRpm}
+          blended={topRpmLane.avgRpm}
           loads={topRpmLane.loadCount}
         />
       ) : (
@@ -69,7 +78,8 @@ export const LanesKpis = ({ summary }: Props) => {
           label="Highest volume"
           icon={TRUCK}
           title={highestVolumeLane.lane}
-          rpm={highestVolumeLane.avgRpm}
+          rpm={highestVolumeLane.medianRpm}
+          blended={highestVolumeLane.avgRpm}
           loads={highestVolumeLane.loadCount}
         />
       ) : (
@@ -80,7 +90,8 @@ export const LanesKpis = ({ summary }: Props) => {
           label="Best origin market"
           icon={CROWN}
           title={bestOriginMarket.market}
-          rpm={bestOriginMarket.avgRpm}
+          rpm={bestOriginMarket.medianRpm}
+          blended={bestOriginMarket.avgRpm}
           loads={bestOriginMarket.loadCount}
         />
       ) : (

--- a/frontend/src/components/lanes/LanesTable.tsx
+++ b/frontend/src/components/lanes/LanesTable.tsx
@@ -32,7 +32,7 @@ export const LanesTable = ({ rollup }: Props) => {
         <tr className="text-muted-text text-xs text-left">
           <th className="py-2 px-2 font-normal">Region / market / lane</th>
           <th className="py-2 px-2 font-normal text-right w-20">Loads</th>
-          <th className="py-2 px-2 font-normal text-right w-24">Avg RPM</th>
+          <th className="py-2 px-2 font-normal text-right w-24">Typical $/mi</th>
         </tr>
       </thead>
       <tbody>
@@ -53,8 +53,8 @@ export const LanesTable = ({ rollup }: Props) => {
                   {region.region}
                 </td>
                 <td className="py-2 px-2 text-right">{region.loadCount}</td>
-                <td className={`py-2 px-2 text-right ${rpmTextClass(region.avgRpm)}`}>
-                  {fmtRpm(region.avgRpm)}
+                <td className={`py-2 px-2 text-right ${rpmTextClass(region.medianRpm)}`}>
+                  {fmtRpm(region.medianRpm)}
                 </td>
               </tr>
               {rOpen &&
@@ -79,9 +79,9 @@ export const LanesTable = ({ rollup }: Props) => {
                           {market.loadCount}
                         </td>
                         <td
-                          className={`py-2 px-2 text-right ${rpmTextClass(market.avgRpm)}`}
+                          className={`py-2 px-2 text-right ${rpmTextClass(market.medianRpm)}`}
                         >
-                          {fmtRpm(market.avgRpm)}
+                          {fmtRpm(market.medianRpm)}
                         </td>
                       </tr>
                       {mOpen &&
@@ -99,9 +99,17 @@ export const LanesTable = ({ rollup }: Props) => {
                               {lane.loadCount}
                             </td>
                             <td
-                              className={`py-1.5 px-2 text-right text-xs bg-iron ${rpmTextClass(lane.avgRpm)}`}
+                              className={`py-1.5 px-2 text-right text-xs bg-iron ${rpmTextClass(lane.medianRpm)}`}
                             >
-                              {fmtRpm(lane.avgRpm)}
+                              {fmtRpm(lane.medianRpm)}
+                              {lane.avgRpm !== null && (
+                                <span
+                                  className="block text-[10px]"
+                                  style={{ color: "#5b6b82" }}
+                                >
+                                  blended {fmtRpm(lane.avgRpm)}
+                                </span>
+                              )}
                             </td>
                           </tr>
                         ))}

--- a/frontend/src/hooks/useMaintenanceAlerts.ts
+++ b/frontend/src/hooks/useMaintenanceAlerts.ts
@@ -15,7 +15,7 @@ import { getFuelEntries } from "@/services/fuelService";
 import {
   maintenanceAlerts,
   currentTractorMiles,
-  avgMilesPerMonth,
+  recentMilesPerMonth,
   maxOdometer,
 } from "@/lib/metrics/maintenance";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
@@ -68,6 +68,6 @@ export const useMaintenanceAlerts = (loads: Load[]): Alert[] => {
       ),
       trailer: maxOdometer(svcOdo("trailer")),
     };
-    return maintenanceAlerts(items, currentMiles, now, avgMilesPerMonth(loads, now));
+    return maintenanceAlerts(items, currentMiles, now, recentMilesPerMonth(loads, now));
   }, [items, services, fuelEntries, loads]);
 };

--- a/frontend/src/lib/metrics/dashboard.test.ts
+++ b/frontend/src/lib/metrics/dashboard.test.ts
@@ -273,17 +273,23 @@ describe("getRecentDeliveredLoads", () => {
 });
 
 describe("getOutstandingSummary", () => {
-  it("totals revenue and averages aging", () => {
+  it("totals revenue and reports median + oldest aging", () => {
     const summary = getOutstandingSummary([
       { load_id: "1", load_number: "1", broker: "B", revenue: 1000, daysOutstanding: 10 },
       { load_id: "2", load_number: "2", broker: "B", revenue: 500, daysOutstanding: 20 },
+      { load_id: "3", load_number: "3", broker: "B", revenue: 300, daysOutstanding: 61 },
     ]);
-    expect(summary.total).toBe(1500);
-    expect(summary.avgDaysOutstanding).toBe(15);
+    expect(summary.total).toBe(1800);
+    expect(summary.medianDaysOutstanding).toBe(20); // not the 30.3 mean the 61 would force
+    expect(summary.oldestDaysOutstanding).toBe(61);
   });
 
   it("returns null aging when there is nothing outstanding", () => {
-    expect(getOutstandingSummary([])).toEqual({ total: 0, avgDaysOutstanding: null });
+    expect(getOutstandingSummary([])).toEqual({
+      total: 0,
+      medianDaysOutstanding: null,
+      oldestDaysOutstanding: null,
+    });
   });
 });
 

--- a/frontend/src/lib/metrics/dashboard.ts
+++ b/frontend/src/lib/metrics/dashboard.ts
@@ -1,6 +1,7 @@
 import type { Load } from "@/types/load";
 import type { Trip } from "@/types/trip";
 import { loadRevenue } from "./rateTargets";
+import { median } from "./stats";
 
 // Revenue = the owner-op's NET take (their company gross), via loadRevenue —
 // so every dashboard tile reflects money kept, not the full pre-cut rate.
@@ -253,21 +254,27 @@ export interface OutstandingLoad {
 
 export interface OutstandingSummary {
   total: number;
-  avgDaysOutstanding: number | null;
+  medianDaysOutstanding: number | null; // typical aging — robust to one stuck invoice
+  oldestDaysOutstanding: number | null; // the tail, surfaced rather than hidden
 }
 
-// Total unpaid $ and average aging across the outstanding loads. NOTE: this is
-// aging of currently-unpaid loads, not true days-to-pay (that needs a payment
-// date we don't track yet).
+// Total unpaid $ and aging across the outstanding loads. We headline the MEDIAN
+// aging (one disputed invoice sitting for months shouldn't drag the typical
+// number) and expose the oldest as the tail. NOTE: this is aging of currently-
+// unpaid loads, not true days-to-pay (that needs a payment date we don't track
+// yet).
 export const getOutstandingSummary = (
   outstanding: OutstandingLoad[],
 ): OutstandingSummary => {
-  if (outstanding.length === 0) return { total: 0, avgDaysOutstanding: null };
+  if (outstanding.length === 0)
+    return { total: 0, medianDaysOutstanding: null, oldestDaysOutstanding: null };
   const total = outstanding.reduce((sum, o) => sum + o.revenue, 0);
-  const avg =
-    outstanding.reduce((sum, o) => sum + o.daysOutstanding, 0) /
-    outstanding.length;
-  return { total, avgDaysOutstanding: avg };
+  const days = outstanding.map((o) => o.daysOutstanding);
+  return {
+    total,
+    medianDaysOutstanding: median(days),
+    oldestDaysOutstanding: Math.max(...days),
+  };
 };
 
 // ---- GET OUTSTANDING LOADS ---- (delivered + unpaid/invoiced, aged from delivery, oldest first)

--- a/frontend/src/lib/metrics/lanes.test.ts
+++ b/frontend/src/lib/metrics/lanes.test.ts
@@ -145,6 +145,7 @@ describe("getLanesSummary", () => {
     const summary = getLanesSummary(loads);
     expect(summary.topRpmLane?.destination).toBe("Dallas");
     expect(summary.topRpmLane?.avgRpm).toBeCloseTo(3.0, 5);
+    expect(summary.topRpmLane?.medianRpm).toBeCloseTo(3.0, 5);
     expect(summary.highestVolumeLane?.loadCount).toBe(3);
     expect(summary.bestOriginMarket?.market).toBe("Atlanta");
   });
@@ -154,6 +155,27 @@ describe("getLanesSummary", () => {
     expect(summary.topRpmLane).toBeNull();
     expect(summary.highestVolumeLane).toBeNull();
     expect(summary.bestOriginMarket).toBeNull();
+  });
+
+  it("ranks lanes on the typical (median) rate, not a blended fluke", () => {
+    const loads = [
+      // Atlanta → Dallas: 3 steady loads at $2.00/mi
+      makeLoad({ linehaul: "2000", loaded_miles: 1000 }),
+      makeLoad({ linehaul: "2000", loaded_miles: 1000 }),
+      makeLoad({ linehaul: "2000", loaded_miles: 1000 }),
+      // Atlanta → Miami: two $2.10 loads + one short oversize fluke at $6/mi.
+      // Blended (revenue-weighted) tops $2.10; median stays $2.10.
+      makeLoad({ delivery_market: "Miami", linehaul: "2100", loaded_miles: 1000 }),
+      makeLoad({ delivery_market: "Miami", linehaul: "2100", loaded_miles: 1000 }),
+      makeLoad({ delivery_market: "Miami", linehaul: "1200", loaded_miles: 200 }),
+    ];
+    const summary = getLanesSummary(loads);
+    // Miami's blended rate is inflated by the fluke, but its typical load is
+    // $2.10 — so Dallas ($2.00) shouldn't lose the crown to a rate Miami can't
+    // repeat. Median ranking keeps Miami on top only on its typical strength.
+    expect(summary.topRpmLane?.destination).toBe("Miami");
+    expect(summary.topRpmLane?.medianRpm).toBeCloseTo(2.1, 5);
+    expect(summary.topRpmLane?.avgRpm ?? 0).toBeGreaterThan(2.2); // blended is pulled up
   });
 });
 

--- a/frontend/src/lib/metrics/lanes.ts
+++ b/frontend/src/lib/metrics/lanes.ts
@@ -1,22 +1,28 @@
 import type { Load } from "@/types/load";
 import { getRegion, getStateName } from "@/lib/constants/states";
+import { median } from "./stats";
 
 // Minimum loads before a lane/market can win an RPM-based KPI — keeps a single
 // lucky run from crowning a corridor. Volume KPIs ignore this.
 export const MIN_KPI_LOADS = 3;
 
+// avgRpm = blended (revenue ÷ miles), what you actually earned per mile.
+// medianRpm = the typical single load's $/mile — robust to one high-accessorial
+// fluke, and what the RPM KPIs rank on.
 export interface LaneStat {
   lane: string; // "Origin Market → Destination Market"
   origin: string;
   destination: string;
   loadCount: number;
   avgRpm: number | null;
+  medianRpm: number | null;
 }
 
 export interface MarketStat {
   market: string;
   loadCount: number;
   avgRpm: number | null;
+  medianRpm: number | null;
   lanes: LaneStat[];
 }
 
@@ -24,6 +30,7 @@ export interface RegionStat {
   region: string;
   loadCount: number;
   avgRpm: number | null;
+  medianRpm: number | null;
   markets: MarketStat[];
 }
 
@@ -62,6 +69,24 @@ const avgRpm = (loads: Load[]): number | null => {
   if (miles <= 0) return null;
   return grossRevenue(loads) / miles;
 };
+
+// A single load's all-in $/loaded-mile (null when it has no loaded miles).
+const loadRpm = (load: Load): number | null => {
+  const miles = Number(load.loaded_miles);
+  if (miles <= 0) return null;
+  return (
+    (Number(load.linehaul) +
+      Number(load.fuel_surcharge) +
+      Number(load.total_accessorials)) /
+    miles
+  );
+};
+
+// Typical RPM = median of the per-load rates. Robust to a single oversize load
+// with sky-high accessorials that would inflate the blended number — this is
+// what "expect on the next load" looks like, so it ranks the KPIs.
+const medianRpm = (loads: Load[]): number | null =>
+  median(loads.map(loadRpm).filter((r): r is number => r !== null));
 
 const groupBy = <T>(items: T[], key: (item: T) => string): Map<string, T[]> => {
   const map = new Map<string, T[]>();
@@ -120,14 +145,16 @@ export const getRegionRollup = (loads: Load[]): RegionStat[] => {
           destination: first.delivery_market,
           loadCount: laneLoads.length,
           avgRpm: avgRpm(laneLoads),
+          medianRpm: medianRpm(laneLoads),
         });
       }
 
-      lanes.sort((a, b) => (b.avgRpm ?? -1) - (a.avgRpm ?? -1));
+      lanes.sort((a, b) => (b.medianRpm ?? -1) - (a.medianRpm ?? -1));
       markets.push({
         market,
         loadCount: marketLoads.length,
         avgRpm: avgRpm(marketLoads),
+        medianRpm: medianRpm(marketLoads),
         lanes,
       });
     }
@@ -137,6 +164,7 @@ export const getRegionRollup = (loads: Load[]): RegionStat[] => {
       region,
       loadCount: regionLoads.length,
       avgRpm: avgRpm(regionLoads),
+      medianRpm: medianRpm(regionLoads),
       markets,
     });
   }
@@ -206,15 +234,17 @@ export const getLanesSummary = (loads: Load[]): LanesSummary => {
   const markets = rollup.flatMap((r) => r.markets);
 
   const rpmEligibleLanes = lanes.filter(
-    (l) => l.loadCount >= MIN_KPI_LOADS && l.avgRpm !== null,
+    (l) => l.loadCount >= MIN_KPI_LOADS && l.medianRpm !== null,
   );
   const rpmEligibleMarkets = markets.filter(
-    (m) => m.loadCount >= MIN_KPI_LOADS && m.avgRpm !== null,
+    (m) => m.loadCount >= MIN_KPI_LOADS && m.medianRpm !== null,
   );
 
+  // Rank on the typical (median) rate — the fluke oversize load doesn't crown a
+  // corridor it can't repeat.
   const topRpmLane = rpmEligibleLanes.length
     ? rpmEligibleLanes.reduce((best, l) =>
-        (l.avgRpm as number) > (best.avgRpm as number) ? l : best,
+        (l.medianRpm as number) > (best.medianRpm as number) ? l : best,
       )
     : null;
 
@@ -224,7 +254,7 @@ export const getLanesSummary = (loads: Load[]): LanesSummary => {
 
   const bestOriginMarket = rpmEligibleMarkets.length
     ? rpmEligibleMarkets.reduce((best, m) =>
-        (m.avgRpm as number) > (best.avgRpm as number) ? m : best,
+        (m.medianRpm as number) > (best.medianRpm as number) ? m : best,
       )
     : null;
 

--- a/frontend/src/lib/metrics/maintenance.test.ts
+++ b/frontend/src/lib/metrics/maintenance.test.ts
@@ -5,7 +5,7 @@ import {
   computeDue,
   addMonths,
   currentTractorMiles,
-  avgMilesPerMonth,
+  recentMilesPerMonth,
   maxOdometer,
   maintenanceAlerts,
   fleetHealth,
@@ -211,7 +211,7 @@ describe("computeDue — both lenses, worst wins", () => {
   });
 });
 
-describe("currentTractorMiles / avgMilesPerMonth", () => {
+describe("currentTractorMiles / recentMilesPerMonth", () => {
   it("takes the highest odometer reading", () => {
     const loads = [
       load({ odometer_end: 560000 }),
@@ -221,17 +221,20 @@ describe("currentTractorMiles / avgMilesPerMonth", () => {
     expect(currentTractorMiles(loads)).toBe(568737);
   });
 
-  it("averages last-90-day delivered miles into a monthly pace", () => {
+  it("takes the median of recent monthly totals, ignoring a low outlier month", () => {
+    // now = 2026-07-09 (see top of file). Three months: May 9000, June 8000,
+    // July 1000 (a breakdown month). A mean would say 6000; the median holds at
+    // the typical 8000 so the projection doesn't lurch.
     const loads = [
-      load({ delivery_date: "2026-06-20", odometer_start: 0, odometer_end: 9000 }),
-      load({ delivery_date: "2026-07-01", odometer_start: 0, odometer_end: 9000 }),
-      load({ delivery_date: "2026-01-01", odometer_start: 0, odometer_end: 9999 }), // outside 90d
+      load({ delivery_date: "2026-05-10", odometer_start: 0, odometer_end: 9000 }),
+      load({ delivery_date: "2026-06-10", odometer_start: 0, odometer_end: 8000 }),
+      load({ delivery_date: "2026-07-05", odometer_start: 0, odometer_end: 1000 }),
     ];
-    expect(avgMilesPerMonth(loads, now)).toBeCloseTo(6000, 5); // 18000 / 3
+    expect(recentMilesPerMonth(loads, now)).toBeCloseTo(8000, 5);
   });
 
   it("null pace when there are no recent miles", () => {
-    expect(avgMilesPerMonth([], now)).toBeNull();
+    expect(recentMilesPerMonth([], now)).toBeNull();
   });
 });
 

--- a/frontend/src/lib/metrics/maintenance.ts
+++ b/frontend/src/lib/metrics/maintenance.ts
@@ -1,6 +1,7 @@
 import type { MaintenanceItem } from "@/types/maintenance";
 import type { Load } from "@/types/load";
 import type { Alert } from "@/types/alert";
+import { median } from "./stats";
 
 const MS_DAY = 86_400_000;
 const DAYS_PER_MONTH = 30.44;
@@ -116,18 +117,29 @@ export const currentTractorMiles = (loads: Load[]): number | null => {
   return max;
 };
 
-// Recent driving pace (miles/month) from delivered loads in the last 90 days —
-// drives the mileage→date projection.
-export const avgMilesPerMonth = (loads: Load[], now: Date): number | null => {
-  const cutoff = now.getTime() - 90 * MS_DAY;
-  let miles = 0;
+// Recent driving pace (miles/month) that drives the mileage→date projection.
+// We bucket delivered miles by calendar month over a recent window, then take
+// the MEDIAN of the last few monthly totals — so one anomalous month (a
+// breakdown that idles the truck, a monster haul, or the partial current month)
+// can't skew the projection the way a mean would. Window is generous (120d) to
+// reliably capture ~3 full months.
+export const recentMilesPerMonth = (loads: Load[], now: Date): number | null => {
+  const cutoff = now.getTime() - 120 * MS_DAY;
+  const byMonth = new Map<string, number>();
   for (const l of loads) {
     if (l.load_status !== "delivered" || !l.delivery_date) continue;
     if (new Date(l.delivery_date).getTime() < cutoff) continue;
-    if (l.odometer_end != null && l.odometer_start != null)
-      miles += Number(l.odometer_end) - Number(l.odometer_start);
+    if (l.odometer_end == null || l.odometer_start == null) continue;
+    const miles = Number(l.odometer_end) - Number(l.odometer_start);
+    if (miles <= 0) continue;
+    const key = l.delivery_date.slice(0, 7); // YYYY-MM (ISO prefix, UTC-safe)
+    byMonth.set(key, (byMonth.get(key) ?? 0) + miles);
   }
-  return miles > 0 ? miles / 3 : null;
+  const recent = [...byMonth.keys()]
+    .sort()
+    .slice(-3)
+    .map((k) => byMonth.get(k)!);
+  return median(recent);
 };
 
 // Overdue / due-soon items → dashboard alerts (overdue = critical, first).

--- a/frontend/src/lib/metrics/stats.test.ts
+++ b/frontend/src/lib/metrics/stats.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { median } from "./stats";
+
+describe("median", () => {
+  it("returns the middle of an odd-length list", () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  it("averages the two middle values of an even-length list", () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it("ignores an outlier that a mean would chase", () => {
+    // mean = 25.4, median = 18 — the 61 doesn't move it.
+    expect(median([12, 14, 18, 22, 61])).toBe(18);
+  });
+
+  it("returns null for an empty list", () => {
+    expect(median([])).toBeNull();
+  });
+
+  it("does not mutate the input", () => {
+    const xs = [3, 1, 2];
+    median(xs);
+    expect(xs).toEqual([3, 1, 2]);
+  });
+});

--- a/frontend/src/lib/metrics/stats.ts
+++ b/frontend/src/lib/metrics/stats.ts
@@ -1,0 +1,12 @@
+// Small statistics helpers shared across the metrics. Kept separate so they're
+// easy to unit-test and reuse.
+
+// Median of a numeric list — robust to outliers, where a mean would be dragged
+// by one extreme value. Returns null for an empty list. Copies before sorting,
+// so the caller's array is left untouched.
+export const median = (xs: number[]): number | null => {
+  if (xs.length === 0) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+};

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -286,6 +286,43 @@ const GuidePage = () => (
       </Metric>
 
       <Metric
+        title="Lane rate — typical vs blended"
+        answers="On the Lanes page each rate is the typical load, so one fluke haul can't crown a lane it can't repeat."
+      >
+        <Formula>
+          typical $/mi = median of each load's rate · blended = gross ÷ all loaded
+          miles
+        </Formula>
+        <Eg>
+          Five loads near $2.10 and one short oversize at $6.00 → blended reads $2.72,
+          but <span className="text-light">typical is $2.10</span> — the number you'll
+          actually see next time. Lanes rank on typical; blended rides underneath.
+        </Eg>
+        <Why>
+          A lane with only a handful of loads is easily skewed by a single
+          high-accessorial run. The median asks "what does a normal load here pay,"
+          which is the honest basis for deciding where to book.
+        </Why>
+      </Metric>
+
+      <Metric
+        title="Outstanding loads — how long money sits"
+        answers="The headline aging is the typical unpaid load, with the oldest called out separately."
+      >
+        <Formula>median days outstanding · oldest days outstanding</Formula>
+        <Eg>
+          Loads out 12, 18, and 61 days → <span className="text-light">median 18d</span>
+          , oldest 61d. A mean would say 30d and bury the fact that one disputed
+          invoice is the real problem.
+        </Eg>
+        <Why>
+          One stuck invoice shouldn't make routine collections look slow. The median
+          shows the normal pace; the oldest surfaces the exception instead of hiding
+          it.
+        </Why>
+      </Metric>
+
+      <Metric
         title="Deadhead"
         answers="The share of your miles that ran empty."
       >

--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -9,7 +9,7 @@ import {
 import { getFuelEntries } from "@/services/fuelService";
 import {
   currentTractorMiles,
-  avgMilesPerMonth,
+  recentMilesPerMonth,
   maxOdometer,
 } from "@/lib/metrics/maintenance";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
@@ -77,7 +77,7 @@ const MaintenancePage = () => {
     };
   }, [loads, services, fuelEntries]);
 
-  const milesPerMonth = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
+  const milesPerMonth = useMemo(() => recentMilesPerMonth(loads, new Date()), [loads]);
 
   const tabBtn = (key: "schedule" | "services", label: string) => (
     <button

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -11,7 +11,7 @@ import {
 import { useLoads } from "@/hooks/useLoads";
 import {
   computeDue,
-  avgMilesPerMonth,
+  recentMilesPerMonth,
   maxOdometer,
 } from "@/lib/metrics/maintenance";
 import { loadTrailerNet } from "@/lib/metrics/rateTargets";
@@ -118,7 +118,7 @@ const TrailerDetailPage = () => {
     return maxOdometer(trailer.current_hub, ...svcHubs) ?? trailer.current_hub;
   }, [trailer, services]);
 
-  const mpm = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
+  const mpm = useMemo(() => recentMilesPerMonth(loads, new Date()), [loads]);
   const trailerLoads = useMemo(
     () => loads.filter((l) => l.trailer_id === id),
     [loads, id],

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -13,7 +13,7 @@ import { getFuelEntries } from "@/services/fuelService";
 import { useLoads } from "@/hooks/useLoads";
 import {
   computeDue,
-  avgMilesPerMonth,
+  recentMilesPerMonth,
   maxOdometer,
 } from "@/lib/metrics/maintenance";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
@@ -147,7 +147,7 @@ const TruckDetailPage = () => {
     );
   }, [truck, truckLoads, services, fuelEntries, id]);
 
-  const mpm = useMemo(() => avgMilesPerMonth(loads, new Date()), [loads]);
+  const mpm = useMemo(() => recentMilesPerMonth(loads, new Date()), [loads]);
   const due = useMemo(() => {
     let overdue = 0;
     let soon = 0;


### PR DESCRIPTION
## v1.72.0 — median over mean where it tames outliers

Three metrics were being dragged by a single outlier. Each now **leads with a median** (robust to the fluke) while keeping the mean/tail visible so nothing's hidden. Adds a shared `median()` helper (`src/lib/metrics/stats.ts`).

### ① AR aging — Outstanding loads
Headline the **median** days outstanding with the **oldest** called out separately. One disputed invoice sitting for months no longer inflates the "typical" aging.

### ② Lane rate — typical vs blended
The Lanes KPIs and table now **rank and headline on the typical (median per-load) $/mi**, with the **blended** (revenue-weighted) rate as a quiet sub-line. A short high-accessorial oversize load can't crown a corridor it can't repeat. State-map hover intentionally stays blended (state aggregates already dilute outliers).

### ③ Maintenance pace
`avgMilesPerMonth` → **`recentMilesPerMonth`**, now the **median of recent monthly mile-totals** — a breakdown or monster month can't jerk the due-date projections.

**Deliberately not changed:** the break-even / cost-per-mile basis (must recover lumpy costs). **Guide** updated with "typical vs blended" and median-aging explainers.

Frontend-only, no migration. Build clean, **218 tests** (6 new).

Closes #235