### PR TITLE
feat: driver page cluster — Overall grade, equipment strips, hometime (#230, #245, #233)

### DIFF
--- a/backend/db/migrations/043_hometime_threshold.sql
+++ b/backend/db/migrations/043_hometime_threshold.sql
@@ -1,0 +1,8 @@
+-- Hometime threshold: the driver page flags when the days since your most recent
+-- "home" mark on the per-diem calendar exceed this. A per-user preference, so it
+-- rides on the settlement_schedules row — already the de-facto user-settings table
+-- (detention-free hours, per-diem rate live here too). RLS is already enabled on
+-- this table (migration 042); no policy needed (backend connects as owner).
+ALTER TABLE settlement_schedules
+  ADD COLUMN IF NOT EXISTS hometime_threshold_days integer NOT NULL DEFAULT 21
+    CHECK (hometime_threshold_days >= 1 AND hometime_threshold_days <= 365);

--- a/backend/src/routes/perDiemRoutes.js
+++ b/backend/src/routes/perDiemRoutes.js
@@ -2,12 +2,28 @@ import express from "express";
 import { requireAuth } from "../middleware/requireAuth.js";
 import {
   getPerDiemDays,
+  getLastHomeDay,
   upsertPerDiemDay,
   deletePerDiemDay,
 } from "../services/perDiemServices.js";
 
 const router = express.Router();
 router.use(requireAuth);
+
+// ---- GET the last home day (for the hometime metric) ----
+// Declared before "/" so the literal path matches ahead of the year list.
+router.get("/last-home", async (req, res) => {
+  try {
+    const result = await getLastHomeDay(req.user.user_id);
+    return res.status(200).json(result);
+  } catch (err) {
+    if (err.type === "validation")
+      return res.status(err.statusCode).json({ error: err.message });
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: err.message });
+  }
+});
 
 // ---- GET a year's marked days ----
 router.get("/", async (req, res) => {

--- a/backend/src/services/perDiemServices.js
+++ b/backend/src/services/perDiemServices.js
@@ -24,6 +24,20 @@ export async function getPerDiemDays(user_id, year) {
   return result.rows;
 }
 
+// ---- most recent "home" day on or before today ---- (drives the hometime
+// metric — "days since you were last home"). Future home marks are excluded so a
+// planned home day doesn't reset the count early. null when nothing's marked.
+export async function getLastHomeDay(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const result = await db.query(
+    `SELECT to_char(max(day), 'YYYY-MM-DD') AS last_home
+       FROM per_diem_days
+      WHERE user_id = $1 AND status = 'home' AND day <= CURRENT_DATE`,
+    [user_id],
+  );
+  return { last_home: result.rows[0]?.last_home ?? null };
+}
+
 // ---- UPSERT a day's status ----
 export async function upsertPerDiemDay(user_id, day, status) {
   if (!user_id) throw new ValidationError("Missing user_id");

--- a/backend/src/services/settlementScheduleServices.js
+++ b/backend/src/services/settlementScheduleServices.js
@@ -12,6 +12,7 @@ const DEFAULTS = {
   detention_free_hours: 3,
   per_diem_rate: 69,
   per_diem_deduct_pct: 0.8,
+  hometime_threshold_days: 21,
 };
 
 const PCT_FIELDS = [
@@ -27,6 +28,7 @@ const COLUMNS = [
   "detention_free_hours",
   "per_diem_rate",
   "per_diem_deduct_pct",
+  "hometime_threshold_days",
 ];
 
 // ---- GET ---- (always returns a schedule; defaults if none saved yet)
@@ -78,6 +80,15 @@ export async function upsertSettlementSchedule(user_id, data) {
     provided.per_diem_deduct_pct = n;
   }
 
+  if (data.hometime_threshold_days !== undefined) {
+    const n = Number(data.hometime_threshold_days);
+    if (!Number.isInteger(n) || n < 1 || n > 365)
+      throw new ValidationError(
+        "hometime_threshold_days must be a whole number between 1 and 365",
+      );
+    provided.hometime_threshold_days = n;
+  }
+
   if (Object.keys(provided).length === 0)
     throw new ValidationError("No valid fields to update");
 
@@ -87,18 +98,19 @@ export async function upsertSettlementSchedule(user_id, data) {
 
   const result = await db.query(
     `INSERT INTO settlement_schedules
-       (user_id, linehaul_pct, trailer_pct, fuel_surcharge_pct, accessorial_pct, carrier_name, detention_free_hours, per_diem_rate, per_diem_deduct_pct)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+       (user_id, linehaul_pct, trailer_pct, fuel_surcharge_pct, accessorial_pct, carrier_name, detention_free_hours, per_diem_rate, per_diem_deduct_pct, hometime_threshold_days)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
      ON CONFLICT (user_id) DO UPDATE SET
-       linehaul_pct         = EXCLUDED.linehaul_pct,
-       trailer_pct          = EXCLUDED.trailer_pct,
-       fuel_surcharge_pct   = EXCLUDED.fuel_surcharge_pct,
-       accessorial_pct      = EXCLUDED.accessorial_pct,
-       carrier_name         = EXCLUDED.carrier_name,
-       detention_free_hours = EXCLUDED.detention_free_hours,
-       per_diem_rate        = EXCLUDED.per_diem_rate,
-       per_diem_deduct_pct  = EXCLUDED.per_diem_deduct_pct,
-       updated_at           = NOW()
+       linehaul_pct            = EXCLUDED.linehaul_pct,
+       trailer_pct             = EXCLUDED.trailer_pct,
+       fuel_surcharge_pct      = EXCLUDED.fuel_surcharge_pct,
+       accessorial_pct         = EXCLUDED.accessorial_pct,
+       carrier_name            = EXCLUDED.carrier_name,
+       detention_free_hours    = EXCLUDED.detention_free_hours,
+       per_diem_rate           = EXCLUDED.per_diem_rate,
+       per_diem_deduct_pct     = EXCLUDED.per_diem_deduct_pct,
+       hometime_threshold_days = EXCLUDED.hometime_threshold_days,
+       updated_at              = NOW()
      RETURNING ${COLUMNS.join(", ")}`,
     [
       user_id,
@@ -110,6 +122,7 @@ export async function upsertSettlementSchedule(user_id, data) {
       m.detention_free_hours,
       m.per_diem_rate,
       m.per_diem_deduct_pct,
+      m.hometime_threshold_days,
     ],
   );
   return result.rows[0];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.85.0",
+  "version": "1.86.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/playercard/PlayerCard.tsx
+++ b/frontend/src/components/playercard/PlayerCard.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
-import { Truck } from "lucide-react";
+import { Truck, Maximize2, Weight, Home } from "lucide-react";
 import type { Grade, CareerRank, SeasonStats } from "@/lib/metrics/playerCard";
+import { STRIP_MIN_COUNT, type TypeMix } from "@/lib/metrics/loadMix";
+import type { Hometime } from "@/lib/metrics/hometime";
 import type { Medal } from "@/lib/awards/medals";
 import { fmtMiles } from "@/lib/metrics/mileClub";
 import { RANK_TIERS } from "@/lib/constants/playerCard";
@@ -9,6 +11,7 @@ import { MedalBadge } from "@/components/awards/MedalBadge";
 
 const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const pct1 = (n: number) => `${(n * 100).toFixed(1)}%`;
+const pct0 = (n: number) => `${Math.round(n * 100)}%`;
 
 const GREEN = "#4ade80";
 const RED = "#f87171";
@@ -65,6 +68,98 @@ const Stat = ({
   </div>
 );
 
+// An equipment-mix identity strip (oversize / heavy haul). Oversize and heavy
+// haul are DIFFERENT disciplines, so each gets its own strip. The specialist
+// styling only lights when the underlying mix says so.
+const TypeStrip = ({
+  icon,
+  label,
+  mix,
+}: {
+  icon: ReactNode;
+  label: string;
+  mix: TypeMix;
+}) => {
+  const spec = mix.specialist;
+  return (
+    <div
+      className="inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-[11px]"
+      style={
+        spec
+          ? { background: "#241a06", border: "1px solid #85500b" }
+          : { background: "#1a2130", border: "1px solid #2a3347" }
+      }
+    >
+      <span
+        className="inline-flex items-center gap-1.5 font-semibold uppercase tracking-wide"
+        style={{ color: spec ? "#f5b03a" : "#9fb0c9" }}
+      >
+        {icon}
+        {spec ? `${label} specialist` : label}
+      </span>
+      <span style={{ color: spec ? "#c7935a" : "#7d8ba3" }}>
+        {mix.count} {mix.count === 1 ? "load" : "loads"}
+        {mix.pct != null ? ` · ${pct0(mix.pct)}` : ""}
+      </span>
+    </div>
+  );
+};
+
+const shortDate = (key: string): string =>
+  new Date(`${key}T00:00:00Z`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+// Hometime status strip — reads the days since your last "home" mark and flags
+// when you've been out past your threshold. Four states, calm by default.
+const HometimeChip = ({ hometime }: { hometime: Hometime }) => {
+  const { state, daysOut, toTarget, lastHome } = hometime;
+  const S =
+    state === "over"
+      ? { bg: "#3a1a1a", border: "#a32d2d", fg: "#f87171", sub: "#c98a8a" }
+      : state === "home"
+        ? { bg: "#123020", border: "#1f6e4a", fg: "#4ade80", sub: "#8fb9a4" }
+        : { bg: "#1a2130", border: "#2a3347", fg: "#cdd8e8", sub: "#7d8ba3" };
+
+  const title =
+    state === "none"
+      ? "No hometime data yet"
+      : state === "home"
+        ? "Home"
+        : `Out ${daysOut} ${daysOut === 1 ? "day" : "days"}`;
+
+  const sub =
+    state === "none"
+      ? "Mark home days on the per-diem calendar"
+      : state === "home"
+        ? "you're home today"
+        : state === "over"
+          ? `past your ${hometime.threshold}-day target${lastHome ? ` · last home ${shortDate(lastHome)}` : ""}`
+          : `${toTarget} to your ${hometime.threshold}-day target`;
+
+  return (
+    <div
+      className="flex items-center gap-2.5 mt-4 px-3 py-2 rounded-lg"
+      style={{ background: S.bg, border: `1px solid ${S.border}` }}
+    >
+      <Home size={18} style={{ color: S.fg, flexShrink: 0 }} />
+      <div className="min-w-0">
+        <p
+          className="text-sm font-semibold uppercase tracking-wide"
+          style={{ color: S.fg }}
+        >
+          {title}
+        </p>
+        <p className="text-[10.5px]" style={{ color: S.sub }}>
+          {sub}
+        </p>
+      </div>
+    </div>
+  );
+};
+
 export interface PlayerCardProps {
   name: string;
   business: string;
@@ -76,6 +171,9 @@ export interface PlayerCardProps {
   form: Grade | null;
   windowRpm: number | null;
   medals: Medal[]; // earned tiers only — worn by the name
+  oversize?: TypeMix; // oversize equipment mix; strip hidden when count is 0
+  heavyHaul?: TypeMix; // heavy-haul mix — a distinct discipline from oversize
+  hometime?: Hometime; // days-since-home status; strip hidden when not provided
 }
 
 export const PlayerCard = ({
@@ -89,6 +187,9 @@ export const PlayerCard = ({
   form,
   windowRpm,
   medals,
+  oversize,
+  heavyHaul,
+  hometime,
 }: PlayerCardProps) => {
   const stars = "★".repeat(rank.index + 1) + "☆".repeat(RANK_TIERS.length - rank.index - 1);
 
@@ -113,6 +214,25 @@ export const PlayerCard = ({
               )}
             </div>
             <p className="text-xs text-muted-text mb-3 mt-1">{business}</p>
+            {((oversize && oversize.count >= STRIP_MIN_COUNT) ||
+              (heavyHaul && heavyHaul.count >= STRIP_MIN_COUNT)) && (
+              <div className="flex flex-wrap gap-2 mb-3">
+                {oversize && oversize.count >= STRIP_MIN_COUNT && (
+                  <TypeStrip
+                    icon={<Maximize2 size={13} />}
+                    label="Oversize"
+                    mix={oversize}
+                  />
+                )}
+                {heavyHaul && heavyHaul.count >= STRIP_MIN_COUNT && (
+                  <TypeStrip
+                    icon={<Weight size={13} />}
+                    label="Heavy haul"
+                    mix={heavyHaul}
+                  />
+                )}
+              </div>
+            )}
             <div className="flex items-center gap-3">
               <div
                 className="w-11 h-11 rounded-full flex items-center justify-center shrink-0"
@@ -140,6 +260,8 @@ export const PlayerCard = ({
           </div>
         </div>
 
+        {hometime && <HometimeChip hometime={hometime} />}
+
         <div className="flex items-center gap-2 flex-wrap mt-4 pt-3 border-t relative" style={{ borderColor: "#2a3347" }}>
           <span className="font-condensed text-sm tracking-wide text-muted-text">SEASON · {season.label}</span>
           <span className="text-[11px] text-muted-text">Rate</span>
@@ -147,7 +269,12 @@ export const PlayerCard = ({
           <span className="text-[11px] text-muted-text">Op margin</span>
           <GradeChip grade={marginGrade} value={season.netMargin != null ? pct1(season.netMargin) : undefined} />
           <span className="flex-1" />
-          <span className="text-[11px] text-muted-text">Form</span>
+          <span
+            className="text-[11px] text-muted-text"
+            title="The weaker of your rate and margin grade"
+          >
+            Overall
+          </span>
           {form ? (
             <span className="font-comic px-2.5 py-0.5 rounded-full" style={{ background: GRADE_META[form].bg, color: GRADE_META[form].fg, letterSpacing: "2px", fontSize: 14 }}>
               {GRADE_META[form].label}

--- a/frontend/src/lib/metrics/hometime.test.ts
+++ b/frontend/src/lib/metrics/hometime.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { hometimeStatus } from "./hometime";
+
+// today is passed in explicitly, so these tests never touch the real clock.
+const today = new Date(2026, 6, 15); // 2026-07-15 (local), matches dayKey()
+
+describe("hometimeStatus", () => {
+  it("returns 'none' with null days when no home day is marked", () => {
+    const h = hometimeStatus(null, 21, today);
+    expect(h.state).toBe("none");
+    expect(h.daysOut).toBeNull();
+    expect(h.toTarget).toBeNull();
+  });
+
+  it("returns 'home' when the last home mark is today", () => {
+    const h = hometimeStatus("2026-07-15", 21, today);
+    expect(h.state).toBe("home");
+    expect(h.daysOut).toBe(0);
+    expect(h.toTarget).toBe(21);
+  });
+
+  it("returns 'ok' with days left when out but within threshold", () => {
+    const h = hometimeStatus("2026-07-09", 21, today); // 6 days out
+    expect(h.state).toBe("ok");
+    expect(h.daysOut).toBe(6);
+    expect(h.toTarget).toBe(15);
+  });
+
+  it("treats exactly the threshold as still 'ok' (0 to target)", () => {
+    const h = hometimeStatus("2026-06-24", 21, today); // 21 days out
+    expect(h.state).toBe("ok");
+    expect(h.daysOut).toBe(21);
+    expect(h.toTarget).toBe(0);
+  });
+
+  it("returns 'over' once past the threshold", () => {
+    const h = hometimeStatus("2026-06-23", 21, today); // 22 days out
+    expect(h.state).toBe("over");
+    expect(h.daysOut).toBe(22);
+    expect(h.toTarget).toBeNull();
+  });
+
+  it("clamps a future home mark to 0 days out", () => {
+    const h = hometimeStatus("2026-07-20", 21, today); // planned home, future
+    expect(h.state).toBe("home");
+    expect(h.daysOut).toBe(0);
+  });
+});

--- a/frontend/src/lib/metrics/hometime.ts
+++ b/frontend/src/lib/metrics/hometime.ts
@@ -1,0 +1,48 @@
+import { dayKey } from "@/lib/perDiem";
+
+// Hometime = days since your most recent "home" mark on the per-diem calendar.
+//   none → no home marks yet (show a nudge, never a false alarm)
+//   home → home today (daysOut 0)
+//   ok   → out, but within your threshold
+//   over → out past your threshold (flag it)
+export type HometimeState = "none" | "home" | "ok" | "over";
+
+export interface Hometime {
+  state: HometimeState;
+  daysOut: number | null; // days since last home; null when no marks
+  toTarget: number | null; // days left before the threshold (>=0); null unless ok/home
+  lastHome: string | null; // "YYYY-MM-DD"
+  threshold: number;
+}
+
+// Whole calendar days between two "YYYY-MM-DD" dates, both anchored at UTC
+// midnight so the difference is timezone-proof (no DST drift).
+const daysBetween = (from: string, to: string): number =>
+  Math.round(
+    (Date.parse(`${to}T00:00:00Z`) - Date.parse(`${from}T00:00:00Z`)) /
+      86_400_000,
+  );
+
+export const hometimeStatus = (
+  lastHome: string | null,
+  threshold: number,
+  today: Date,
+): Hometime => {
+  if (!lastHome)
+    return {
+      state: "none",
+      daysOut: null,
+      toTarget: null,
+      lastHome: null,
+      threshold,
+    };
+
+  // A future home mark (planned home time) shouldn't read as "negative days out".
+  const daysOut = Math.max(0, daysBetween(lastHome, dayKey(today)));
+
+  if (daysOut === 0)
+    return { state: "home", daysOut: 0, toTarget: threshold, lastHome, threshold };
+  if (daysOut > threshold)
+    return { state: "over", daysOut, toTarget: null, lastHome, threshold };
+  return { state: "ok", daysOut, toTarget: threshold - daysOut, lastHome, threshold };
+};

--- a/frontend/src/lib/metrics/loadMix.test.ts
+++ b/frontend/src/lib/metrics/loadMix.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { loadTypeMix } from "./loadMix";
+import type { Load } from "@/types/load";
+
+const load = (load_type: string, load_status: string): Load =>
+  ({ load_type, load_status }) as Load;
+
+describe("loadTypeMix", () => {
+  it("returns null pct and no specialist when there are no loads", () => {
+    const mix = loadTypeMix([], "oversize");
+    expect(mix.count).toBe(0);
+    expect(mix.pct).toBeNull();
+    expect(mix.specialist).toBe(false);
+  });
+
+  it("returns null pct when the driver has no delivered loads", () => {
+    // booked/in-transit haven't happened yet — they don't form a denominator.
+    const loads = [load("oversize", "booked"), load("oversize", "in_transit")];
+    const mix = loadTypeMix(loads, "oversize");
+    expect(mix.count).toBe(0);
+    expect(mix.pct).toBeNull();
+    expect(mix.specialist).toBe(false);
+  });
+
+  it("counts only delivered loads of the given type", () => {
+    const loads = [
+      load("oversize", "delivered"),
+      load("oversize", "delivered"),
+      load("oversize", "cancelled"), // excluded — didn't happen
+      load("standard flatbed", "delivered"),
+    ];
+    const mix = loadTypeMix(loads, "oversize");
+    expect(mix.count).toBe(2);
+    expect(mix.pct).toBeCloseTo(2 / 3); // 2 oversize of 3 delivered
+  });
+
+  it("keeps oversize and heavy haul distinct", () => {
+    const loads = [
+      load("oversize", "delivered"),
+      load("heavy haul", "delivered"),
+      load("heavy haul", "delivered"),
+    ];
+    expect(loadTypeMix(loads, "oversize").count).toBe(1);
+    expect(loadTypeMix(loads, "heavy haul").count).toBe(2);
+  });
+
+  it("flags specialist at >=40% and >=5 loads", () => {
+    // 5 of 12 delivered = 41.7% → specialist
+    const loads = [
+      ...Array.from({ length: 5 }, () => load("oversize", "delivered")),
+      ...Array.from({ length: 7 }, () => load("standard flatbed", "delivered")),
+    ];
+    const mix = loadTypeMix(loads, "oversize");
+    expect(mix.pct).toBeCloseTo(5 / 12);
+    expect(mix.specialist).toBe(true);
+  });
+
+  it("does not flag specialist below the 40% share even with 5 loads", () => {
+    // 5 of 13 delivered = 38.5% → not a specialist
+    const loads = [
+      ...Array.from({ length: 5 }, () => load("oversize", "delivered")),
+      ...Array.from({ length: 8 }, () => load("standard flatbed", "delivered")),
+    ];
+    const mix = loadTypeMix(loads, "oversize");
+    expect(mix.specialist).toBe(false);
+  });
+
+  it("does not flag specialist below 5 loads even at a high share", () => {
+    // 4 of 8 delivered = 50% but only 4 loads → not yet a specialist
+    const loads = [
+      ...Array.from({ length: 4 }, () => load("oversize", "delivered")),
+      ...Array.from({ length: 4 }, () => load("standard flatbed", "delivered")),
+    ];
+    const mix = loadTypeMix(loads, "oversize");
+    expect(mix.count).toBe(4);
+    expect(mix.pct).toBeCloseTo(0.5);
+    expect(mix.specialist).toBe(false);
+  });
+});

--- a/frontend/src/lib/metrics/loadMix.ts
+++ b/frontend/src/lib/metrics/loadMix.ts
@@ -1,0 +1,29 @@
+import type { Load } from "@/types/load";
+
+// A driver's share of a given load_type among their DELIVERED loads — the work
+// actually run (booked/in-transit haven't happened; cancelled didn't). The
+// "specialist" flag lights up only when the share is genuinely high, so the
+// badge on the card means something instead of firing on a single load.
+export interface TypeMix {
+  count: number; // delivered loads of this type
+  pct: number | null; // count / delivered total; null when no delivered loads
+  specialist: boolean;
+}
+
+export const SPECIALIST_MIN_PCT = 0.4;
+export const SPECIALIST_MIN_COUNT = 5;
+// A strip only appears once the driver has run a real body of that work, so a
+// one-off doesn't earn a card. (Display floor — distinct from the specialist bar.)
+export const STRIP_MIN_COUNT = 10;
+
+export const loadTypeMix = (loads: Array<Load>, loadType: string): TypeMix => {
+  const delivered = loads.filter((l) => l.load_status === "delivered");
+  const count = delivered.filter((l) => l.load_type === loadType).length;
+  const pct = delivered.length > 0 ? count / delivered.length : null;
+  return {
+    count,
+    pct,
+    specialist:
+      pct != null && pct >= SPECIALIST_MIN_PCT && count >= SPECIALIST_MIN_COUNT,
+  };
+};

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -11,6 +11,9 @@ import { getExpensePeriods } from "@/services/expensesService";
 import { getObligations } from "@/services/obligationsService";
 import { getFuelEntries } from "@/services/fuelService";
 import { getTrucks } from "@/services/trucksService";
+import { getLastHomeDay } from "@/services/perDiemService";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import { hometimeStatus } from "@/lib/metrics/hometime";
 import { useLoads } from "@/hooks/useLoads";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
@@ -33,6 +36,7 @@ import {
   personalBests,
 } from "@/lib/metrics/playerCard";
 import { computeGrind } from "@/lib/metrics/grind";
+import { loadTypeMix } from "@/lib/metrics/loadMix";
 import { computePatches } from "@/lib/awards/patches";
 import { computeMedals, earnedMedals } from "@/lib/awards/medals";
 import { assetLoanStatus } from "@/lib/metrics/payoff";
@@ -63,6 +67,8 @@ const DriverDetailPage = () => {
   const [obligations, setObligations] = useState<Obligation[]>([]);
   const [fuel, setFuel] = useState<FuelEntry[]>([]);
   const [trucks, setTrucks] = useState<Truck[]>([]);
+  const [lastHome, setLastHome] = useState<string | null>(null);
+  const [hometimeThreshold, setHometimeThreshold] = useState(21);
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -80,6 +86,10 @@ const DriverDetailPage = () => {
     getObligations().then(setObligations).catch(() => {});
     getFuelEntries().then(setFuel).catch(() => {});
     getTrucks().then(setTrucks).catch(() => {});
+    getLastHomeDay().then(setLastHome).catch(() => {});
+    getSettlementSchedule()
+      .then((s) => setHometimeThreshold(s.hometime_threshold_days))
+      .catch(() => {});
   }, []);
 
   const driverLoads = useMemo(
@@ -147,8 +157,17 @@ const DriverDetailPage = () => {
       medals: earnedMedals(medals),
       bests: personalBests(driverLoads, fuel, now),
       patches: computePatches(driverLoads, fuel),
+      // Equipment identity — oversize and heavy haul kept as separate disciplines.
+      oversize: loadTypeMix(driverLoads, "oversize"),
+      heavyHaul: loadTypeMix(driverLoads, "heavy haul"),
     };
   }, [driverLoads, periods, obligations, fuel, trucks]);
+
+  // Hometime status for the (owner-op) driver — days since their last home mark.
+  const hometime = useMemo(
+    () => hometimeStatus(lastHome, hometimeThreshold, new Date()),
+    [lastHome, hometimeThreshold],
+  );
 
   const saveEdit = async (data: Record<string, unknown>) => {
     if (!driver) return;
@@ -213,6 +232,9 @@ const DriverDetailPage = () => {
             form={card.form}
             windowRpm={card.windowRpm}
             medals={card.medals}
+            oversize={card.oversize}
+            heavyHaul={card.heavyHaul}
+            hometime={hometime}
           />
           <RecordBook records={driverRecordChips(card.bests)} />
           <PatchBoard patches={card.patches} />

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -479,6 +479,59 @@ const GuidePage = () => (
       </Section>
 
       <h2 className="font-condensed text-2xl mb-3 mt-8" style={{ color: AMBER_HI }}>
+        The driver card
+      </h2>
+
+      <Metric
+        title="Overall — your current grade"
+        answers="The weaker of your rate grade and your operating-margin grade — a weakest-link read on how the season is going."
+      >
+        <Formula>Overall = the lower of your Rate grade and Op-margin grade</Formula>
+        <Why>
+          A strong rate can't paper over a thin margin, and vice-versa, so the card
+          shows whichever is lagging. Rate and Op margin each grade{" "}
+          <span className="text-light">Below → Minimum → Target → Strong</span>{" "}
+          against your break-even ladder. (This was labeled "Form" before.)
+        </Why>
+      </Metric>
+
+      <Metric
+        title="Equipment mix — oversize &amp; heavy haul"
+        answers="How much of your delivered work is oversize, and separately, heavy haul. Clear a high bar in either and the card names you a specialist."
+      >
+        <Formula>loads of that type ÷ your delivered loads</Formula>
+        <Eg>
+          12 oversize of 48 delivered → <span className="text-light">25%</span>. The
+          specialist badge lights at{" "}
+          <span className="text-light">40% and at least 5 loads</span>.
+        </Eg>
+        <Why>
+          Oversize and heavy haul are different disciplines — different equipment,
+          permits, and skill — so each gets its own strip and its own badge. A strip
+          appears once you've delivered{" "}
+          <span className="text-light">10+ loads</span> of that type, so a one-off
+          doesn't earn a card. Standard and hazmat loads aren't counted toward either.
+        </Why>
+      </Metric>
+
+      <Metric
+        title="Hometime — days since you were home"
+        answers="Days since your most recent home day. Past your threshold, the card flags it so a long stretch out doesn't sneak up on you."
+      >
+        <Formula>today − your last home day · flag when it crosses your threshold</Formula>
+        <Eg>
+          Home June 27, today July 15 → <span className="text-light">18 days out</span>.
+          Under a 21-day target it stays calm; cross 21 and it turns to a red flag.
+        </Eg>
+        <Why>
+          It reads home days from the Per Diem calendar — mark them there to keep it
+          honest. Set the threshold on the Settings page (default{" "}
+          <span className="text-light">21 days</span>). No home marks yet? The card
+          nudges you to start rather than guess.
+        </Why>
+      </Metric>
+
+      <h2 className="font-condensed text-2xl mb-3 mt-8" style={{ color: AMBER_HI }}>
         The truck
       </h2>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -55,6 +55,7 @@ const SettingsPage = () => {
   const [freeHours, setFreeHours] = useState(3);
   const [perDiemRate, setPerDiemRate] = useState(69);
   const [perDiemPct, setPerDiemPct] = useState(80); // stored as %, saved as fraction
+  const [hometimeThresh, setHometimeThresh] = useState(21);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
@@ -72,6 +73,7 @@ const SettingsPage = () => {
         setFreeHours(s.detention_free_hours);
         setPerDiemRate(s.per_diem_rate);
         setPerDiemPct(Math.round(s.per_diem_deduct_pct * 100));
+        setHometimeThresh(s.hometime_threshold_days);
       })
       .catch(() => setErr("Couldn't load your settlement schedule."));
   }, []);
@@ -96,6 +98,7 @@ const SettingsPage = () => {
         detention_free_hours: freeHours,
         per_diem_rate: perDiemRate,
         per_diem_deduct_pct: perDiemPct / 100,
+        hometime_threshold_days: hometimeThresh,
       });
       setMsg("Saved. Your revenue and targets now use this split.");
     } catch (e) {
@@ -291,6 +294,36 @@ const SettingsPage = () => {
         <span className="text-xs text-muted-text mt-3 block">
           Saved with the schedule above.
         </span>
+      </Panel>
+
+      <Panel className="mt-6 max-w-[680px] p-5">
+        <h2 className="text-lg font-medium text-light">Hometime</h2>
+        <p className="text-sm text-muted-text mt-1">
+          How many days out before the driver page flags your hometime. "Days
+          out" counts from your most recent home day on the Per Diem calendar, so
+          mark home days there to keep it accurate.
+        </p>
+        <label className="block mt-4">
+          <span className="text-sm text-light">Flag after</span>
+          <div className="flex items-center gap-2 mt-1">
+            <input
+              type="number"
+              min={1}
+              max={365}
+              step={1}
+              value={Number.isFinite(hometimeThresh) ? hometimeThresh : ""}
+              onChange={(e) => {
+                setMsg(null);
+                setHometimeThresh(Math.round(Number(e.target.value)));
+              }}
+              className="w-24 bg-steel rounded px-2 py-1.5 text-light text-right tabular-nums"
+            />
+            <span className="text-muted-text">days out</span>
+          </div>
+          <span className="text-xs text-muted-text mt-1 block">
+            Saved with the schedule above.
+          </span>
+        </label>
       </Panel>
 
       <AccessorialRatesCard />

--- a/frontend/src/services/perDiemService.ts
+++ b/frontend/src/services/perDiemService.ts
@@ -17,3 +17,9 @@ export const setPerDiemDay = async (
 export const clearPerDiemDay = async (day: string): Promise<void> => {
   await api.delete(`/per-diem/${day}`);
 };
+
+// Most recent home day on/before today, or null when nothing's marked.
+export const getLastHomeDay = async (): Promise<string | null> => {
+  const res = await api.get("/per-diem/last-home");
+  return res.data.last_home ?? null;
+};

--- a/frontend/src/services/settlementScheduleService.ts
+++ b/frontend/src/services/settlementScheduleService.ts
@@ -12,6 +12,10 @@ const coerce = (s: Record<string, unknown>): SettlementSchedule => ({
   per_diem_rate: s.per_diem_rate != null ? Number(s.per_diem_rate) : 69,
   per_diem_deduct_pct:
     s.per_diem_deduct_pct != null ? Number(s.per_diem_deduct_pct) : 0.8,
+  hometime_threshold_days:
+    s.hometime_threshold_days != null
+      ? Number(s.hometime_threshold_days)
+      : 21,
 });
 
 export const getSettlementSchedule = async (): Promise<SettlementSchedule> => {

--- a/frontend/src/types/settlementSchedule.ts
+++ b/frontend/src/types/settlementSchedule.ts
@@ -10,4 +10,5 @@ export interface SettlementSchedule {
   detention_free_hours: number; // free time per stop before detention accrues
   per_diem_rate: number; // IRS special M&IE daily rate
   per_diem_deduct_pct: number; // deductible share (0.80 for DOT drivers)
+  hometime_threshold_days: number; // flag the driver page past this many days out
 }


### PR DESCRIPTION
Closes #230, closes #245, closes #233.

One cohesive pass over the driver player card.

## Changes
- **#230 — "Form" → "Overall".** Relabels the card grade with a tooltip: it's the *weaker* of your Rate and Op-margin grades (a weakest-link read).
- **#245 — Oversize & Heavy haul strips.** Two **separate** identity strips (distinct disciplines — different equipment, permits, skill), each showing count + % of delivered loads with a **specialist** badge at ≥40% and ≥5 loads. A strip only appears once you've delivered **10+ loads** of that type, so a one-off doesn't earn a card.
- **#233 — Hometime.** Days since your most recent per-diem `home` mark, flagged on the card past a per-user threshold (**default 21**, editable in Settings → Hometime). Four states: over (red), within-threshold (calm), home today, and a no-data nudge so missing marks never false-alarm.

## Backend
- Migration **043**: `hometime_threshold_days` on `settlement_schedules` (default 21, CHECK 1–365). **Applied to dev + prod** ahead of merge.
- `getLastHomeDay` service + `GET /per-diem/last-home` route (last `home` day on/before today; excludes future planned-home marks).
- Settlement-schedule service carries the new field through DEFAULTS / validation / upsert.

## Guide
New **"The driver card"** section explaining Overall, the equipment mix + specialist bar + 10-load floor, and hometime.

## Verification
- 275 frontend tests pass (13 new: `loadMix` + `hometime`, boundary cases incl. threshold edges and future-home clamp). Strict production build clean.
- Checked against real prod data: `load_type` strings match (`oversize`, `heavy haul`); with the 10-load floor the live card shows Oversize (12/48 = 25%, plain) and hides Heavy haul (1 load). Last-home query returns null (0 home marks) → hometime shows the nudge state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)