### PR TITLE
feat: profit-lever bottleneck on the driver card — Phase A of #268

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.89.0",
+  "version": "1.90.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/playercard/PlayerCard.tsx
+++ b/frontend/src/components/playercard/PlayerCard.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
-import { Truck, Maximize2, Weight, Home } from "lucide-react";
-import type { Grade, CareerRank, SeasonStats } from "@/lib/metrics/playerCard";
+import { Truck, Maximize2, Weight, Home, Gauge } from "lucide-react";
+import type { Grade, CareerRank, SeasonStats, Lever } from "@/lib/metrics/playerCard";
+import { bottleneckLevers, allLeversOnTarget } from "@/lib/metrics/playerCard";
 import { STRIP_MIN_COUNT, type TypeMix } from "@/lib/metrics/loadMix";
 import type { Hometime } from "@/lib/metrics/hometime";
 import type { Medal } from "@/lib/awards/medals";
@@ -30,18 +31,6 @@ const GRADE_META: Record<Grade, { label: string; fg: string; bg: string }> = {
   minimum: { label: "MINIMUM", fg: "#e8940a", bg: "#3a2a0a" },
   target: { label: "TARGET", fg: "#4ade80", bg: "#1a3a2a" },
   strong: { label: "STRONG", fg: "#fbbf24", bg: "#3a300a" },
-};
-
-const GradeChip = ({ grade, value }: { grade: Grade | null; value?: string }) => {
-  if (!grade)
-    return <span className="text-[11px] px-2 py-0.5 rounded-full bg-plate text-muted-text">—</span>;
-  const m = GRADE_META[grade];
-  return (
-    <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full whitespace-nowrap" style={{ background: m.bg, color: m.fg }}>
-      {m.label}
-      {value ? ` · ${value}` : ""}
-    </span>
-  );
 };
 
 const gradeColor = (g: Grade | null): string | undefined => (g ? GRADE_META[g].fg : undefined);
@@ -160,6 +149,45 @@ const HometimeChip = ({ hometime }: { hometime: Hometime }) => {
   );
 };
 
+// A short, plain-language nudge for whichever lever is the bottleneck.
+const LEVER_HINTS: Record<string, string> = {
+  rate: "you're booking below target — hold out for better-paying freight.",
+  util: "the truck sitting is what's capping the season — keep it rolling.",
+  margin: "costs are eating the margin — watch deadhead and fuel.",
+};
+
+// One profit lever: its value and grade. Border tints to the grade.
+const LeverTile = ({
+  label,
+  value,
+  grade,
+}: {
+  label: string;
+  value: string;
+  grade: Grade | null;
+}) => {
+  const m = grade ? GRADE_META[grade] : null;
+  return (
+    <div
+      className="rounded-[10px] px-3 py-2.5"
+      style={{ background: "#141b28", border: `1px solid ${m ? m.bg : "#2a3347"}` }}
+    >
+      <p className="text-[10px] tracking-wide text-muted-text uppercase">{label}</p>
+      <p className="text-lg font-condensed my-0.5 truncate">{value}</p>
+      {m ? (
+        <span
+          className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
+          style={{ background: m.bg, color: m.fg }}
+        >
+          {m.label}
+        </span>
+      ) : (
+        <span className="text-[10px] text-muted-text">—</span>
+      )}
+    </div>
+  );
+};
+
 export interface PlayerCardProps {
   name: string;
   business: string;
@@ -168,7 +196,8 @@ export interface PlayerCardProps {
   season: SeasonStats;
   rpmGrade: Grade | null;
   marginGrade: Grade | null;
-  form: Grade | null;
+  utilization: number | null; // 0..1, days-based; the third profit lever
+  utilGrade: Grade | null;
   windowRpm: number | null;
   medals: Medal[]; // earned tiers only — worn by the name
   oversize?: TypeMix; // oversize equipment mix; strip hidden when count is 0
@@ -184,7 +213,8 @@ export const PlayerCard = ({
   season,
   rpmGrade,
   marginGrade,
-  form,
+  utilization,
+  utilGrade,
   windowRpm,
   medals,
   oversize,
@@ -192,6 +222,18 @@ export const PlayerCard = ({
   hometime,
 }: PlayerCardProps) => {
   const stars = "★".repeat(rank.index + 1) + "☆".repeat(RANK_TIERS.length - rank.index - 1);
+
+  // The three profit levers and their bottleneck (weakest, if below/minimum).
+  const levers: Lever[] = [
+    { key: "rate", label: "Rate", grade: rpmGrade },
+    { key: "util", label: "Utilization", grade: utilGrade },
+    { key: "margin", label: "Op margin", grade: marginGrade },
+  ];
+  const bottleneck = bottleneckLevers(levers);
+  const onTarget = allLeversOnTarget(levers);
+  const rateVal = windowRpm != null ? `$${windowRpm.toFixed(2)}/mi` : "—";
+  const utilVal = utilization != null ? pct0(utilization) : "—";
+  const marginVal = season.netMargin != null ? pct1(season.netMargin) : "—";
 
   return (
     <div>
@@ -262,25 +304,49 @@ export const PlayerCard = ({
 
         {hometime && <HometimeChip hometime={hometime} />}
 
-        <div className="flex items-center gap-2 flex-wrap mt-4 pt-3 border-t relative" style={{ borderColor: "#2a3347" }}>
-          <span className="font-condensed text-sm tracking-wide text-muted-text">SEASON · {season.label}</span>
-          <span className="text-[11px] text-muted-text">Rate</span>
-          <GradeChip grade={rpmGrade} value={windowRpm != null ? `$${windowRpm.toFixed(2)}` : undefined} />
-          <span className="text-[11px] text-muted-text">Op margin</span>
-          <GradeChip grade={marginGrade} value={season.netMargin != null ? pct1(season.netMargin) : undefined} />
-          <span className="flex-1" />
-          <span
-            className="text-[11px] text-muted-text"
-            title="The weaker of your rate and margin grade"
-          >
-            Overall
-          </span>
-          {form ? (
-            <span className="font-comic px-2.5 py-0.5 rounded-full" style={{ background: GRADE_META[form].bg, color: GRADE_META[form].fg, letterSpacing: "2px", fontSize: 14 }}>
-              {GRADE_META[form].label}
+        <div className="mt-4 pt-3 border-t relative" style={{ borderColor: "#2a3347" }}>
+          <div className="flex items-baseline gap-2 mb-2.5">
+            <span className="font-condensed text-sm tracking-wide text-muted-text">
+              SEASON · {season.label}
             </span>
+            <span className="text-[11px] text-muted-text">your three profit levers</span>
+          </div>
+          <div className="grid grid-cols-3 gap-2.5">
+            <LeverTile label="Rate" value={rateVal} grade={rpmGrade} />
+            <LeverTile label="Utilization" value={utilVal} grade={utilGrade} />
+            <LeverTile label="Op margin" value={marginVal} grade={marginGrade} />
+          </div>
+          {bottleneck.length > 0 ? (
+            <div
+              className="flex items-center gap-3 mt-3 px-3.5 py-2.5 rounded-[10px]"
+              style={{ background: "#231a06", border: "1px solid #85500b" }}
+            >
+              <Gauge size={24} style={{ color: "#f5b03a", flexShrink: 0 }} />
+              <div className="min-w-0">
+                <p className="text-[13px] font-semibold tracking-wide uppercase" style={{ color: "#f5b03a" }}>
+                  Bottleneck · {bottleneck.map((l) => l.label).join(" & ")}
+                </p>
+                <p className="text-[11px]" style={{ color: "#c7935a" }}>
+                  {bottleneck.length === 1
+                    ? LEVER_HINTS[bottleneck[0].key]
+                    : "two levers are lagging — tackle the weakest first."}
+                </p>
+              </div>
+            </div>
+          ) : onTarget ? (
+            <div
+              className="flex items-center gap-3 mt-3 px-3.5 py-2.5 rounded-[10px]"
+              style={{ background: "#12261a", border: "1px solid #1f6e4a" }}
+            >
+              <Gauge size={24} style={{ color: "#4ade80", flexShrink: 0 }} />
+              <p className="text-[13px] font-semibold tracking-wide uppercase" style={{ color: "#4ade80" }}>
+                Firing on all cylinders
+              </p>
+            </div>
           ) : (
-            <span className="text-[11px] text-muted-text">— needs a full month</span>
+            <p className="text-[11px] text-muted-text mt-3">
+              Grades build over a full month of data.
+            </p>
           )}
         </div>
       </div>

--- a/frontend/src/lib/metrics/playerCard.test.ts
+++ b/frontend/src/lib/metrics/playerCard.test.ts
@@ -7,6 +7,9 @@ import {
   marginGrade,
   rpmGrade,
   worseGrade,
+  utilizationGrade,
+  bottleneckLevers,
+  allLeversOnTarget,
   getSeasonStats,
   personalBests,
   earnedTrophies,
@@ -98,6 +101,44 @@ describe("grades", () => {
     expect(worseGrade("below", "strong")).toBe("below");
     expect(worseGrade(null, "target")).toBe("target");
     expect(worseGrade(null, null)).toBeNull();
+  });
+
+  it("utilizationGrade maps to the 70/80/85 benchmark", () => {
+    expect(utilizationGrade(0.9)).toBe("strong");
+    expect(utilizationGrade(0.82)).toBe("target");
+    expect(utilizationGrade(0.73)).toBe("minimum");
+    expect(utilizationGrade(0.6)).toBe("below");
+    expect(utilizationGrade(null)).toBeNull();
+  });
+
+  it("bottleneckLevers names the weakest lever when it's below/minimum", () => {
+    const levers = [
+      { key: "rate", label: "Rate", grade: "target" as const },
+      { key: "util", label: "Utilization", grade: "minimum" as const },
+      { key: "margin", label: "Op margin", grade: "strong" as const },
+    ];
+    const bn = bottleneckLevers(levers);
+    expect(bn.map((l) => l.key)).toEqual(["util"]);
+    expect(allLeversOnTarget(levers)).toBe(false);
+  });
+
+  it("returns every lever tied for weakest", () => {
+    const bn = bottleneckLevers([
+      { key: "rate", label: "Rate", grade: "below" },
+      { key: "util", label: "Utilization", grade: "below" },
+      { key: "margin", label: "Op margin", grade: "target" },
+    ]);
+    expect(bn.map((l) => l.key).sort()).toEqual(["rate", "util"]);
+  });
+
+  it("flags no bottleneck when every lever is target or better", () => {
+    const levers = [
+      { key: "rate", label: "Rate", grade: "target" as const },
+      { key: "util", label: "Utilization", grade: "strong" as const },
+      { key: "margin", label: "Op margin", grade: "target" as const },
+    ];
+    expect(bottleneckLevers(levers)).toEqual([]);
+    expect(allLeversOnTarget(levers)).toBe(true);
   });
 });
 

--- a/frontend/src/lib/metrics/playerCard.ts
+++ b/frontend/src/lib/metrics/playerCard.ts
@@ -77,6 +77,46 @@ export const rpmGrade = (rpm: number | null, ladder: RateLadder): Grade | null =
   return rpm >= ladder.walkAway ? "minimum" : "below";
 };
 
+// Utilization graded on the industry benchmark (70 / 80 / 85%).
+export const utilizationGrade = (u: number | null): Grade | null => {
+  if (u == null) return null;
+  if (u >= 0.85) return "strong";
+  if (u >= 0.8) return "target";
+  if (u >= 0.7) return "minimum";
+  return "below";
+};
+
+// ---------- profit-lever bottleneck (Rate × Utilization × Margin) ----------
+export interface Lever {
+  key: string;
+  label: string;
+  grade: Grade | null;
+}
+
+const GRADE_RANK: Record<Grade, number> = {
+  below: 0,
+  minimum: 1,
+  target: 2,
+  strong: 3,
+};
+
+// The weakest lever(s) worth flagging — only when the weakest is below/minimum.
+// Ties return every lever at that grade. Empty = no bottleneck (all at target+,
+// or nothing graded yet).
+export const bottleneckLevers = (levers: Lever[]): Lever[] => {
+  const graded = levers.filter((l) => l.grade != null);
+  if (!graded.length) return [];
+  const minRank = Math.min(...graded.map((l) => GRADE_RANK[l.grade!]));
+  if (minRank > GRADE_RANK.minimum) return [];
+  return graded.filter((l) => GRADE_RANK[l.grade!] === minRank);
+};
+
+// True when every graded lever is at target or better — no bottleneck to flag.
+export const allLeversOnTarget = (levers: Lever[]): boolean => {
+  const graded = levers.filter((l) => l.grade != null);
+  return graded.length > 0 && graded.every((l) => GRADE_RANK[l.grade!] >= GRADE_RANK.target);
+};
+
 // ---------- season stat line ----------
 export interface SeasonStats {
   label: string; // e.g. "Apr–Jun 2026"

--- a/frontend/src/lib/metrics/underLoad.ts
+++ b/frontend/src/lib/metrics/underLoad.ts
@@ -28,6 +28,14 @@ export const underLoadDaySet = (
   return set;
 };
 
+// The earliest delivered-load pickup day ("YYYY-MM-DD"), or null. The utilization
+// window start for a driver-scoped view (no truck in-service date needed).
+export const firstDeliveredPickup = (loads: Load[]): string | null =>
+  loads
+    .filter((l) => l.load_status === "delivered" && l.pickup_date)
+    .map((l) => l.pickup_date.slice(0, 10))
+    .sort()[0] ?? null;
+
 // Lengths of each consecutive-day run of under-load days (gaps-and-islands) — the
 // stretches the truck rolled without a break. Feeds the Relentless patch.
 export const underLoadRuns = (loads: Load[]): number[] => {

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -32,11 +32,12 @@ import {
   getSeasonStats,
   marginGrade,
   rpmGrade,
-  worseGrade,
+  utilizationGrade,
   personalBests,
 } from "@/lib/metrics/playerCard";
 import { computeGrind } from "@/lib/metrics/grind";
 import { loadTypeMix } from "@/lib/metrics/loadMix";
+import { underLoadDaySet, firstDeliveredPickup } from "@/lib/metrics/underLoad";
 import { computePatches } from "@/lib/awards/patches";
 import { computeMedals, earnedMedals } from "@/lib/awards/medals";
 import { assetLoanStatus } from "@/lib/metrics/payoff";
@@ -134,6 +135,23 @@ const DriverDetailPage = () => {
     const season = getSeasonStats(periods, driverLoads, now, 3, obligationsDebt);
     const rpmG = rpmGrade(basis.windowRpm, ladder);
     const marginG = marginGrade(season.netMargin);
+    // Driver utilization (days-based) — under-load days ÷ days since first load.
+    const nowKey = now.toISOString().slice(0, 10);
+    const winStart = firstDeliveredPickup(driverLoads);
+    const winDays = winStart
+      ? Math.max(
+          1,
+          Math.round(
+            (Date.parse(`${nowKey}T00:00:00Z`) -
+              Date.parse(`${winStart}T00:00:00Z`)) /
+              86_400_000,
+          ),
+        )
+      : 0;
+    const utilization =
+      winDays > 0
+        ? Math.min(1, underLoadDaySet(driverLoads, winStart, nowKey).size / winDays)
+        : null;
     const grind = computeGrind(driverLoads, periods, obligationsTotal, now);
     // Medals (fixed tiers), records (improving bests), patches (hard stackable feats).
     const del = driverLoads.filter((l) => l.load_status === "delivered");
@@ -156,7 +174,8 @@ const DriverDetailPage = () => {
       season,
       rpmGrade: rpmG,
       marginGrade: marginG,
-      form: worseGrade(rpmG, marginG),
+      utilization,
+      utilGrade: utilizationGrade(utilization),
       windowRpm: basis.windowRpm,
       medals: earnedMedals(medals),
       bests: personalBests(driverLoads, fuel, now),
@@ -233,7 +252,8 @@ const DriverDetailPage = () => {
             season={card.season}
             rpmGrade={card.rpmGrade}
             marginGrade={card.marginGrade}
-            form={card.form}
+            utilization={card.utilization}
+            utilGrade={card.utilGrade}
             windowRpm={card.windowRpm}
             medals={card.medals}
             oversize={card.oversize}

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -484,15 +484,19 @@ const GuidePage = () => (
       </h2>
 
       <Metric
-        title="Overall — your current grade"
-        answers="The weaker of your rate grade and your operating-margin grade — a weakest-link read on how the season is going."
+        title="Bottleneck — your three profit levers"
+        answers="Your season net breaks into Rate × Utilization × Margin. The card grades all three and names the weakest — the one holding you back."
       >
-        <Formula>Overall = the lower of your Rate grade and Op-margin grade</Formula>
+        <Formula>net ≈ Rate × Utilization × Margin · bottleneck = the weakest lever</Formula>
         <Why>
-          A strong rate can't paper over a thin margin, and vice-versa, so the card
-          shows whichever is lagging. Rate and Op margin each grade{" "}
-          <span className="text-light">Below → Minimum → Target → Strong</span>{" "}
-          against your break-even ladder. (This was labeled "Form" before.)
+          Each lever grades <span className="text-light">Below → Minimum → Target →
+          Strong</span>: <span className="text-light">Rate</span> against your
+          break-even ladder, <span className="text-light">Utilization</span> against
+          the 70/80/85% benchmark, <span className="text-light">Op margin</span>{" "}
+          against your margin tiers. They mask each other — a great rate with the
+          truck sitting still nets mediocre — so the card names whichever is lagging
+          and what to do about it. When all three reach Target, it reads{" "}
+          <span style={{ color: "#4ade80" }}>Firing on all cylinders</span>.
         </Why>
       </Metric>
 


### PR DESCRIPTION
Phase A of #268 (profit-lever diagnostic). Ships standalone and lays the shared lever engine for Phases B and C.

## What
Evolves the card's "Overall" grade into a **three-lever diagnostic** — Rate, Utilization, Margin graded side by side — with the **weakest named as the bottleneck**.

- **Utilization** joins as the third lever (days-based, driver-scoped: under-load days ÷ days since first load), graded on the **70/80/85%** benchmark.
- Three graded tiles + a bottleneck band naming the weakest lever and what to do; all three at target → **"Firing on all cylinders."**
- Replaces the two-lever "Overall" chip (which was just the weaker of rate/margin).

## Foundation
`utilizationGrade` / `bottleneckLevers` / `allLeversOnTarget` (pure, tested) plus `firstDeliveredPickup` are the start of the **lever engine** — Phase B (in-month dollar bridge) and Phase C (month-end attribution) reuse it.

## Verification
- Your real utilization: **73% → MINIMUM**, so the card names **Utilization** the bottleneck (Rate/Margin fine).
- **302 tests** (4 new: util grade + bottleneck logic incl. ties and all-clear). Strict build clean. **No schema change.**

Does not close #268 — Phases B and C remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)