### PR TITLE
feat: facility merge tool (#252 Phase 2)

### DIFF
--- a/backend/src/routes/facilityRoutes.js
+++ b/backend/src/routes/facilityRoutes.js
@@ -6,10 +6,28 @@ import {
   createFacility,
   patchFacility,
   deleteFacility,
+  mergeFacilities,
 } from "../services/facilityServices.js";
 
 const router = express.Router();
 router.use(requireAuth);
+
+// ---- MERGE FACILITIES ---- (must precede /:facility_id routes)
+router.post("/merge", async (req, res) => {
+  try {
+    const { keeper_id, merge_ids } = req.body;
+    const result = await mergeFacilities(req.user.user_id, keeper_id, merge_ids);
+    return res.status(200).json({ message: "Facilities merged", ...result });
+  } catch (err) {
+    if (err.type === "validation")
+      return res.status(err.statusCode).json({ error: err.message });
+    if (err.type === "not_found")
+      return res.status(err.statusCode).json({ error: err.message });
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: err.message });
+  }
+});
 
 // ---- GET ALL FACILITIES ----
 router.get("/", async (req, res) => {

--- a/backend/src/services/facilityServices.js
+++ b/backend/src/services/facilityServices.js
@@ -138,6 +138,59 @@ export async function patchFacility(user_id, facility_id, data) {
   return result.rows[0];
 }
 
+// ---- MERGE FACILITIES ---- (fold duplicates into one keeper, atomically)
+// Reassigns every load off the merged facilities onto the keeper, then deletes
+// the duplicates — all in one transaction so it can't half-apply.
+export async function mergeFacilities(user_id, keeper_id, merge_ids) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!keeper_id) throw new ValidationError("Missing keeper_id");
+  if (!Array.isArray(merge_ids) || merge_ids.length === 0)
+    throw new ValidationError("Provide at least one facility to merge");
+  if (merge_ids.includes(keeper_id))
+    throw new ValidationError("The keeper can't also be in the merge list");
+
+  const client = await db.pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    // Every id (keeper + merges) must belong to this user.
+    const ids = [keeper_id, ...merge_ids];
+    const owned = await client.query(
+      `SELECT facility_id FROM facilities WHERE user_id = $1 AND facility_id = ANY($2::uuid[])`,
+      [user_id, ids],
+    );
+    if (owned.rowCount !== ids.length)
+      throw new NotFoundError("One or more facilities not found");
+
+    const s = await client.query(
+      `UPDATE loads SET shipper_facility_id = $1
+         WHERE user_id = $2 AND shipper_facility_id = ANY($3::uuid[])`,
+      [keeper_id, user_id, merge_ids],
+    );
+    const r = await client.query(
+      `UPDATE loads SET receiver_facility_id = $1
+         WHERE user_id = $2 AND receiver_facility_id = ANY($3::uuid[])`,
+      [keeper_id, user_id, merge_ids],
+    );
+    const d = await client.query(
+      `DELETE FROM facilities WHERE user_id = $1 AND facility_id = ANY($2::uuid[])`,
+      [user_id, merge_ids],
+    );
+
+    await client.query("COMMIT");
+    return {
+      keeper_id,
+      merged: d.rowCount,
+      loads_reassigned: s.rowCount + r.rowCount,
+    };
+  } catch (e) {
+    await client.query("ROLLBACK");
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
 // ---- DELETE FACILITY SERVICE ---- (loads keep their history; link goes null)
 export async function deleteFacility(user_id, facility_id) {
   if (!user_id) throw new ValidationError("Missing user_id");

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.78.0",
+  "version": "1.79.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/facilityMatch.test.ts
+++ b/frontend/src/lib/facilityMatch.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import type { Facility } from "@/types/facility";
-import { normalizeFacilityName, findDuplicate, facilityLabel } from "./facilityMatch";
+import {
+  normalizeFacilityName,
+  findDuplicate,
+  facilityLabel,
+  possibleDuplicates,
+} from "./facilityMatch";
 
 describe("normalizeFacilityName", () => {
   it("collapses the Inc/LLC/comma variants to one key", () => {
@@ -76,6 +81,32 @@ describe("findDuplicate", () => {
     expect(
       findDuplicate(existing, { kind: "business", name: "", address: null, city: "Chicago", state: "IL" }),
     ).toBeNull();
+  });
+});
+
+describe("possibleDuplicates", () => {
+  it("clusters the variants and leaves singletons out", () => {
+    const facs = [
+      F({ facility_id: "1", name: "ABC Manufacturing", city: "Chicago", state: "IL" }),
+      F({ facility_id: "2", name: "ABC Manufacturing Inc", city: "Chicago", state: "IL" }),
+      F({ facility_id: "3", name: "ABC Manufacturing", city: "Dallas", state: "TX" }), // diff city
+      F({ facility_id: "4", name: "Nucor", city: "Decatur", state: "AL" }),
+    ];
+    const clusters = possibleDuplicates(facs);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].map((f) => f.facility_id).sort()).toEqual(["1", "2"]);
+  });
+
+  it("clusters job sites by address", () => {
+    const facs = [
+      F({ facility_id: "1", kind: "job_site", address: "1420 Construction Pkwy", city: "Houston", state: "TX" }),
+      F({ facility_id: "2", kind: "job_site", address: "1420 Construction Parkway", city: "Houston", state: "TX" }),
+    ];
+    // "Pkwy" vs "Parkway" won't collapse (no abbrev expansion in v1) — distinct keys
+    expect(possibleDuplicates(facs)).toHaveLength(0);
+    // but identical address does cluster
+    facs[1].address = "1420 Construction Pkwy";
+    expect(possibleDuplicates(facs)).toHaveLength(1);
   });
 });
 

--- a/frontend/src/lib/facilityMatch.ts
+++ b/frontend/src/lib/facilityMatch.ts
@@ -72,3 +72,17 @@ export const facilityLabel = (f: {
   name: string | null;
   address: string | null;
 }): string => f.name || f.address || "Unnamed";
+
+// Cluster facilities that share a dedup key — the likely-duplicate groups (2+).
+// Generic so it preserves the caller's row type (with load counts).
+export const possibleDuplicates = <T extends Identity>(facilities: T[]): T[][] => {
+  const groups = new Map<string, T[]>();
+  for (const f of facilities) {
+    const key = facilityKey(f);
+    if (!key) continue;
+    const g = groups.get(key);
+    if (g) g.push(f);
+    else groups.set(key, [f]);
+  }
+  return [...groups.values()].filter((g) => g.length > 1);
+};

--- a/frontend/src/pages/FacilitiesPage.tsx
+++ b/frontend/src/pages/FacilitiesPage.tsx
@@ -3,8 +3,11 @@ import { Link } from "react-router-dom";
 import { Plus } from "lucide-react";
 import { useFacilities } from "@/hooks/useFacilities";
 import { FacilityCreateForm } from "@/components/FacilityCreateForm";
-import { facilityLabel } from "@/lib/facilityMatch";
+import { facilityLabel, possibleDuplicates } from "@/lib/facilityMatch";
+import { mergeFacilities } from "@/services/facilitiesService";
 import type { FacilityRow } from "@/types/facility";
+
+const loadCount = (f: FacilityRow) => f.as_shipper + f.as_receiver;
 
 const roleLabel = (f: FacilityRow): string =>
   f.as_shipper && f.as_receiver
@@ -33,6 +36,39 @@ const FacilitiesPage = () => {
   const { facilities, isLoading } = useFacilities(refreshKey);
   const [showForm, setShowForm] = useState(false);
   const [search, setSearch] = useState("");
+  const [keeperSel, setKeeperSel] = useState<Record<string, string>>({});
+  const [confirmCluster, setConfirmCluster] = useState<FacilityRow[] | null>(null);
+  const [merging, setMerging] = useState(false);
+  const [mergeErr, setMergeErr] = useState<string | null>(null);
+
+  const dupes = useMemo(() => possibleDuplicates(facilities), [facilities]);
+  const clusterKey = (c: FacilityRow[]) => c[0].facility_id;
+  const defaultKeeper = (c: FacilityRow[]) =>
+    [...c].sort((a, b) => loadCount(b) - loadCount(a))[0].facility_id;
+  const keeperFor = (c: FacilityRow[]) =>
+    keeperSel[clusterKey(c)] ?? defaultKeeper(c);
+
+  const runMerge = async () => {
+    if (!confirmCluster) return;
+    const keeperId = keeperFor(confirmCluster);
+    const mergeIds = confirmCluster
+      .filter((f) => f.facility_id !== keeperId)
+      .map((f) => f.facility_id);
+    setMerging(true);
+    setMergeErr(null);
+    try {
+      await mergeFacilities(keeperId, mergeIds);
+      setConfirmCluster(null);
+      setRefreshKey((p) => p + 1);
+    } catch (e) {
+      setMergeErr(
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Merge failed",
+      );
+    } finally {
+      setMerging(false);
+    }
+  };
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -68,6 +104,75 @@ const FacilitiesPage = () => {
             }}
             onCancel={() => setShowForm(false)}
           />
+        </div>
+      )}
+
+      {dupes.length > 0 && (
+        <div className="mb-4 flex flex-col gap-3">
+          <p className="text-xs text-muted-text uppercase tracking-wider">
+            Possible duplicates
+          </p>
+          {dupes.map((cluster) => {
+            const keeperId = keeperFor(cluster);
+            return (
+              <div
+                key={clusterKey(cluster)}
+                className="bg-plate rounded-lg p-4 border max-w-lg"
+                style={{ borderColor: "#3a2a12" }}
+              >
+                <div className="flex justify-between items-center mb-1">
+                  <span
+                    className="font-condensed text-base"
+                    style={{ color: "#f5c37a" }}
+                  >
+                    Possible duplicate · {cluster[0].city}, {cluster[0].state}{" "}
+                    <KindTag kind={cluster[0].kind} />
+                  </span>
+                  <span className="text-[11px] text-muted-text">
+                    pick the one to keep
+                  </span>
+                </div>
+                {cluster.map((f) => (
+                  <label
+                    key={f.facility_id}
+                    className="flex items-center gap-2 py-1.5 border-t border-iron cursor-pointer text-sm"
+                  >
+                    <input
+                      type="radio"
+                      checked={keeperId === f.facility_id}
+                      onChange={() =>
+                        setKeeperSel((s) => ({
+                          ...s,
+                          [clusterKey(cluster)]: f.facility_id,
+                        }))
+                      }
+                      style={{ accentColor: "#e8940a" }}
+                    />
+                    <span className="flex-1">{facilityLabel(f)}</span>
+                    <span className="text-muted-text text-xs">
+                      {loadCount(f)} loads
+                    </span>
+                    {keeperId === f.facility_id && (
+                      <span
+                        className="text-[9px] px-1.5 py-0.5 rounded-full"
+                        style={{ background: "#2a1e0e", color: "#f5c37a" }}
+                      >
+                        keeper
+                      </span>
+                    )}
+                  </label>
+                ))}
+                <div className="flex justify-end mt-2">
+                  <button
+                    onClick={() => setConfirmCluster(cluster)}
+                    className="bg-amber text-steel text-xs px-3 py-1.5 rounded font-semibold"
+                  >
+                    Merge {cluster.length - 1} into keeper →
+                  </button>
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
 
@@ -122,6 +227,70 @@ const FacilitiesPage = () => {
           </table>
         </div>
       )}
+
+      {confirmCluster &&
+        (() => {
+          const keeperId = keeperFor(confirmCluster);
+          const keeper = confirmCluster.find((f) => f.facility_id === keeperId)!;
+          const merges = confirmCluster.filter((f) => f.facility_id !== keeperId);
+          const totalLoads = merges.reduce((n, f) => n + loadCount(f), 0);
+          return (
+            <div className="fixed inset-0 z-50 flex items-center justify-center">
+              <div
+                className="absolute inset-0 bg-black/50"
+                onClick={() => setConfirmCluster(null)}
+              />
+              <div className="relative bg-iron border border-steel rounded-xl p-5 max-w-md mx-4">
+                <h3 className="font-condensed text-xl mb-2">Merge facilities?</h3>
+                <p className="text-sm text-muted-text">Everything moves onto:</p>
+                <p className="text-sm mb-3">
+                  <b>{facilityLabel(keeper)}</b>{" "}
+                  <span className="text-muted-text">
+                    · {keeper.city}, {keeper.state}
+                  </span>
+                </p>
+                <p className="text-sm text-muted-text">
+                  <b className="text-light">
+                    {totalLoads} load{totalLoads === 1 ? "" : "s"}
+                  </b>{" "}
+                  reassigned from {merges.length}{" "}
+                  {merges.length === 1 ? "facility" : "facilities"}, then deleted:
+                </p>
+                <div className="text-sm mt-2 flex flex-col gap-1">
+                  {merges.map((f) => (
+                    <span key={f.facility_id}>
+                      • {facilityLabel(f)}{" "}
+                      <span className="text-muted-text">
+                        ({loadCount(f)} loads)
+                      </span>
+                    </span>
+                  ))}
+                </div>
+                <p className="text-[11px] mt-3" style={{ color: "#f2a6a3" }}>
+                  ⚠ This can't be undone.
+                </p>
+                {mergeErr && (
+                  <p className="text-destructive text-xs mt-2">{mergeErr}</p>
+                )}
+                <div className="flex gap-2 justify-end mt-4">
+                  <button
+                    onClick={() => setConfirmCluster(null)}
+                    className="bg-steel text-light text-sm px-3 py-1.5 rounded"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={runMerge}
+                    disabled={merging}
+                    className="bg-amber text-steel text-sm px-3 py-1.5 rounded font-semibold disabled:opacity-50"
+                  >
+                    {merging ? "Merging…" : "Merge"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+        })()}
     </div>
   );
 };

--- a/frontend/src/pages/FacilityDetailPage.tsx
+++ b/frontend/src/pages/FacilityDetailPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { Warehouse } from "lucide-react";
 import type { Facility } from "@/types/facility";
-import { getFacility } from "@/services/facilitiesService";
+import { getFacility, mergeFacilities } from "@/services/facilitiesService";
+import { useFacilities } from "@/hooks/useFacilities";
 import { useLoads } from "@/hooks/useLoads";
 import { dwell } from "@/lib/stopTimes";
 import { facilityStops, scoreStops } from "@/lib/metrics/stopScore";
@@ -30,9 +31,26 @@ interface StopRow {
 
 const FacilityDetailPage = () => {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const [facility, setFacility] = useState<Facility | null>(null);
   const [freeHours, setFreeHours] = useState(3);
   const { loads } = useLoads(0);
+  const { facilities } = useFacilities(0);
+  const [mergeTarget, setMergeTarget] = useState("");
+  const [merging, setMerging] = useState(false);
+
+  // Merge THIS facility into another (the fallback for dupes the finder can't
+  // auto-cluster). Reassigns its loads onto the target, then deletes this one.
+  const doMerge = async () => {
+    if (!id || !mergeTarget) return;
+    setMerging(true);
+    try {
+      await mergeFacilities(mergeTarget, [id]);
+      navigate(`/facilities/${mergeTarget}`);
+    } catch {
+      setMerging(false);
+    }
+  };
 
   useEffect(() => {
     if (!id) return;
@@ -167,6 +185,39 @@ const FacilityDetailPage = () => {
           </div>
         )}
       </div>
+
+      <details className="mt-4 text-sm">
+        <summary className="text-muted-text cursor-pointer">
+          Merge this facility into another…
+        </summary>
+        <div className="mt-2 flex gap-2 items-center flex-wrap">
+          <select
+            className="bg-steel rounded px-2 py-1.5 text-sm text-light"
+            value={mergeTarget}
+            onChange={(e) => setMergeTarget(e.target.value)}
+          >
+            <option value="">Choose the facility to keep…</option>
+            {facilities
+              .filter((f) => f.facility_id !== id)
+              .map((f) => (
+                <option key={f.facility_id} value={f.facility_id}>
+                  {facilityLabel(f)} · {f.city}, {f.state}
+                </option>
+              ))}
+          </select>
+          <button
+            onClick={doMerge}
+            disabled={!mergeTarget || merging}
+            className="bg-amber text-steel text-xs px-3 py-1.5 rounded font-semibold disabled:opacity-50"
+          >
+            {merging ? "Merging…" : "Merge & delete this"}
+          </button>
+        </div>
+        <p className="text-[11px] text-muted-text mt-1">
+          Moves this facility's {rows.length} load{rows.length === 1 ? "" : "s"}{" "}
+          onto the chosen one and deletes this facility. Can't be undone.
+        </p>
+      </details>
     </div>
   );
 };

--- a/frontend/src/services/facilitiesService.ts
+++ b/frontend/src/services/facilitiesService.ts
@@ -25,3 +25,16 @@ export const patchFacility = async (
   const res = await api.patch(`/facilities/${id}`, data);
   return res.data.facility;
 };
+
+// Fold duplicates into one keeper: reassigns their loads onto the keeper and
+// deletes them (backend does it in one transaction).
+export const mergeFacilities = async (
+  keeperId: string,
+  mergeIds: string[],
+): Promise<{ merged: number; loads_reassigned: number }> => {
+  const res = await api.post("/facilities/merge", {
+    keeper_id: keeperId,
+    merge_ids: mergeIds,
+  });
+  return res.data;
+};


### PR DESCRIPTION
## v1.79.0 — #252 Phase 2: merge tool (closes the epic)

Cleans up the near-duplicates already in the dataset.

- **Backend** — `mergeFacilities`: reassigns every load (shipper + receiver) off the merged facilities onto the keeper, then deletes them, **all in one transaction**. `POST /facilities/merge`, ownership-checked. Verified on dev with a controlled reassign-and-restore test.
- **`possibleDuplicates`** — clusters facilities sharing a normalized key (2+). Tested.
- **Facilities page** — a **"Possible duplicates"** panel auto-surfaces clusters; pick the keeper (defaults to most-loads), a **confirm** spells out "N loads reassigned, M deleted, can't be undone", then merge.
- **Facility detail** — a manual **"Merge into…"** fallback for dupes the finder can't auto-cluster (abbreviation variants like Pkwy/Parkway — v1 normalization deliberately doesn't expand abbreviations).

No migration. Build clean, **257 tests**.

Closes #252 — prevention (Phase 1) + merge (Phase 2) both shipped.