### PR TITLE
feat: RLS hardening — enable RLS on all public tables (#240)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ These are stable lessons that apply regardless of the specific project. Concrete
 - **Branch-per-issue:** fresh branch per issue → PR → squash-merge → delete branch → repeat. Never reuse a long-lived branch; never commit straight to main.
 - **Semver by additive-vs-corrective**, NOT by visibility: a new capability is a `feat` (minor) even if invisible; a correction is `fix` (patch); a broken contract is major.
 - **Always run the strict production build locally before pushing.** Dev servers are lenient; the production/type build is strict and matches CI. Catch errors locally, not in a failed deploy.
+- **RLS on by default (Supabase, added 2026-07-14).** Every `public` table must have Row-Level Security enabled. The backend connects as the `postgres` owner role, which BYPASSES RLS, so the app is unaffected — RLS just walls tables off from Supabase's auto-exposed PostgREST API on the public anon/authenticated keys. **The enforcement is a convention: every migration that creates a `public` table MUST include `ALTER TABLE … ENABLE ROW LEVEL SECURITY`.** Migration 042 also installs a best-effort event trigger (`rls_on_create_table`) that auto-enables RLS on new tables — but creating it needs superuser, which **dev has and prod does not**, so the trigger is live on dev only and is gracefully skipped on prod. Don't rely on the trigger for prod; add the explicit `ENABLE ROW LEVEL SECURITY` every time. Don't add per-user policies unless the app ever talks to Postgres as a non-`postgres` role.
 
 **Code correctness (recurring traps to watch for):**
 

--- a/backend/db/migrations/042_rls_hardening.sql
+++ b/backend/db/migrations/042_rls_hardening.sql
@@ -1,0 +1,46 @@
+-- Security hardening — enable Row-Level Security on the public tables that lacked
+-- it, matching the established pattern (RLS ON, no policies). The backend connects
+-- as the `postgres` owner role, which BYPASSES RLS, so the app is unaffected; this
+-- walls the tables off from Supabase's auto-exposed PostgREST API on the public
+-- anon/authenticated keys. (obligations covers its payoff columns — RLS is
+-- table-level.)
+ALTER TABLE accessorial_pay_rates     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE compliance_items          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE expense_category_defaults ENABLE ROW LEVEL SECURITY;
+ALTER TABLE expense_lines             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE expense_periods           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE facilities                ENABLE ROW LEVEL SECURITY;
+ALTER TABLE maintenance_items         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE maintenance_service_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE maintenance_services      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE obligations               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE per_diem_days             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE settlement_schedules      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trailers                  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trophies                  ENABLE ROW LEVEL SECURITY;
+
+-- Best-effort "never revisit": an event trigger that enables RLS on every future
+-- public table automatically. Creating an event trigger needs superuser, which the
+-- dev role has but the prod role doesn't — so we create it where allowed and skip
+-- it (with a notice) where not. On prod the convention below is the enforcement:
+-- every table-creating migration MUST enable RLS explicitly (see CLAUDE.md).
+CREATE OR REPLACE FUNCTION public.enable_rls_on_new_table()
+RETURNS event_trigger LANGUAGE plpgsql AS $fn$
+DECLARE obj record;
+BEGIN
+  FOR obj IN SELECT * FROM pg_event_trigger_ddl_commands()
+    WHERE command_tag = 'CREATE TABLE' AND schema_name = 'public'
+  LOOP
+    EXECUTE format('ALTER TABLE %s ENABLE ROW LEVEL SECURITY', obj.object_identity);
+  END LOOP;
+END $fn$;
+
+DO $$
+BEGIN
+  DROP EVENT TRIGGER IF EXISTS rls_on_create_table;
+  CREATE EVENT TRIGGER rls_on_create_table ON ddl_command_end
+    WHEN TAG IN ('CREATE TABLE') EXECUTE FUNCTION public.enable_rls_on_new_table();
+EXCEPTION WHEN insufficient_privilege THEN
+  RAISE NOTICE 'rls_on_create_table event trigger skipped (needs superuser); RLS enforced by migration convention instead';
+END
+$$;


### PR DESCRIPTION
Closes #240.

## What
Enable Row-Level Security on the 14 `public` tables that lacked it, matching the established pattern (**RLS ON, no policies**):
`accessorial_pay_rates`, `compliance_items`, `expense_category_defaults`, `expense_lines`, `expense_periods`, `facilities`, `maintenance_items`, `maintenance_service_items`, `maintenance_services`, `obligations`, `per_diem_days`, `settlement_schedules`, `trailers`, `trophies`.

## Why it's safe
The backend connects as the `postgres` owner role, which **bypasses RLS**, so the app is unaffected. RLS only walls these tables off from Supabase's auto-exposed PostgREST API on the public anon/authenticated keys — closing the hole where those keys could read/write the tables directly.

## "Never revisit" — future tables
Migration 042 installs a best-effort event trigger (`rls_on_create_table`) that auto-enables RLS on every new `public` table. Creating an event trigger requires **superuser**: dev's role has it, **prod's does not**, so the trigger is created on dev and **gracefully skipped on prod** (catches `insufficient_privilege`). The durable, environment-independent enforcement is the CLAUDE.md convention: **every migration that creates a `public` table must include `ENABLE ROW LEVEL SECURITY`**.

## Deploy status
Migration 042 already applied to **dev** and **prod** ahead of merge. Post-apply verification:
- **Prod:** 0 unprotected / 29 public tables; helper function present; trigger skipped (expected).
- **Dev:** 0 unprotected / 29 public tables; trigger live (auto-hardens future tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)