### PR TITLE
feat: trips count toward truck odometer + auto-attribution; fix Trips date (#227)

### DIFF
--- a/backend/src/services/tripServices.js
+++ b/backend/src/services/tripServices.js
@@ -5,6 +5,13 @@ import {
 } from "../utils/validation/tripsValidation.js";
 import { ValidationError, NotFoundError } from "../utils/error.js";
 
+// The account's single id from a query, or null unless there's exactly one — so a
+// new trip auto-attributes its truck/driver (mirrors the loads/maintenance rule).
+async function loneId(sql, user_id) {
+  const r = await db.query(sql, [user_id]);
+  return r.rowCount === 1 ? Object.values(r.rows[0])[0] : null;
+}
+
 // ---- GET TRIPS SERVICE ----
 export async function getTrips(user_id) {
   if (!user_id) throw new ValidationError("Missing user_id");
@@ -19,7 +26,7 @@ export async function getTrips(user_id) {
             drivers.first_name AS driver_name,
             trip_type,
             trip_source,
-            trip_date,
+            to_char(trip_date, 'YYYY-MM-DD') AS trip_date,
             trips.status,
             trips.trip_purpose,
             odometer_start,
@@ -54,7 +61,7 @@ export async function getTrip(user_id, trip_id) {
             drivers.first_name AS driver_name,
             trip_type,
             trip_source,
-            trip_date,
+            to_char(trip_date, 'YYYY-MM-DD') AS trip_date,
             trips.status,
             trips.trip_purpose,
             odometer_start,
@@ -124,6 +131,23 @@ export async function createTrip(user_id, data) {
   const errors = validateTripCreate(data);
 
   if (errors.length > 0) throw new ValidationError("Validation failed", errors);
+
+  // Auto-assign the single truck + driver when the account has exactly one, so a
+  // trip is attributed like a load and its odometer counts toward the truck.
+  if (data.truck_id === undefined) {
+    const truckId = await loneId(
+      "SELECT truck_id FROM trucks WHERE user_id = $1 AND is_deleted = false",
+      user_id,
+    );
+    if (truckId) data.truck_id = truckId;
+  }
+  if (data.driver_id === undefined) {
+    const driverId = await loneId(
+      "SELECT driver_id FROM drivers WHERE user_id = $1 AND active = true",
+      user_id,
+    );
+    if (driverId) data.driver_id = driverId;
+  }
 
   // Add system fields
   const tripData = {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.91.0",
+  "version": "1.92.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/hooks/useMaintenanceAlerts.ts
+++ b/frontend/src/hooks/useMaintenanceAlerts.ts
@@ -7,16 +7,19 @@ import type {
   MaintenanceUnit,
 } from "@/types/maintenance";
 import type { FuelEntry } from "@/types/fuelEntry";
+import type { Trip } from "@/types/trip";
 import {
   getMaintenanceItems,
   getMaintenanceServices,
 } from "@/services/maintenanceService";
 import { getFuelEntries } from "@/services/fuelService";
+import { getTrips } from "@/services/tripsService";
 import {
   maintenanceAlerts,
   currentTractorMiles,
   recentMilesPerMonth,
   maxOdometer,
+  maxTripOdometer,
 } from "@/lib/metrics/maintenance";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 
@@ -26,6 +29,7 @@ export const useMaintenanceAlerts = (loads: Load[]): Alert[] => {
   const [items, setItems] = useState<MaintenanceItem[]>([]);
   const [services, setServices] = useState<MaintenanceService[]>([]);
   const [fuelEntries, setFuelEntries] = useState<FuelEntry[]>([]);
+  const [trips, setTrips] = useState<Trip[]>([]);
 
   useEffect(() => {
     let active = true;
@@ -33,12 +37,14 @@ export const useMaintenanceAlerts = (loads: Load[]): Alert[] => {
       getMaintenanceItems(),
       getMaintenanceServices(),
       getFuelEntries(),
+      getTrips(),
     ])
-      .then(([its, svcs, fuel]) => {
+      .then(([its, svcs, fuel, trps]) => {
         if (!active) return;
         setItems(its);
         setServices(svcs);
         setFuelEntries(fuel);
+        setTrips(trps);
       })
       .catch(() => {});
     return () => {
@@ -65,9 +71,10 @@ export const useMaintenanceAlerts = (loads: Load[]): Alert[] => {
         currentTractorMiles(loads),
         svcOdo("tractor"),
         maxFuelOdometer(fuelEntries),
+        maxTripOdometer(trips),
       ),
       trailer: maxOdometer(svcOdo("trailer")),
     };
     return maintenanceAlerts(items, currentMiles, now, recentMilesPerMonth(loads, now));
-  }, [items, services, fuelEntries, loads]);
+  }, [items, services, fuelEntries, trips, loads]);
 };

--- a/frontend/src/lib/metrics/maintenance.test.ts
+++ b/frontend/src/lib/metrics/maintenance.test.ts
@@ -7,6 +7,7 @@ import {
   currentTractorMiles,
   recentMilesPerMonth,
   maxOdometer,
+  maxTripOdometer,
   maintenanceAlerts,
   fleetHealth,
 } from "./maintenance";
@@ -243,6 +244,25 @@ describe("maxOdometer", () => {
     expect(maxOdometer(314697, 568387, null)).toBe(568387); // fuel-style fresh read wins
     expect(maxOdometer(null, undefined)).toBeNull();
     expect(maxOdometer(560000)).toBe(560000);
+  });
+});
+
+describe("maxTripOdometer", () => {
+  const trips = [
+    { truck_id: "t1", odometer_end: 570100 },
+    { truck_id: "t1", odometer_end: 569000 },
+    { truck_id: "t2", odometer_end: 999999 },
+    { truck_id: "t1", odometer_end: null },
+  ];
+
+  it("takes the highest trip odometer, scoped to one truck when given", () => {
+    expect(maxTripOdometer(trips, "t1")).toBe(570100); // ignores t2's reading
+    expect(maxTripOdometer(trips)).toBe(999999); // unscoped = all trips
+  });
+
+  it("returns null when no trip carries a reading", () => {
+    expect(maxTripOdometer([{ truck_id: "t1", odometer_end: null }], "t1")).toBeNull();
+    expect(maxTripOdometer([])).toBeNull();
   });
 });
 

--- a/frontend/src/lib/metrics/maintenance.ts
+++ b/frontend/src/lib/metrics/maintenance.ts
@@ -105,6 +105,19 @@ export const maxOdometer = (
   return max;
 };
 
+// Highest odometer recorded on trips (optionally scoped to one truck). A trip
+// carries the tractor's odometer, so a repositioning or home-time move counts
+// toward its latest reading just like a load does.
+export const maxTripOdometer = (
+  trips: { truck_id?: string | null; odometer_end?: number | null }[],
+  truckId?: string,
+): number | null =>
+  maxOdometer(
+    ...trips
+      .filter((t) => (truckId ? t.truck_id === truckId : true))
+      .map((t) => t.odometer_end ?? null),
+  );
+
 // Current tractor odometer = the highest odometer reading across loads.
 export const currentTractorMiles = (loads: Load[]): number | null => {
   let max: number | null = null;

--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -7,10 +7,13 @@ import {
   getMaintenanceServices,
 } from "@/services/maintenanceService";
 import { getFuelEntries } from "@/services/fuelService";
+import { getTrips } from "@/services/tripsService";
+import type { Trip } from "@/types/trip";
 import {
   currentTractorMiles,
   recentMilesPerMonth,
   maxOdometer,
+  maxTripOdometer,
 } from "@/lib/metrics/maintenance";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { ScheduleTab } from "@/components/maintenance/ScheduleTab";
@@ -21,6 +24,7 @@ const MaintenancePage = () => {
   const [items, setItems] = useState<MaintenanceItem[]>([]);
   const [services, setServices] = useState<MaintenanceService[]>([]);
   const [fuelEntries, setFuelEntries] = useState<FuelEntry[]>([]);
+  const [trips, setTrips] = useState<Trip[]>([]);
   const [tab, setTab] = useState<"schedule" | "services">("schedule");
   const [refreshKey, setRefreshKey] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -32,12 +36,14 @@ const MaintenancePage = () => {
       getMaintenanceItems(),
       getMaintenanceServices(),
       getFuelEntries(),
+      getTrips(),
     ])
-      .then(([its, svcs, fuel]) => {
+      .then(([its, svcs, fuel, trps]) => {
         if (!active) return;
         setItems(its);
         setServices(svcs);
         setFuelEntries(fuel);
+        setTrips(trps);
       })
       .catch(() => {})
       .finally(() => {
@@ -72,10 +78,11 @@ const MaintenancePage = () => {
         currentTractorMiles(loads),
         maxServiceOdo("tractor"),
         maxFuelOdometer(fuelEntries),
+        maxTripOdometer(trips),
       ),
       trailer: maxOdometer(maxServiceOdo("trailer")),
     };
-  }, [loads, services, fuelEntries]);
+  }, [loads, services, fuelEntries, trips]);
 
   const milesPerMonth = useMemo(() => recentMilesPerMonth(loads, new Date()), [loads]);
 

--- a/frontend/src/pages/TripsPage.tsx
+++ b/frontend/src/pages/TripsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTrips } from "@/hooks/useTrips";
 import TripForm from "@/components/TripForm";
+import { formatDate } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 
 // Components
@@ -65,7 +66,7 @@ const TripsPage = () => {
                 <TableCell className="text-foreground">
                   {trip.trip_number}
                 </TableCell>
-                <TableCell>{trip.trip_date}</TableCell>
+                <TableCell>{formatDate(trip.trip_date)}</TableCell>
                 <TableCell>{trip.trip_purpose}</TableCell>
                 <TableCell>{trip.odometer_start}</TableCell>
                 <TableCell>{trip.odometer_end}</TableCell>

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -16,10 +16,13 @@ import {
   computeDue,
   recentMilesPerMonth,
   maxOdometer,
+  maxTripOdometer,
 } from "@/lib/metrics/maintenance";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { loadRevenue } from "@/lib/metrics/rateTargets";
 import { getObligations } from "@/services/obligationsService";
+import { getTrips } from "@/services/tripsService";
+import type { Trip } from "@/types/trip";
 import type { Obligation } from "@/types/obligation";
 import { isPayoffTracked, assetLoanStatus } from "@/lib/metrics/payoff";
 import { PayoffTracker } from "@/components/fleet/PayoffTracker";
@@ -87,6 +90,7 @@ const TruckDetailPage = () => {
   const [services, setServices] = useState<MaintenanceService[]>([]);
   const [fuelEntries, setFuelEntries] = useState<FuelEntry[]>([]);
   const [obligations, setObligations] = useState<Obligation[]>([]);
+  const [trips, setTrips] = useState<Trip[]>([]);
   const [homeDays, setHomeDays] = useState<string[]>([]);
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -108,6 +112,9 @@ const TruckDetailPage = () => {
       .catch(() => {});
     getObligations()
       .then(setObligations)
+      .catch(() => {});
+    getTrips()
+      .then(setTrips)
       .catch(() => {});
     getHomeDays()
       .then(setHomeDays)
@@ -137,7 +144,7 @@ const TruckDetailPage = () => {
   );
 
   // Latest odometer, derived from the app: stored value + newest load + newest
-  // service reading + newest fuel fill-up (fuel is usually the freshest).
+  // trip + newest service reading + newest fuel fill-up (fuel is usually freshest).
   const odometer = useMemo(() => {
     if (!truck) return 0;
     const loadOdos = truckLoads.map((l) => l.odometer_end ?? null);
@@ -148,10 +155,15 @@ const TruckDetailPage = () => {
       fuelEntries.filter((f) => f.truck_id === id),
     );
     return (
-      maxOdometer(truck.current_odometer, ...loadOdos, ...svcOdos, fuelOdo) ??
-      truck.current_odometer
+      maxOdometer(
+        truck.current_odometer,
+        ...loadOdos,
+        ...svcOdos,
+        fuelOdo,
+        maxTripOdometer(trips, id),
+      ) ?? truck.current_odometer
     );
-  }, [truck, truckLoads, services, fuelEntries, id]);
+  }, [truck, truckLoads, services, fuelEntries, trips, id]);
 
   const mpm = useMemo(() => recentMilesPerMonth(loads, new Date()), [loads]);
   const due = useMemo(() => {


### PR DESCRIPTION
Closes #227, plus two related Trips fixes surfaced while verifying it.

## Changes
- **#227 — Trips date** rendered the raw value: a `DATE` serialized to an ISO timestamp *with timezone*. Backend now returns `to_char(trip_date,'YYYY-MM-DD')`; the page formats with `formatDate` → **"Jul 9, 2026"**, no time/tz.
- **Trips now count toward the truck's latest odometer.** They were absent from the formula, so a home-time/repositioning trip didn't advance it. New `maxTripOdometer` helper folds trips into the odometer on the truck page (truck-scoped) and both maintenance-due calcs, keeping them consistent.
- **Trips auto-assign the lone truck + driver** in `createTrip` (the pattern loads/maintenance already use), so new trips are attributed instead of floating unattached (which is what excluded them from the truck-scoped odometer).

## Data
The one existing unattached prod trip (#3) was backfilled — truck/driver set on that row only (dry-run confirmed a single row; dev was already clean).

## Verification
Against real prod data: the truck's latest odometer now reads **584,219** (from the home-time trip) instead of the stale 584,057. `to_char` returns the exact date with no day-shift. 304 tests (2 new for `maxTripOdometer`), strict build clean, backend syntax checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)