### PR TITLE
feat: roll the Layered design system across the app

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.83.0",
+  "version": "1.84.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/Kpi.tsx
+++ b/frontend/src/components/Kpi.tsx
@@ -1,4 +1,6 @@
 // Shared KPI card in the coherent theme (bg-plate, muted label, condensed value).
+import { Panel } from "@/components/ui/Panel";
+
 export const Kpi = ({
   label,
   value,
@@ -10,9 +12,9 @@ export const Kpi = ({
   sub?: string;
   valueClass?: string;
 }) => (
-  <div className="bg-plate rounded-lg p-4">
+  <Panel className="p-4">
     <p className="text-xs text-muted-text">{label}</p>
     <p className={`text-2xl font-condensed mt-1 ${valueClass}`}>{value}</p>
     {sub && <p className="text-xs text-muted-text mt-1">{sub}</p>}
-  </div>
+  </Panel>
 );

--- a/frontend/src/components/TripForm.tsx
+++ b/frontend/src/components/TripForm.tsx
@@ -4,6 +4,7 @@ import { createTrip, getLatestOdometer } from "@/services/tripsService";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Panel } from "@/components/ui/Panel";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -88,7 +89,7 @@ const TripForm = ({ onSuccess, onClose }: TripFormProps) => {
   };
 
   return (
-    <div className="bg-plate rounded p-6 mb-6">
+    <Panel className="p-6 mb-6">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-xl font-condensed text-light">Log Trip</h2>
         <button onClick={onClose} className="text-muted-text hover:text-light">
@@ -197,7 +198,7 @@ const TripForm = ({ onSuccess, onClose }: TripFormProps) => {
           Cancel
         </Button>
       </div>
-    </div>
+    </Panel>
   );
 };
 

--- a/frontend/src/components/agents/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard.tsx
@@ -55,7 +55,7 @@ export const AgentCard = ({
   return (
     <Link
       to={`/agents/${agent.agent_id}`}
-      className="relative overflow-hidden block bg-plate border border-[#3b4660] rounded-lg p-3.5 hover:border-amber transition-colors"
+      className="relative overflow-hidden block ds-panel ds-panel--default ds-panel--interactive border border-[#3b4660] p-3.5 hover:border-amber transition-colors"
     >
       <PrestigeBadge tier={tier} />
 

--- a/frontend/src/components/compliance/ComplianceItemForm.tsx
+++ b/frontend/src/components/compliance/ComplianceItemForm.tsx
@@ -4,6 +4,7 @@ import type {
   ComplianceItemInput,
   ComplianceScope,
 } from "@/types/compliance";
+import { Panel } from "@/components/ui/Panel";
 
 const inputCls = "bg-steel rounded px-2 py-1.5 text-sm w-full text-light";
 const lbl = "text-xs text-muted-text mb-1 block";
@@ -108,7 +109,7 @@ export const ComplianceItemForm = ({
   };
 
   return (
-    <div className="bg-steel rounded-lg p-3 mt-2">
+    <Panel variant="panel" className="p-3 mt-2">
       {!initial && (
         <div className="mb-3">
           <label className={lbl}>Start from a common doc</label>
@@ -206,6 +207,6 @@ export const ComplianceItemForm = ({
           Cancel
         </button>
       </div>
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/expenses/ExpenseUpload.tsx
+++ b/frontend/src/components/expenses/ExpenseUpload.tsx
@@ -10,6 +10,7 @@ import {
   saveExpensePeriod,
 } from "@/services/expensesService";
 import type { ExpenseType } from "@/types/expense";
+import { Panel } from "@/components/ui/Panel";
 
 interface Props {
   onSaved: () => void;
@@ -75,7 +76,7 @@ export const ExpenseUpload = ({ onSaved, onCancel }: Props) => {
   };
 
   return (
-    <div className="bg-plate rounded-lg p-4 mb-6">
+    <Panel className="p-4 mb-6">
       {!proposed ? (
         <div>
           <p className="text-sm text-light mb-2">
@@ -158,6 +159,6 @@ export const ExpenseUpload = ({ onSaved, onCancel }: Props) => {
         </div>
       )}
       {error && <p className="text-destructive text-sm mt-2">{error}</p>}
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/expenses/ExpenseYtdChart.tsx
+++ b/frontend/src/components/expenses/ExpenseYtdChart.tsx
@@ -9,6 +9,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { ExpensePeriod } from "@/types/expense";
+import { Panel } from "@/components/ui/Panel";
 
 interface Datum {
   month: string;
@@ -76,7 +77,7 @@ export const ExpenseYtdChart = ({
   if (data.length === 0) return null;
 
   return (
-    <div className="bg-plate rounded-lg p-4" style={{ height: 280 }}>
+    <Panel className="p-4" style={{ height: 280 }}>
       <p className="text-xs text-muted-text mb-2">
         Revenue vs {obligationsTotal > 0 ? "true cost" : "cost"} · year to date
       </p>
@@ -117,6 +118,6 @@ export const ExpenseYtdChart = ({
           />
         </LineChart>
       </ResponsiveContainer>
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/expenses/ObligationsCard.tsx
+++ b/frontend/src/components/expenses/ObligationsCard.tsx
@@ -6,6 +6,7 @@ import {
   patchObligation,
   deleteObligation,
 } from "@/services/obligationsService";
+import { Panel } from "@/components/ui/Panel";
 
 interface Props {
   items: Obligation[];
@@ -52,7 +53,7 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
     .reduce((s, o) => s + o.amount, 0);
 
   return (
-    <div className="bg-plate rounded-lg p-4 mb-6">
+    <Panel className="p-4 mb-6">
       <div className="flex justify-between items-start mb-1">
         <p className="text-xs text-muted-text">
           Monthly obligations · cash out that's not on your P&amp;L
@@ -316,6 +317,6 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
         </tbody>
       </table>
       {error && <p className="text-destructive text-sm mt-2">{error}</p>}
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/fleet/EntityForm.tsx
+++ b/frontend/src/components/fleet/EntityForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Check, X } from "lucide-react";
+import { Panel } from "@/components/ui/Panel";
 
 export interface FormField {
   name: string;
@@ -49,7 +50,7 @@ export const EntityForm = ({
   };
 
   return (
-    <div className="bg-plate rounded-lg p-4 mb-4">
+    <Panel className="p-4 mb-4">
       <p className="text-sm font-medium mb-3">{title}</p>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
         {fields.map((f) => (
@@ -100,6 +101,6 @@ export const EntityForm = ({
           <X size={15} /> Cancel
         </button>
       </div>
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/fuel/DieselCompareCard.tsx
+++ b/frontend/src/components/fuel/DieselCompareCard.tsx
@@ -1,5 +1,6 @@
 import type { NationalDiesel } from "@/types/fuelEntry";
 import { Stamp } from "@/components/Stamp";
+import { Panel } from "@/components/ui/Panel";
 
 const money3 = (n: number) => `$${n.toFixed(3)}`;
 
@@ -28,7 +29,7 @@ export const DieselCompareCard = ({
   const deltaColor = delta == null ? "#9daabb" : under ? "#4ade80" : "#e8940a";
 
   return (
-    <div className="bg-plate rounded-lg p-4 mt-4">
+    <Panel className="p-4 mt-4">
       <div className="flex items-start justify-between gap-3 flex-wrap">
         <div>
           <p className="text-xs text-muted-text uppercase tracking-wider">
@@ -66,6 +67,6 @@ export const DieselCompareCard = ({
           </p>
         </div>
       </div>
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/fuel/MpgChart.tsx
+++ b/frontend/src/components/fuel/MpgChart.tsx
@@ -8,6 +8,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { MpgWindow } from "@/lib/metrics/fuelEconomy";
+import { Panel } from "@/components/ui/Panel";
 
 const fmtDate = (d: string) =>
   new Date(d.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", {
@@ -17,7 +18,7 @@ const fmtDate = (d: string) =>
   });
 
 export const MpgChart = ({ windows }: { windows: MpgWindow[] }) => (
-  <div className="bg-plate rounded-lg p-4">
+  <Panel className="p-4">
     <h3 className="text-sm font-medium mb-1 text-light">MPG per tank</h3>
     <p className="text-xs text-muted-text mb-4">One point per full tank</p>
     {windows.length === 0 ? (
@@ -66,5 +67,5 @@ export const MpgChart = ({ windows }: { windows: MpgWindow[] }) => (
         </LineChart>
       </ResponsiveContainer>
     )}
-  </div>
+  </Panel>
 );

--- a/frontend/src/components/fuel/WeeklyCostChart.tsx
+++ b/frontend/src/components/fuel/WeeklyCostChart.tsx
@@ -9,6 +9,7 @@ import {
   ReferenceLine,
 } from "recharts";
 import type { WeekCost } from "@/lib/metrics/fuelEconomy";
+import { Panel } from "@/components/ui/Panel";
 
 const fmtWeek = (d: string) =>
   new Date(d + "T00:00:00Z").toLocaleDateString("en-US", {
@@ -26,7 +27,7 @@ export const WeeklyCostChart = ({
   data: WeekCost[];
   avg: number | null;
 }) => (
-  <div className="bg-plate rounded-lg p-4">
+  <Panel className="p-4">
     <h3 className="text-sm font-medium mb-1 text-light">Weekly fuel cost</h3>
     <p className="text-xs text-muted-text mb-4">
       Spend per week{avg != null ? " · dashed = 90-day avg" : ""}
@@ -84,5 +85,5 @@ export const WeeklyCostChart = ({
         </BarChart>
       </ResponsiveContainer>
     )}
-  </div>
+  </Panel>
 );

--- a/frontend/src/components/lanes/LanesKpis.tsx
+++ b/frontend/src/components/lanes/LanesKpis.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Flame, Truck, Crown } from "lucide-react";
 import type { LanesSummary } from "@/lib/metrics/lanes";
 import { fmtRpm, rpmTextClass } from "./rpmStyle";
+import { Panel } from "@/components/ui/Panel";
 
 interface Props {
   summary: LanesSummary;
@@ -22,7 +23,7 @@ const Card = ({
   blended: number | null; // revenue-weighted — the quiet sub-line
   loads: number;
 }) => (
-  <div className="bg-plate rounded-lg p-4">
+  <Panel className="p-4">
     <p className="text-xs text-muted-text flex items-center gap-1.5">
       {icon}
       {label}
@@ -38,18 +39,18 @@ const Card = ({
         blended {fmtRpm(blended)}
       </p>
     )}
-  </div>
+  </Panel>
 );
 
 const EmptyCard = ({ label, icon }: { label: string; icon: ReactNode }) => (
-  <div className="bg-plate rounded-lg p-4">
+  <Panel className="p-4">
     <p className="text-xs text-muted-text flex items-center gap-1.5">
       {icon}
       {label}
     </p>
     <p className="text-base font-condensed text-muted-text mt-1">—</p>
     <p className="text-sm text-muted-text mt-1">not enough data</p>
-  </div>
+  </Panel>
 );
 
 const FLAME = <Flame size={14} style={{ color: "#e8621e" }} />;

--- a/frontend/src/components/lanes/LanesMap.tsx
+++ b/frontend/src/components/lanes/LanesMap.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import { Flame } from "lucide-react";
+import { Panel } from "@/components/ui/Panel";
 import { geoAlbersUsa, geoPath } from "d3-geo";
 import { feature } from "topojson-client";
 import type { FeatureCollection, Geometry } from "geojson";
@@ -72,7 +73,7 @@ export const LanesMap = ({ data, windowDays }: Props) => {
   };
 
   return (
-    <div ref={containerRef} className="bg-plate rounded-lg p-4 relative">
+    <Panel ref={containerRef} className="p-4 relative">
       <p className="text-xs text-muted-text mb-2 flex items-center gap-1 flex-wrap">
         Footprint · shaded by loads ·
         <Flame size={12} style={{ color: "#e8621e" }} /> best-paying states ·
@@ -148,6 +149,6 @@ export const LanesMap = ({ data, windowDays }: Props) => {
           )}
         </div>
       )}
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/maintenance/HealthGauge.tsx
+++ b/frontend/src/components/maintenance/HealthGauge.tsx
@@ -1,5 +1,6 @@
 import { Truck } from "lucide-react";
 import { fleetHealth } from "@/lib/metrics/maintenance";
+import { Panel } from "@/components/ui/Panel";
 
 const rad = (deg: number) => (deg * Math.PI) / 180;
 // Score 0–100 maps across the 180° dial (180° left → 0° right).
@@ -29,7 +30,7 @@ export const HealthGauge = ({ counts }: { counts: Counts }) => {
   const n = needle(h.score ?? 0);
 
   return (
-    <div className="bg-plate rounded-lg p-4 flex gap-5 items-center flex-wrap mb-4">
+    <Panel className="p-4 flex gap-5 items-center flex-wrap mb-4">
       <svg viewBox="0 0 200 116" width={180} height={104} className="shrink-0">
         <path
           d="M20,100 A80,80 0 0 1 124.7,23.9"
@@ -89,6 +90,6 @@ export const HealthGauge = ({ counts }: { counts: Counts }) => {
           {counts.unknown > 0 && chip(counts.unknown, "no baseline", "#9daabb")}
         </div>
       </div>
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/maintenance/MaintenanceItemForm.tsx
+++ b/frontend/src/components/maintenance/MaintenanceItemForm.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Check, X } from "lucide-react";
 import type { MaintenanceItem, MaintenanceUnit } from "@/types/maintenance";
 import type { ItemInput } from "@/services/maintenanceService";
+import { Panel } from "@/components/ui/Panel";
 
 const CATEGORIES = ["engine", "chassis", "brakes", "compliance", "trailer", "other"];
 
@@ -49,7 +50,7 @@ export const MaintenanceItemForm = ({
   };
 
   return (
-    <div className="bg-plate rounded-lg p-4 mb-4">
+    <Panel className="p-4 mb-4">
       <p className="text-sm font-medium mb-3">
         {initial ? "Edit item" : "New maintenance item"}
       </p>
@@ -166,6 +167,6 @@ export const MaintenanceItemForm = ({
           <X size={15} /> Cancel
         </button>
       </div>
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/maintenance/ScheduleTab.tsx
+++ b/frontend/src/components/maintenance/ScheduleTab.tsx
@@ -12,6 +12,7 @@ import { computeDue, type Due, type DueLevel } from "@/lib/metrics/maintenance";
 import { MaintenanceItemForm } from "./MaintenanceItemForm";
 import { HealthGauge } from "./HealthGauge";
 import { Stamp } from "@/components/Stamp";
+import { Panel } from "@/components/ui/Panel";
 
 interface Props {
   items: MaintenanceItem[];
@@ -122,7 +123,7 @@ export const ScheduleTab = ({
 
   if (items.length === 0 && !showForm) {
     return (
-      <div className="bg-plate rounded-lg p-6 text-center">
+      <Panel className="p-6 text-center">
         <p className="text-muted-text mb-4">
           No maintenance schedule yet. Load the starter schedule for your LT625 +
           X15 (severe-duty intervals you can tune), or add items yourself.
@@ -146,7 +147,7 @@ export const ScheduleTab = ({
             Add item
           </button>
         </div>
-      </div>
+      </Panel>
     );
   }
 
@@ -251,7 +252,7 @@ export const ScheduleTab = ({
           if (group.length === 0) return null;
           group.sort((a, b) => (b.due.progress ?? 0) - (a.due.progress ?? 0));
           return (
-            <div key={section} className="bg-plate rounded-lg p-4 mb-4">
+            <Panel key={section} className="p-4 mb-4">
               <p className="text-sm font-medium mb-1">
                 {section}{" "}
                 <span className="text-xs text-muted-text">· {group.length}</span>
@@ -259,11 +260,11 @@ export const ScheduleTab = ({
               {group.map(({ item, due }) => (
                 <ItemRow key={item.item_id} item={item} due={due} />
               ))}
-            </div>
+            </Panel>
           );
         })
       ) : (
-        <div className="bg-plate rounded-lg p-4 overflow-x-auto">
+        <Panel className="p-4 overflow-x-auto">
           <table className="w-full text-sm min-w-[560px] [&_th]:pr-4 [&_td]:pr-4 [&_th:last-child]:pr-0 [&_td:last-child]:pr-0">
             <thead>
               <tr className="text-xs text-muted-text text-left">
@@ -297,7 +298,7 @@ export const ScheduleTab = ({
                 ))}
             </tbody>
           </table>
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/frontend/src/components/maintenance/ServiceForm.tsx
+++ b/frontend/src/components/maintenance/ServiceForm.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Check, X } from "lucide-react";
 import type { MaintenanceItem, ServiceUnit } from "@/types/maintenance";
 import type { ServiceInput } from "@/services/maintenanceService";
+import { Panel } from "@/components/ui/Panel";
 
 const field = "bg-steel rounded px-2 py-1 text-sm w-full";
 const lbl = "text-xs text-muted-text mb-1 block";
@@ -64,7 +65,7 @@ export const ServiceForm = ({
   );
 
   return (
-    <div className="bg-plate rounded-lg p-4 mb-4">
+    <Panel className="p-4 mb-4">
       <p className="text-sm font-medium mb-3">Log service</p>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3">
         <div>
@@ -216,6 +217,6 @@ export const ServiceForm = ({
           <X size={15} /> Cancel
         </button>
       </div>
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/maintenance/ServicesTab.tsx
+++ b/frontend/src/components/maintenance/ServicesTab.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/services/maintenanceService";
 import { ServiceForm } from "./ServiceForm";
 import { Stamp } from "@/components/Stamp";
+import { Panel } from "@/components/ui/Panel";
 
 interface Props {
   services: MaintenanceService[];
@@ -175,10 +176,10 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
       </div>
 
       {justLogged && (
-        <div className="flex items-center gap-3 bg-plate rounded-lg p-3 mb-3">
+        <Panel className="flex items-center gap-3 p-3 mb-3">
           <Stamp label="Done!" color="#1d9e75" />
           <span className="text-sm text-muted-text">Service logged.</span>
-        </div>
+        </Panel>
       )}
 
       {error && <p className="text-destructive text-sm mb-3">{error}</p>}
@@ -192,7 +193,7 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
         />
       )}
 
-      <div className="bg-plate rounded-lg p-3 mb-4">
+      <Panel className="p-3 mb-4">
         <div className="flex flex-wrap items-center gap-2">
           {PRESETS.map(([key, label]) => (
             <button
@@ -244,10 +245,10 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
             </div>
           </div>
         )}
-      </div>
+      </Panel>
 
       {vendors.length > 0 && (
-        <div className="bg-plate rounded-lg p-4 mb-4">
+        <Panel className="p-4 mb-4">
           <p className="text-xs text-muted-text mb-2">Vendor pricing</p>
           <table className="w-full text-sm">
             <thead>
@@ -271,7 +272,7 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
               ))}
             </tbody>
           </table>
-        </div>
+        </Panel>
       )}
 
       {filtered.length === 0 ? (
@@ -281,7 +282,7 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
             : "No services in this month range."}
         </p>
       ) : (
-        <div className="bg-plate rounded-lg p-4 overflow-x-auto">
+        <Panel className="p-4 overflow-x-auto">
           <table className="w-full text-sm min-w-[720px] [&_th]:pr-5 [&_td]:pr-5 [&_th:last-child]:pr-0 [&_td:last-child]:pr-0">
             <thead>
               <tr className="text-xs text-muted-text text-left">
@@ -340,7 +341,7 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
               ))}
             </tbody>
           </table>
-        </div>
+        </Panel>
       )}
     </div>
   );

--- a/frontend/src/components/settings/AccessorialRatesCard.tsx
+++ b/frontend/src/components/settings/AccessorialRatesCard.tsx
@@ -6,6 +6,7 @@ import {
   upsertAccessorialRate,
   deleteAccessorialRate,
 } from "@/services/accessorialRateService";
+import { Panel } from "@/components/ui/Panel";
 
 const errText = (e: unknown): string =>
   (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
@@ -75,7 +76,7 @@ export const AccessorialRatesCard = () => {
   };
 
   return (
-    <div className="mt-6 max-w-[680px] bg-plate rounded-lg p-5">
+    <Panel className="mt-6 max-w-[680px] p-5">
       <h2 className="text-lg font-medium text-light">Accessorial rates</h2>
       <p className="text-sm text-muted-text mt-1">
         What you keep of each accessorial charge. These feed your net revenue and
@@ -156,6 +157,6 @@ export const AccessorialRatesCard = () => {
           {err && <p className="text-destructive text-sm mt-3">{err}</p>}
         </div>
       )}
-    </div>
+    </Panel>
   );
 };

--- a/frontend/src/components/ui/Panel.tsx
+++ b/frontend/src/components/ui/Panel.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from "react";
+import { forwardRef, type HTMLAttributes } from "react";
 
 export type PanelVariant = "default" | "panel" | "hero";
 
@@ -14,20 +14,19 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 }
 
 // The layered surface primitive. One place for the app's card depth, so every
-// panel reads as part of one system.
-export const Panel = ({
-  variant = "default",
-  interactive = false,
-  className = "",
-  children,
-  ...rest
-}: Props) => (
-  <div
-    className={`ds-panel ${VARIANT[variant]} ${
-      interactive ? "ds-panel--interactive" : ""
-    } ${className}`}
-    {...rest}
-  >
-    {children}
-  </div>
+// panel reads as part of one system. Forwards a ref so ref'd containers (e.g.
+// hover-tooltip measurement) can adopt it too.
+export const Panel = forwardRef<HTMLDivElement, Props>(
+  ({ variant = "default", interactive = false, className = "", children, ...rest }, ref) => (
+    <div
+      ref={ref}
+      className={`ds-panel ${VARIANT[variant]} ${
+        interactive ? "ds-panel--interactive" : ""
+      } ${className}`}
+      {...rest}
+    >
+      {children}
+    </div>
+  ),
 );
+Panel.displayName = "Panel";

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -33,6 +33,7 @@ import {
   buildTimeline,
 } from "@/lib/metrics/agent";
 import { loadRevenue } from "@/lib/metrics/loads";
+import { Panel } from "@/components/ui/Panel";
 
 const money0 = (n: number) =>
   n.toLocaleString("en-US", {
@@ -218,7 +219,7 @@ const AgentDetailPage = () => {
         <Kpi label="Last worked" value={lastWorked ? fmtDate(lastWorked) : "Never"} />
       </div>
 
-      <div className="bg-plate rounded-lg p-4 mt-4">
+      <Panel className="p-4 mt-4">
         <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
           Time on the dock · this agent's freight
         </p>
@@ -227,13 +228,13 @@ const AgentDetailPage = () => {
           countLabel="Loads"
           countValue={getLoadCount(loads)}
         />
-      </div>
+      </Panel>
 
       <div className="mt-4">
         <TrophyCase honors={honors} log={season} live={live} />
       </div>
 
-      <div className="bg-plate rounded-lg p-4 mt-4">
+      <Panel className="p-4 mt-4">
         <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
           Loads with this agent
         </p>
@@ -289,10 +290,10 @@ const AgentDetailPage = () => {
             </table>
           </div>
         )}
-      </div>
+      </Panel>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
-        <div className="md:col-span-2 bg-plate rounded-lg p-4">
+        <Panel className="md:col-span-2 p-4">
           <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
             Activity
           </p>
@@ -374,9 +375,9 @@ const AgentDetailPage = () => {
               )}
             </div>
           )}
-        </div>
+        </Panel>
 
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
             Contact
           </p>
@@ -390,7 +391,7 @@ const AgentDetailPage = () => {
           </p>
           <p className="text-xs text-muted-text">Preferred</p>
           <p className="text-sm capitalize">{agent.preferred_contact || "—"}</p>
-        </div>
+        </Panel>
       </div>
     </div>
   );

--- a/frontend/src/pages/CompliancePage.tsx
+++ b/frontend/src/pages/CompliancePage.tsx
@@ -45,6 +45,7 @@ import {
 import { Kpi } from "@/components/Kpi";
 import { Stamp } from "@/components/Stamp";
 import { ComplianceItemForm } from "@/components/compliance/ComplianceItemForm";
+import { Panel } from "@/components/ui/Panel";
 
 const fmtDate = (d: string) =>
   new Date(d.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", {
@@ -310,7 +311,7 @@ const CompliancePage = () => {
   ) => {
     const isAdding = adding?.scope === scope && adding?.entityId === entityId;
     return (
-      <div key={key} className="bg-plate rounded-lg px-4 pb-3 pt-1 mt-4">
+      <Panel key={key} className="px-4 pb-3 pt-1 mt-4">
         <div className="flex items-center gap-2 py-3">
           <Icon size={18} className="text-amber-light" />
           <span className="font-condensed text-lg">{title}</span>
@@ -348,7 +349,7 @@ const CompliancePage = () => {
             />
           </div>
         )}
-      </div>
+      </Panel>
     );
   };
 
@@ -450,7 +451,7 @@ const CdlForm = ({
   const [exp, setExp] = useState(driver.cdl_expiration?.slice(0, 10) ?? "");
   const [endorsements, setEndorsements] = useState(driver.endorsements ?? "");
   return (
-    <div className="bg-steel rounded-lg p-3 border-t border-[#3b4660]">
+    <Panel variant="panel" className="p-3 border-t border-[#3b4660]">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
           <label className={lbl}>CDL #</label>
@@ -489,7 +490,7 @@ const CdlForm = ({
           Cancel
         </button>
       </div>
-    </div>
+    </Panel>
   );
 };
 

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -16,6 +16,7 @@ import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { DRIVER_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
+import { Panel } from "@/components/ui/Panel";
 import {
   getCostBasis,
   getRateLadder,
@@ -237,7 +238,7 @@ const DriverDetailPage = () => {
       )}
 
       {/* driver details — demoted below the card, still fully editable */}
-      <div className="bg-plate rounded-lg p-4 mt-4">
+      <Panel className="p-4 mt-4">
         {editing ? (
           <EntityForm
             title="Edit driver"
@@ -285,29 +286,29 @@ const DriverDetailPage = () => {
             </p>
           </>
         )}
-      </div>
+      </Panel>
 
       {/* plain-page stats for a non-hauling driver (hauling stats live in the card) */}
       {!card && (
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-4">
-          <div className="bg-plate rounded-lg p-4">
+          <Panel className="p-4">
             <p className="text-xs text-muted-text mb-1">Loads hauled</p>
             <p className="text-2xl font-condensed">{earnedLoads.length}</p>
-          </div>
-          <div className="bg-plate rounded-lg p-4">
+          </Panel>
+          <Panel className="p-4">
             <p className="text-xs text-muted-text mb-1">Net revenue · all time</p>
             <p className="text-2xl font-condensed">{money(revenue)}</p>
-          </div>
-          <div className="bg-plate rounded-lg p-4">
+          </Panel>
+          <Panel className="p-4">
             <p className="text-xs text-muted-text mb-1">Miles hauled</p>
             <p className="text-2xl font-condensed">
               {milesHauled.toLocaleString("en-US")}
             </p>
-          </div>
+          </Panel>
         </div>
       )}
 
-      <div className="bg-plate rounded-lg p-4 mt-4">
+      <Panel className="p-4 mt-4">
         <p className="text-xs text-muted-text mb-2">Recent loads</p>
         {earnedLoads.length === 0 ? (
           <p className="text-sm text-muted-text">None for this driver yet.</p>
@@ -323,7 +324,7 @@ const DriverDetailPage = () => {
             ))}
           </div>
         )}
-      </div>
+      </Panel>
     </div>
   );
 };

--- a/frontend/src/pages/DriversPage.tsx
+++ b/frontend/src/pages/DriversPage.tsx
@@ -108,7 +108,7 @@ const DriversPage = () => {
               <Link
                 key={d.driver_id}
                 to={`/drivers/${d.driver_id}`}
-                className="relative overflow-hidden bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
+                className="relative overflow-hidden ds-panel ds-panel--default ds-panel--interactive p-4 flex gap-3 items-center"
               >
                 {m.crossed != null && (
                   <div className="absolute -top-2 -right-2 rotate-[-8deg]">

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -22,6 +22,7 @@ import { ExpenseUpload } from "@/components/expenses/ExpenseUpload";
 import { ExpenseLedger } from "@/components/expenses/ExpenseLedger";
 import { ExpenseYtdChart } from "@/components/expenses/ExpenseYtdChart";
 import { ObligationsCard } from "@/components/expenses/ObligationsCard";
+import { Panel } from "@/components/ui/Panel";
 
 const money = (n: number): string =>
   `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
@@ -51,10 +52,10 @@ const monthMiles = (loads: Load[], periodMonth: string) => {
 };
 
 const Kpi = ({ label, value }: { label: string; value: string }) => (
-  <div className="bg-plate rounded-lg p-4">
+  <Panel className="p-4">
     <p className="text-xs text-muted-text">{label}</p>
     <p className="text-2xl font-condensed mt-1">{value}</p>
-  </div>
+  </Panel>
 );
 
 const ExpensesPage = () => {
@@ -280,7 +281,7 @@ const ExpensesPage = () => {
           </p>
 
           {rateLadder.walkAway != null && (
-            <div className="bg-plate rounded-lg p-4 mb-6">
+            <Panel className="p-4 mb-6">
               <p className="text-xs text-muted-text mb-3">
                 Rate to book · gross $/mile driven · last {rateBasis.months}{" "}
                 complete month{rateBasis.months > 1 ? "s" : ""}
@@ -319,14 +320,14 @@ const ExpensesPage = () => {
                 {Math.round(linehaulTake * 100)}% keep. Book above it with your
                 deadhead folded into the miles and you clear cost.
               </p>
-            </div>
+            </Panel>
           )}
 
           {periods.length > 1 && (
             <ExpenseYtdChart periods={periods} obligationsTotal={obligationsTotal} />
           )}
 
-          <div className="bg-plate rounded-lg p-4 mb-6 mt-6">
+          <Panel className="p-4 mb-6 mt-6">
             <p className="text-xs text-muted-text mb-2">
               Fixed vs variable · P&amp;L operating · {money(metrics.monthlyCost)}
             </p>
@@ -359,11 +360,11 @@ const ExpensesPage = () => {
                 true monthly cost
               </p>
             )}
-          </div>
+          </Panel>
 
           <ObligationsCard items={obligations} onChange={reloadObligations} />
 
-          <div className="bg-plate rounded-lg p-4 mb-6">
+          <Panel className="p-4 mb-6">
             <p className="text-xs text-muted-text mb-2">
               All expenses · reclassify, edit value, add or delete
             </p>
@@ -373,7 +374,7 @@ const ExpensesPage = () => {
               income={selected.income_total}
               onChange={refresh}
             />
-          </div>
+          </Panel>
         </>
       ) : null}
     </div>

--- a/frontend/src/pages/FacilitiesPage.tsx
+++ b/frontend/src/pages/FacilitiesPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Plus } from "lucide-react";
 import { useFacilities } from "@/hooks/useFacilities";
 import { FacilityCreateForm } from "@/components/FacilityCreateForm";
+import { Panel } from "@/components/ui/Panel";
 import { facilityLabel, possibleDuplicates } from "@/lib/facilityMatch";
 import { mergeFacilities } from "@/services/facilitiesService";
 import type { FacilityRow } from "@/types/facility";
@@ -115,9 +116,9 @@ const FacilitiesPage = () => {
           {dupes.map((cluster) => {
             const keeperId = keeperFor(cluster);
             return (
-              <div
+              <Panel
                 key={clusterKey(cluster)}
-                className="bg-plate rounded-lg p-4 border max-w-lg"
+                className="p-4 border max-w-lg"
                 style={{ borderColor: "#3a2a12" }}
               >
                 <div className="flex justify-between items-center mb-1">
@@ -170,7 +171,7 @@ const FacilitiesPage = () => {
                     Merge {cluster.length - 1} into keeper →
                   </button>
                 </div>
-              </div>
+              </Panel>
             );
           })}
         </div>
@@ -194,7 +195,7 @@ const FacilitiesPage = () => {
       ) : filtered.length === 0 ? (
         <p className="text-muted-text">No facilities match "{search}".</p>
       ) : (
-        <div className="bg-plate rounded-lg p-4 overflow-x-auto">
+        <Panel className="p-4 overflow-x-auto">
           <table className="w-full text-sm" style={{ minWidth: 480 }}>
             <thead>
               <tr className="text-muted-text text-left text-xs">
@@ -225,7 +226,7 @@ const FacilitiesPage = () => {
               ))}
             </tbody>
           </table>
-        </div>
+        </Panel>
       )}
 
       {confirmCluster &&

--- a/frontend/src/pages/FacilityDetailPage.tsx
+++ b/frontend/src/pages/FacilityDetailPage.tsx
@@ -10,6 +10,7 @@ import { facilityStops, scoreStops } from "@/lib/metrics/stopScore";
 import { StopScorecard } from "@/components/StopScorecard";
 import { facilityLabel } from "@/lib/facilityMatch";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import { Panel } from "@/components/ui/Panel";
 
 const fmtDate = (d?: string | null) =>
   d
@@ -145,14 +146,14 @@ const FacilityDetailPage = () => {
         </div>
       </div>
 
-      <div className="bg-plate rounded-lg p-4 mb-4">
+      <Panel className="p-4 mb-4">
         <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
           Scorecard
         </p>
         <StopScorecard score={score} countLabel="Loads" countValue={rows.length} />
-      </div>
+      </Panel>
 
-      <div className="bg-plate rounded-lg p-4">
+      <Panel className="p-4">
         <p className="text-xs text-muted-text uppercase tracking-wider mb-2">
           Loads through here
         </p>
@@ -184,7 +185,7 @@ const FacilityDetailPage = () => {
             ))}
           </div>
         )}
-      </div>
+      </Panel>
 
       <details className="mt-4 text-sm">
         <summary className="text-muted-text cursor-pointer">

--- a/frontend/src/pages/FuelEntriesPage.tsx
+++ b/frontend/src/pages/FuelEntriesPage.tsx
@@ -16,6 +16,7 @@ import {
   entryCost,
 } from "@/lib/metrics/fuelEconomy";
 import { Kpi } from "@/components/Kpi";
+import { Panel } from "@/components/ui/Panel";
 import { MpgChart } from "@/components/fuel/MpgChart";
 import { WeeklyCostChart } from "@/components/fuel/WeeklyCostChart";
 import { DieselCompareCard } from "@/components/fuel/DieselCompareCard";
@@ -215,7 +216,7 @@ const FuelEntriesPage = () => {
       />
 
       {showForm && (
-        <div className="bg-plate rounded-lg p-4 mt-4">
+        <Panel className="p-4 mt-4">
           <p className="text-sm font-medium mb-3">Add fill-up</p>
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3">
             <div>
@@ -329,7 +330,7 @@ const FuelEntriesPage = () => {
               Cancel
             </button>
           </div>
-        </div>
+        </Panel>
       )}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
@@ -337,7 +338,7 @@ const FuelEntriesPage = () => {
         <WeeklyCostChart data={weekly} avg={stats.avgWeeklyCost90} />
       </div>
 
-      <div className="bg-plate rounded-lg p-4 mt-4 overflow-x-auto">
+      <Panel className="p-4 mt-4 overflow-x-auto">
         <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
           Fill-ups
         </p>
@@ -417,7 +418,7 @@ const FuelEntriesPage = () => {
             </tbody>
           </table>
         )}
-      </div>
+      </Panel>
     </div>
   );
 };

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -33,7 +33,7 @@ const TIERS: [PrestigeTier, string][] = [
 ];
 
 const Section = ({ title, children }: { title: string; children: ReactNode }) => (
-  <section className="bg-plate rounded-lg p-5 mb-4">
+  <section className="ds-panel ds-panel--default p-5 mb-4">
     <h2 className="font-condensed text-xl mb-3">{title}</h2>
     {children}
   </section>
@@ -70,7 +70,7 @@ const Metric = ({
   answers: string;
   children: ReactNode;
 }) => (
-  <section className="bg-plate rounded-lg p-5 mb-4">
+  <section className="ds-panel ds-panel--default p-5 mb-4">
     <h3 className="font-condensed text-lg" style={{ color: AMBER_HI }}>
       {title}
     </h3>

--- a/frontend/src/pages/LanesPage.tsx
+++ b/frontend/src/pages/LanesPage.tsx
@@ -9,6 +9,7 @@ import {
 import { LanesKpis } from "@/components/lanes/LanesKpis";
 import { LanesMap } from "@/components/lanes/LanesMap";
 import { LanesTable } from "@/components/lanes/LanesTable";
+import { Panel } from "@/components/ui/Panel";
 
 const WINDOWS = [30, 60, 90];
 
@@ -41,7 +42,7 @@ const LanesPage = () => {
     <div className="p-6 bg-iron text-light font-body min-h-screen">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-condensed text-light">Lanes</h1>
-        <div className="flex gap-1 bg-plate rounded-lg p-1">
+        <div className="flex gap-1 bg-steel rounded-lg p-1">
           {WINDOWS.map((w) => (
             <button
               key={w}
@@ -64,12 +65,12 @@ const LanesPage = () => {
         <LanesMap data={mapData} windowDays={windowDays} />
       </div>
 
-      <div className="mt-6 bg-plate rounded-lg p-4">
+      <Panel className="mt-6 p-4">
         <p className="text-xs text-muted-text mb-2">
           By region · last {windowDays} days · expand a market for its lanes
         </p>
         <LanesTable rollup={rollup} />
-      </div>
+      </Panel>
     </div>
   );
 };

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -39,6 +39,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Panel } from "@/components/ui/Panel";
 
 import { loadRevenue, loadRpm, deadheadShare } from "@/lib/metrics/loads";
 import {
@@ -493,7 +494,7 @@ export const LoadDetailPage = () => {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <p className={cardLbl}>Route</p>
           <div className="flex gap-3">
             <div className="flex flex-col items-center pt-1.5">
@@ -514,9 +515,9 @@ export const LoadDetailPage = () => {
               <p className="text-xs text-muted-text">{load.delivery_market}</p>
             </div>
           </div>
-        </div>
+        </Panel>
 
-        <div className="bg-plate rounded-lg p-4 border border-amber">
+        <Panel className="p-4 border border-amber">
           <p className={`${cardLbl} text-amber-light`}>Fleet</p>
           <Row
             label={
@@ -575,9 +576,9 @@ export const LoadDetailPage = () => {
               )
             }
           />
-        </div>
+        </Panel>
 
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <p className={cardLbl}>Revenue</p>
           <Row label="Linehaul" value={money2(Number(load.linehaul))} />
           <Row
@@ -605,9 +606,9 @@ export const LoadDetailPage = () => {
               </p>
             </>
           )}
-        </div>
+        </Panel>
 
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <p className={cardLbl}>Mileage</p>
           <Row
             label="Loaded"
@@ -625,9 +626,9 @@ export const LoadDetailPage = () => {
                 : "Not recorded"
             }
           />
-        </div>
+        </Panel>
 
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <p className={cardLbl}>Cargo</p>
           <Row label="Commodity" value={load.commodity || "—"} />
           <Row
@@ -635,9 +636,9 @@ export const LoadDetailPage = () => {
             value={load.weight ? `${load.weight.toLocaleString("en-US")} lb` : "—"}
           />
           <Row label="Dimensions" value={load.dimensions || "Legal"} />
-        </div>
+        </Panel>
 
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <div className="flex items-baseline justify-between gap-2">
             <p className={`${cardLbl} mb-0`}>Shipper</p>
             <div className="flex items-center gap-2">
@@ -674,9 +675,9 @@ export const LoadDetailPage = () => {
             </p>
           )}
           <StopTimes inTime={load.shipper_in} outTime={load.shipper_out} />
-        </div>
+        </Panel>
 
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <div className="flex items-baseline justify-between gap-2">
             <p className={`${cardLbl} mb-0`}>Receiver</p>
             <div className="flex items-center gap-2">
@@ -714,9 +715,9 @@ export const LoadDetailPage = () => {
             </p>
           )}
           <StopTimes inTime={load.receiver_in} outTime={load.receiver_out} />
-        </div>
+        </Panel>
 
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <div className="flex items-center gap-2 mb-2">
             <p className={`${cardLbl} mb-0`}>Fuel</p>
             <span
@@ -761,9 +762,9 @@ export const LoadDetailPage = () => {
               Add loaded miles to estimate fuel.
             </p>
           )}
-        </div>
+        </Panel>
 
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <p className={cardLbl}>Broker · agent</p>
           <p className="text-sm">{load.broker}</p>
           <p className="text-sm text-muted-text">
@@ -775,9 +776,9 @@ export const LoadDetailPage = () => {
             </Link>
             {load.agent_email ? ` · ${load.agent_email}` : ""}
           </p>
-        </div>
+        </Panel>
 
-        <div className="bg-plate rounded-lg p-4 md:col-span-2">
+        <Panel className="p-4 md:col-span-2">
           <p className={cardLbl}>Update status</p>
           <div className="flex flex-wrap gap-2 items-center">
             <select
@@ -810,10 +811,10 @@ export const LoadDetailPage = () => {
               {isSaving ? "Saving…" : "Save"}
             </button>
           </div>
-        </div>
+        </Panel>
       </div>
 
-      <div className="bg-plate rounded-lg p-4 mt-4">
+      <Panel className="p-4 mt-4">
         <div className="flex justify-between items-center mb-2">
           <p className={`${cardLbl} mb-0`}>Accessorials</p>
           <span className="text-xs text-muted-text">
@@ -958,7 +959,7 @@ export const LoadDetailPage = () => {
             Add
           </button>
         </div>
-      </div>
+      </Panel>
     </div>
   );
 };

--- a/frontend/src/pages/LoadsPage.tsx
+++ b/frontend/src/pages/LoadsPage.tsx
@@ -9,6 +9,7 @@ import { useMarkets } from "@/hooks/useMarkets";
 import { useFacilities } from "@/hooks/useFacilities";
 import { StatusBadge } from "@/components/StatusBadge";
 import { Kpi } from "@/components/Kpi";
+import { Panel } from "@/components/ui/Panel";
 import LoadForm from "../components/LoadForm";
 import { createLoad } from "@/services/createLoadService";
 import { loadsKpis, loadRevenue } from "@/lib/metrics/loads";
@@ -345,7 +346,7 @@ const LoadsPage = () => {
         </div>
       )}
 
-      <div className="bg-plate rounded-lg p-4 mt-4 overflow-x-auto">
+      <Panel className="p-4 mt-4 overflow-x-auto">
         {rest.length === 0 ? (
           <p className="text-muted-text text-sm">
             {(loads ?? []).length === 0
@@ -374,7 +375,7 @@ const LoadsPage = () => {
             </tbody>
           </table>
         )}
-      </div>
+      </Panel>
     </div>
   );
 };

--- a/frontend/src/pages/RecapPage.tsx
+++ b/frontend/src/pages/RecapPage.tsx
@@ -96,7 +96,7 @@ const RecapPage = () => {
     <div className="p-6 bg-iron text-light font-body min-h-screen">
       <div className="flex items-center justify-between gap-3 mb-5 flex-wrap">
         <h1 className="text-3xl font-condensed">Recap</h1>
-        <div className="flex gap-1 bg-plate rounded-lg p-1">
+        <div className="flex gap-1 bg-steel rounded-lg p-1">
           {SCOPES.map((s) => (
             <button
               key={s.key}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import {
   updateSettlementSchedule,
 } from "@/services/settlementScheduleService";
 import { AccessorialRatesCard } from "@/components/settings/AccessorialRatesCard";
+import { Panel } from "@/components/ui/Panel";
 
 const money = (n: number) =>
   `$${n.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
@@ -112,7 +113,7 @@ const SettingsPage = () => {
     <div className="p-6 bg-iron text-light font-body min-h-screen">
       <h1 className="text-3xl font-condensed">Settings</h1>
 
-      <div className="mt-6 max-w-[680px] bg-plate rounded-lg p-5">
+      <Panel className="mt-6 max-w-[680px] p-5">
         <h2 className="text-lg font-medium text-light">Settlement schedule</h2>
         <p className="text-sm text-muted-text mt-1">
           Your carrier's pay split. You keep entering each load's full customer
@@ -203,9 +204,9 @@ const SettingsPage = () => {
             </button>
           </>
         )}
-      </div>
+      </Panel>
 
-      <div className="mt-6 max-w-[680px] bg-plate rounded-lg p-5">
+      <Panel className="mt-6 max-w-[680px] p-5">
         <h2 className="text-lg font-medium text-light">Detention</h2>
         <p className="text-sm text-muted-text mt-1">
           Free time at a stop before detention starts accruing, applied to the
@@ -233,7 +234,7 @@ const SettingsPage = () => {
             Saved with the schedule above.
           </span>
         </label>
-      </div>
+      </Panel>
 
       <AccessorialRatesCard />
     </div>

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -34,6 +34,7 @@ import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
 import { TRAILER_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
+import { Panel } from "@/components/ui/Panel";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const num = (n: number) => Math.round(n).toLocaleString("en-US");
@@ -323,7 +324,7 @@ const TrailerDetailPage = () => {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4">
         <Link
           to="/maintenance"
-          className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors block"
+          className="ds-panel ds-panel--default ds-panel--interactive p-4 block"
         >
           <p className="text-xs text-muted-text mb-2">Maintenance</p>
           <div className="flex gap-3 text-sm">
@@ -331,17 +332,17 @@ const TrailerDetailPage = () => {
             <span style={{ color: "#e8940a" }}>{due.soon} due soon</span>
           </div>
         </Link>
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <p className="text-xs text-muted-text mb-1">Loads hauled</p>
           <p className="text-2xl font-condensed">{earnedLoads.length}</p>
-        </div>
-        <div className="bg-plate rounded-lg p-4">
+        </Panel>
+        <Panel className="p-4">
           <p className="text-xs text-muted-text mb-1">Trailer earnings · all time</p>
           <p className="text-2xl font-condensed">{money(revenue)}</p>
           <p className="text-[11px] text-muted-text mt-1">
             its cut of every load it carried
           </p>
-        </div>
+        </Panel>
       </div>
     </div>
   );

--- a/frontend/src/pages/TrailersPage.tsx
+++ b/frontend/src/pages/TrailersPage.tsx
@@ -7,6 +7,7 @@ import { getTrailers, createTrailer } from "@/services/trailersService";
 import { getMaintenanceServices } from "@/services/maintenanceService";
 import { useLoads } from "@/hooks/useLoads";
 import { trailerFleetSummary } from "@/lib/metrics/trailerMetrics";
+import { Panel } from "@/components/ui/Panel";
 import { AvatarFallback } from "@/components/fleet/AvatarFallback";
 import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
 import { MilestoneBurst } from "@/components/fleet/MilestoneBurst";
@@ -134,7 +135,7 @@ const TrailersPage = () => {
       )}
 
       {fleet.length > 1 && (
-        <div className="bg-plate rounded-lg p-4 mb-4 overflow-x-auto">
+        <Panel className="p-4 mb-4 overflow-x-auto">
           <p className="text-xs text-muted-text mb-2">
             Fleet comparison{" "}
             <span className="text-[11px]">· best per column highlighted</span>
@@ -169,7 +170,7 @@ const TrailersPage = () => {
               ))}
             </tbody>
           </table>
-        </div>
+        </Panel>
       )}
 
       {loading ? (
@@ -186,7 +187,7 @@ const TrailersPage = () => {
               <Link
                 key={t.trailer_id}
                 to={`/trailers/${t.trailer_id}`}
-                className="relative overflow-hidden bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
+                className="relative overflow-hidden ds-panel ds-panel--default ds-panel--interactive p-4 flex gap-3 items-center"
               >
                 {m.crossed != null && (
                   <div className="absolute -top-2 -right-2 rotate-[-8deg]">

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -37,6 +37,7 @@ import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
 import { TRUCK_FIELDS, toFormValues } from "@/lib/fleetFields";
 import { formatDate } from "@/lib/format";
+import { Panel } from "@/components/ui/Panel";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const num = (n: number) => Math.round(n).toLocaleString("en-US");
@@ -325,7 +326,7 @@ const TruckDetailPage = () => {
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
         <Link
           to="/maintenance"
-          className="bg-plate rounded-lg p-4 hover:bg-steel transition-colors"
+          className="ds-panel ds-panel--default ds-panel--interactive p-4"
         >
           <p className="text-xs text-muted-text mb-2">Maintenance</p>
           <div className="flex gap-3 text-sm">
@@ -333,17 +334,17 @@ const TruckDetailPage = () => {
             <span style={{ color: "#e8940a" }}>{due.soon} due soon</span>
           </div>
         </Link>
-        <div className="bg-plate rounded-lg p-4">
+        <Panel className="p-4">
           <p className="text-xs text-muted-text mb-1">Loads hauled</p>
           <p className="text-2xl font-condensed">{earnedLoads.length}</p>
-        </div>
-        <div className="bg-plate rounded-lg p-4">
+        </Panel>
+        <Panel className="p-4">
           <p className="text-xs text-muted-text mb-1">Net revenue · all time</p>
           <p className="text-2xl font-condensed">{money(revenue)}</p>
-        </div>
+        </Panel>
       </div>
 
-      <div className="bg-plate rounded-lg p-4 mt-4">
+      <Panel className="p-4 mt-4">
         <p className="text-xs text-muted-text mb-2">Recent loads</p>
         {earnedLoads.length === 0 ? (
           <p className="text-sm text-muted-text">None on this truck yet.</p>
@@ -359,7 +360,7 @@ const TruckDetailPage = () => {
             ))}
           </div>
         )}
-      </div>
+      </Panel>
     </div>
   );
 };

--- a/frontend/src/pages/TrucksPage.tsx
+++ b/frontend/src/pages/TrucksPage.tsx
@@ -9,6 +9,7 @@ import { getFuelEntries } from "@/services/fuelService";
 import { getMaintenanceServices } from "@/services/maintenanceService";
 import { useLoads } from "@/hooks/useLoads";
 import { fleetSummary } from "@/lib/metrics/truckMetrics";
+import { Panel } from "@/components/ui/Panel";
 import { AvatarFallback } from "@/components/fleet/AvatarFallback";
 import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
 import { MilestoneBurst } from "@/components/fleet/MilestoneBurst";
@@ -119,7 +120,7 @@ const TrucksPage = () => {
       )}
 
       {fleet.length > 1 && (
-        <div className="bg-plate rounded-lg p-4 mb-4 overflow-x-auto">
+        <Panel className="p-4 mb-4 overflow-x-auto">
           <p className="text-xs text-muted-text mb-2">
             Fleet comparison{" "}
             <span className="text-[11px]">· best per column highlighted</span>
@@ -154,7 +155,7 @@ const TrucksPage = () => {
               ))}
             </tbody>
           </table>
-        </div>
+        </Panel>
       )}
 
       {loading ? (
@@ -171,7 +172,7 @@ const TrucksPage = () => {
               <Link
                 key={t.truck_id}
                 to={`/trucks/${t.truck_id}`}
-                className="relative overflow-hidden bg-plate rounded-lg p-4 flex gap-3 items-center hover:bg-steel transition-colors"
+                className="relative overflow-hidden ds-panel ds-panel--default ds-panel--interactive p-4 flex gap-3 items-center"
               >
                 {m.crossed != null && (
                   <div className="absolute -top-2 -right-2 rotate-[-8deg]">


### PR DESCRIPTION
## v1.84.0 — design system rollout

Migrates **~72 raw card wrappers** to the `Panel` primitives across **38 files** — load detail, every list + detail page, expenses/maintenance, settings/lanes/compliance, fuel, and the Guide. The whole app now reads as one layered system.

- Content cards → `<Panel>` (lifted default; steel for structural).
- Clickable entity cards (trucks/trailers/drivers/agents) → **interactive panels** with hover-lift; agent card keeps its amber-border hover.
- `Panel` now **forwards refs**, so the lanes map's ref'd tooltip container adopts it too.
- **Left flat by design:** segmented toggles, the loads filter bar, and nested stat tiles.

Done as a parallel subagent migration, then reconciled (reverted two over-converted toggle-groups, handled the ref'd container + Guide cards + agent card). Frontend-only. Build clean, **257 tests**.

Follow-up (queued): the signature features — instrument gauges, odometer-roll numbers, command palette.