### PR TITLE
feat: signature flourishes pass A — rubber-stamp marks + odometer roll

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.93.0",
+  "version": "1.94.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/comic/RollingNumber.tsx
+++ b/frontend/src/components/comic/RollingNumber.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState, type CSSProperties } from "react";
+
+// One digit as a 0–9 vertical strip, clipped to a single row. On mount (and on
+// value change) it rolls up to its target, like a mechanical odometer wheel.
+const Digit = ({ target, delay }: { target: number; delay: number }) => {
+  const [n, setN] = useState(0);
+  useEffect(() => {
+    const t = setTimeout(() => setN(target), delay);
+    return () => clearTimeout(t);
+  }, [target, delay]);
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        height: "1em",
+        overflow: "hidden",
+        verticalAlign: "bottom",
+      }}
+    >
+      <span
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          transform: `translateY(-${n}em)`,
+          transition: "transform 0.9s cubic-bezier(0.2, 0.8, 0.2, 1)",
+        }}
+      >
+        {Array.from({ length: 10 }, (_, k) => (
+          <span key={k} style={{ height: "1em", lineHeight: "1em" }}>
+            {k}
+          </span>
+        ))}
+      </span>
+    </span>
+  );
+};
+
+// A number whose digits roll up into place. Commas/other chars render static.
+// Reusable for the truck odometer and big KPI numbers.
+export const RollingNumber = ({
+  value,
+  className,
+  style,
+}: {
+  value: number;
+  className?: string;
+  style?: CSSProperties;
+}) => {
+  const chars = Math.round(value).toLocaleString("en-US").split("");
+  return (
+    <span
+      className={className}
+      style={{ display: "inline-flex", fontVariantNumeric: "tabular-nums", ...style }}
+    >
+      {chars.map((c, i) =>
+        /\d/.test(c) ? (
+          <Digit key={i} target={Number(c)} delay={80 + i * 45} />
+        ) : (
+          <span key={i}>{c}</span>
+        ),
+      )}
+    </span>
+  );
+};

--- a/frontend/src/components/comic/RubberStamp.tsx
+++ b/frontend/src/components/comic/RubberStamp.tsx
@@ -1,0 +1,51 @@
+// A distressed, rotated ink stamp that slams down on a load's "won" state —
+// DELIVERED / PAID / CANCELLED / TONU. Pure CSS, no dependency.
+const STAMP_META: Record<string, string> = {
+  paid: "#4ade80",
+  delivered: "#4ade80",
+  cancelled: "#7d8ba3",
+  tonu: "#f87171",
+};
+
+// The single most notable stamp for a load: paid trumps delivered, then the
+// off-ramps. Returns null for booked/in-transit (nothing to slam yet).
+export const loadStamp = (
+  loadStatus: string,
+  paymentStatus: string,
+): string | null => {
+  if (paymentStatus === "paid") return "paid";
+  if (loadStatus === "delivered") return "delivered";
+  if (loadStatus === "cancelled") return "cancelled";
+  if (loadStatus === "tonu") return "tonu";
+  return null;
+};
+
+export const RubberStamp = ({
+  value,
+  size = 22,
+}: {
+  value: string | null;
+  size?: number;
+}) => {
+  if (!value || !(value in STAMP_META)) return null;
+  const color = STAMP_META[value];
+  return (
+    <span
+      className="font-comic select-none"
+      style={{
+        display: "inline-block",
+        border: `3px solid ${color}`,
+        color,
+        opacity: 0.85,
+        borderRadius: 8,
+        padding: "1px 12px",
+        fontSize: size,
+        letterSpacing: 2,
+        lineHeight: 1.15,
+        animation: "stampSlam 0.4s cubic-bezier(0.2, 1.5, 0.4, 1) both",
+      }}
+    >
+      {value.toUpperCase()}
+    </span>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -244,6 +244,12 @@
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
+/* Rubber-stamp slam — the mark drops in oversized and settles with a bounce. */
+@keyframes stampSlam {
+  0% { transform: rotate(-12deg) scale(2.6); opacity: 0; }
+  55% { opacity: 0.9; }
+  100% { transform: rotate(-12deg) scale(1); opacity: 0.85; }
+}
 .ds-skeleton {
   background: linear-gradient(90deg, #2a3347 25%, #384259 50%, #2a3347 75%);
   background-size: 200% 100%;

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -20,6 +20,7 @@ import { getAccessorialRates } from "@/services/accessorialRateService";
 
 import LoadForm from "@/components/LoadForm";
 import { StatusBadge } from "@/components/StatusBadge";
+import { RubberStamp, loadStamp } from "@/components/comic/RubberStamp";
 import { Kpi } from "@/components/Kpi";
 import { fmtTime, dwell } from "@/lib/stopTimes";
 import {
@@ -406,6 +407,7 @@ export const LoadDetailPage = () => {
             <h1 className="text-3xl font-condensed">{load.load_number}</h1>
             <StatusBadge value={load.load_status} />
             <StatusBadge value={load.payment_status} />
+            <RubberStamp value={loadStamp(load.load_status, load.payment_status)} />
           </div>
           <p className="text-muted-text text-sm mt-1">
             {load.broker} · {load.agent} · {capitalize(load.load_type)}

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -27,6 +27,7 @@ import type { Obligation } from "@/types/obligation";
 import { isPayoffTracked, assetLoanStatus } from "@/lib/metrics/payoff";
 import { PayoffTracker } from "@/components/fleet/PayoffTracker";
 import { computeTruckMetrics } from "@/lib/metrics/truckMetrics";
+import { RollingNumber } from "@/components/comic/RollingNumber";
 import {
   computeTruckPatches,
   computeTruckMedals,
@@ -285,10 +286,13 @@ const TruckDetailPage = () => {
             <>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                 <Spec label="Unit #" value={truck.unit_number} />
-                <Spec
-                  label="Odometer · latest"
-                  value={`${odometer.toLocaleString("en-US")} mi`}
-                />
+                <div>
+                  <p className="text-xs text-muted-text">Odometer · latest</p>
+                  <p className="text-sm">
+                    <RollingNumber value={odometer} />{" "}
+                    <span className="text-muted-text">mi</span>
+                  </p>
+                </div>
                 <Spec label="VIN" value={truck.vin} />
                 <Spec
                   label="Plate"


### PR DESCRIPTION
First pass of the polish arc — two pure-CSS/JS comic flourishes, **no new dependencies**.

- **RubberStamp** — a distressed, rotated ink stamp that slams down (oversized → bounce-settle via the `stampSlam` keyframe) on the load-detail header: **DELIVERED** / **PAID** (green), **CANCELLED** (gray), **TONU** (red); paid trumps delivered. In Bangers.
- **RollingNumber** — each digit is a 0–9 wheel that rolls up into place on mount, like a mechanical odometer. Drives the truck's "Odometer · latest"; reusable for any big number.

309 tests, strict build clean, frontend-only, no migration. Both are animations — best seen live; the stamp matches the approved mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)