### PR TITLE
feat: loads-table traffic light + on-the-road group (#247 Phase B2)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.75.0",
+  "version": "1.76.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/detention.test.ts
+++ b/frontend/src/lib/detention.test.ts
@@ -7,6 +7,7 @@ import {
   detentionLabel,
   detentionOwed,
   tonuOwed,
+  loadFlag,
 } from "./detention";
 
 const L = (o: Record<string, unknown>): Load => o as unknown as Load;
@@ -84,5 +85,32 @@ describe("tonuOwed", () => {
     expect(tonuOwed(L({ load_status: "tonu", tonu_paid: false }))).toBe(true);
     expect(tonuOwed(L({ load_status: "tonu", tonu_paid: true }))).toBe(false);
     expect(tonuOwed(L({ load_status: "delivered", tonu_paid: false }))).toBe(false);
+  });
+});
+
+describe("loadFlag priority", () => {
+  const detentioned = { shipper_in: "08:00", shipper_out: "14:00" }; // 6h → owed at 3h free
+
+  it("unpaid TONU wins even over detention", () => {
+    expect(
+      loadFlag(L({ load_status: "tonu", tonu_paid: false, ...detentioned }), 3),
+    ).toBe("tonu");
+  });
+
+  it("unpaid detention beats in-transit", () => {
+    expect(
+      loadFlag(L({ load_status: "in_transit", detention_paid: false, ...detentioned }), 3),
+    ).toBe("detention");
+  });
+
+  it("in-transit when nothing is owed", () => {
+    expect(loadFlag(L({ load_status: "in_transit" }), 3)).toBe("in-transit");
+  });
+
+  it("null once fees are paid / nothing applies", () => {
+    expect(
+      loadFlag(L({ load_status: "tonu", tonu_paid: true }), 3),
+    ).toBeNull();
+    expect(loadFlag(L({ load_status: "delivered" }), 3)).toBeNull();
   });
 });

--- a/frontend/src/lib/detention.ts
+++ b/frontend/src/lib/detention.ts
@@ -57,3 +57,14 @@ export const detentionOwed = (load: Load, freeHours: number): boolean =>
 // A TONU load's fee is owed until marked paid → the red flag/banner.
 export const tonuOwed = (load: Load): boolean =>
   load.load_status === "tonu" && !load.tonu_paid;
+
+// The loads-table traffic-light flag, in priority order: an unpaid TONU (red)
+// beats unpaid detention (amber) beats an in-transit load (green). null = none.
+export type LoadFlag = "tonu" | "detention" | "in-transit";
+
+export const loadFlag = (load: Load, freeHours: number): LoadFlag | null => {
+  if (tonuOwed(load)) return "tonu";
+  if (detentionOwed(load, freeHours)) return "detention";
+  if (load.load_status === "in_transit") return "in-transit";
+  return null;
+};

--- a/frontend/src/pages/LoadsPage.tsx
+++ b/frontend/src/pages/LoadsPage.tsx
@@ -1,6 +1,7 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Link } from "react-router";
 
+import type { Load } from "@/types/load";
 import { useLoads } from "@/hooks/useLoads";
 import { useBrokers } from "@/hooks/useBrokers";
 import { useAgents } from "@/hooks/useAgents";
@@ -12,6 +13,13 @@ import LoadForm from "../components/LoadForm";
 import { createLoad } from "@/services/createLoadService";
 import { loadsKpis, loadRevenue } from "@/lib/metrics/loads";
 import { fmtRpm, rpmTextClass } from "@/components/lanes/rpmStyle";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import {
+  loadFlag,
+  detentionOwed,
+  detentionMinutes,
+  type LoadFlag,
+} from "@/lib/detention";
 
 const money = (n: number) =>
   n.toLocaleString("en-US", {
@@ -29,14 +37,95 @@ const fmtDate = (d: string) =>
     timeZone: "UTC",
   });
 
+// "In transit" is gone from the pills — those loads live in the pinned "On the
+// road" group, so filtering by it would be redundant. Detention is derived
+// (owed & unpaid), not a load_status.
 const STATUS_FILTERS: [string, string][] = [
   ["all", "All"],
   ["booked", "Booked"],
-  ["in_transit", "In transit"],
   ["delivered", "Delivered"],
+  ["tonu", "TONU"],
+  ["detention", "Detention"],
 ];
 
 const plural = (n: number) => (n !== 1 ? "s" : "");
+
+// Traffic-light colors for the row's left bar (all three) + row tint (the two
+// "money owed" states).
+const BAR: Record<LoadFlag, string> = {
+  tonu: "#e24b4a",
+  detention: "#e8940a",
+  "in-transit": "#3fb950",
+};
+const TINT: Partial<Record<LoadFlag, string>> = {
+  tonu: "rgba(226,75,74,0.10)",
+  detention: "rgba(232,148,10,0.10)",
+};
+
+const Chip = ({ bg, fg, text }: { bg: string; fg: string; text: string }) => (
+  <span
+    className="ml-1.5 text-[9px] font-bold px-1.5 py-0.5 rounded-full align-middle"
+    style={{ background: bg, color: fg }}
+  >
+    {text}
+  </span>
+);
+
+// One loads-table row, shared by the "On the road" group and the main table.
+const LoadRow = ({ load, freeHours }: { load: Load; freeHours: number }) => {
+  const flag = loadFlag(load, freeHours);
+  const detPaid = load.detention_paid && detentionMinutes(load, freeHours) > 0;
+  const tonuPaid = load.load_status === "tonu" && load.tonu_paid;
+  return (
+    <tr
+      className="border-t border-steel align-top"
+      style={flag && TINT[flag] ? { background: TINT[flag] } : undefined}
+    >
+      <td
+        className="py-2 whitespace-nowrap"
+        style={flag ? { borderLeft: `3px solid ${BAR[flag]}`, paddingLeft: 8 } : undefined}
+      >
+        <Link
+          to={`/loads/${load.load_id}`}
+          className="text-amber-light hover:underline font-medium"
+        >
+          {load.load_number}
+        </Link>
+        {flag === "detention" && <Chip bg="#7a4718" fg="#f5c37a" text="DET" />}
+        {detPaid && <Chip bg="#12251a" fg="#6f9a80" text="det paid" />}
+        {tonuPaid && <Chip bg="#12251a" fg="#6f9a80" text="tonu paid" />}
+      </td>
+      <td className="py-2">
+        <StatusBadge value={load.load_status} />
+      </td>
+      <td className="py-2">
+        {load.broker}
+        <span className="text-xs block">
+          <Link
+            to={`/agents/${load.agent_id}`}
+            className="text-muted-text hover:text-amber-light hover:underline"
+          >
+            {load.agent}
+          </Link>
+        </span>
+      </td>
+      <td className="py-2 whitespace-nowrap">
+        {load.origin_city}, {load.origin_state}
+        <span className="text-muted-text"> → </span>
+        {load.destination_city}, {load.destination_state}
+      </td>
+      <td className="py-2 text-muted-text whitespace-nowrap">
+        {fmtDate(load.pickup_date)}
+      </td>
+      <td className="py-2 text-right whitespace-nowrap">
+        {money(loadRevenue(load))}
+      </td>
+      <td className="py-2">
+        <StatusBadge value={load.payment_status} />
+      </td>
+    </tr>
+  );
+};
 
 const LoadsPage = () => {
   const [refreshKey, setRefreshKey] = useState(0);
@@ -55,18 +144,26 @@ const LoadsPage = () => {
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [paymentFilter, setPaymentFilter] = useState("all");
+  const [freeHours, setFreeHours] = useState(3);
+
+  useEffect(() => {
+    getSettlementSchedule()
+      .then((s) => setFreeHours(s.detention_free_hours))
+      .catch(() => {});
+  }, []);
 
   // KPIs describe the whole business, so they ignore the table filters.
   const kpis = useMemo(() => loadsKpis(loads ?? [], new Date()), [loads]);
 
-  const filtered = useMemo(() => {
+  // In-transit loads lift into their own pinned group; the status pill filters
+  // only the main table below. The search box + payment filter narrow both.
+  const { inTransit, rest } = useMemo(() => {
     const q = search.trim().toLowerCase();
-    return (loads ?? []).filter((l) => {
-      if (statusFilter !== "all" && l.load_status !== statusFilter) return false;
+    const searchPayMatch = (l: Load) => {
       if (paymentFilter !== "all" && l.payment_status !== paymentFilter)
         return false;
       if (!q) return true;
-      const hay = [
+      return [
         l.load_number,
         l.broker,
         l.agent,
@@ -76,10 +173,26 @@ const LoadsPage = () => {
         l.destination_state,
       ]
         .join(" ")
-        .toLowerCase();
-      return hay.includes(q);
-    });
-  }, [loads, search, statusFilter, paymentFilter]);
+        .toLowerCase()
+        .includes(q);
+    };
+    const statusMatch = (l: Load) => {
+      if (statusFilter === "all") return true;
+      if (statusFilter === "tonu") return l.load_status === "tonu";
+      if (statusFilter === "detention") return detentionOwed(l, freeHours);
+      return l.load_status === statusFilter;
+    };
+    const base = loads ?? [];
+    return {
+      inTransit: base.filter(
+        (l) => searchPayMatch(l) && l.load_status === "in_transit",
+      ),
+      rest: base.filter(
+        (l) =>
+          searchPayMatch(l) && statusMatch(l) && l.load_status !== "in_transit",
+      ),
+    };
+  }, [loads, search, statusFilter, paymentFilter, freeHours]);
 
   if (isLoading)
     return (
@@ -194,12 +307,52 @@ const LoadsPage = () => {
         </select>
       </div>
 
+      {inTransit.length > 0 && (
+        <div
+          className="border rounded-xl overflow-hidden mt-4"
+          style={{ borderColor: "#1f4d33" }}
+        >
+          <div
+            className="px-3 py-2 flex items-center gap-2"
+            style={{
+              background: "rgba(63,185,80,0.12)",
+              borderBottom: "1px solid #1f4d33",
+            }}
+          >
+            <span className="text-base">🚚</span>
+            <span className="font-condensed text-lg" style={{ color: "#6fd08c" }}>
+              On the road
+            </span>
+            <span
+              className="text-[11px] px-2 py-0.5 rounded-full"
+              style={{ background: "#12251a", color: "#6fd08c" }}
+            >
+              {inTransit.length}
+            </span>
+            <span className="text-[11px] text-muted-text ml-auto">
+              what's rolling now
+            </span>
+          </div>
+          <div className="overflow-x-auto" style={{ background: "#12180f" }}>
+            <table className="w-full text-sm min-w-[760px] px-2 [&_td]:pr-5 [&_td:last-child]:pr-0 [&_td:first-child]:pl-3">
+              <tbody>
+                {inTransit.map((load) => (
+                  <LoadRow key={load.load_id} load={load} freeHours={freeHours} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
       <div className="bg-plate rounded-lg p-4 mt-4 overflow-x-auto">
-        {filtered.length === 0 ? (
+        {rest.length === 0 ? (
           <p className="text-muted-text text-sm">
-            {loads.length === 0
+            {(loads ?? []).length === 0
               ? "No loads yet."
-              : "No loads match these filters."}
+              : inTransit.length > 0
+                ? "No other loads match these filters."
+                : "No loads match these filters."}
           </p>
         ) : (
           <table className="w-full text-sm min-w-[760px] [&_th]:pr-5 [&_td]:pr-5 [&_th:last-child]:pr-0 [&_td:last-child]:pr-0">
@@ -215,54 +368,8 @@ const LoadsPage = () => {
               </tr>
             </thead>
             <tbody>
-              {filtered.map((load) => (
-                <tr
-                  key={load.load_id}
-                  className="border-t border-steel align-top"
-                >
-                  <td
-                    className={`py-2 whitespace-nowrap ${
-                      load.load_status === "in_transit"
-                        ? "border-l-2 border-l-amber pl-2"
-                        : ""
-                    }`}
-                  >
-                    <Link
-                      to={`/loads/${load.load_id}`}
-                      className="text-amber-light hover:underline font-medium"
-                    >
-                      {load.load_number}
-                    </Link>
-                  </td>
-                  <td className="py-2">
-                    <StatusBadge value={load.load_status} />
-                  </td>
-                  <td className="py-2">
-                    {load.broker}
-                    <span className="text-xs block">
-                      <Link
-                        to={`/agents/${load.agent_id}`}
-                        className="text-muted-text hover:text-amber-light hover:underline"
-                      >
-                        {load.agent}
-                      </Link>
-                    </span>
-                  </td>
-                  <td className="py-2 whitespace-nowrap">
-                    {load.origin_city}, {load.origin_state}
-                    <span className="text-muted-text"> → </span>
-                    {load.destination_city}, {load.destination_state}
-                  </td>
-                  <td className="py-2 text-muted-text whitespace-nowrap">
-                    {fmtDate(load.pickup_date)}
-                  </td>
-                  <td className="py-2 text-right whitespace-nowrap">
-                    {money(loadRevenue(load))}
-                  </td>
-                  <td className="py-2">
-                    <StatusBadge value={load.payment_status} />
-                  </td>
-                </tr>
+              {rest.map((load) => (
+                <LoadRow key={load.load_id} load={load} freeHours={freeHours} />
               ))}
             </tbody>
           </table>


### PR DESCRIPTION
## v1.76.0 — #247 Phase B2: loads-table traffic light

Finishes Phase B. The loads table becomes an at-a-glance ops view.

- **`loadFlag`** — traffic-light priority: unpaid **TONU (red)** › unpaid **detention (amber)** › **in-transit (green)**. Unit-tested.
- **On the road group** — in-transit loads lift into a pinned group above the main table; **persists across status filters** (search + payment narrow both).
- **Row cues** — left bar per flag; the two money-owed states also get a **row tint** + **DET** chip, clearing to muted **det paid** / **tonu paid**.
- **Filters** — dropped the redundant **In transit** pill; added **TONU** (status) and **Detention** (derived, owed & unpaid).

Frontend-only, no migration. Build clean, **242 tests** (+4).

Closes #247 Phase B (Phase C — scorecards — remains, tracked in the issue).