### PR TITLE
feat: Layered design system — primitives + dashboard adoption (#123)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.82.0",
+  "version": "1.83.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/KpiCard.tsx
+++ b/frontend/src/components/KpiCard.tsx
@@ -1,3 +1,6 @@
+import { Panel } from "@/components/ui/Panel";
+import { Sparkline } from "@/components/ui/Sparkline";
+
 type Status = "good" | "bad" | "neutral";
 
 interface Delta {
@@ -10,7 +13,8 @@ interface Props {
   value: string; // pre-formatted display string (currency, %, etc.)
   status?: Status; // colors the value (good=green, bad=red, neutral=default)
   delta?: Delta | null; // optional "▲12% vs last month"
-  subtext?: string; // optional small line under value (e.g. "above $4.66 break-even")
+  subtext?: string; // optional small line under value
+  trend?: number[]; // optional sparkline series
 }
 
 const statusColor: Record<Status, string> = {
@@ -19,36 +23,42 @@ const statusColor: Record<Status, string> = {
   neutral: "text-light",
 };
 
+const sparkColor: Record<Status, string> = {
+  good: "#4ade80",
+  bad: "#f87171",
+  neutral: "#60a5fa",
+};
+
 export const KpiCard = ({
   label,
   value,
   status = "neutral",
   delta,
   subtext,
-}: Props) => {
-  return (
-    <div className="bg-steel rounded-lg p-4 flex flex-col gap-1">
-      <p className="text-xs uppercase tracking-wider text-muted-text">
-        {label}
-      </p>
-      <p className={`text-2xl font-condensed ${statusColor[status]}`}>
-        {value}
-      </p>
-
-      {delta && (
-        <p
-          className={`text-xs ${
-            delta.direction === "up"
-              ? "text-status-positive-text"
-              : "text-status-negative-text"
-          }`}
-        >
-          {delta.direction === "up" ? "▲" : "▼"}{" "}
-          {Math.abs(delta.percent).toFixed(0)}% vs last month
-        </p>
+  trend,
+}: Props) => (
+  <Panel variant="default" interactive className="p-4 flex flex-col gap-1">
+    <div className="flex items-start justify-between gap-2">
+      <p className="text-xs uppercase tracking-wider text-muted-text">{label}</p>
+      {trend && trend.length >= 2 && (
+        <Sparkline data={trend} color={sparkColor[status]} />
       )}
-
-      {subtext && <p className="text-xs text-muted-text">{subtext}</p>}
     </div>
-  );
-};
+    <p className={`text-2xl font-condensed ${statusColor[status]}`}>{value}</p>
+
+    {delta && (
+      <p
+        className={`text-xs ${
+          delta.direction === "up"
+            ? "text-status-positive-text"
+            : "text-status-negative-text"
+        }`}
+      >
+        {delta.direction === "up" ? "▲" : "▼"}{" "}
+        {Math.abs(delta.percent).toFixed(0)}% vs last month
+      </p>
+    )}
+
+    {subtext && <p className="text-xs text-muted-text">{subtext}</p>}
+  </Panel>
+);

--- a/frontend/src/components/OutstandingLoadsList.tsx
+++ b/frontend/src/components/OutstandingLoadsList.tsx
@@ -3,6 +3,8 @@ import {
   getOutstandingSummary,
   type OutstandingLoad,
 } from "@/lib/metrics/dashboard";
+import { Panel } from "@/components/ui/Panel";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 interface Props {
   loads: OutstandingLoad[];
@@ -27,7 +29,7 @@ export const OutstandingLoadsList = ({ loads }: Props) => {
     getOutstandingSummary(loads);
 
   return (
-    <div className="bg-plate rounded-lg p-4">
+    <Panel variant="panel" className="p-4">
       <div className="flex items-baseline justify-between mb-4">
         <h3 className="text-sm font-medium text-light">Outstanding loads</h3>
         <span className="text-sm text-status-aware-text font-medium">
@@ -50,9 +52,7 @@ export const OutstandingLoadsList = ({ loads }: Props) => {
       </div>
 
       {loads.length === 0 ? (
-        <p className="text-sm text-muted-text italic py-4">
-          Nothing outstanding — all paid up.
-        </p>
+        <EmptyState title="All paid up" hint="Nothing outstanding — clean books." />
       ) : (
         <div className="flex flex-col gap-2">
           {loads.map((load) => (
@@ -74,6 +74,6 @@ export const OutstandingLoadsList = ({ loads }: Props) => {
           ))}
         </div>
       )}
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/RevenueChart.tsx
+++ b/frontend/src/components/RevenueChart.tsx
@@ -9,6 +9,7 @@ import {
   ReferenceLine,
   Cell,
 } from "recharts";
+import { Panel } from "@/components/ui/Panel";
 
 interface MonthlyRevenue {
   month: string; // "2026-06"
@@ -41,7 +42,7 @@ const GRID = "#2a3347";
 
 export const RevenueChart = ({ data, target }: Props) => {
   return (
-    <div className="bg-plate rounded-lg p-4">
+    <Panel className="p-4">
       <h3 className="text-sm font-medium mb-1 text-light">Revenue over time</h3>
       <p className="text-xs text-muted-text mb-4">
         Monthly gross{target ? " · dashed line = target" : ""}
@@ -99,6 +100,6 @@ export const RevenueChart = ({ data, target }: Props) => {
           </Bar>
         </BarChart>
       </ResponsiveContainer>
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/RpmChart.tsx
+++ b/frontend/src/components/RpmChart.tsx
@@ -8,6 +8,7 @@ import {
   ResponsiveContainer,
   ReferenceLine,
 } from "recharts";
+import { Panel } from "@/components/ui/Panel";
 
 interface MonthlyRpm {
   month: string; // "2026-06"
@@ -35,7 +36,7 @@ const GRID = "#2a3347";
 
 export const RpmChart = ({ data, breakEven }: Props) => {
   return (
-    <div className="bg-plate rounded-lg p-4">
+    <Panel className="p-4">
       <h3 className="text-sm font-medium mb-1 text-light">RPM vs break-even</h3>
       <p className="text-xs text-muted-text mb-4">
         Blended monthly rate · red line = ${breakEven.toFixed(2)} break-even
@@ -97,6 +98,6 @@ export const RpmChart = ({ data, breakEven }: Props) => {
           />
         </LineChart>
       </ResponsiveContainer>
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -1,5 +1,6 @@
 import type { useRateTargets } from "@/hooks/useRateTargets";
 import { RateLadder } from "./RateLadder";
+import { Panel } from "@/components/ui/Panel";
 
 type Targets = ReturnType<typeof useRateTargets>;
 
@@ -153,7 +154,7 @@ export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
     weekEarned >= gross.weeklyTarget;
 
   return (
-    <div className="bg-plate rounded-lg p-4">
+    <Panel className="p-4">
       <div className="flex justify-between items-baseline mb-3">
         <p className="text-sm font-medium text-light">Rate &amp; pace targets</p>
         <p className="text-xs text-muted-text">
@@ -235,6 +236,6 @@ export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
           </div>
         </div>
       )}
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+// A little flatbed on an open road — the character piece for "nothing here yet".
+const TruckRoad = () => (
+  <svg width="132" height="66" viewBox="0 0 132 66" className="mx-auto" aria-hidden="true">
+    {/* horizon glow */}
+    <circle cx="104" cy="30" r="13" fill="#e8940a" opacity="0.12" />
+    {/* road */}
+    <line x1="8" y1="54" x2="124" y2="54" stroke="#3a4459" strokeWidth="2.5" strokeLinecap="round" />
+    <line
+      x1="14"
+      y1="54"
+      x2="118"
+      y2="54"
+      stroke="#5b6b82"
+      strokeWidth="2"
+      strokeDasharray="6 9"
+      strokeLinecap="round"
+      opacity="0.55"
+    />
+    {/* trailer bed */}
+    <rect x="20" y="36" width="44" height="11" rx="1.5" fill="#2a3347" stroke="#4a5570" strokeWidth="1" />
+    <rect x="20" y="43" width="44" height="2" fill="#e8940a" opacity="0.75" />
+    {/* cab */}
+    <path d="M66 47 V31 h7 l6 8 v8 Z" fill="#9daabb" />
+    <rect x="67.5" y="32.5" width="5.5" height="5.5" rx="1" fill="#60a5fa" opacity="0.55" />
+    {/* wheels */}
+    <circle cx="31" cy="48" r="4.2" fill="#0d1117" stroke="#5b6b82" strokeWidth="1.3" />
+    <circle cx="55" cy="48" r="4.2" fill="#0d1117" stroke="#5b6b82" strokeWidth="1.3" />
+    <circle cx="72" cy="48" r="4.2" fill="#0d1117" stroke="#5b6b82" strokeWidth="1.3" />
+  </svg>
+);
+
+interface Props {
+  title: string;
+  hint?: ReactNode;
+  icon?: ReactNode; // override the default illustration
+}
+
+export const EmptyState = ({ title, hint, icon }: Props) => (
+  <div className="text-center py-8 px-4">
+    {icon ?? <TruckRoad />}
+    <p className="text-light font-condensed text-lg mt-3">{title}</p>
+    {hint && <p className="text-muted-text text-sm mt-1">{hint}</p>}
+  </div>
+);

--- a/frontend/src/components/ui/Panel.tsx
+++ b/frontend/src/components/ui/Panel.tsx
@@ -1,0 +1,33 @@
+import type { HTMLAttributes } from "react";
+
+export type PanelVariant = "default" | "panel" | "hero";
+
+const VARIANT: Record<PanelVariant, string> = {
+  default: "ds-panel--default", // lifted — the everyday card
+  panel: "ds-panel--steel", // structural / industrial
+  hero: "ds-panel--hero", // comic — for wins & highlights
+};
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  variant?: PanelVariant;
+  interactive?: boolean; // hover-lift + press feedback
+}
+
+// The layered surface primitive. One place for the app's card depth, so every
+// panel reads as part of one system.
+export const Panel = ({
+  variant = "default",
+  interactive = false,
+  className = "",
+  children,
+  ...rest
+}: Props) => (
+  <div
+    className={`ds-panel ${VARIANT[variant]} ${
+      interactive ? "ds-panel--interactive" : ""
+    } ${className}`}
+    {...rest}
+  >
+    {children}
+  </div>
+);

--- a/frontend/src/components/ui/Sparkline.tsx
+++ b/frontend/src/components/ui/Sparkline.tsx
@@ -1,0 +1,36 @@
+interface Props {
+  data: number[];
+  color?: string;
+  width?: number;
+  height?: number;
+}
+
+// A tiny trend line for KPI cards — a light area under a stroked line. Renders
+// nothing with fewer than two points, so callers can pass it unconditionally.
+export const Sparkline = ({
+  data,
+  color = "#60a5fa",
+  width = 64,
+  height = 20,
+}: Props) => {
+  if (!data || data.length < 2) return null;
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const x = (i: number) => (i / (data.length - 1)) * width;
+  const y = (v: number) => height - 2 - ((v - min) / range) * (height - 4);
+  const line = data.map((v, i) => `${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(" ");
+  return (
+    <svg width={width} height={height} className="block" aria-hidden="true">
+      <polygon points={`${line} ${width},${height} 0,${height}`} fill={color} opacity={0.12} />
+      <polyline
+        points={line}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-accent", className)}
+      className={cn("ds-skeleton", className)}
       {...props}
     />
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -202,3 +202,51 @@
   from { transform: translateX(40px); opacity: 0; }
   to { transform: translateX(0); opacity: 1; }
 }
+
+/* ===== Design system — layered panels + primitives ===== */
+.ds-panel { position: relative; border-radius: 13px; }
+.ds-panel--default {
+  background: linear-gradient(180deg, #313b53, #262f42);
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.42);
+}
+.ds-panel--steel {
+  background: linear-gradient(160deg, #37415a 0%, #2a3347 45%, #242c3e 100%);
+  border-top: 1px solid rgba(255, 255, 255, 0.11);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.5);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.45);
+}
+.ds-panel--hero {
+  background: #2a3347;
+  border: 2px solid #e8940a;
+  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.42);
+}
+.ds-panel--hero::before {
+  content: "";
+  position: absolute; top: 0; right: 0;
+  width: 72px; height: 72px;
+  background-image: radial-gradient(#e8940a 1.3px, transparent 1.4px);
+  background-size: 7px 7px;
+  opacity: 0.13; pointer-events: none;
+  border-top-right-radius: inherit;
+}
+.ds-panel--interactive { transition: transform 0.15s ease, box-shadow 0.15s ease; }
+.ds-panel--interactive:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.55);
+}
+.ds-panel--interactive:active {
+  transform: translateY(0);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+@keyframes ds-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+.ds-skeleton {
+  background: linear-gradient(90deg, #2a3347 25%, #384259 50%, #2a3347 75%);
+  background-size: 200% 100%;
+  animation: ds-shimmer 1.4s ease-in-out infinite;
+  border-radius: 6px;
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3,6 +3,8 @@ import { useLoads } from "@/hooks/useLoads";
 import { useTrips } from "@/hooks/useTrips";
 import { Link } from "react-router-dom";
 import { KpiCard } from "@/components/KpiCard";
+import { Panel } from "@/components/ui/Panel";
+import { Skeleton } from "@/components/ui/skeleton";
 import { BREAK_EVEN_RPM, DEADHEAD_TARGET } from "@/lib/constants/targets";
 import {
   getRevenueMTD,
@@ -84,8 +86,18 @@ const DashboardPage = () => {
 
   if (isLoading)
     return (
-      <div className="p-6 bg-iron text-light min-h-screen">
-        <p className="text-muted-text">Loading dashboard...</p>
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <Skeleton className="h-8 w-40 mb-6" />
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-24" style={{ borderRadius: 13 }} />
+          ))}
+        </div>
+        <Skeleton className="h-28 mt-6" style={{ borderRadius: 13 }} />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-6">
+          <Skeleton className="h-56 lg:col-span-2" style={{ borderRadius: 13 }} />
+          <Skeleton className="h-56" style={{ borderRadius: 13 }} />
+        </div>
       </div>
     );
 
@@ -108,6 +120,10 @@ const DashboardPage = () => {
   const loadsDelta = computeDelta(loadsMonthly.thisMonth, loadsMonthly.lastMonth);
   const monthlyRevenue = getMonthlyRevenue(loads);
   const monthlyRpm = getMonthlyRPM(loads);
+  const revenueTrend = monthlyRevenue.map((d) => d.revenue);
+  const rpmTrend = monthlyRpm
+    .map((d) => d.rpm)
+    .filter((r): r is number => r != null);
   const outstanding = getOutstandingLoads(loads);
   const topAgents = getTopAgentsByRevenue(loads);
   const now = new Date();
@@ -152,11 +168,16 @@ const DashboardPage = () => {
           value={formatCurrency(revenueMTD)}
           delta={mtdDelta}
         />
-        <KpiCard label="Net revenue · YTD" value={formatCurrency(revenueYTD)} />
+        <KpiCard
+          label="Net revenue · YTD"
+          value={formatCurrency(revenueYTD)}
+          trend={revenueTrend}
+        />
         <KpiCard
           label="Net RPM · 3mo"
           value={formatRpm(avgRpm)}
           status={rpmStatus}
+          trend={rpmTrend}
           subtext={
             avgRpm === null
               ? undefined
@@ -203,18 +224,18 @@ const DashboardPage = () => {
         <div className="lg:col-span-2">
           <RpmChart data={monthlyRpm} breakEven={liveBreakEven} />
         </div>
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <p className="text-xs text-muted-text mb-2">What's next · booked</p>
           <WhatsNext loads={upcoming} />
-        </div>
+        </Panel>
       </div>
 
       {/* Recent loads + outstanding */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <p className="text-xs text-muted-text mb-2">Recent loads</p>
           <RecentLoads loads={recentLoads} />
-        </div>
+        </Panel>
         <OutstandingLoadsList loads={outstanding} />
       </div>
     </div>


### PR DESCRIPTION
## v1.83.0 — #123 design system (first pass)

Built around the **Layered** direction, with the polish four baked in. Every existing token kept — the change is **depth**.

### Primitives (`components/ui`)
- **`Panel`** — layered surface: `default` (lifted) / `panel` (steel) / `hero` (comic), plus `interactive` = hover-lift + press.
- **`Skeleton`** — shimmer sweep.
- **`Sparkline`** — tiny KPI trend line.
- **`EmptyState`** — flatbed-on-an-open-road illustration + copy.
- Depth/shimmer tokens in `index.css`.

### Dashboard adoption (proof surface)
- KPI cards → **lifted interactive panels** with **sparklines** on Net revenue + RPM.
- Rate/pace + charts on lifted panels; **Outstanding** on the steel panel; grind + leaderboard stay comic **hero** → the hierarchy reads.
- Loading → **shimmer skeleton**; "all paid up" → **character empty state**.

Rollout to fleet/detail/loads pages is the next pass (fast now the primitives exist). Frontend-only. Build clean, **257 tests**.

Closes #123