### PR TITLE
feat: operation setting + flatbed/oversize achievement set (#231)

### DIFF
--- a/backend/db/migrations/046_operation.sql
+++ b/backend/db/migrations/046_operation.sql
@@ -1,0 +1,10 @@
+-- The user's operation (equipment/discipline), which tailors their achievements:
+-- open-deck operations (flatbed, heavy haul, oversize) earn the oversize badge set;
+-- others keep the universal badges. Per-user preference on the settlement_schedules
+-- row (the de-facto settings table). RLS already enabled there (migration 042).
+ALTER TABLE settlement_schedules
+  ADD COLUMN IF NOT EXISTS operation text NOT NULL DEFAULT 'flatbed'
+    CHECK (operation IN (
+      'flatbed', 'heavy haul', 'oversize', 'tank',
+      'van', 'reefer', 'dump', 'car hauler', 'other'
+    ));

--- a/backend/src/services/settlementScheduleServices.js
+++ b/backend/src/services/settlementScheduleServices.js
@@ -13,7 +13,20 @@ const DEFAULTS = {
   per_diem_rate: 69,
   per_diem_deduct_pct: 0.8,
   hometime_threshold_days: 21,
+  operation: "flatbed",
 };
+
+const OPERATIONS = [
+  "flatbed",
+  "heavy haul",
+  "oversize",
+  "tank",
+  "van",
+  "reefer",
+  "dump",
+  "car hauler",
+  "other",
+];
 
 const PCT_FIELDS = [
   "linehaul_pct",
@@ -29,6 +42,7 @@ const COLUMNS = [
   "per_diem_rate",
   "per_diem_deduct_pct",
   "hometime_threshold_days",
+  "operation",
 ];
 
 // ---- GET ---- (always returns a schedule; defaults if none saved yet)
@@ -89,6 +103,12 @@ export async function upsertSettlementSchedule(user_id, data) {
     provided.hometime_threshold_days = n;
   }
 
+  if (data.operation !== undefined) {
+    if (!OPERATIONS.includes(data.operation))
+      throw new ValidationError(`operation must be one of: ${OPERATIONS.join(", ")}`);
+    provided.operation = data.operation;
+  }
+
   if (Object.keys(provided).length === 0)
     throw new ValidationError("No valid fields to update");
 
@@ -98,8 +118,8 @@ export async function upsertSettlementSchedule(user_id, data) {
 
   const result = await db.query(
     `INSERT INTO settlement_schedules
-       (user_id, linehaul_pct, trailer_pct, fuel_surcharge_pct, accessorial_pct, carrier_name, detention_free_hours, per_diem_rate, per_diem_deduct_pct, hometime_threshold_days)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       (user_id, linehaul_pct, trailer_pct, fuel_surcharge_pct, accessorial_pct, carrier_name, detention_free_hours, per_diem_rate, per_diem_deduct_pct, hometime_threshold_days, operation)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
      ON CONFLICT (user_id) DO UPDATE SET
        linehaul_pct            = EXCLUDED.linehaul_pct,
        trailer_pct             = EXCLUDED.trailer_pct,
@@ -110,6 +130,7 @@ export async function upsertSettlementSchedule(user_id, data) {
        per_diem_rate           = EXCLUDED.per_diem_rate,
        per_diem_deduct_pct     = EXCLUDED.per_diem_deduct_pct,
        hometime_threshold_days = EXCLUDED.hometime_threshold_days,
+       operation               = EXCLUDED.operation,
        updated_at              = NOW()
      RETURNING ${COLUMNS.join(", ")}`,
     [
@@ -123,6 +144,7 @@ export async function upsertSettlementSchedule(user_id, data) {
       m.per_diem_rate,
       m.per_diem_deduct_pct,
       m.hometime_threshold_days,
+      m.operation,
     ],
   );
   return result.rows[0];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.87.0",
+  "version": "1.88.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/awards/PatchBoard.tsx
+++ b/frontend/src/components/awards/PatchBoard.tsx
@@ -3,6 +3,7 @@ import { awardIcon } from "./awardIcons";
 
 const PatchEmblem = ({ p }: { p: Patch }) => {
   const earned = p.count > 0;
+  const blue = !!p.operational; // operation-specific feats read blue vs amber
   const Icon = awardIcon(p.icon);
   return (
     <div style={{ width: 96, textAlign: "center", position: "relative", opacity: earned ? 1 : 0.5 }}>
@@ -15,11 +16,11 @@ const PatchEmblem = ({ p }: { p: Patch }) => {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: earned ? "#2a1e0e" : "#141a26",
-          border: `3px solid ${earned ? "#e8940a" : "#2a3550"}`,
+          background: earned ? (blue ? "#0f1d33" : "#2a1e0e") : "#141a26",
+          border: `3px solid ${earned ? (blue ? "#3b82f6" : "#e8940a") : "#2a3550"}`,
         }}
       >
-        <Icon size={28} style={{ color: earned ? "#f5b03a" : "#5b6b82" }} />
+        <Icon size={28} style={{ color: earned ? (blue ? "#60a5fa" : "#f5b03a") : "#5b6b82" }} />
       </div>
       {earned && (
         <span
@@ -28,8 +29,8 @@ const PatchEmblem = ({ p }: { p: Patch }) => {
             position: "absolute",
             top: -3,
             right: 12,
-            background: "#e8940a",
-            color: "#120f08",
+            background: blue ? "#3b82f6" : "#e8940a",
+            color: blue ? "#08111f" : "#120f08",
             borderRadius: 99,
             fontSize: 11,
             padding: "0 6px",

--- a/frontend/src/components/awards/awardIcons.ts
+++ b/frontend/src/components/awards/awardIcons.ts
@@ -20,6 +20,9 @@ import {
   Flag,
   Droplet,
   Weight,
+  MoveHorizontal,
+  Ruler,
+  Crown,
   type LucideIcon,
 } from "lucide-react";
 
@@ -48,6 +51,9 @@ const MAP: Record<string, LucideIcon> = {
   flag: Flag,
   droplet: Droplet,
   weight: Weight,
+  "move-horizontal": MoveHorizontal,
+  ruler: Ruler,
+  crown: Crown,
 };
 
 export const awardIcon = (name: string): LucideIcon => MAP[name] ?? Trophy;

--- a/frontend/src/lib/awards/patches.test.ts
+++ b/frontend/src/lib/awards/patches.test.ts
@@ -55,4 +55,56 @@ describe("computePatches", () => {
     ];
     expect(find(loads, "coast-to-coast").count).toBe(1);
   });
+
+  // ---- Operation-specific (open-deck) set ----
+  const findOp = (loads: Load[], key: string, operation: string) =>
+    computePatches(loads, [] as FuelEntry[], operation).find((p) => p.key === key);
+
+  it("gates the oversize set to open-deck operations", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", linehaul: "2000", width_in: 156, length_in: 617, weight: 40000 }),
+    ];
+    // flatbed → the set is present and marked operational
+    const wide = findOp(loads, "wide-load", "flatbed");
+    expect(wide).toBeDefined();
+    expect(wide!.operational).toBe(true);
+    expect(findOp(loads, "mountain-mover", "flatbed")).toBeDefined();
+    // van → the whole operational set is absent
+    expect(findOp(loads, "wide-load", "van")).toBeUndefined();
+    expect(findOp(loads, "long-load", "van")).toBeUndefined();
+    expect(findOp(loads, "super-load", "van")).toBeUndefined();
+    expect(findOp(loads, "mountain-mover", "van")).toBeUndefined();
+  });
+
+  it("Wide Load earns only above the 12' floor", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", linehaul: "2000", width_in: 156 }), // 13'0" → clears
+      L({ delivery_date: "2026-05-02", linehaul: "2000", width_in: 120 }), // 10'0" → under
+    ];
+    const wide = findOp(loads, "wide-load", "flatbed")!;
+    expect(wide.count).toBe(1);
+    expect(wide.bar).toBe(144); // 12' floor holds until history builds
+    expect(wide.hint).toBe("clear 12'0\"");
+  });
+
+  it("Long Load holds an 80' floor most loads never reach", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", linehaul: "2000", length_in: 617 }), // 51'5" → under 80'
+    ];
+    const long = findOp(loads, "long-load", "flatbed")!;
+    expect(long.count).toBe(0);
+    expect(long.bar).toBe(960); // 80'
+  });
+
+  it("Super Load is structural and fires on a real superload threshold", () => {
+    const loads = [
+      L({ delivery_date: "2026-05-01", linehaul: "2000", width_in: 200 }), // 16'8" wide → superload
+      L({ delivery_date: "2026-05-02", linehaul: "2000", width_in: 156 }), // 13' → not
+      L({ delivery_date: "2026-05-03", linehaul: "2000", weight: 210000 }), // >200k lb → superload
+    ];
+    const sl = findOp(loads, "super-load", "flatbed")!;
+    expect(sl.count).toBe(2);
+    expect(sl.bar).toBeNull();
+    expect(sl.operational).toBe(true);
+  });
 });

--- a/frontend/src/lib/awards/patches.ts
+++ b/frontend/src/lib/awards/patches.ts
@@ -6,6 +6,7 @@
 import type { Load } from "@/types/load";
 import type { FuelEntry } from "@/types/fuelEntry";
 import { loadGross, loadRevenue } from "@/lib/metrics/rateTargets";
+import { formatInches } from "@/lib/dimensions";
 import { computeStack, type BarOpts } from "./adaptiveBar";
 
 export interface Patch {
@@ -14,9 +15,25 @@ export interface Patch {
   icon: string;
   count: number; // ×N earned (0 = not yet)
   bar: number | null; // current threshold to clear now (null = structural)
-  unit: "money" | "miles" | "pct" | "weight" | null;
+  unit: "money" | "miles" | "pct" | "weight" | "length" | null;
+  operational?: boolean; // true = operation-specific set (shown blue), else universal
   hint: string; // one-liner requirement / progress
 }
+
+// Operations that run open-deck freight and so earn the oversize/flatbed set.
+const OPEN_DECK = new Set(["flatbed", "heavy haul", "oversize"]);
+
+// A genuine superload by the common cross-state thresholds (varies by state):
+// beyond ~16' wide/high, ~150' long, or ~200,000 lb. See #231 research.
+const SUPER_WIDTH_IN = 16 * 12;
+const SUPER_HEIGHT_IN = 16 * 12;
+const SUPER_LENGTH_IN = 150 * 12;
+const SUPER_WEIGHT_LB = 200_000;
+const isSuperload = (l: Load): boolean =>
+  (Number(l.width_in) || 0) >= SUPER_WIDTH_IN ||
+  (Number(l.height_in) || 0) >= SUPER_HEIGHT_IN ||
+  (Number(l.length_in) || 0) >= SUPER_LENGTH_IN ||
+  (Number(l.weight) || 0) >= SUPER_WEIGHT_LB;
 
 const delivered = (loads: Load[]): Load[] =>
   loads
@@ -62,12 +79,15 @@ const ADAPTIVE: {
 }[] = [
   { key: "big-ticket", name: "Big Ticket", icon: "cash", unit: "money", opts: { n: 5, floor: 7000 }, value: (l) => loadGross(l) },
   { key: "long-hauler", name: "Long Hauler", icon: "road", unit: "miles", opts: { n: 5, floor: 1200 }, value: (l) => Number(l.loaded_miles) || 0 },
-  { key: "mountain-mover", name: "Mountain Mover", icon: "mountain", unit: "weight", opts: { n: 5, floor: 46000 }, value: (l) => Number(l.weight) || 0 },
 ];
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 
-export const computePatches = (loads: Load[], _fuel: FuelEntry[]): Patch[] => {
+export const computePatches = (
+  loads: Load[],
+  _fuel: FuelEntry[],
+  operation: string = "flatbed",
+): Patch[] => {
   const dl = delivered(loads);
   const out: Patch[] = [];
 
@@ -121,6 +141,30 @@ export const computePatches = (loads: Load[], _fuel: FuelEntry[]): Patch[] => {
   const doubles = [...perDay.values()].filter((c) => c >= 2).length;
   out.push({ key: "doubleheader", name: "Doubleheader", icon: "layers-subtract", count: doubles, bar: null, unit: null, hint: "2+ delivered in a day" });
 
+  // ---- Operation-specific set (open-deck): the oversize/flatbed feats, shown blue.
+  // Gated so a tanker or van never sees "Wide Load". Dimensions come from #244.
+  if (OPEN_DECK.has(operation)) {
+    // Wide Load — adaptive on cargo width, floor 12' (only true wide loads count).
+    const widths = dl.map((l) => Number(l.width_in) || 0).filter((v) => v > 0);
+    const wide = computeStack(widths, { n: 5, floor: 12 * 12 });
+    out.push({ key: "wide-load", name: "Wide Load", icon: "move-horizontal", count: wide.count, bar: wide.bar, unit: "length", operational: true, hint: `clear ${formatInches(Math.round(wide.bar))}` });
+
+    // Long Load — adaptive on cargo length, floor 80'.
+    const lengths = dl.map((l) => Number(l.length_in) || 0).filter((v) => v > 0);
+    const long = computeStack(lengths, { n: 5, floor: 80 * 12 });
+    out.push({ key: "long-load", name: "Long Load", icon: "ruler", count: long.count, bar: long.bar, unit: "length", operational: true, hint: `clear ${formatInches(Math.round(long.bar))}` });
+
+    // Mountain Mover — adaptive on weight (operation-specific for open-deck).
+    const weights = dl.map((l) => Number(l.weight) || 0).filter((v) => v > 0);
+    const mm = computeStack(weights, { n: 5, floor: 46000 });
+    out.push({ key: "mountain-mover", name: "Mountain Mover", icon: "mountain", count: mm.count, bar: mm.bar, unit: "weight", operational: true, hint: `clear ${Math.round(mm.bar).toLocaleString("en-US")} lb` });
+
+    // Super Load — structural: a genuine superload by the real thresholds. Sits at
+    // x0 until you run one — a career milestone, not an everyday feat.
+    const supers = dl.filter(isSuperload).length;
+    out.push({ key: "super-load", name: "Super Load", icon: "crown", count: supers, bar: null, unit: null, operational: true, hint: "16'W · 16'H · 150'L · 200k lb" });
+  }
+
   return out;
 };
 
@@ -128,7 +172,10 @@ export const computePatches = (loads: Load[], _fuel: FuelEntry[]): Patch[] => {
 export const PATCH_GUIDE: { name: string; icon: string; how: string }[] = [
   { name: "Big Ticket", icon: "cash", how: "Land a top-tier load gross — the bar rises as you book bigger." },
   { name: "Long Hauler", icon: "road", how: "A haul among your longest — 1,000+ mi and climbing." },
-  { name: "Mountain Mover", icon: "mountain", how: "One of your heaviest loads — oversize and over-weight." },
+  { name: "Wide Load", icon: "move-horizontal", how: "An over-12' load — climbs toward your widest. (Open-deck operations.)" },
+  { name: "Long Load", icon: "ruler", how: "An 80'+ load by cargo length — the long stuff. (Open-deck operations.)" },
+  { name: "Mountain Mover", icon: "mountain", how: "One of your heaviest loads. (Open-deck operations.)" },
+  { name: "Super Load", icon: "crown", how: "A true superload — 16' wide/high, 150' long, or 200k lb. A career milestone." },
   { name: "Rainmaker", icon: "coins", how: "A top-tier net month." },
   { name: "Iron Week", icon: "barbell", how: "One of your busiest pay-weeks by load count." },
   { name: "Clean Run", icon: "gauge", how: "A week with your tightest deadhead." },

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -69,6 +69,7 @@ const DriverDetailPage = () => {
   const [trucks, setTrucks] = useState<Truck[]>([]);
   const [lastHome, setLastHome] = useState<string | null>(null);
   const [hometimeThreshold, setHometimeThreshold] = useState(21);
+  const [operation, setOperation] = useState("flatbed");
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -88,7 +89,10 @@ const DriverDetailPage = () => {
     getTrucks().then(setTrucks).catch(() => {});
     getLastHomeDay().then(setLastHome).catch(() => {});
     getSettlementSchedule()
-      .then((s) => setHometimeThreshold(s.hometime_threshold_days))
+      .then((s) => {
+        setHometimeThreshold(s.hometime_threshold_days);
+        setOperation(s.operation);
+      })
       .catch(() => {});
   }, []);
 
@@ -156,12 +160,12 @@ const DriverDetailPage = () => {
       windowRpm: basis.windowRpm,
       medals: earnedMedals(medals),
       bests: personalBests(driverLoads, fuel, now),
-      patches: computePatches(driverLoads, fuel),
+      patches: computePatches(driverLoads, fuel, operation),
       // Equipment identity — oversize and heavy haul kept as separate disciplines.
       oversize: loadTypeMix(driverLoads, "oversize"),
       heavyHaul: loadTypeMix(driverLoads, "heavy haul"),
     };
-  }, [driverLoads, periods, obligations, fuel, trucks]);
+  }, [driverLoads, periods, obligations, fuel, trucks, operation]);
 
   // Hometime status for the (owner-op) driver — days since their last home mark.
   const hometime = useMemo(

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
 import { Trophy, ArrowRight } from "lucide-react";
 import { RatingMedallion } from "@/components/agents/RatingMedallion";
 import { PrestigeBurst, PRESTIGE_META } from "@/components/agents/PrestigeBadge";
@@ -630,6 +631,17 @@ const GuidePage = () => (
       </Section>
 
       <Section title="Driver patches — hard, and they stack">
+        <p className="text-sm text-muted-text mb-3">
+          Patches earned in <span style={{ color: "#60a5fa" }}>blue</span> are your{" "}
+          <span className="text-light">operation-specific</span> feats — the
+          oversize/flatbed set (Wide, Long, Super Load, Mountain Mover) tied to your
+          Operation setting. The rest are <span style={{ color: "#f5b03a" }}>amber</span>{" "}
+          universal feats every operation can earn. Set your operation on the{" "}
+          <Link to="/settings" className="text-status-info-text hover:underline">
+            Settings page
+          </Link>
+          .
+        </p>
         <div className="grid sm:grid-cols-2 gap-x-6">
           {PATCH_GUIDE.map((p) => (
             <AwardLine key={p.name} icon={p.icon} name={p.name} sub={p.how} />

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -56,6 +56,7 @@ const SettingsPage = () => {
   const [perDiemRate, setPerDiemRate] = useState(69);
   const [perDiemPct, setPerDiemPct] = useState(80); // stored as %, saved as fraction
   const [hometimeThresh, setHometimeThresh] = useState(21);
+  const [operation, setOperation] = useState("flatbed");
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
@@ -74,6 +75,7 @@ const SettingsPage = () => {
         setPerDiemRate(s.per_diem_rate);
         setPerDiemPct(Math.round(s.per_diem_deduct_pct * 100));
         setHometimeThresh(s.hometime_threshold_days);
+        setOperation(s.operation);
       })
       .catch(() => setErr("Couldn't load your settlement schedule."));
   }, []);
@@ -99,6 +101,7 @@ const SettingsPage = () => {
         per_diem_rate: perDiemRate,
         per_diem_deduct_pct: perDiemPct / 100,
         hometime_threshold_days: hometimeThresh,
+        operation,
       });
       setMsg("Saved. Your revenue and targets now use this split.");
     } catch (e) {
@@ -294,6 +297,39 @@ const SettingsPage = () => {
         <span className="text-xs text-muted-text mt-3 block">
           Saved with the schedule above.
         </span>
+      </Panel>
+
+      <Panel className="mt-6 max-w-[680px] p-5">
+        <h2 className="text-lg font-medium text-light">Operation</h2>
+        <p className="text-sm text-muted-text mt-1">
+          Your equipment and discipline. It tailors your achievements — open-deck
+          operations (flatbed, heavy haul, oversize) earn the oversize badge set;
+          others keep the universal badges.
+        </p>
+        <label className="block mt-4">
+          <span className="text-sm text-light">Operation type</span>
+          <select
+            value={operation}
+            onChange={(e) => {
+              setMsg(null);
+              setOperation(e.target.value);
+            }}
+            className="block mt-1 w-56 bg-steel rounded px-2 py-1.5 text-light"
+          >
+            <option value="flatbed">Flatbed / Platform</option>
+            <option value="heavy haul">Heavy Haul</option>
+            <option value="oversize">Oversize</option>
+            <option value="tank">Tank</option>
+            <option value="van">Dry Van</option>
+            <option value="reefer">Reefer</option>
+            <option value="dump">Dump</option>
+            <option value="car hauler">Car Hauler</option>
+            <option value="other">Other</option>
+          </select>
+          <span className="text-xs text-muted-text mt-1 block">
+            Saved with the schedule above.
+          </span>
+        </label>
       </Panel>
 
       <Panel className="mt-6 max-w-[680px] p-5">

--- a/frontend/src/services/settlementScheduleService.ts
+++ b/frontend/src/services/settlementScheduleService.ts
@@ -16,6 +16,7 @@ const coerce = (s: Record<string, unknown>): SettlementSchedule => ({
     s.hometime_threshold_days != null
       ? Number(s.hometime_threshold_days)
       : 21,
+  operation: (s.operation as string) ?? "flatbed",
 });
 
 export const getSettlementSchedule = async (): Promise<SettlementSchedule> => {

--- a/frontend/src/types/settlementSchedule.ts
+++ b/frontend/src/types/settlementSchedule.ts
@@ -11,4 +11,5 @@ export interface SettlementSchedule {
   per_diem_rate: number; // IRS special M&IE daily rate
   per_diem_deduct_pct: number; // deductible share (0.80 for DOT drivers)
   hometime_threshold_days: number; // flag the driver page past this many days out
+  operation: string; // equipment/discipline — tailors which achievements apply
 }


### PR DESCRIPTION
Closes #231.

Achievements now tailor to the user's **operation**. Built on #244's structured dimensions.

## What
- **Operation setting** — Settings → Operation, per-user on `settlement_schedules`, default **Flatbed / Platform**. Single select, 9 operations.
- **Blue operation-specific patch set**, gated to open-deck operations (flatbed / heavy haul / oversize):
  - **Wide Load** — adaptive on cargo width, **12' floor**
  - **Long Load** — adaptive on cargo length, **80' floor**
  - **Mountain Mover** — weight (moved into the operational set)
  - **Super Load** — structural, real superload thresholds (**16' W/H, 150' L, 200k lb**)
- Operation-specific feats render **blue**; universal feats stay **amber**; locked stays gray. A tanker/van never sees Wide Load.
- Guide explains blue vs amber and links to the setting.

## Scope
Deliberately just the flatbed/oversize set (Jason's operation, per the scope decision); the enum scaffolds the other operations for later. `computePatches` gates by operation and defaults to `flatbed`, so dashboard award-pops are unaffected without extra plumbing.

## Verification
- Migration 046 (add `operation`, additive) applied to **dev + prod**; defaults to `flatbed`.
- Real prod data: Wide Load ×1 (widest *delivered* 12'4"), Mountain Mover ×2 (47k lb), Long Load + Super Load locked — gating and floors compute correctly.
- 288 tests pass (4 new: gating, Wide/Long floors, Super Load structural). Strict build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)