### PR TITLE
feat: days-based truck utilization + Road Warrior / Relentless achievements

### DIFF
--- a/backend/src/routes/perDiemRoutes.js
+++ b/backend/src/routes/perDiemRoutes.js
@@ -3,6 +3,7 @@ import { requireAuth } from "../middleware/requireAuth.js";
 import {
   getPerDiemDays,
   getLastHomeDay,
+  getHomeDays,
   upsertPerDiemDay,
   deletePerDiemDay,
 } from "../services/perDiemServices.js";
@@ -16,6 +17,20 @@ router.get("/last-home", async (req, res) => {
   try {
     const result = await getLastHomeDay(req.user.user_id);
     return res.status(200).json(result);
+  } catch (err) {
+    if (err.type === "validation")
+      return res.status(err.statusCode).json({ error: err.message });
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: err.message });
+  }
+});
+
+// ---- GET all home days (for the truck utilization week breakdown) ----
+router.get("/home-days", async (req, res) => {
+  try {
+    const days = await getHomeDays(req.user.user_id);
+    return res.status(200).json({ days });
   } catch (err) {
     if (err.type === "validation")
       return res.status(err.statusCode).json({ error: err.message });

--- a/backend/src/services/perDiemServices.js
+++ b/backend/src/services/perDiemServices.js
@@ -38,6 +38,19 @@ export async function getLastHomeDay(user_id) {
   return { last_home: result.rows[0]?.last_home ?? null };
 }
 
+// ---- all "home" days ---- (for the truck utilization week breakdown)
+export async function getHomeDays(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const result = await db.query(
+    `SELECT to_char(day, 'YYYY-MM-DD') AS day
+       FROM per_diem_days
+      WHERE user_id = $1 AND status = 'home'
+      ORDER BY day`,
+    [user_id],
+  );
+  return result.rows.map((r) => r.day);
+}
+
 // ---- UPSERT a day's status ----
 export async function upsertPerDiemDay(user_id, day, status) {
   if (!user_id) throw new ValidationError("Missing user_id");

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.88.0",
+  "version": "1.89.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/awards/truckAwards.test.ts
+++ b/frontend/src/lib/awards/truckAwards.test.ts
@@ -14,18 +14,20 @@ const L = (o: Record<string, unknown>): Load =>
 
 describe("computeTruckMedals", () => {
   it("tiers Mile Club on the odometer and adds Fuel Miser / Debt Crusher when present", () => {
-    const m = computeTruckMedals({ odometer: 582_450, avgMpg: 7.1, deliveredCount: 47, loanPaidPct: 0.36 });
+    const m = computeTruckMedals({ odometer: 582_450, avgMpg: 7.1, deliveredCount: 47, loanPaidPct: 0.36, utilization: 0.82 });
     const byKey = Object.fromEntries(m.map((x) => [x.key, x]));
     expect(byKey["mile-club"].tier).toBe(3); // ≥500k
     expect(byKey["fuel-miser"].tier).toBe(2); // ≥7.0
     expect(byKey["workhorse"].tier).toBe(0); // 47 < 100
     expect(byKey["debt-crusher"].tier).toBe(1); // ≥25%
+    expect(byKey["road-warrior"].tier).toBe(2); // ≥80%
   });
 
-  it("omits Fuel Miser / Debt Crusher when there's no data", () => {
-    const keys = computeTruckMedals({ odometer: 0, avgMpg: null, deliveredCount: 0, loanPaidPct: null }).map((m) => m.key);
+  it("omits Fuel Miser / Debt Crusher / Road Warrior when there's no data", () => {
+    const keys = computeTruckMedals({ odometer: 0, avgMpg: null, deliveredCount: 0, loanPaidPct: null, utilization: null }).map((m) => m.key);
     expect(keys).not.toContain("fuel-miser");
     expect(keys).not.toContain("debt-crusher");
+    expect(keys).not.toContain("road-warrior");
   });
 });
 

--- a/frontend/src/lib/awards/truckAwards.ts
+++ b/frontend/src/lib/awards/truckAwards.ts
@@ -5,6 +5,7 @@ import type { Load } from "@/types/load";
 import type { FuelEntry } from "@/types/fuelEntry";
 import { loadRevenue } from "@/lib/metrics/rateTargets";
 import { mpgWindows } from "@/lib/metrics/fuelEconomy";
+import { underLoadRuns } from "@/lib/metrics/underLoad";
 import { computeStack } from "./adaptiveBar";
 import { tiered, type Medal } from "./medals";
 import type { Patch } from "./patches";
@@ -59,6 +60,10 @@ export const computeTruckPatches = (truckLoads: Load[], truckFuel: FuelEntry[]):
   const th = computeStack(costPerMi, { n: 5, floor: 0.6, lowerIsBetter: true });
   out.push({ key: "thrifty", name: "Thrifty", icon: "coins", count: th.count, bar: th.bar, unit: "money", hint: `tank under $${th.bar.toFixed(2)}/mi` });
 
+  // Relentless — a run among your longest of consecutive days under a load.
+  const rel = computeStack(underLoadRuns(truckLoads), { n: 5, floor: 7 });
+  out.push({ key: "relentless", name: "Relentless", icon: "flame", count: rel.count, bar: rel.bar, unit: null, hint: `${Math.round(rel.bar)}-day run under load` });
+
   return out;
 };
 
@@ -67,6 +72,7 @@ export interface TruckMedalData {
   avgMpg: number | null;
   deliveredCount: number;
   loanPaidPct: number | null; // truck payoff
+  utilization: number | null; // days-based (0..1); drives Road Warrior
 }
 
 export const computeTruckMedals = (d: TruckMedalData): Medal[] => {
@@ -78,6 +84,8 @@ export const computeTruckMedals = (d: TruckMedalData): Medal[] => {
     medals.push(tiered("fuel-miser", "Fuel Miser", "droplet", [6.5, 7, 7.5], d.avgMpg, (n) => `${n.toFixed(1)} mpg`));
   if (d.loanPaidPct != null)
     medals.push(tiered("debt-crusher", "Debt Crusher", "lock-open", [0.25, 0.5, 0.75], d.loanPaidPct, (n) => `${Math.round(n * 100)}%`));
+  if (d.utilization != null)
+    medals.push(tiered("road-warrior", "Road Warrior", "gauge", [0.7, 0.8, 0.85], d.utilization, (n) => `${Math.round(n * 100)}%`));
   return medals;
 };
 
@@ -113,6 +121,7 @@ export const TRUCK_PATCH_GUIDE: { name: string; icon: string; how: string }[] = 
   { name: "Iron Horse", icon: "road", how: "A workhorse month — one of your highest for miles driven." },
   { name: "Marathon", icon: "flag", how: "One of your longest single hauls." },
   { name: "Thrifty", icon: "coins", how: "A tank under your best fuel cost per mile." },
+  { name: "Relentless", icon: "flame", how: "A run among your longest of consecutive days under a load." },
 ];
 
 export const TRUCK_MEDAL_GUIDE: { name: string; icon: string; tiers: string }[] = [
@@ -120,4 +129,5 @@ export const TRUCK_MEDAL_GUIDE: { name: string; icon: string; tiers: string }[] 
   { name: "Fuel Miser", icon: "droplet", tiers: "6.5 · 7.0 · 7.5 avg mpg" },
   { name: "Workhorse", icon: "stack-2", tiers: "100 · 250 · 500 loads hauled" },
   { name: "Debt Crusher", icon: "lock-open", tiers: "25% · 50% · 75% paid off" },
+  { name: "Road Warrior", icon: "gauge", tiers: "70% · 80% · 85% utilization" },
 ];

--- a/frontend/src/lib/metrics/truckMetrics.test.ts
+++ b/frontend/src/lib/metrics/truckMetrics.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { computeTruckMetrics } from "./truckMetrics";
+import type { Truck } from "@/types/truck";
+import type { Load } from "@/types/load";
+import type { FuelEntry } from "@/types/fuelEntry";
+import type { MaintenanceService } from "@/types/maintenance";
+
+const load = (pickup_date: string, delivery_date: string): Load =>
+  ({
+    load_status: "delivered",
+    payment_status: "paid",
+    pickup_date,
+    delivery_date,
+    loaded_miles: 500,
+    deadhead_miles: 0,
+    linehaul: "1000",
+    fuel_surcharge: "0",
+    total_accessorials: "0",
+  }) as unknown as Load;
+
+const now = new Date("2026-02-01T00:00:00Z");
+const run = (truck: Truck, loads: Load[], homeDays: string[]) =>
+  computeTruckMetrics(truck, loads, [] as FuelEntry[], [] as MaintenanceService[], now, homeDays);
+
+describe("computeTruckMetrics — days-based utilization", () => {
+  it("is under-load days ÷ window days, split into under-load / home / idle", () => {
+    const truck = { in_service_date: "2026-01-01", current_odometer: 0 } as Truck;
+    const loads = [
+      load("2026-01-05", "2026-01-07"), // 3 under-load days
+      load("2026-01-10", "2026-01-10"), // 1 under-load day
+    ];
+    const m = run(truck, loads, ["2026-01-15"]); // 1 home day, not under load
+
+    // window starts at the first pickup (later than in-service), runs to now.
+    expect(m.windowDays).toBe(27); // 2026-01-05 → 2026-02-01
+    expect(m.underLoadDays).toBe(4);
+    expect(m.homeDays).toBe(1);
+    expect(m.idleDays).toBe(22);
+    expect(m.underLoadDays + m.homeDays + m.idleDays).toBe(m.windowDays);
+    expect(m.utilization).toBeCloseTo(4 / 27);
+  });
+
+  it("starts the window at the later of in-service and first load", () => {
+    // in-service is AFTER the first pickup → days before it are not counted.
+    const truck = { in_service_date: "2026-01-06", current_odometer: 0 } as Truck;
+    const loads = [load("2026-01-05", "2026-01-07")]; // 01-05 is pre-window
+    const m = run(truck, loads, []);
+    expect(m.underLoadDays).toBe(2); // only 01-06 and 01-07
+  });
+
+  it("does not count a home day that was also under a load", () => {
+    const truck = { in_service_date: "2026-01-01", current_odometer: 0 } as Truck;
+    const loads = [load("2026-01-05", "2026-01-07")];
+    const m = run(truck, loads, ["2026-01-06"]); // home marked mid-haul
+    expect(m.homeDays).toBe(0); // 01-06 is under load, not a home gap
+  });
+});

--- a/frontend/src/lib/metrics/truckMetrics.ts
+++ b/frontend/src/lib/metrics/truckMetrics.ts
@@ -8,10 +8,17 @@ import type { MaintenanceService } from "@/types/maintenance";
 import type { Truck } from "@/types/truck";
 import { loadRevenue } from "./rateTargets";
 import { fuelStats } from "./fuelEconomy";
+import { underLoadDaySet } from "./underLoad";
 
 export interface TruckMetrics {
-  utilization: number | null; // active weeks ÷ weeks in service (0..1)
-  activeWeeks: number;
+  utilization: number | null; // under-load days ÷ window days (0..1)
+  // Breakdown of the window days so a low utilization is interpretable.
+  // underLoad + home + idle = windowDays. Home days count against utilization —
+  // this just explains why it wasn't earning (chosen time off vs. no freight).
+  windowDays: number; // days since the later of in-service and first logged load
+  underLoadDays: number; // days under a load (pickup→delivery spans, deduped)
+  homeDays: number; // days marked home and not under load
+  idleDays: number; // days with no load and no home mark — the true idle
   avgMpg: number | null;
   bestTank: number | null;
   fuelPerMile: number | null;
@@ -34,13 +41,6 @@ const loadMiles = (l: Load): number => {
   return odo > 0 ? odo : Number(l.loaded_miles || 0) + Number(l.deadhead_miles || 0);
 };
 
-const weekKey = (iso: string): string => {
-  const d = new Date(iso.slice(0, 10) + "T00:00:00Z");
-  const monday = new Date(d);
-  monday.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
-  return monday.toISOString().slice(0, 10);
-};
-
 // Maintenance services attributable to the tractor (no per-truck link exists yet,
 // so tractor + both count; fine for a single truck).
 const truckServiceSpend = (services: MaintenanceService[]): number =>
@@ -54,6 +54,7 @@ export const computeTruckMetrics = (
   truckFuel: FuelEntry[],
   services: MaintenanceService[],
   now: Date,
+  homeDays: string[] = [], // "YYYY-MM-DD" home marks, for the week breakdown
 ): TruckMetrics => {
   // Earned freight — delivered AND paid — matches the truck's net revenue elsewhere.
   const earned = truckLoads.filter(
@@ -66,20 +67,53 @@ export const computeTruckMetrics = (
   const fuelSpend = fs.totalSpend;
   const maintSpend = truckServiceSpend(services);
 
-  // Utilization — share of the weeks it's been in service that it actually ran.
+  // Utilization — days the truck was under a load ÷ days in the window. The window
+  // starts at the LATER of the in-service date and the first logged load, so weeks
+  // before you were running loads don't read as "idle" — they're unmeasured, not
+  // wasted. Days basis (not weeks) so intensity shows: a light week and a heavy one
+  // no longer look identical.
   const inService = truck.in_service_date
     ? new Date(truck.in_service_date.slice(0, 10) + "T00:00:00Z")
     : null;
-  const weeksInService = inService
-    ? Math.max(1, Math.round((now.getTime() - inService.getTime()) / (7 * DAY)))
+  const nowDay = now.toISOString().slice(0, 10);
+  const inServiceDay = truck.in_service_date
+    ? truck.in_service_date.slice(0, 10)
     : null;
-  const activeWeeks = new Set(
-    earned.filter((l) => l.delivery_date).map((l) => weekKey(l.delivery_date!)),
-  ).size;
+  const firstPickup = truckLoads
+    .filter((l) => l.load_status === "delivered" && l.pickup_date)
+    .map((l) => l.pickup_date.slice(0, 10))
+    .sort()[0];
+  const windowStart =
+    [inServiceDay, firstPickup].filter((d): d is string => !!d).sort().at(-1) ??
+    null;
+  const windowDays = windowStart
+    ? Math.max(
+        1,
+        Math.round(
+          (Date.parse(`${nowDay}T00:00:00Z`) -
+            Date.parse(`${windowStart}T00:00:00Z`)) /
+            DAY,
+        ),
+      )
+    : 0;
+
+  const underLoadSet = underLoadDaySet(truckLoads, windowStart, nowDay);
+  const underLoadDays = underLoadSet.size;
   const utilization =
-    weeksInService && weeksInService > 0
-      ? Math.min(1, activeWeeks / weeksInService)
-      : null;
+    windowDays > 0 ? Math.min(1, underLoadDays / windowDays) : null;
+
+  // Split the non-working days: home (marked home, not under load) vs truly idle.
+  // Home days still count against utilization (the truck's costs accrue) — this
+  // only labels why it wasn't earning.
+  const homeDayCount = new Set(
+    homeDays.filter(
+      (d) =>
+        (!windowStart || d >= windowStart) &&
+        d <= nowDay &&
+        !underLoadSet.has(d),
+    ),
+  ).size;
+  const idleDays = Math.max(0, windowDays - underLoadDays - homeDayCount);
 
   const monthsInService = inService
     ? Math.max(1, (now.getTime() - inService.getTime()) / (30.44 * DAY))
@@ -87,7 +121,10 @@ export const computeTruckMetrics = (
 
   return {
     utilization,
-    activeWeeks,
+    windowDays,
+    underLoadDays,
+    homeDays: homeDayCount,
+    idleDays,
     avgMpg: fs.avgMpg,
     bestTank: fs.bestMpg,
     fuelPerMile: fs.costPerMile,

--- a/frontend/src/lib/metrics/underLoad.test.ts
+++ b/frontend/src/lib/metrics/underLoad.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { underLoadDaySet, underLoadRuns } from "./underLoad";
+import type { Load } from "@/types/load";
+
+const L = (pickup_date: string, delivery_date: string): Load =>
+  ({ load_status: "delivered", pickup_date, delivery_date }) as unknown as Load;
+
+describe("underLoadDaySet", () => {
+  it("counts every day of a pickup→delivery span, inclusive", () => {
+    const set = underLoadDaySet([L("2026-02-02", "2026-02-04")], null, "9999-12-31");
+    expect([...set].sort()).toEqual(["2026-02-02", "2026-02-03", "2026-02-04"]);
+  });
+
+  it("dedupes overlapping loads — a day counts once", () => {
+    const set = underLoadDaySet(
+      [L("2026-02-02", "2026-02-04"), L("2026-02-03", "2026-02-05")],
+      null,
+      "9999-12-31",
+    );
+    expect(set.size).toBe(4); // 02-02..02-05
+  });
+
+  it("bounds to the window", () => {
+    const set = underLoadDaySet([L("2026-01-30", "2026-02-03")], "2026-02-01", "2026-02-02");
+    expect([...set].sort()).toEqual(["2026-02-01", "2026-02-02"]);
+  });
+
+  it("ignores non-delivered loads", () => {
+    const booked = { load_status: "booked", pickup_date: "2026-02-02", delivery_date: "2026-02-03" } as unknown as Load;
+    expect(underLoadDaySet([booked], null, "9999-12-31").size).toBe(0);
+  });
+});
+
+describe("underLoadRuns", () => {
+  it("returns the length of each consecutive run", () => {
+    // 02-02..02-04 (3), gap, 02-07..02-08 (2)
+    const runs = underLoadRuns([L("2026-02-02", "2026-02-04"), L("2026-02-07", "2026-02-08")]);
+    expect(runs.sort((a, b) => a - b)).toEqual([2, 3]);
+  });
+
+  it("merges touching spans into one run", () => {
+    const runs = underLoadRuns([L("2026-02-02", "2026-02-03"), L("2026-02-04", "2026-02-05")]);
+    expect(runs).toEqual([4]); // 02-02..02-05 unbroken
+  });
+
+  it("returns empty for no loads", () => {
+    expect(underLoadRuns([])).toEqual([]);
+  });
+});

--- a/frontend/src/lib/metrics/underLoad.ts
+++ b/frontend/src/lib/metrics/underLoad.ts
@@ -1,0 +1,49 @@
+import type { Load } from "@/types/load";
+
+const DAY = 86_400_000;
+
+// Distinct calendar days the truck was under a load — each delivered load's
+// pickup→delivery span, inclusive — optionally bounded to [startKey, endKey].
+// This is the honest basis for utilization: a day counts once no matter how many
+// loads overlap it, and a multi-day haul counts every day it was working.
+export const underLoadDaySet = (
+  loads: Load[],
+  startKey: string | null,
+  endKey: string,
+): Set<string> => {
+  const set = new Set<string>();
+  for (const l of loads) {
+    if (l.load_status !== "delivered" || !l.pickup_date) continue;
+    const s = l.pickup_date.slice(0, 10);
+    const e = (l.delivery_date ?? l.pickup_date).slice(0, 10);
+    const cur = new Date(`${s}T00:00:00Z`);
+    const end = new Date(`${e}T00:00:00Z`);
+    let guard = 0;
+    while (cur <= end && guard++ < 500) {
+      const k = cur.toISOString().slice(0, 10);
+      if ((!startKey || k >= startKey) && k <= endKey) set.add(k);
+      cur.setUTCDate(cur.getUTCDate() + 1);
+    }
+  }
+  return set;
+};
+
+// Lengths of each consecutive-day run of under-load days (gaps-and-islands) — the
+// stretches the truck rolled without a break. Feeds the Relentless patch.
+export const underLoadRuns = (loads: Load[]): number[] => {
+  const days = [...underLoadDaySet(loads, null, "9999-12-31")].sort();
+  const runs: number[] = [];
+  let runLen = 0;
+  let prevMs = -Infinity;
+  for (const d of days) {
+    const ms = Date.parse(`${d}T00:00:00Z`);
+    if (ms - prevMs === DAY) runLen++;
+    else {
+      if (runLen > 0) runs.push(runLen);
+      runLen = 1;
+    }
+    prevMs = ms;
+  }
+  if (runLen > 0) runs.push(runLen);
+  return runs;
+};

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -537,20 +537,54 @@ const GuidePage = () => (
       </h2>
 
       <Metric
-        title="Utilization — how often the truck earns"
-        answers="The share of the weeks it's been in service that it actually ran a load. Idle weeks pull it down."
+        title="Utilization — how hard the truck runs"
+        answers="The share of days the truck was under a load — pickup to delivery — since your first logged load. Idle days pull it down."
       >
-        <Formula>active weeks ÷ weeks in service</Formula>
+        <Formula>days under load ÷ days in window</Formula>
         <div className="mt-3">
-          <UtilBar active={23} total={26} />
+          <UtilBar active={138} total={190} />
         </div>
         <Eg>
-          In service 26 weeks, ran a load in 23 →{" "}
-          <span className="text-light">88%</span>.
+          Under a load 138 of 190 days →{" "}
+          <span className="text-light">73%</span>. The day breakdown splits the
+          rest: <span style={{ color: "#60a5fa" }}>home</span> days (you marked
+          home and ran nothing) vs <span style={{ color: "#f87171" }}>idle</span>{" "}
+          days (no load, not home) — so a low number tells you whether it was time
+          off or missing freight. Home days still count against utilization; it's
+          your truck's real opportunity cost. The window starts at your first logged
+          load, so weeks before you were entering loads don't read as idle.
         </Eg>
         <Why>
-          Across a fleet, this is the number that exposes a truck sitting idle
-          while the others run.
+          Across a fleet, this is the number that exposes a truck sitting idle while
+          the others run.{" "}
+          <span className="text-light">Benchmark:</span> best-in-class fleets run{" "}
+          <span className="text-light">80–85%</span>; under{" "}
+          <span className="text-light">70%</span> signals real idle time or weak
+          load planning. Measuring days-under-load (not hours) keeps it close to the
+          industry's revenue-hours ÷ available-hours, so the benchmark is a fair
+          read. It also powers the <span className="text-light">Road Warrior</span>{" "}
+          medal (70 · 80 · 85%).
+          <span className="block mt-1 text-xs text-muted-text">
+            Sources:{" "}
+            <a
+              href="https://fleetrabbit.com/industry/transportation-and-logistics/improving-truck-fleet-utilization-above-85-percent-across-lanes-and-terminals-2026"
+              target="_blank"
+              rel="noreferrer"
+              className="text-status-info-text hover:underline"
+            >
+              FleetRabbit (2026)
+            </a>
+            ,{" "}
+            <a
+              href="https://www.atbs.com/post/how-have-owner-operators-performed-so-far"
+              target="_blank"
+              rel="noreferrer"
+              className="text-status-info-text hover:underline"
+            >
+              ATBS
+            </a>
+            .
+          </span>
         </Why>
       </Metric>
 

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   getMaintenanceServices,
 } from "@/services/maintenanceService";
 import { getFuelEntries } from "@/services/fuelService";
+import { getHomeDays } from "@/services/perDiemService";
 import { useLoads } from "@/hooks/useLoads";
 import {
   computeDue,
@@ -86,6 +87,7 @@ const TruckDetailPage = () => {
   const [services, setServices] = useState<MaintenanceService[]>([]);
   const [fuelEntries, setFuelEntries] = useState<FuelEntry[]>([]);
   const [obligations, setObligations] = useState<Obligation[]>([]);
+  const [homeDays, setHomeDays] = useState<string[]>([]);
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -106,6 +108,9 @@ const TruckDetailPage = () => {
       .catch(() => {});
     getObligations()
       .then(setObligations)
+      .catch(() => {});
+    getHomeDays()
+      .then(setHomeDays)
       .catch(() => {});
   }, [id]);
 
@@ -188,13 +193,14 @@ const TruckDetailPage = () => {
   const revenue = earnedLoads.reduce((s, l) => s + loadRevenue(l), 0);
   const now = new Date();
   const truckFuel = fuelEntries.filter((f) => f.truck_id === id);
-  const metrics = computeTruckMetrics(truck, truckLoads, truckFuel, services, now);
+  const metrics = computeTruckMetrics(truck, truckLoads, truckFuel, services, now, homeDays);
   const truckMedals = earnedMedals(
     computeTruckMedals({
       odometer,
       avgMpg: metrics.avgMpg,
       deliveredCount: earnedLoads.length,
       loanPaidPct: assetLoanStatus(obligations, "truck", now)?.ownedPct ?? null,
+      utilization: metrics.utilization,
     }),
   );
   const patches = computeTruckPatches(truckLoads, truckFuel);
@@ -302,7 +308,7 @@ const TruckDetailPage = () => {
               {metrics.utilization != null ? `${Math.round(metrics.utilization * 100)}%` : "—"}
             </div>
             <div className="text-[9px] mt-1 tracking-wide" style={{ color: "#8fd6a8" }}>
-              UTILIZATION · ACTIVE WEEKS
+              UTILIZATION · DAYS UNDER LOAD
             </div>
           </div>
           <Kpi value={metrics.avgMpg != null ? metrics.avgMpg.toFixed(1) : "—"} label="AVG MPG" />
@@ -316,6 +322,16 @@ const TruckDetailPage = () => {
           />
           <Kpi value={metrics.milesPerMonth != null ? num(metrics.milesPerMonth) : "—"} label="MI / MONTH" />
         </div>
+        {metrics.windowDays > 0 && (
+          <p className="text-[11px] text-muted-text mt-2">
+            {metrics.windowDays.toLocaleString("en-US")} days ·{" "}
+            <span style={{ color: "#4ade80" }}>
+              {metrics.underLoadDays} under load
+            </span>{" "}
+            · <span style={{ color: "#60a5fa" }}>{metrics.homeDays} home</span> ·{" "}
+            <span style={{ color: "#f87171" }}>{metrics.idleDays} idle</span>
+          </p>
+        )}
       </div>
 
       {truckLoan && <PayoffTracker obligation={truckLoan} kind="truck" />}

--- a/frontend/src/services/perDiemService.ts
+++ b/frontend/src/services/perDiemService.ts
@@ -23,3 +23,9 @@ export const getLastHomeDay = async (): Promise<string | null> => {
   const res = await api.get("/per-diem/last-home");
   return res.data.last_home ?? null;
 };
+
+// All home days ("YYYY-MM-DD"), for the truck utilization week breakdown.
+export const getHomeDays = async (): Promise<string[]> => {
+  const res = await api.get("/per-diem/home-days");
+  return res.data.days ?? [];
+};


### PR DESCRIPTION
Reworks truck utilization to be honest and adds two utilization-driven truck achievements. (Supersedes #265, closed as won't-do — we keep utilization asset-honest rather than excluding home time.)

## Why
Weeks-binary utilization (active weeks ÷ weeks in service) pegged at **100%** once you delivered something most weeks — it couldn't tell a light week from a heavy one. And counting weeks before the first logged load as "idle" produced a phantom ~46%. Days-based fixes both.

## What
- **Utilization = under-load days ÷ window days.** Under-load days = each delivered load's pickup→delivery span, deduped. Window starts at the **later of in-service and your first logged load**.
- **Day breakdown** on the truck page — under-load · home · idle — so a low number is interpretable (time off vs. no freight). Home days still count against utilization (real opportunity cost); the split just explains why.
- **Shared `lib/metrics/underLoad`** (day set + consecutive runs), backing a read-only `/per-diem/home-days` endpoint.
- **Road Warrior** medal (70/80/85% — the researched benchmark tiers) and **Relentless** patch (longest consecutive under-load run).
- Guide utilization explainer rewritten days-based with the benchmark + citation.

## Verification
- Prod: **138 under-load days ÷ 190 = 73%** (all 48 delivered loads truck-assigned, zero orphans). Road Warrior → tier I.
- **298 tests** (10 new: `underLoad`, days-based `truckMetrics`). Strict build clean. **No migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)