### PR TITLE
feat: facility + agent stop scorecards (#247 Phase C)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.76.0",
+  "version": "1.77.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/StopScorecard.tsx
+++ b/frontend/src/components/StopScorecard.tsx
@@ -1,0 +1,84 @@
+import type { StopScore } from "@/lib/metrics/stopScore";
+import { fmtDuration } from "@/lib/stopTimes";
+
+// Shorter dwell is better — green under 90m, amber under 3h, red beyond.
+const dwellTone = (mins: number | null): string => {
+  if (mins == null) return "#f5e6c8";
+  if (mins < 90) return "#8fd6a8";
+  if (mins < 180) return "#f5c37a";
+  return "#f2a6a3";
+};
+
+const Tile = ({
+  value,
+  label,
+  tone,
+}: {
+  value: string;
+  label: string;
+  tone?: string;
+}) => (
+  <div
+    className="rounded-[10px] px-3 py-2.5 text-center flex-1 min-w-[88px]"
+    style={{ background: "#0f1626" }}
+  >
+    <div
+      className="font-condensed text-xl leading-none"
+      style={{ color: tone ?? "#f5e6c8" }}
+    >
+      {value}
+    </div>
+    <div className="text-[9px] text-muted-text mt-1 tracking-wide uppercase">
+      {label}
+    </div>
+  </div>
+);
+
+interface Props {
+  score: StopScore | null;
+  countLabel: string; // e.g. "Loads"
+  countValue: number;
+}
+
+// The Phase C dwell / on-time / detention tiles, or a "needs data" note until
+// there are enough timed stops. Shared by the facility and agent pages.
+export const StopScorecard = ({ score, countLabel, countValue }: Props) => {
+  if (!score || !score.hasData)
+    return (
+      <p className="text-sm text-muted-text">
+        Fills in as loads accrue — needs at least 3 stops with in/out times logged
+        {score ? ` (${score.timedStops} so far)` : ""}.
+      </p>
+    );
+
+  return (
+    <>
+      <div className="flex gap-2 flex-wrap">
+        <Tile
+          value={fmtDuration(score.medianDwellMin) ?? "—"}
+          label="Typical dwell"
+          tone={dwellTone(score.medianDwellMin)}
+        />
+        <Tile
+          value={
+            score.onTimePct != null ? `${Math.round(score.onTimePct * 100)}%` : "—"
+          }
+          label="On-time"
+          tone={score.onTimePct != null ? "#8fd6a8" : undefined}
+        />
+        <Tile
+          value={`${score.detentionCount} / ${score.timedStops}`}
+          label="Detention"
+          tone={score.detentionCount > 0 ? "#f5c37a" : "#8fd6a8"}
+        />
+        <Tile value={String(countValue)} label={countLabel} />
+      </div>
+      {score.unpaidCount > 0 && (
+        <p className="text-[11px] mt-2" style={{ color: "#f2a6a3" }}>
+          {score.unpaidCount} detention {score.unpaidCount === 1 ? "load" : "loads"}{" "}
+          still unpaid — worth chasing.
+        </p>
+      )}
+    </>
+  );
+};

--- a/frontend/src/lib/metrics/stopScore.test.ts
+++ b/frontend/src/lib/metrics/stopScore.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import { facilityStops, agentStops, scoreStops, MIN_STOPS } from "./stopScore";
+
+const L = (o: Record<string, unknown>): Load => o as unknown as Load;
+
+// A load where FAC is the shipper: dwell = out−in, appt vs arrival, detention.
+const shipLoad = (o: Record<string, unknown>) =>
+  L({ shipper_facility_id: "FAC", detention_paid: false, ...o });
+
+describe("facilityStops + scoreStops", () => {
+  it("says 'not enough data' under the minimum", () => {
+    const loads = [
+      shipLoad({ shipper_in: "08:00", shipper_out: "10:00" }),
+      shipLoad({ shipper_in: "08:00", shipper_out: "09:00" }),
+    ];
+    const score = scoreStops(facilityStops(loads, "FAC", 3));
+    expect(score.timedStops).toBe(2); // < MIN_STOPS
+    expect(score.hasData).toBe(false);
+    expect(score.medianDwellMin).toBeNull();
+  });
+
+  it("medians dwell and counts detention past free time", () => {
+    // dwells: 2h, 3h, 5h (=120,180,300 min); free 3h → detention on the 5h stop.
+    const loads = [
+      shipLoad({ shipper_in: "06:00", shipper_out: "08:00" }),
+      shipLoad({ shipper_in: "06:00", shipper_out: "09:00" }),
+      shipLoad({ shipper_in: "06:00", shipper_out: "11:00", detention_paid: false }),
+    ];
+    const score = scoreStops(facilityStops(loads, "FAC", 3));
+    expect(score.hasData).toBe(true);
+    expect(score.medianDwellMin).toBe(180); // median of 120/180/300
+    expect(score.detentionCount).toBe(1); // only the 5h stop (120 over free)
+    expect(score.unpaidCount).toBe(1);
+  });
+
+  it("scores on-time only over graded stops (excludes ones with no appt)", () => {
+    // three graded (2 on-time, 1 late) + one with no appt (not graded)
+    const loads = [
+      shipLoad({ shipper_in: "08:50", shipper_out: "10:00", pickup_appt_start: "09:00" }),
+      shipLoad({ shipper_in: "08:55", shipper_out: "10:00", pickup_appt_start: "09:00" }),
+      shipLoad({ shipper_in: "09:30", shipper_out: "11:00", pickup_appt_start: "09:00" }),
+      shipLoad({ shipper_in: "07:00", shipper_out: "08:00" }),
+    ];
+    const score = scoreStops(facilityStops(loads, "FAC", 3));
+    expect(score.gradedStops).toBe(3); // the no-appt stop isn't graded
+    expect(score.onTimePct).toBeCloseTo(2 / 3, 5); // 2 of 3 graded were on-time
+  });
+});
+
+describe("agentStops", () => {
+  it("scores both stops of each load", () => {
+    const loads = [
+      L({
+        shipper_in: "06:00",
+        shipper_out: "08:00", // 2h
+        receiver_in: "06:00",
+        receiver_out: "10:00", // 4h → detention at 3h free
+        detention_paid: false,
+      }),
+      L({
+        shipper_in: "06:00",
+        shipper_out: "07:30", // 1.5h
+        receiver_in: "06:00",
+        receiver_out: "07:00", // 1h
+      }),
+    ];
+    const score = scoreStops(agentStops(loads, 3));
+    expect(score.timedStops).toBe(4);
+    expect(score.detentionCount).toBe(1); // the 4h receiver stop
+  });
+});
+
+describe("MIN_STOPS", () => {
+  it("is the documented threshold", () => {
+    expect(MIN_STOPS).toBe(3);
+  });
+});

--- a/frontend/src/lib/metrics/stopScore.ts
+++ b/frontend/src/lib/metrics/stopScore.ts
@@ -1,0 +1,128 @@
+// Dwell / on-time / detention scoring over a set of stops — the Phase C
+// scorecards for a facility (its own stops) and an agent (both stops of their
+// freight). Medians throughout (per #235), and everything null/gated until
+// there's enough logged data to mean something.
+import type { Load } from "@/types/load";
+import { dwellMinutes } from "@/lib/stopTimes";
+import { onTimeStatus, stopDetentionMinutes, type OnTime } from "@/lib/detention";
+import { median } from "./stats";
+
+// Below this many timed stops, we don't compute — we say "not enough data".
+export const MIN_STOPS = 3;
+
+interface Stop {
+  dwellMin: number | null;
+  onTime: OnTime | null;
+  detentionMin: number;
+  detentionUnpaid: boolean;
+}
+
+export interface StopScore {
+  timedStops: number; // stops with in+out logged — the sample size
+  medianDwellMin: number | null; // null until MIN_STOPS
+  onTimePct: number | null; // 0..1 of graded stops that hit on-time
+  gradedStops: number; // stops with an appointment + arrival
+  detentionCount: number; // timed stops that ran past free time
+  unpaidCount: number; // of those, still not marked paid
+  totalDwellMin: number; // summed dwell across timed stops
+  hasData: boolean; // timedStops >= MIN_STOPS
+}
+
+const stopOf = (
+  inT: string | null | undefined,
+  outT: string | null | undefined,
+  apptS: string | null | undefined,
+  apptE: string | null | undefined,
+  paid: boolean,
+  freeHours: number,
+): Stop => {
+  const detentionMin = stopDetentionMinutes(inT, outT, freeHours);
+  return {
+    dwellMin: dwellMinutes(inT, outT),
+    onTime: onTimeStatus(apptS, apptE, inT),
+    detentionMin,
+    detentionUnpaid: detentionMin > 0 && !paid,
+  };
+};
+
+// Every stop this facility played across the loads, as shipper and/or receiver.
+export const facilityStops = (
+  loads: Load[],
+  facilityId: string,
+  freeHours: number,
+): Stop[] => {
+  const out: Stop[] = [];
+  for (const l of loads) {
+    if (l.shipper_facility_id === facilityId)
+      out.push(
+        stopOf(
+          l.shipper_in,
+          l.shipper_out,
+          l.pickup_appt_start,
+          l.pickup_appt_end,
+          !!l.detention_paid,
+          freeHours,
+        ),
+      );
+    if (l.receiver_facility_id === facilityId)
+      out.push(
+        stopOf(
+          l.receiver_in,
+          l.receiver_out,
+          l.delivery_appt_start,
+          l.delivery_appt_end,
+          !!l.detention_paid,
+          freeHours,
+        ),
+      );
+  }
+  return out;
+};
+
+// Both stops of every load (used for an agent, whose loads are pre-filtered).
+export const agentStops = (loads: Load[], freeHours: number): Stop[] => {
+  const out: Stop[] = [];
+  for (const l of loads) {
+    out.push(
+      stopOf(
+        l.shipper_in,
+        l.shipper_out,
+        l.pickup_appt_start,
+        l.pickup_appt_end,
+        !!l.detention_paid,
+        freeHours,
+      ),
+    );
+    out.push(
+      stopOf(
+        l.receiver_in,
+        l.receiver_out,
+        l.delivery_appt_start,
+        l.delivery_appt_end,
+        !!l.detention_paid,
+        freeHours,
+      ),
+    );
+  }
+  return out;
+};
+
+export const scoreStops = (stops: Stop[]): StopScore => {
+  const timed = stops.filter((s) => s.dwellMin != null);
+  const dwells = timed.map((s) => s.dwellMin as number);
+  const graded = stops.filter((s) => s.onTime != null);
+  const onTimeN = graded.filter((s) => s.onTime === "on-time").length;
+  const detStops = timed.filter((s) => s.detentionMin > 0);
+  const enough = timed.length >= MIN_STOPS;
+
+  return {
+    timedStops: timed.length,
+    medianDwellMin: enough ? median(dwells) : null,
+    onTimePct: graded.length >= MIN_STOPS ? onTimeN / graded.length : null,
+    gradedStops: graded.length,
+    detentionCount: detStops.length,
+    unpaidCount: detStops.filter((s) => s.detentionUnpaid).length,
+    totalDwellMin: dwells.reduce((a, b) => a + b, 0),
+    hasData: enough,
+  };
+};

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Link } from "react-router";
 import { Mail, Phone, StickyNote, Star } from "lucide-react";
 
@@ -6,8 +6,11 @@ import { useAgent } from "@/hooks/useAgent";
 import { useLoads } from "@/hooks/useLoads";
 import { useCarrierName } from "@/hooks/useCarrierName";
 import { createAgentNote } from "@/services/createAgentNoteService";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import { agentStops, scoreStops } from "@/lib/metrics/stopScore";
 
 import RatingForm from "@/components/RatingForm";
+import { StopScorecard } from "@/components/StopScorecard";
 import { Kpi } from "@/components/Kpi";
 import { StatusBadge } from "@/components/StatusBadge";
 import { RatingStamp } from "@/components/agents/RatingStamp";
@@ -58,6 +61,19 @@ const AgentDetailPage = () => {
   const [noteInitials, setNoteInitials] = useState("");
   const [noteError, setNoteError] = useState<string | null>(null);
   const [savingNote, setSavingNote] = useState(false);
+  const [freeHours, setFreeHours] = useState(3);
+
+  useEffect(() => {
+    getSettlementSchedule()
+      .then((s) => setFreeHours(s.detention_free_hours))
+      .catch(() => {});
+  }, []);
+
+  // How this agent's freight behaves on the clock — dwell, on-time, detention.
+  const timeScore = useMemo(
+    () => scoreStops(agentStops(loads ?? [], freeHours)),
+    [loads, freeHours],
+  );
 
   const agentId = agent?.agent_id;
   const honors = useMemo(
@@ -200,6 +216,17 @@ const AgentDetailPage = () => {
         />
         <Kpi label="Cancelled" value={String(getCancelledCount(loads))} />
         <Kpi label="Last worked" value={lastWorked ? fmtDate(lastWorked) : "Never"} />
+      </div>
+
+      <div className="bg-plate rounded-lg p-4 mt-4">
+        <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
+          Time on the dock · this agent's freight
+        </p>
+        <StopScorecard
+          score={timeScore}
+          countLabel="Loads"
+          countValue={getLoadCount(loads)}
+        />
       </div>
 
       <div className="mt-4">

--- a/frontend/src/pages/FacilityDetailPage.tsx
+++ b/frontend/src/pages/FacilityDetailPage.tsx
@@ -5,6 +5,9 @@ import type { Facility } from "@/types/facility";
 import { getFacility } from "@/services/facilitiesService";
 import { useLoads } from "@/hooks/useLoads";
 import { dwell } from "@/lib/stopTimes";
+import { facilityStops, scoreStops } from "@/lib/metrics/stopScore";
+import { StopScorecard } from "@/components/StopScorecard";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
 
 const fmtDate = (d?: string | null) =>
   d
@@ -27,6 +30,7 @@ interface StopRow {
 const FacilityDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const [facility, setFacility] = useState<Facility | null>(null);
+  const [freeHours, setFreeHours] = useState(3);
   const { loads } = useLoads(0);
 
   useEffect(() => {
@@ -35,6 +39,17 @@ const FacilityDetailPage = () => {
       .then(setFacility)
       .catch(() => {});
   }, [id]);
+
+  useEffect(() => {
+    getSettlementSchedule()
+      .then((s) => setFreeHours(s.detention_free_hours))
+      .catch(() => {});
+  }, []);
+
+  const score = useMemo(
+    () => (id ? scoreStops(facilityStops(loads ?? [], id, freeHours)) : null),
+    [loads, id, freeHours],
+  );
 
   // Every stop this facility played on a load — as shipper and/or receiver.
   const rows = useMemo<StopRow[]>(() => {
@@ -97,6 +112,13 @@ const FacilityDetailPage = () => {
         </div>
       </div>
 
+      <div className="bg-plate rounded-lg p-4 mb-4">
+        <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
+          Scorecard
+        </p>
+        <StopScorecard score={score} countLabel="Loads" countValue={rows.length} />
+      </div>
+
       <div className="bg-plate rounded-lg p-4">
         <p className="text-xs text-muted-text uppercase tracking-wider mb-2">
           Loads through here
@@ -130,11 +152,6 @@ const FacilityDetailPage = () => {
           </div>
         )}
       </div>
-
-      <p className="text-[11px] text-muted-text mt-3">
-        Dwell/on-time/detention scorecard lands here once appointment data starts
-        accruing (Phase C).
-      </p>
     </div>
   );
 };


### PR DESCRIPTION
## v1.77.0 — #247 Phase C: scorecards (closes the epic)

Turns the accruing appointment / in-out / detention data into decision surfaces.

- **`stopScore`** — `facilityStops` / `agentStops` / `scoreStops`: **median** dwell (per #235), on-time % over graded stops, detention count + unpaid — **gated behind ≥3 timed stops** so a median of one load never shows. Unit-tested.
- **`StopScorecard`** — shared tiles (typical dwell, on-time, detention, loads) with a "fills in as loads accrue" state + a red nudge for unpaid detention.
- **Facility detail** — scorecard replaces the Phase A placeholder.
- **Agent detail** — a **"Time on the dock"** scorecard on the agent's freight.

**Effective $/hr deferred** — needs a drive-time estimate, and a guessed speed doesn't belong in a headline number. The non-estimated metrics are all here.

Frontend-only, no migration. Build clean, **247 tests**.

Closes #247 — Phases A (facilities), B (scheduling + detention), C (scorecards) all shipped.