### PR TITLE
feat: sliding session so an active user isn't kicked mid-work (#242)

### DIFF
--- a/backend/src/middleware/requireAuth.js
+++ b/backend/src/middleware/requireAuth.js
@@ -1,4 +1,4 @@
-import { verifyToken } from "../utils/jwt.js";
+import { verifyToken, signToken } from "../utils/jwt.js";
 
 export function requireAuth(req, res, next) {
   const header = req.headers.authorization;
@@ -11,6 +11,18 @@ export function requireAuth(req, res, next) {
   try {
     const payload = verifyToken(token);
     req.user = payload; // attach decoded payload
+
+    // Sliding session: once the token is past the halfway point of its lifetime,
+    // hand back a fresh one via a response header so an active session keeps
+    // renewing and never expires mid-work. Only a true idle gap lets it lapse.
+    if (payload.iat && payload.exp) {
+      const nowSec = Math.floor(Date.now() / 1000);
+      const halfway = payload.iat + (payload.exp - payload.iat) / 2;
+      if (nowSec >= halfway) {
+        res.set("X-Refreshed-Token", signToken({ user_id: payload.user_id }));
+      }
+    }
+
     next();
   } catch (err) {
     return res.status(401).json({ message: "Invalid or expired token" });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -32,7 +32,8 @@ import accessorialRateRouter from "./routes/accessorialRateRoutes.js";
 const app = express();
 
 // ---- MIDDLEWARE ----
-app.use(cors());
+// Expose the sliding-session header so the browser can read the refreshed token.
+app.use(cors({ exposedHeaders: ["X-Refreshed-Token"] }));
 app.use(express.json());
 
 // ---- ROUTES ----

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.90.1",
+  "version": "1.91.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -24,17 +24,28 @@ api.interceptors.request.use(
   },
 );
 
-// Handle global response errors (optional but recommended)
 api.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    // Sliding session: if the backend handed back a renewed token, keep it so the
+    // next request rides the extended session and the user is never kicked mid-work.
+    const refreshed = response.headers["x-refreshed-token"];
+    if (refreshed) {
+      localStorage.setItem("token", refreshed);
+    }
+    return response;
+  },
   (error) => {
-    // Example: auto-handle unauthorized access
+    // Bounce to login only when a real session actually expired — i.e. we HAD a
+    // token. A failed login/signup also 401s but shouldn't trigger the redirect.
     if (error.response && error.response.status === 401) {
-      localStorage.removeItem("token");
-      localStorage.removeItem("user_id");
-
-      // Optional: redirect to login
-      window.location.href = "/login";
+      const hadToken = localStorage.getItem("token");
+      const url = error.config?.url || "";
+      const isAuthAttempt = url.includes("/auth/login") || url.includes("/auth/signup");
+      if (hadToken && !isAuthAttempt) {
+        localStorage.removeItem("token");
+        localStorage.removeItem("user_id");
+        window.location.href = "/login";
+      }
     }
 
     return Promise.reject(error);


### PR DESCRIPTION
Closes #242.

The 1h access token had no refresh, and any 401 hard-redirected to login, so an active user (Brandie, dispatching all day) got bounced mid-task every hour.

## What
- **Backend** — `requireAuth` re-issues a fresh token via an `X-Refreshed-Token` response header once the current token is **past halfway to expiry**; CORS exposes the header.
- **Frontend** — every response swaps a refreshed token into localStorage, so the next request rides the extended session. An active session slides forward indefinitely.
- The **401 handler is softened** — bounce to login only on a genuinely expired session, not on a failed login/signup 401.

## Effect
While you're working, you're never kicked mid-task. Only a true idle gap longer than the base token life (env `JWT_EXPIRES_IN=1h`, now effectively the idle timeout) lapses it → clean re-login. Bump the env in Railway/dev for a longer idle grace; the slide works at any value.

## Notes
No refresh-token infrastructure, no DB, no migration. Both changes are backward-compatible, so Vercel/Railway deploy order can't cause a break window.

## Verification
Refresh-decision math checked (refreshes at t+1800s of a 1h token), backend syntax, 302 tests, strict build. Live slide is time-based — confirm on dev by working past ~30 min and watching the Network tab for `X-Refreshed-Token` with no bounce to login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)