### PR TITLE
feat: Load Scorer — "Take It or Leave It" dispatch tool

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.92.0",
+  "version": "1.93.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import LoginPage from "@/pages/LoginPage";
 import DashboardPage from "@/pages/DashboardPage";
 import LoadsPage from "@/pages/LoadsPage";
 import TripsPage from "@/pages/TripsPage";
+import ScoreLoadPage from "@/pages/ScoreLoadPage";
 import ExpensesPage from "@/pages/ExpensesPage";
 import PerDiemPage from "@/pages/PerDiemPage";
 import MaintenancePage from "@/pages/MaintenancePage";
@@ -49,6 +50,7 @@ const App = () => {
           <Route path="/loads" element={<LoadsPage />} />
           <Route path="/loads/:load_id" element={<LoadDetailPage />} />
           <Route path="/trips" element={<TripsPage />} />
+          <Route path="/score" element={<ScoreLoadPage />} />
           <Route
             path="/lanes"
             element={

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -22,6 +22,7 @@ const isGroup = (e: Entry): e is Group => "children" in e;
 
 const nav: Entry[] = [
   { to: "/dashboard", label: "Dashboard" },
+  { to: "/score", label: "Score a Load" },
   {
     label: "Freight",
     children: [

--- a/frontend/src/lib/metrics/loadScore.test.ts
+++ b/frontend/src/lib/metrics/loadScore.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { scoreLoad } from "./loadScore";
+
+// break-even per driven mile = costPerDrivenMile / payTake = 3.08 / 0.78 ≈ $3.95
+const basis = { costPerDrivenMile: 3.08, payTake: 0.78 };
+
+describe("scoreLoad", () => {
+  it("bakes deadhead into the all-in rate and lands TAKE IT above target", () => {
+    const s = scoreLoad({ rate: 2900, loadedMiles: 460, deadheadMiles: 80 }, basis);
+    expect(s.drivenMiles).toBe(540);
+    expect(s.allInRpm).toBeCloseTo(2900 / 540); // ~5.37, over loaded+deadhead
+    expect(s.breakevenRpm).toBeCloseTo(3.95, 1);
+    expect(s.pctOverBreakeven).toBeGreaterThan(0.35); // clears target
+    expect(s.verdict).toBe("take");
+    expect(s.profit).toBeGreaterThan(0);
+  });
+
+  it("PASSes a load that loses money once deadhead is counted", () => {
+    // $2.10/loaded looks ok, but 200 deadhead on 500 loaded sinks it under break-even
+    const s = scoreLoad({ rate: 1500, loadedMiles: 500, deadheadMiles: 200 }, basis);
+    expect(s.allInRpm).toBeCloseTo(1500 / 700); // ~2.14 < 3.95
+    expect(s.verdict).toBe("pass");
+    expect(s.profit).toBeLessThan(0);
+  });
+
+  it("STEALs a load 60%+ over break-even", () => {
+    const s = scoreLoad({ rate: 4200, loadedMiles: 400, deadheadMiles: 60 }, basis);
+    expect(s.allInRpm).toBeCloseTo(4200 / 460); // ~9.13
+    expect(s.pctOverBreakeven).toBeGreaterThan(0.6);
+    expect(s.verdict).toBe("steal");
+  });
+
+  it("MEHs a load just above break-even but under target", () => {
+    // aim ~15% over break-even: rate ≈ 3.95*1.15 * driven
+    const s = scoreLoad({ rate: 2560, loadedMiles: 500, deadheadMiles: 60 }, basis);
+    expect(s.verdict).toBe("meh");
+    expect(s.pctOverBreakeven).toBeGreaterThan(0);
+    expect(s.pctOverBreakeven).toBeLessThan(0.35);
+  });
+
+  it("returns a null verdict when there's no cost basis or no miles", () => {
+    expect(
+      scoreLoad({ rate: 2000, loadedMiles: 400, deadheadMiles: 0 }, {
+        costPerDrivenMile: null,
+        payTake: null,
+      }).verdict,
+    ).toBeNull();
+    expect(scoreLoad({ rate: 2000, loadedMiles: 0, deadheadMiles: 0 }, basis).verdict).toBeNull();
+  });
+});

--- a/frontend/src/lib/metrics/loadScore.ts
+++ b/frontend/src/lib/metrics/loadScore.ts
@@ -1,0 +1,92 @@
+import { RATE_TIERS } from "@/lib/constants/targets";
+
+// The "Take It or Leave It" load scorer. Judges ONE offered load by what it
+// actually pays per mile you DRIVE (loaded + deadhead), against your real
+// break-even per driven mile. Deadhead is baked into the headline on purpose —
+// it's the cost agents leave out.
+export type Verdict = "pass" | "meh" | "take" | "steal";
+
+export interface ScoreInput {
+  rate: number; // the all-in GROSS $ offered
+  loadedMiles: number;
+  deadheadMiles: number;
+}
+
+// From the trailing cost engine (getCostBasis).
+export interface ScoreBasis {
+  costPerDrivenMile: number | null; // net cost ÷ total (driven) miles
+  payTake: number | null; // net ÷ gross — your blended keep after the carrier
+}
+
+export interface LoadScore {
+  drivenMiles: number;
+  allInRpm: number | null; // gross rate ÷ driven miles (the headline)
+  breakevenRpm: number | null; // gross break-even ÷ driven mile
+  pctOverBreakeven: number | null; // +0.36 = 36% over break-even
+  net: number | null; // rate after the carrier's cut
+  cost: number | null; // cost of the driven miles
+  profit: number | null; // net − cost
+  verdict: Verdict | null; // null when there's no cost basis yet
+}
+
+export const scoreLoad = (input: ScoreInput, basis: ScoreBasis): LoadScore => {
+  const driven =
+    (Number(input.loadedMiles) || 0) + (Number(input.deadheadMiles) || 0);
+  const rate = Number(input.rate) || 0;
+  const { costPerDrivenMile, payTake } = basis;
+
+  const empty: LoadScore = {
+    drivenMiles: driven,
+    allInRpm: null,
+    breakevenRpm: null,
+    pctOverBreakeven: null,
+    net: null,
+    cost: null,
+    profit: null,
+    verdict: null,
+  };
+
+  // Need miles and a calibrated cost basis to score anything.
+  if (
+    driven <= 0 ||
+    costPerDrivenMile == null ||
+    costPerDrivenMile <= 0 ||
+    payTake == null ||
+    payTake <= 0
+  )
+    return empty;
+
+  const allInRpm = rate / driven; // gross per driven mile
+  const breakevenRpm = costPerDrivenMile / payTake; // gross break-even per driven mile
+  const pctOverBreakeven = allInRpm / breakevenRpm - 1;
+  const net = rate * payTake;
+  const cost = driven * costPerDrivenMile;
+  const profit = net - cost;
+
+  let verdict: Verdict;
+  if (allInRpm < breakevenRpm) verdict = "pass";
+  else if (pctOverBreakeven < RATE_TIERS.target) verdict = "meh";
+  else if (pctOverBreakeven < RATE_TIERS.strong) verdict = "take";
+  else verdict = "steal";
+
+  return {
+    drivenMiles: driven,
+    allInRpm,
+    breakevenRpm,
+    pctOverBreakeven,
+    net,
+    cost,
+    profit,
+    verdict,
+  };
+};
+
+export const VERDICT_META: Record<
+  Verdict,
+  { label: string; fg: string; bg: string }
+> = {
+  pass: { label: "PASS", fg: "#f87171", bg: "#3a1a1a" },
+  meh: { label: "MEH", fg: "#e8940a", bg: "#3a2a0a" },
+  take: { label: "TAKE IT", fg: "#4ade80", bg: "#1a3a2a" },
+  steal: { label: "STEAL", fg: "#fbbf24", bg: "#3a300a" },
+};

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -81,6 +81,7 @@ export interface CostBasis {
   windowRpm: number | null; // net revenue ÷ loaded miles over the window
   costPerTotalMile: number | null; // true cost ÷ TOTAL miles — cost per mile driven
   grossPerTotalMile: number | null; // full gross ÷ TOTAL miles — your booked rate/mile
+  payTake: number | null; // net ÷ gross — your blended keep after the carrier's cut
   months: number; // months with a P&L that were actually included
 }
 
@@ -126,6 +127,7 @@ export const getCostBasis = (
     windowRpm: loaded > 0 ? revenue / loaded : null,
     costPerTotalMile: total > 0 ? cost / total : null,
     grossPerTotalMile: total > 0 ? grossRev / total : null,
+    payTake: grossRev > 0 ? revenue / grossRev : null,
     months: n,
   };
 };

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -260,6 +260,28 @@ const GuidePage = () => (
       </Metric>
 
       <Metric
+        title="Load Scorer — Take It or Leave It"
+        answers="Punch a rate, loaded miles, and deadhead into the Score a Load page and get an instant verdict on whether the load's worth taking."
+      >
+        <Formula>all-in $/mi = rate ÷ (loaded + deadhead) · vs your break-even per driven mile</Formula>
+        <Eg>
+          $2,900 for 460 loaded + 80 deadhead = 540 miles you drive →{" "}
+          <span className="text-light">$5.37/mi</span>. The deadhead is baked in on
+          purpose — it's the empty cost agents leave out.
+        </Eg>
+        <Why>
+          The break-even here is per <span className="text-light">driven</span> mile
+          (your cost/mile ÷ your Landstar take), so it's apples-to-apples with the
+          all-in rate — a lower number than the dashboard's per-loaded-mile ladder,
+          by design. The stamp maps to your tiers:{" "}
+          <span style={{ color: "#f87171" }}>PASS</span> below break-even,{" "}
+          <span style={{ color: "#e8940a" }}>MEH</span> under +35%,{" "}
+          <span style={{ color: "#4ade80" }}>TAKE IT</span> at +35%,{" "}
+          <span style={{ color: "#fbbf24" }}>STEAL</span> at +60%.
+        </Why>
+      </Metric>
+
+      <Metric
         title="Weekly & daily targets"
         answers="The gross dollars to book each week and day."
       >

--- a/frontend/src/pages/ScoreLoadPage.tsx
+++ b/frontend/src/pages/ScoreLoadPage.tsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { useLoads } from "@/hooks/useLoads";
+import { useRateTargets } from "@/hooks/useRateTargets";
+import { scoreLoad, VERDICT_META } from "@/lib/metrics/loadScore";
+import { RATE_TIERS } from "@/lib/constants/targets";
+
+const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+const rpm = (n: number | null) => (n != null ? `$${n.toFixed(2)}` : "—");
+
+// Where the load sits on the PASS | MEH | TAKE IT | STEAL bar (0–100%).
+const markerPct = (pct: number | null, allIn: number | null, be: number | null): number => {
+  if (pct == null || allIn == null || be == null) return 0;
+  if (allIn < be) return Math.max(0, Math.min(25, (allIn / be) * 25)); // PASS band
+  if (pct < RATE_TIERS.target) return 25 + (pct / RATE_TIERS.target) * 25; // MEH
+  if (pct < RATE_TIERS.strong)
+    return 50 + ((pct - RATE_TIERS.target) / (RATE_TIERS.strong - RATE_TIERS.target)) * 25; // TAKE
+  return 75 + Math.min(1, (pct - RATE_TIERS.strong) / 0.4) * 25; // STEAL
+};
+
+const Field = ({
+  label,
+  value,
+  onChange,
+  accent,
+  suffix,
+  prefix,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  accent?: boolean;
+  suffix?: string;
+  prefix?: string;
+}) => (
+  <div
+    className="flex items-center justify-between rounded-[9px] px-3 py-2.5"
+    style={{ background: "#161d2b", border: `1px solid ${accent ? "#85500b" : "#2a3347"}` }}
+  >
+    <span className="text-xs" style={{ color: accent ? "#f5b03a" : "#9fb0c9" }}>
+      {label}
+    </span>
+    <span className="flex items-baseline gap-1">
+      {prefix && <span className="text-xs text-muted-text">{prefix}</span>}
+      <input
+        type="number"
+        inputMode="decimal"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="0"
+        className="w-24 bg-transparent text-right text-lg outline-none"
+        style={{ color: accent ? "#f5b03a" : "#f4f7fb" }}
+      />
+      {suffix && <span className="text-[11px] text-muted-text">{suffix}</span>}
+    </span>
+  </div>
+);
+
+const ScoreLoadPage = () => {
+  const { loads } = useLoads(0);
+  const targets = useRateTargets(loads);
+  const [rate, setRate] = useState("");
+  const [loaded, setLoaded] = useState("");
+  const [deadhead, setDeadhead] = useState("");
+
+  const entered = rate !== "" && loaded !== "";
+  const score = scoreLoad(
+    {
+      rate: Number(rate),
+      loadedMiles: Number(loaded),
+      deadheadMiles: Number(deadhead),
+    },
+    {
+      costPerDrivenMile: targets.basis.costPerTotalMile,
+      payTake: targets.basis.payTake,
+    },
+  );
+  const meta = score.verdict ? VERDICT_META[score.verdict] : null;
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <div
+        className="mx-auto"
+        style={{ maxWidth: 400, background: "#10151f", border: "1px solid #2a3347", borderRadius: 16, padding: 18 }}
+      >
+        <div className="text-[17px] font-semibold uppercase tracking-wide" style={{ color: "#f4f7fb" }}>
+          Score a Load
+        </div>
+        <div className="text-[11px] text-muted-text mt-0.5 mb-3.5">Punch it in at the phone.</div>
+
+        <div className="flex flex-col gap-2.5">
+          <Field label="Rate" value={rate} onChange={setRate} prefix="$" />
+          <div className="flex gap-2.5">
+            <div className="flex-1">
+              <Field label="Loaded" value={loaded} onChange={setLoaded} suffix="mi" />
+            </div>
+            <div className="flex-1">
+              <Field label="Deadhead" value={deadhead} onChange={setDeadhead} accent suffix="mi" />
+            </div>
+          </div>
+        </div>
+
+        {!targets.ready ? (
+          <p className="text-xs text-muted-text mt-4 text-center">
+            Upload a P&amp;L on the Expenses page to calibrate your break-even, then loads can be scored.
+          </p>
+        ) : !entered ? (
+          <p className="text-xs text-muted-text mt-6 text-center">
+            Enter a rate and loaded miles to get a verdict.
+          </p>
+        ) : (
+          <>
+            <div className="text-center mt-4 mb-1.5">
+              <div
+                className="inline-block font-bold"
+                style={{
+                  transform: "rotate(-7deg)",
+                  border: `4px solid ${meta!.fg}`,
+                  color: meta!.fg,
+                  borderRadius: 12,
+                  padding: "6px 22px",
+                  fontSize: 34,
+                  letterSpacing: 3,
+                  fontFamily: "Georgia, serif",
+                }}
+              >
+                {meta!.label}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-2 mt-3.5">
+              <div className="rounded-[9px] py-2 text-center" style={{ background: "#141b28" }}>
+                <div className="text-[9px] text-muted-text tracking-wide">ALL-IN / MI</div>
+                <div className="text-lg font-semibold" style={{ color: meta!.fg }}>{rpm(score.allInRpm)}</div>
+                <div className="text-[9px]" style={{ color: "#5f6b80" }}>{score.drivenMiles.toLocaleString("en-US")} mi driven</div>
+              </div>
+              <div className="rounded-[9px] py-2 text-center" style={{ background: "#141b28" }}>
+                <div className="text-[9px] text-muted-text tracking-wide">BREAK-EVEN</div>
+                <div className="text-lg font-semibold" style={{ color: "#cdd8e8" }}>{rpm(score.breakevenRpm)}</div>
+                <div className="text-[9px]" style={{ color: "#5f6b80" }}>
+                  {score.pctOverBreakeven != null
+                    ? `${score.pctOverBreakeven >= 0 ? "+" : ""}${Math.round(score.pctOverBreakeven * 100)}%`
+                    : ""}
+                </div>
+              </div>
+              <div className="rounded-[9px] py-2 text-center" style={{ background: "#141b28" }}>
+                <div className="text-[9px] text-muted-text tracking-wide">PROFIT</div>
+                <div className="text-lg font-semibold" style={{ color: (score.profit ?? 0) >= 0 ? "#4ade80" : "#f87171" }}>
+                  {score.profit != null ? money(score.profit) : "—"}
+                </div>
+                <div className="text-[9px]" style={{ color: "#5f6b80" }}>after the cut</div>
+              </div>
+            </div>
+
+            <div className="mt-4">
+              <div className="text-[9px] text-muted-text tracking-wide mb-1.5">WHERE IT LANDS</div>
+              <div className="flex rounded-[5px] overflow-hidden relative" style={{ height: 10 }}>
+                <div style={{ flex: 1, background: "#3a1a1a" }} />
+                <div style={{ flex: 1, background: "#3a2a0a" }} />
+                <div style={{ flex: 1, background: "#1a3a2a" }} />
+                <div style={{ flex: 1, background: "#3a300a" }} />
+                <div
+                  style={{
+                    position: "absolute",
+                    left: `${markerPct(score.pctOverBreakeven, score.allInRpm, score.breakevenRpm)}%`,
+                    top: -3,
+                    width: 2,
+                    height: 16,
+                    background: "#f4f7fb",
+                  }}
+                />
+              </div>
+              <div className="flex justify-between text-[8.5px] mt-1">
+                <span style={{ color: "#f87171" }}>PASS</span>
+                <span style={{ color: "#e8940a" }}>MEH</span>
+                <span style={{ color: "#4ade80" }}>TAKE IT</span>
+                <span style={{ color: "#fbbf24" }}>STEAL</span>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ScoreLoadPage;


### PR DESCRIPTION
A mobile-first **Score a Load** page (top-level nav) that turns your break-even into a go/no-go call at the phone.

## What
Punch in **rate, loaded miles, deadhead** → an instant verdict.
- Headline is **all-in $/mi = rate ÷ (loaded + deadhead)** — deadhead baked in on purpose (the empty cost agents leave out).
- Judged against **break-even per *driven* mile** (cost/driven-mile ÷ your Landstar take) — apples-to-apples with the all-in rate, so it's a lower number than the dashboard's per-loaded-mile ladder, by design.
- Comic verdict stamp maps to your rate ladder: **PASS** (below break-even) · **MEH** (< +35%) · **TAKE IT** (+35%) · **STEAL** (+60%), plus all-in rate / break-even / load profit and a where-it-lands bar.

## Under the hood
- New pure `lib/metrics/loadScore` engine (**5 tests** — deadhead, tiers, pass/steal, null basis).
- Added `payTake` (net ÷ gross) to the cost basis so a gross rate converts correctly.
- Guide explainer added (guide-update rule).

## Verification
Against real prod data the break-even computes to **$4.41/driven-mile** (cost $3.35 ÷ take 0.76) — you average $5.00, ~13% over. 309 tests, strict build clean, frontend-only, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)