### PR TITLE
feat: leaderboard matches the grind theme (#226)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.80.0",
+  "version": "1.81.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/TopAgents.tsx
+++ b/frontend/src/components/dashboard/TopAgents.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Trophy } from "lucide-react";
 import type { AgentRevenue } from "@/lib/metrics/dashboard";
 import type { AgentHonors, LiveStanding } from "@/lib/metrics/agentLeaderboard";
 import { agentPrestige } from "@/lib/metrics/agentLeaderboard";
@@ -12,64 +13,151 @@ interface Props {
 
 const fmtK = (n: number): string => `$${(n / 1000).toFixed(1)}k`;
 
-export const TopAgents = ({ agents, honors, standings }: Props) => {
-  if (agents.length === 0)
-    return (
-      <p className="text-muted-text text-sm">
+// Gold, silver, bronze for the podium (index 0/1/2).
+const MEDAL = [
+  { bg: "#f5b03a", fg: "#3a2400" },
+  { bg: "#c8d0dc", fg: "#2a3040" },
+  { bg: "#c9884a", fg: "#2a1808" },
+];
+
+const Rank = ({ i }: { i: number }) =>
+  i < 3 ? (
+    <span
+      className="font-comic shrink-0 flex items-center justify-center text-[15px]"
+      style={{
+        width: 26,
+        height: 26,
+        borderRadius: "50%",
+        background: MEDAL[i].bg,
+        color: MEDAL[i].fg,
+        border: "2px solid #10151f",
+      }}
+    >
+      {i + 1}
+    </span>
+  ) : (
+    <span
+      className="font-comic shrink-0 text-center text-muted-text text-[15px]"
+      style={{ width: 26 }}
+    >
+      {i + 1}
+    </span>
+  );
+
+const Pulse = () => (
+  <span
+    className="w-1.5 h-1.5 rounded-full bg-amber animate-pulse shrink-0"
+    title="on the board this quarter"
+  />
+);
+
+export const TopAgents = ({ agents, honors, standings }: Props) => (
+  <div
+    className="relative overflow-hidden rounded-2xl border-2 p-4"
+    style={{ background: "#10151f", borderColor: "#e8940a" }}
+  >
+    <div
+      className="absolute top-0 right-0 w-24 h-24 pointer-events-none"
+      style={{
+        backgroundImage: "radial-gradient(#e8940a 1.3px, transparent 1.4px)",
+        backgroundSize: "7px 7px",
+        opacity: 0.12,
+      }}
+    />
+
+    <div className="relative flex items-center gap-2 mb-2.5">
+      <Trophy size={17} style={{ color: "#f5b03a" }} />
+      <span className="font-comic text-xl" style={{ color: "#f5b03a" }}>
+        TOP AGENTS
+      </span>
+      <span className="flex-1" />
+      <span className="text-[10px] text-muted-text">90 days</span>
+    </div>
+
+    {agents.length === 0 ? (
+      <p className="relative text-muted-text text-sm">
         No agents with 2+ loads in the last 90 days.
       </p>
-    );
+    ) : (
+      <div className="relative">
+        {agents.map((agent, i) => {
+          const tier = agentPrestige(honors.get(agent.agentId));
+          const live = standings.get(agent.agentId);
+          const onBoard =
+            !!live &&
+            (live.result === "gold" ||
+              live.result === "silver" ||
+              live.result === "board");
+          const first = i === 0;
 
-  return (
-    <div>
-      {agents.map((agent, i) => {
-        const tier = agentPrestige(honors.get(agent.agentId));
-        const live = standings.get(agent.agentId);
-        const onBoard =
-          live &&
-          (live.result === "gold" ||
-            live.result === "silver" ||
-            live.result === "board");
-        return (
-          <Link
-            key={agent.agentId}
-            to={`/agents/${agent.agentId}`}
-            className="flex items-center gap-2.5 py-1.5 border-t border-[#232c3f] first:border-t-0 hover:opacity-80"
-          >
-            <span
-              className={`w-3.5 text-right font-condensed ${
-                i === 0 ? "text-amber" : "text-muted-text"
-              }`}
-            >
-              {i + 1}
-            </span>
-            <span className="w-[26px] shrink-0 flex justify-center">
-              <PrestigeBurst tier={tier} size={26} />
-            </span>
-            <span
-              className={`flex-1 text-sm truncate ${
-                i === 0 ? "text-amber-light" : "text-light"
-              }`}
-            >
-              {agent.agent}
-            </span>
-            {onBoard && (
-              <span
-                className="w-1.5 h-1.5 rounded-full bg-amber animate-pulse shrink-0"
-                title="on the board this quarter"
-              />
-            )}
-            <span className="text-right shrink-0">
-              <span className="block text-sm font-condensed">
-                {fmtK(agent.revenue)}
+          const inner = (
+            <>
+              <Rank i={i} />
+              <span className="w-[22px] shrink-0 flex justify-center">
+                <PrestigeBurst tier={tier} size={22} />
               </span>
-              <span className="block text-[10px] text-muted-text">
-                {agent.loadCount} loads
+              <span className="flex-1 min-w-0">
+                {first ? (
+                  <span
+                    className="font-comic block truncate leading-none text-[17px]"
+                    style={{ color: "#f5b03a" }}
+                  >
+                    {agent.agent}
+                  </span>
+                ) : (
+                  <span className="block truncate text-sm text-light">
+                    {agent.agent}
+                  </span>
+                )}
+                {first && onBoard && (
+                  <span className="flex items-center gap-1.5 mt-1">
+                    <Pulse />
+                    <span className="text-[9px] text-muted-text">
+                      on the board this quarter
+                    </span>
+                  </span>
+                )}
               </span>
-            </span>
-          </Link>
-        );
-      })}
-    </div>
-  );
-};
+              {!first && onBoard && <Pulse />}
+              <span className="text-right shrink-0">
+                <span
+                  className="font-comic block leading-none"
+                  style={{
+                    fontSize: first ? 19 : 15,
+                    color: first ? "#f5b03a" : i < 3 ? "#e8eef7" : "#9daabb",
+                  }}
+                >
+                  {fmtK(agent.revenue)}
+                </span>
+                {i < 3 && (
+                  <span className="block text-[10px] text-muted-text">
+                    {agent.loadCount} loads
+                  </span>
+                )}
+              </span>
+            </>
+          );
+
+          return first ? (
+            <Link
+              key={agent.agentId}
+              to={`/agents/${agent.agentId}`}
+              className="flex items-center gap-2.5 rounded-[10px] p-2 mb-1 hover:opacity-80"
+              style={{ background: "rgba(232,148,10,0.12)", border: "1px solid #7a4718" }}
+            >
+              {inner}
+            </Link>
+          ) : (
+            <Link
+              key={agent.agentId}
+              to={`/agents/${agent.agentId}`}
+              className="flex items-center gap-2.5 py-2 px-1 border-t border-[#232c3f] hover:opacity-80"
+            >
+              {inner}
+            </Link>
+          );
+        })}
+      </div>
+    )}
+  </div>
+);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -191,16 +191,11 @@ const DashboardPage = () => {
         <div className="lg:col-span-2">
           <RevenueChart data={monthlyRevenue} />
         </div>
-        <div className="bg-plate rounded-lg p-4">
-          <p className="text-xs text-muted-text mb-2">
-            Top 5 agents · last 90 days
-          </p>
-          <TopAgents
-            agents={topAgents}
-            honors={agentHonors}
-            standings={agentStandings}
-          />
-        </div>
+        <TopAgents
+          agents={topAgents}
+          honors={agentHonors}
+          standings={agentStandings}
+        />
       </div>
 
       {/* RPM chart + what's next */}


### PR DESCRIPTION
## v1.81.0 — leaderboard in the grind theme

Restyles the dashboard **Top Agents** leaderboard to match the grind meter above it and stand out:

- Amber `border-2` + halftone dots + `font-comic` **"TOP AGENTS"** header
- **Gold/silver/bronze** podium medallions; **#1 crowned** in an amber-tinted row
- Revenue in the comic font; prestige starburst + "on the board" pulse carry over; #4–5 stay quiet
- Card styling folded into the component (plain dashboard wrapper removed)

Frontend-only. Build clean, **257 tests**.

Closes #226