### PR TITLE
feat: facility duplicate prevention + job-site kind (#252 Phase 1)

### DIFF
--- a/backend/db/migrations/040_facility_kind.sql
+++ b/backend/db/migrations/040_facility_kind.sql
@@ -1,0 +1,10 @@
+-- Facilities come in two kinds. A business is identified by its name (with the
+-- Inc/LLC normalization handled app-side); a job site has no company name and is
+-- identified by its address/location instead. So name becomes optional, and a
+-- kind flag says which identity applies.
+ALTER TABLE facilities
+    ADD COLUMN IF NOT EXISTS kind text NOT NULL DEFAULT 'business'
+    CHECK (kind IN ('business', 'job_site'));
+
+-- A job site may have no name — the address carries the identity.
+ALTER TABLE facilities ALTER COLUMN name DROP NOT NULL;

--- a/backend/src/services/facilityServices.js
+++ b/backend/src/services/facilityServices.js
@@ -24,6 +24,7 @@ export async function getFacilities(user_id) {
         SELECT
             f.facility_id,
             f.name,
+            f.kind,
             f.city,
             f.state,
             f.address,
@@ -47,7 +48,7 @@ export async function getFacility(user_id, facility_id) {
   if (!facility_id) throw new ValidationError("Missing facility_id");
 
   const query = `
-        SELECT facility_id, name, city, state, address, notes, created_at, updated_at
+        SELECT facility_id, name, kind, city, state, address, notes, created_at, updated_at
         FROM facilities
         WHERE user_id = $1 AND facility_id = $2;
     `;
@@ -61,7 +62,7 @@ export async function getFacility(user_id, facility_id) {
 export async function createFacility(user_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
 
-  const allowedFields = ["name", "city", "state", "address", "notes"];
+  const allowedFields = ["name", "kind", "city", "state", "address", "notes"];
   for (const field in data) {
     if (!allowedFields.includes(field))
       throw new ValidationError(`${field} not allowed`);
@@ -74,19 +75,20 @@ export async function createFacility(user_id, data) {
   // On a name+city+state collision, return the existing facility rather than
   // erroring or duplicating — picking "the same dock" should just find it.
   const query = `
-        INSERT INTO facilities (user_id, name, city, state, address, notes)
-        VALUES ($1, $2, $3, $4, $5, $6)
+        INSERT INTO facilities (user_id, name, city, state, address, notes, kind)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
         ON CONFLICT (user_id, name, city, state)
         DO UPDATE SET updated_at = NOW()
         RETURNING *;
     `;
   const values = [
     user_id,
-    clean.name,
+    clean.name ?? null,
     clean.city,
     clean.state,
     clean.address ?? null,
     clean.notes ?? null,
+    clean.kind ?? "business",
   ];
 
   const result = await db.query(query, values);
@@ -98,7 +100,7 @@ export async function patchFacility(user_id, facility_id, data) {
   if (!user_id) throw new ValidationError("Missing user_id");
   if (!facility_id) throw new ValidationError("Missing facility_id");
 
-  const allowedFields = ["name", "city", "state", "address", "notes"];
+  const allowedFields = ["name", "kind", "city", "state", "address", "notes"];
   for (const field in data) {
     if (!allowedFields.includes(field))
       throw new ValidationError(`${field} not allowed`);

--- a/backend/src/utils/validation/facilityValidation.js
+++ b/backend/src/utils/validation/facilityValidation.js
@@ -17,7 +17,9 @@ const optionalString = (field, value, errors) => {
 };
 
 const rules = {
-  name: (v, e) => nonBlankString("name", v, e),
+  // Name is optional at the field level — a job site may have none; the create
+  // check below requires it for a business.
+  name: (v, e) => optionalString("name", v, e),
   city: (v, e) => nonBlankString("city", v, e),
   state: (v, e) => {
     if (!isValidType("string", v)) {
@@ -28,15 +30,25 @@ const rules = {
   },
   address: (v, e) => optionalString("address", v, e),
   notes: (v, e) => optionalString("notes", v, e),
+  kind: (v, e) => {
+    if (v !== "business" && v !== "job_site")
+      e.push("kind must be business or job_site");
+  },
 };
 
 // ---- CREATE FACILITY VALIDATION ----
 export const validateFacilityCreate = (data) => {
   const errors = [];
+  const kind = data.kind ?? "business";
 
-  if (!data.name) errors.push("Missing name");
   if (!data.city) errors.push("Missing city");
   if (!data.state) errors.push("Missing state");
+  // A business is identified by name; a job site by its address.
+  if (kind === "job_site") {
+    if (!data.address) errors.push("A job site needs an address");
+  } else if (!data.name) {
+    errors.push("Missing name");
+  }
 
   for (const field in data) {
     if (rules[field]) rules[field](data[field], errors);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.77.0",
+  "version": "1.78.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FacilityCreateForm.tsx
+++ b/frontend/src/components/FacilityCreateForm.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import type { Facility, FacilityKind } from "@/types/facility";
+import { createFacility } from "@/services/facilitiesService";
+import { findDuplicate, facilityLabel } from "@/lib/facilityMatch";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface Props {
+  facilities: Facility[]; // for the soft duplicate check
+  defaultCity?: string;
+  defaultState?: string;
+  defaultName?: string; // prefilled from the picker's search text
+  onResolved: (facility: Facility) => void; // created, or an existing one reused
+  onCancel: () => void;
+}
+
+// Create a facility, with the kind toggle and the soft "looks like this exists"
+// warning. A business is identified by name, a job site by address.
+export const FacilityCreateForm = ({
+  facilities,
+  defaultCity,
+  defaultState,
+  defaultName,
+  onResolved,
+  onCancel,
+}: Props) => {
+  const [kind, setKind] = useState<FacilityKind>("business");
+  const [name, setName] = useState(defaultName ?? "");
+  const [address, setAddress] = useState("");
+  const [city, setCity] = useState(defaultCity ?? "");
+  const [state, setState] = useState(defaultState ?? "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const dup = findDuplicate(facilities, { kind, name, address, city, state });
+  const canSubmit =
+    !!city.trim() &&
+    state.trim().length === 2 &&
+    (kind === "job_site" ? !!address.trim() : !!name.trim());
+
+  const create = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const f = await createFacility({
+        kind,
+        name: name.trim() || null,
+        address: address.trim() || null,
+        city: city.trim(),
+        state: state.trim(),
+      });
+      onResolved(f);
+    } catch (e) {
+      setError(
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Could not create facility",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="border border-dashed border-steel rounded-md p-3 grid gap-2">
+      <div className="inline-flex bg-steel rounded-lg p-0.5 gap-0.5 w-fit">
+        {(["business", "job_site"] as const).map((k) => (
+          <button
+            key={k}
+            type="button"
+            onClick={() => setKind(k)}
+            className={`text-xs px-3 py-1 rounded ${
+              kind === k
+                ? "bg-amber text-steel font-semibold"
+                : "text-muted-text"
+            }`}
+          >
+            {k === "business" ? "Business" : "Job site"}
+          </button>
+        ))}
+      </div>
+
+      {kind === "business" ? (
+        <div>
+          <Label>Name</Label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="ABC Manufacturing"
+          />
+        </div>
+      ) : (
+        <div>
+          <Label>
+            Address / location <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            placeholder="1420 Construction Pkwy"
+          />
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <Input placeholder="City" value={city} onChange={(e) => setCity(e.target.value)} />
+        <Input
+          placeholder="ST"
+          maxLength={2}
+          className="w-16"
+          value={state}
+          onChange={(e) => setState(e.target.value)}
+        />
+      </div>
+
+      {kind === "business" ? (
+        <Input
+          placeholder="Street address (optional)"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+        />
+      ) : (
+        <Input
+          placeholder="Label (optional)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      )}
+
+      {error && <p className="text-destructive text-xs">{error}</p>}
+
+      {dup ? (
+        <div
+          className="rounded-md p-2"
+          style={{ border: "1px solid #7a4718", background: "#241a0e" }}
+        >
+          <p className="text-[11px]" style={{ color: "#f5c37a" }}>
+            ⚠ Looks like{" "}
+            <b>
+              {facilityLabel(dup)} · {dup.city}, {dup.state}
+            </b>{" "}
+            already exists.
+          </p>
+          <div className="flex gap-2 mt-2 items-center">
+            <Button type="button" size="sm" onClick={() => onResolved(dup)}>
+              Use existing
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={create}
+              disabled={busy || !canSubmit}
+            >
+              Create anyway
+            </Button>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="text-xs text-muted-text underline"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          <Button type="button" size="sm" onClick={create} disabled={busy || !canSubmit}>
+            {busy ? "Saving…" : "Create facility"}
+          </Button>
+          <Button type="button" size="sm" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/FacilityPicker.tsx
+++ b/frontend/src/components/FacilityPicker.tsx
@@ -1,17 +1,8 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Facility } from "@/types/facility";
-import { createFacility } from "@/services/facilitiesService";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { normalizeFacilityName, facilityLabel } from "@/lib/facilityMatch";
+import { FacilityCreateForm } from "@/components/FacilityCreateForm";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 
 interface Props {
   label: string; // "Shipper" / "Receiver"
@@ -23,9 +14,22 @@ interface Props {
   onCreated: (facility: Facility) => void;
 }
 
-// Pick an existing facility or create a new one inline. Creating one whose
-// name+city+state already exists just returns that facility (find-or-create on
-// the server), so it can't duplicate a dock.
+const KindTag = ({ kind }: { kind: string }) => (
+  <span
+    className="text-[9px] px-1.5 py-0.5 rounded-full"
+    style={
+      kind === "job_site"
+        ? { background: "#1e2740", color: "#9db2d8" }
+        : { background: "#12251a", color: "#6fd08c" }
+    }
+  >
+    {kind === "job_site" ? "job site" : "business"}
+  </span>
+);
+
+// Type-to-search facility picker. Live-filters existing docks so you reuse one
+// before you'd ever make a near-duplicate; the "looks like this exists" nudge
+// catches the Inc/LLC case that a substring search would miss.
 export const FacilityPicker = ({
   label,
   facilities,
@@ -35,116 +39,143 @@ export const FacilityPicker = ({
   onSelect,
   onCreated,
 }: Props) => {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [form, setForm] = useState({
-    name: "",
-    city: defaultCity ?? "",
-    state: defaultState ?? "",
-    address: "",
-  });
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
-  const create = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      const f = await createFacility({
-        name: form.name,
-        city: form.city,
-        state: form.state,
-        address: form.address || null,
-      });
-      onCreated(f);
-      onSelect(f);
-      setCreating(false);
-      setForm({ name: "", city: defaultCity ?? "", state: defaultState ?? "", address: "" });
-    } catch (e) {
-      setError(
-        (e as { response?: { data?: { error?: string } } })?.response?.data
-          ?.error || "Could not create facility",
-      );
-    } finally {
-      setBusy(false);
-    }
+  const selected = facilities.find((f) => f.facility_id === value) ?? null;
+
+  // Show the selected facility's label in the box when not actively searching.
+  useEffect(() => {
+    if (selected && !open) setQuery(facilityLabel(selected));
+    if (!selected && !open) setQuery("");
+  }, [selected, open]);
+
+  // Click outside closes the dropdown.
+  useEffect(() => {
+    const h = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+        setCreating(false);
+      }
+    };
+    document.addEventListener("mousedown", h);
+    return () => document.removeEventListener("mousedown", h);
+  }, []);
+
+  const q = query.trim().toLowerCase();
+  const matches = q
+    ? facilities.filter((f) =>
+        `${f.name ?? ""} ${f.address ?? ""} ${f.city} ${f.state}`
+          .toLowerCase()
+          .includes(q),
+      )
+    : facilities;
+
+  // Fuzzy nudge: a facility whose normalized name equals the normalized query
+  // but isn't already an exact substring hit (the Inc/LLC case).
+  const nq = normalizeFacilityName(query);
+  const nudge =
+    nq.length > 0
+      ? facilities.find(
+          (f) =>
+            normalizeFacilityName(facilityLabel(f)) === nq &&
+            !matches.some((m) => m.facility_id === f.facility_id),
+        )
+      : undefined;
+
+  const choose = (f: Facility) => {
+    onSelect(f);
+    setQuery(facilityLabel(f));
+    setOpen(false);
+    setCreating(false);
   };
 
-  if (creating) {
-    return (
-      <div>
-        <Label>
-          {label} facility · <span className="text-status-positive-text">new</span>
-        </Label>
-        <div className="border border-dashed border-steel rounded-md p-3 grid gap-2 mt-1">
-          <Input
-            placeholder="Facility name (e.g. Walmart DC 6094)"
-            value={form.name}
-            onChange={(e) => setForm({ ...form, name: e.target.value })}
-          />
-          <div className="flex gap-2">
-            <Input
-              placeholder="City"
-              value={form.city}
-              onChange={(e) => setForm({ ...form, city: e.target.value })}
-            />
-            <Input
-              placeholder="ST"
-              maxLength={2}
-              className="w-16"
-              value={form.state}
-              onChange={(e) => setForm({ ...form, state: e.target.value })}
-            />
-          </div>
-          <Input
-            placeholder="Street address (optional)"
-            value={form.address}
-            onChange={(e) => setForm({ ...form, address: e.target.value })}
-          />
-          {error && <p className="text-destructive text-xs">{error}</p>}
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              onClick={create}
-              disabled={busy || !form.name || !form.city || form.state.trim().length !== 2}
-            >
-              {busy ? "Saving…" : "Create facility"}
-            </Button>
-            <Button type="button" variant="outline" onClick={() => setCreating(false)}>
-              Cancel
-            </Button>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  const resolveCreated = (f: Facility) => {
+    onCreated(f); // parent de-dupes its list
+    choose(f);
+  };
 
   return (
-    <div>
+    <div ref={ref} className="relative">
       <Label>{label} facility</Label>
-      <div className="flex gap-2">
-        <Select
-          value={value ?? ""}
-          onValueChange={(id) =>
-            onSelect(facilities.find((f) => f.facility_id === id) ?? null)
-          }
-        >
-          <SelectTrigger className="flex-1">
-            <SelectValue placeholder={`Select ${label.toLowerCase()} facility`} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              {facilities.map((f) => (
-                <SelectItem key={f.facility_id} value={f.facility_id}>
-                  {f.name} · {f.city}, {f.state}
-                </SelectItem>
+      <input
+        className="w-full bg-steel rounded px-2 py-1.5 text-sm text-light placeholder:text-muted-text"
+        placeholder={`Search or add ${label.toLowerCase()} facility`}
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+          setCreating(false);
+          if (selected) onSelect(null);
+        }}
+        onFocus={() => setOpen(true)}
+      />
+
+      {open && (
+        <div className="absolute z-20 left-0 right-0 mt-1 rounded-md border border-steel bg-iron shadow-xl overflow-hidden">
+          {creating ? (
+            <div className="p-2">
+              <FacilityCreateForm
+                facilities={facilities}
+                defaultCity={defaultCity}
+                defaultState={defaultState}
+                defaultName={query}
+                onResolved={resolveCreated}
+                onCancel={() => setCreating(false)}
+              />
+            </div>
+          ) : (
+            <div className="max-h-72 overflow-y-auto">
+              {nudge && (
+                <div
+                  className="px-2.5 py-2 flex items-center justify-between gap-2"
+                  style={{ background: "#241a0e", borderBottom: "1px solid #3a2a12" }}
+                >
+                  <span className="text-[11px]" style={{ color: "#f5c37a" }}>
+                    ⚠ Looks like this exists · {facilityLabel(nudge)} · {nudge.city},{" "}
+                    {nudge.state}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => choose(nudge)}
+                    className="bg-amber text-steel text-[11px] px-2 py-0.5 rounded font-semibold shrink-0"
+                  >
+                    Use it
+                  </button>
+                </div>
+              )}
+              {matches.slice(0, 30).map((f) => (
+                <button
+                  key={f.facility_id}
+                  type="button"
+                  onClick={() => choose(f)}
+                  className="w-full text-left px-2.5 py-2 text-sm hover:bg-steel flex items-center gap-2 border-t border-plate first:border-t-0"
+                >
+                  <span className="truncate">
+                    {facilityLabel(f)}{" "}
+                    <span className="text-muted-text">
+                      · {f.city}, {f.state}
+                    </span>
+                  </span>
+                  <span className="ml-auto shrink-0">
+                    <KindTag kind={f.kind} />
+                  </span>
+                </button>
               ))}
-            </SelectGroup>
-          </SelectContent>
-        </Select>
-        <Button type="button" variant="outline" onClick={() => setCreating(true)}>
-          ＋ New
-        </Button>
-      </div>
+              <button
+                type="button"
+                onClick={() => setCreating(true)}
+                className="w-full text-left px-2.5 py-2 text-sm border-t border-plate"
+                style={{ color: "#6fd08c" }}
+              >
+                ＋ Add {query.trim() ? `"${query.trim()}"` : "a facility"}…
+              </button>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/LoadForm.tsx
+++ b/frontend/src/components/LoadForm.tsx
@@ -22,6 +22,7 @@ import type { CreateAgentInput } from "@/types/createAgentInput";
 import type { CreateMarketInput } from "@/types/createMarketInput";
 import type { Facility } from "@/types/facility";
 import { FacilityPicker } from "@/components/FacilityPicker";
+import { facilityLabel } from "@/lib/facilityMatch";
 
 // UI Component Imports
 
@@ -936,11 +937,15 @@ const LoadForm = ({
                   setFormData({
                     ...formData,
                     shipper_facility_id: f?.facility_id ?? null,
-                    shipper_name: f?.name ?? null,
+                    shipper_name: f ? facilityLabel(f) : null,
                   })
                 }
                 onCreated={(f) => {
-                  setFacilityList((prev) => [...prev, f]);
+                  setFacilityList((prev) =>
+                    prev.some((x) => x.facility_id === f.facility_id)
+                      ? prev
+                      : [...prev, f],
+                  );
                   onFacilityCreated?.();
                 }}
               />
@@ -982,11 +987,15 @@ const LoadForm = ({
                   setFormData({
                     ...formData,
                     receiver_facility_id: f?.facility_id ?? null,
-                    receiver_name: f?.name ?? null,
+                    receiver_name: f ? facilityLabel(f) : null,
                   })
                 }
                 onCreated={(f) => {
-                  setFacilityList((prev) => [...prev, f]);
+                  setFacilityList((prev) =>
+                    prev.some((x) => x.facility_id === f.facility_id)
+                      ? prev
+                      : [...prev, f],
+                  );
                   onFacilityCreated?.();
                 }}
               />

--- a/frontend/src/lib/facilityMatch.test.ts
+++ b/frontend/src/lib/facilityMatch.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import type { Facility } from "@/types/facility";
+import { normalizeFacilityName, findDuplicate, facilityLabel } from "./facilityMatch";
+
+describe("normalizeFacilityName", () => {
+  it("collapses the Inc/LLC/comma variants to one key", () => {
+    expect(normalizeFacilityName("ABC Manufacturing Inc")).toBe("abc manufacturing");
+    expect(normalizeFacilityName("ABC Manufacturing, LLC")).toBe("abc manufacturing");
+    expect(normalizeFacilityName("ABC Manufacturing")).toBe("abc manufacturing");
+  });
+
+  it("strips stacked suffixes and extra punctuation", () => {
+    expect(normalizeFacilityName("Smith & Sons Co.")).toBe("smith sons");
+    expect(normalizeFacilityName("Foundry Co Inc")).toBe("foundry");
+  });
+
+  it("doesn't strip a suffix that's part of a word", () => {
+    expect(normalizeFacilityName("Costco")).toBe("costco");
+  });
+});
+
+const F = (o: Partial<Facility>): Facility =>
+  ({ kind: "business", name: null, address: null, city: "", state: "", ...o }) as Facility;
+
+describe("findDuplicate", () => {
+  const existing = [
+    F({ facility_id: "1", name: "ABC Manufacturing", city: "Chicago", state: "IL" }),
+    F({ facility_id: "2", kind: "job_site", address: "1420 Construction Pkwy", city: "Houston", state: "TX" }),
+  ];
+
+  it("matches a business across a legal-suffix variant", () => {
+    const hit = findDuplicate(existing, {
+      kind: "business",
+      name: "ABC Manufacturing, LLC",
+      address: null,
+      city: "Chicago",
+      state: "IL",
+    });
+    expect(hit?.facility_id).toBe("1");
+  });
+
+  it("does not match the same name in a different city", () => {
+    expect(
+      findDuplicate(existing, {
+        kind: "business",
+        name: "ABC Manufacturing",
+        address: null,
+        city: "Dallas",
+        state: "TX",
+      }),
+    ).toBeNull();
+  });
+
+  it("keys job sites on address — same address matches, different doesn't", () => {
+    expect(
+      findDuplicate(existing, {
+        kind: "job_site",
+        name: null,
+        address: "1420 Construction Pkwy",
+        city: "Houston",
+        state: "TX",
+      })?.facility_id,
+    ).toBe("2");
+    expect(
+      findDuplicate(existing, {
+        kind: "job_site",
+        name: null,
+        address: "88 Other St",
+        city: "Houston",
+        state: "TX",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null with nothing typed yet", () => {
+    expect(
+      findDuplicate(existing, { kind: "business", name: "", address: null, city: "Chicago", state: "IL" }),
+    ).toBeNull();
+  });
+});
+
+describe("facilityLabel", () => {
+  it("uses the name, falling back to the address for a nameless job site", () => {
+    expect(facilityLabel({ name: "ABC", address: null })).toBe("ABC");
+    expect(facilityLabel({ name: null, address: "1420 Construction Pkwy" })).toBe(
+      "1420 Construction Pkwy",
+    );
+  });
+});

--- a/frontend/src/lib/facilityMatch.ts
+++ b/frontend/src/lib/facilityMatch.ts
@@ -1,0 +1,74 @@
+import type { Facility } from "@/types/facility";
+
+// Common legal suffixes to drop when comparing names — so "ABC Manufacturing
+// Inc", "ABC Manufacturing, LLC", and "ABC Manufacturing" all match.
+const SUFFIXES = [
+  "incorporated",
+  "corporation",
+  "company",
+  "limited",
+  "inc",
+  "llc",
+  "llp",
+  "lp",
+  "ltd",
+  "corp",
+  "co",
+  "plc",
+];
+
+// Normalize a facility's identity string for MATCHING only — never for display.
+// lowercase, punctuation → space, collapse whitespace, drop trailing legal
+// suffixes (which can stack, e.g. "Foundry Co Inc").
+export const normalizeFacilityName = (s: string): string => {
+  let out = s
+    .toLowerCase()
+    .replace(/[.,'"&/\\-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const suf of SUFFIXES) {
+      if (out.endsWith(" " + suf)) {
+        out = out.slice(0, out.length - suf.length - 1).trim();
+        changed = true;
+      }
+    }
+  }
+  return out;
+};
+
+interface Identity {
+  kind: string;
+  name: string | null;
+  address: string | null;
+  city: string;
+  state: string;
+}
+
+// The key a facility dedups on: normalized name (business) or address (job
+// site), plus city + state. Empty when there's no basis yet.
+export const facilityKey = (f: Identity): string => {
+  const basis = f.kind === "job_site" ? (f.address ?? "") : (f.name ?? "");
+  const norm = normalizeFacilityName(basis);
+  if (!norm || !f.city?.trim() || !f.state?.trim()) return "";
+  return `${norm}|${f.city.trim().toLowerCase()}|${f.state.trim().toLowerCase()}`;
+};
+
+// An existing facility the proposed one would duplicate (same kind-appropriate
+// key), or null. Powers the soft "did you mean" warning.
+export const findDuplicate = (
+  facilities: Facility[],
+  proposed: Identity,
+): Facility | null => {
+  const key = facilityKey(proposed);
+  if (!key) return null;
+  return facilities.find((f) => facilityKey(f) === key) ?? null;
+};
+
+// What to show for a facility — its name, or its address for a nameless job site.
+export const facilityLabel = (f: {
+  name: string | null;
+  address: string | null;
+}): string => f.name || f.address || "Unnamed";

--- a/frontend/src/pages/FacilitiesPage.tsx
+++ b/frontend/src/pages/FacilitiesPage.tsx
@@ -1,17 +1,10 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { Plus } from "lucide-react";
 import { useFacilities } from "@/hooks/useFacilities";
-import { createFacility } from "@/services/facilitiesService";
-import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
+import { FacilityCreateForm } from "@/components/FacilityCreateForm";
+import { facilityLabel } from "@/lib/facilityMatch";
 import type { FacilityRow } from "@/types/facility";
-
-const FIELDS: FormField[] = [
-  { name: "name", label: "Name", required: true, placeholder: "Nucor Steel" },
-  { name: "city", label: "City", required: true, placeholder: "Decatur" },
-  { name: "state", label: "State", required: true, placeholder: "AL" },
-  { name: "address", label: "Address", placeholder: "1810 Steelmill Rd (optional)" },
-];
 
 const roleLabel = (f: FacilityRow): string =>
   f.as_shipper && f.as_receiver
@@ -22,29 +15,34 @@ const roleLabel = (f: FacilityRow): string =>
         ? "receives"
         : "—";
 
+const KindTag = ({ kind }: { kind: string }) => (
+  <span
+    className="text-[9px] px-1.5 py-0.5 rounded-full align-middle"
+    style={
+      kind === "job_site"
+        ? { background: "#1e2740", color: "#9db2d8" }
+        : { background: "#12251a", color: "#6fd08c" }
+    }
+  >
+    {kind === "job_site" ? "job site" : "business"}
+  </span>
+);
+
 const FacilitiesPage = () => {
   const [refreshKey, setRefreshKey] = useState(0);
   const { facilities, isLoading } = useFacilities(refreshKey);
   const [showForm, setShowForm] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
 
-  const save = async (data: Record<string, unknown>) => {
-    setBusy(true);
-    setError(null);
-    try {
-      await createFacility(data);
-      setShowForm(false);
-      setRefreshKey((p) => p + 1);
-    } catch (e) {
-      setError(
-        (e as { response?: { data?: { error?: string } } })?.response?.data
-          ?.error || "Could not create the facility",
-      );
-    } finally {
-      setBusy(false);
-    }
-  };
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return facilities;
+    return facilities.filter((f) =>
+      `${f.name ?? ""} ${f.address ?? ""} ${f.city} ${f.state}`
+        .toLowerCase()
+        .includes(q),
+    );
+  }, [facilities, search]);
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -61,16 +59,25 @@ const FacilitiesPage = () => {
       </div>
 
       {showForm && (
-        <div className="mb-4">
-          <EntityForm
-            title="New facility"
-            fields={FIELDS}
-            onSave={save}
+        <div className="mb-4 max-w-md">
+          <FacilityCreateForm
+            facilities={facilities}
+            onResolved={() => {
+              setShowForm(false);
+              setRefreshKey((p) => p + 1);
+            }}
             onCancel={() => setShowForm(false)}
-            busy={busy}
-            error={error}
           />
         </div>
+      )}
+
+      {facilities.length > 0 && (
+        <input
+          className="bg-steel rounded px-3 py-1.5 text-sm text-light placeholder:text-muted-text w-full max-w-xs mb-4"
+          placeholder="Search name, address, city"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
       )}
 
       {isLoading ? (
@@ -79,9 +86,11 @@ const FacilitiesPage = () => {
         <p className="text-muted-text">
           No facilities yet. They're created as you add loads, or add one here.
         </p>
+      ) : filtered.length === 0 ? (
+        <p className="text-muted-text">No facilities match "{search}".</p>
       ) : (
         <div className="bg-plate rounded-lg p-4 overflow-x-auto">
-          <table className="w-full text-sm" style={{ minWidth: 460 }}>
+          <table className="w-full text-sm" style={{ minWidth: 480 }}>
             <thead>
               <tr className="text-muted-text text-left text-xs">
                 <th className="font-normal pb-2">Facility</th>
@@ -91,15 +100,16 @@ const FacilitiesPage = () => {
               </tr>
             </thead>
             <tbody>
-              {facilities.map((f) => (
+              {filtered.map((f) => (
                 <tr key={f.facility_id} className="border-t border-steel">
                   <td className="py-2">
                     <Link
                       to={`/facilities/${f.facility_id}`}
                       className="text-amber-light hover:underline font-medium"
                     >
-                      {f.name}
-                    </Link>
+                      {facilityLabel(f)}
+                    </Link>{" "}
+                    <KindTag kind={f.kind} />
                   </td>
                   <td className="py-2 text-muted-text whitespace-nowrap">
                     {f.city}, {f.state}

--- a/frontend/src/pages/FacilityDetailPage.tsx
+++ b/frontend/src/pages/FacilityDetailPage.tsx
@@ -7,6 +7,7 @@ import { useLoads } from "@/hooks/useLoads";
 import { dwell } from "@/lib/stopTimes";
 import { facilityStops, scoreStops } from "@/lib/metrics/stopScore";
 import { StopScorecard } from "@/components/StopScorecard";
+import { facilityLabel } from "@/lib/facilityMatch";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
 
 const fmtDate = (d?: string | null) =>
@@ -102,10 +103,24 @@ const FacilityDetailPage = () => {
           <Warehouse size={26} className="text-muted-text" />
         </div>
         <div>
-          <h1 className="text-3xl font-condensed">{facility.name}</h1>
+          <h1 className="text-3xl font-condensed">
+            {facilityLabel(facility)}{" "}
+            <span
+              className="text-[10px] px-1.5 py-0.5 rounded-full align-middle font-body"
+              style={
+                facility.kind === "job_site"
+                  ? { background: "#1e2740", color: "#9db2d8" }
+                  : { background: "#12251a", color: "#6fd08c" }
+              }
+            >
+              {facility.kind === "job_site" ? "job site" : "business"}
+            </span>
+          </h1>
           <p className="text-muted-text text-sm">
             {facility.city}, {facility.state}
-            {facility.address ? ` · ${facility.address}` : ""}
+            {facility.kind === "business" && facility.address
+              ? ` · ${facility.address}`
+              : ""}
             <span className="text-steel"> · </span>
             {role}
           </p>

--- a/frontend/src/types/facility.ts
+++ b/frontend/src/types/facility.ts
@@ -1,6 +1,11 @@
+export type FacilityKind = "business" | "job_site";
+
 export interface Facility {
   facility_id: string;
-  name: string;
+  // A business is identified by its name; a job site (name may be null) by its
+  // address.
+  name: string | null;
+  kind: FacilityKind;
   city: string;
   state: string;
   address: string | null;


### PR DESCRIPTION
## v1.78.0 — #252 Phase 1: facility dedup prevention

Stops near-duplicate facilities at entry, and models job sites properly.

### Model
- **Migration 040** — facility `kind` (business | job_site, default business); `name` nullable. Business identified by name, job site by address.

### Matching (tested)
- `facilityMatch` — normalization for matching only (lowercase, punctuation, drop legal suffixes Inc/LLC/Corp/Co/Ltd…) so the ABC variants collapse to one key. `findDuplicate` keyed by name (business) or address (job site), scoped to city+state. 8 tests.

### UI
- Picker → **type-to-search combobox** with the fuzzy **"looks like this exists"** nudge.
- Shared **FacilityCreateForm** with a **Business/Job-site toggle** + soft **Use existing / Create anyway** (never a hard block).
- Facilities list gets a **search box** + kind tags; nameless job sites label by address.

Kind-aware backend validation. Verified on dev; **prod migration applied ahead of deploy** (69 facilities default to business). Build clean, **255 tests**.

Part of #252 (Phase 2 — merge tool for existing dupes — next).