### PR TITLE
feat: multi-user Phase 1 — dispatcher logins under an account (#277)

### DIFF
--- a/backend/db/migrations/047_user_roles.sql
+++ b/backend/db/migrations/047_user_roles.sql
@@ -1,0 +1,10 @@
+-- Multi-user foundation (epic #277). A user is either an account OWNER (admin,
+-- parent_user_id NULL) or a DISPATCHER tied to an owner via parent_user_id.
+-- Business data stays scoped to the owner's user_id, resolved as account_id at
+-- auth (account_id = parent_user_id ?? user_id); identity hangs off the person's
+-- own user_id. Existing users default to admin/owner. RLS already on (042).
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS role text NOT NULL DEFAULT 'admin'
+    CHECK (role IN ('admin', 'dispatcher')),
+  ADD COLUMN IF NOT EXISTS parent_user_id uuid REFERENCES users(user_id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS display_name text;

--- a/backend/src/middleware/requireAuth.js
+++ b/backend/src/middleware/requireAuth.js
@@ -10,16 +10,34 @@ export function requireAuth(req, res, next) {
 
   try {
     const payload = verifyToken(token);
-    req.user = payload; // attach decoded payload
+
+    // Delegated access: data scopes to the account OWNER (account_id), while the
+    // logged-in person's own id rides along as self_id for identity. Old tokens
+    // (pre-roles) have no account_id/role → fall back to owner/admin.
+    const accountId = payload.account_id ?? payload.user_id;
+    req.user = {
+      user_id: accountId, // data scope = the account owner's id
+      self_id: payload.user_id, // the actual logged-in user (identity)
+      account_id: accountId,
+      role: payload.role ?? "admin",
+    };
 
     // Sliding session: once the token is past the halfway point of its lifetime,
     // hand back a fresh one via a response header so an active session keeps
-    // renewing and never expires mid-work. Only a true idle gap lets it lapse.
+    // renewing and never expires mid-work. Preserves identity claims (and upgrades
+    // an old token to carry account_id/role).
     if (payload.iat && payload.exp) {
       const nowSec = Math.floor(Date.now() / 1000);
       const halfway = payload.iat + (payload.exp - payload.iat) / 2;
       if (nowSec >= halfway) {
-        res.set("X-Refreshed-Token", signToken({ user_id: payload.user_id }));
+        res.set(
+          "X-Refreshed-Token",
+          signToken({
+            user_id: payload.user_id,
+            account_id: accountId,
+            role: req.user.role,
+          }),
+        );
       }
     }
 

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -12,10 +12,18 @@ router.post("/signup", async (req, res) => {
 
     const user = await createUser(email, password);
 
-    // Create JWT
-    const accessToken = signToken({ user_id: user.user_id });
+    // A fresh signup is an account owner/admin (account = self).
+    const accessToken = signToken({
+      user_id: user.user_id,
+      account_id: user.user_id,
+      role: "admin",
+    });
 
-    res.status(201).json({ message: "User created", user, token: accessToken });
+    res.status(201).json({
+      message: "User created",
+      user: { ...user, role: "admin", display_name: null },
+      token: accessToken,
+    });
   } catch (err) {
     if (err.message === "Missing fields") {
       return res.status(400).json({ error: err.message });
@@ -39,12 +47,22 @@ router.post("/login", async (req, res) => {
 
     const user = await validateUser(email, password);
 
-    // Create JWT
-    const accessToken = signToken({ user_id: user.user_id });
+    // Data scope resolves to the account owner; a dispatcher rides their owner's id.
+    const account_id = user.parent_user_id ?? user.user_id;
+    const accessToken = signToken({
+      user_id: user.user_id,
+      account_id,
+      role: user.role,
+    });
 
     res.status(200).json({
       message: "User logged in successfully",
-      user,
+      user: {
+        user_id: user.user_id,
+        email: user.email,
+        role: user.role,
+        display_name: user.display_name,
+      },
       token: accessToken,
     });
   } catch (err) {

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -1,128 +1,46 @@
 import express from "express";
-import { db } from "../../db/pool.js";
-import bcrypt from "bcrypt";
-import { createUser } from "../services/userServices.js";
+import { requireAuth } from "../middleware/requireAuth.js";
+import { createDispatcher, listAccountUsers } from "../services/userServices.js";
 
 const router = express.Router();
 
-// GET all users (emails only)
-router.get("/", async (req, res) => {
+// Team management is owner/admin only.
+const adminOnly = (req, res, next) =>
+  req.user?.role === "admin"
+    ? next()
+    : res.status(403).json({ error: "Admin only" });
+
+// ---- LIST the account's team ---- (owner + its dispatchers)
+router.get("/", requireAuth, adminOnly, async (req, res) => {
   try {
-    const result = await db.query("SELECT email FROM users");
-    res.json(result.rows.map((u) => u.email));
+    const team = await listAccountUsers(req.user.account_id);
+    return res.status(200).json({ team });
   } catch (err) {
-    res
+    return res
       .status(500)
-      .json({ message: "Failed to fetch users", error: err.message });
+      .json({ error: "Internal Server Error", message: err.message });
   }
 });
 
-// CREATE user
-router.post("/", async (req, res) => {
-  const { email, password } = req.body;
-  createUser(email, password);
-});
-
-// UPDATE email and/or password
-router.patch("/:id", async (req, res) => {
-  console.log("PATCH route hit", req.params);
-
-  const { id } = req.params;
-  const { email, password } = req.body;
-
-  // ✅ Only error if neither is provided
-  if (!email && !password) {
-    return res.status(400).json({ message: "Nothing to update" });
-  }
-
+// ---- CREATE a dispatcher ---- under this admin's account. role + parent are
+// forced server-side (never trusted from the client), so no privilege escalation.
+router.post("/", requireAuth, adminOnly, async (req, res) => {
   try {
-    // Update email if provided
-    if (email) {
-      if (!email.includes("@")) {
-        return res.status(400).json({ message: "Must be a valid email" });
-      }
-
-      const result = await db.query(
-        `
-        UPDATE users
-        SET email = $1
-        WHERE user_id = $2
-        RETURNING user_id, email, created_at
-        `,
-        [email, id],
-      );
-
-      if (result.rowCount === 0) {
-        return res.status(404).json({ message: "User not found" });
-      }
-
-      // If only updating email, return here.
-      if (!password) {
-        return res
-          .status(200)
-          .json({ message: "Updated email", user: result.rows[0] });
-      }
-      // If also updating password, continue.
-    }
-
-    // Update password if provided
-    if (password) {
-      const passwordHash = await bcrypt.hash(password, 10);
-
-      const result = await db.query(
-        `
-        UPDATE users
-        SET password_hash = $1
-        WHERE user_id = $2
-        RETURNING user_id, email, created_at
-        `,
-        [passwordHash, id],
-      );
-
-      if (result.rowCount === 0) {
-        return res.status(404).json({ message: "User not found" });
-      }
-
-      return res
-        .status(200)
-        .json({ message: "Updated password", user: result.rows[0] });
-    }
-  } catch (err) {
-    if (err.code === "22P02") {
-      // invalid UUID
-      return res.status(400).json({ message: "Invalid user id (UUID)" });
-    }
-    if (err.code === "23505") {
-      return res.status(409).json({ message: "Email already exists" });
-    }
-
-    return res.status(500).json({
-      message: "Update failed",
-      error: err.message,
+    const { email, password, display_name } = req.body;
+    const user = await createDispatcher(req.user.account_id, {
+      email,
+      password,
+      display_name,
     });
-  }
-});
-
-router.delete("/:id", async (req, res) => {
-  const id = req.params.id;
-
-  // ---- DELETE USER ----
-  try {
-    await db.query(
-      `
-      DELETE
-      FROM users
-      WHERE user_id = $1
-      RETURNING user_id, email
-      `,
-      [id],
-    );
-    res.status(200).json({ message: "Deleted user successfully" });
+    return res.status(201).json({ message: "Dispatcher created", user });
   } catch (err) {
-    res.status(500).json({
-      message: "Failed to delete user",
-      errMessage: err,
-    });
+    if (err.message === "Missing fields" || err.message === "Invalid email")
+      return res.status(400).json({ error: err.message });
+    if (err.message === "Email already exists")
+      return res.status(409).json({ error: err.message });
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: err.message });
   }
 });
 

--- a/backend/src/services/userServices.js
+++ b/backend/src/services/userServices.js
@@ -47,7 +47,7 @@ export async function validateUser(email, password) {
   // fetch user row
   const result = await db.query(
     `
-    SELECT user_id, email, password_hash
+    SELECT user_id, email, password_hash, role, parent_user_id, display_name
     FROM users
     WHERE email = $1
     `,
@@ -68,5 +68,46 @@ export async function validateUser(email, password) {
   }
 
   // return a SAFE user object (no password_hash)
-  return { user_id: user.user_id, email: user.email };
+  return {
+    user_id: user.user_id,
+    email: user.email,
+    role: user.role,
+    parent_user_id: user.parent_user_id,
+    display_name: user.display_name,
+  };
+}
+
+// ---- CREATE A DISPATCHER under an owner's account ----
+// role + parent are forced by the caller (the admin's account) — never trusted
+// from the client — so a dispatcher can't be created outside its account.
+export async function createDispatcher(accountId, { email, password, display_name }) {
+  if (!accountId) throw new Error("Missing account");
+  if (!email || !password) throw new Error("Missing fields");
+  if (!email.includes("@")) throw new Error("Invalid email");
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  try {
+    const result = await db.query(
+      `INSERT INTO users (email, password_hash, role, parent_user_id, display_name)
+       VALUES ($1, $2, 'dispatcher', $3, $4)
+       RETURNING user_id, email, role, display_name, created_at`,
+      [email, passwordHash, accountId, display_name ?? null],
+    );
+    return result.rows[0];
+  } catch (err) {
+    if (err.code === "23505") throw new Error("Email already exists");
+    throw err;
+  }
+}
+
+// ---- LIST an account's team ---- (owner + its dispatchers; safe fields only)
+export async function listAccountUsers(accountId) {
+  const result = await db.query(
+    `SELECT user_id, email, role, display_name, created_at
+       FROM users
+      WHERE user_id = $1 OR parent_user_id = $1
+      ORDER BY (user_id = $1) DESC, created_at`,
+    [accountId],
+  );
+  return result.rows;
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.95.0",
+  "version": "1.96.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/settings/TeamCard.tsx
+++ b/frontend/src/components/settings/TeamCard.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import { UserPlus } from "lucide-react";
+import { Panel } from "@/components/ui/Panel";
+import {
+  getTeam,
+  createDispatcher,
+  type TeamMember,
+} from "@/services/teamService";
+
+const input =
+  "bg-steel rounded px-2 py-1.5 text-light text-sm placeholder:text-muted-text";
+
+// Owner/admin-only: manage the account's logins. Create a dispatcher seat for
+// Brandie (or anyone) — they sign in with their own email + password, tied to
+// this account.
+export const TeamCard = () => {
+  const [team, setTeam] = useState<TeamMember[]>([]);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const load = () => getTeam().then(setTeam).catch(() => {});
+  useEffect(() => {
+    load();
+  }, []);
+
+  const add = async () => {
+    setBusy(true);
+    setErr(null);
+    setMsg(null);
+    try {
+      await createDispatcher({ email, password, display_name: name });
+      setMsg(`${name || email} can now sign in as a dispatcher.`);
+      setName("");
+      setEmail("");
+      setPassword("");
+      load();
+    } catch (e) {
+      setErr(
+        (e as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Could not create the login",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Panel className="mt-6 max-w-[680px] p-5">
+      <h2 className="text-lg font-medium text-light">Team</h2>
+      <p className="text-sm text-muted-text mt-1">
+        Give a dispatcher their own login tied to your account — they sign in with
+        their own email and password and share your data, under their own role.
+      </p>
+
+      <div className="mt-4 divide-y divide-steel">
+        {team.map((m) => (
+          <div key={m.user_id} className="flex items-center justify-between py-2">
+            <div className="min-w-0">
+              <span className="text-sm text-light">{m.display_name || m.email}</span>
+              {m.display_name && (
+                <span className="text-xs text-muted-text ml-2">{m.email}</span>
+              )}
+            </div>
+            <span className="text-[11px] px-2 py-0.5 rounded-full bg-steel text-muted-text shrink-0">
+              {m.role === "admin" ? "Owner · Admin" : "Dispatcher"}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-2">
+        <input
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className={input}
+        />
+        <input
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className={input}
+        />
+        <input
+          placeholder="Initial password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className={input}
+        />
+      </div>
+      <button
+        onClick={add}
+        disabled={busy || !email || !password}
+        className="mt-3 flex items-center gap-1.5 text-sm px-4 py-1.5 rounded-lg disabled:opacity-50"
+        style={{ background: "#e8940a", color: "#10151f" }}
+      >
+        <UserPlus size={14} /> {busy ? "Creating…" : "Add dispatcher"}
+      </button>
+      {msg && <p className="text-xs text-status-positive-text mt-2">{msg}</p>}
+      {err && <p className="text-xs text-status-negative-text mt-2">{err}</p>}
+      <p className="text-xs text-muted-text mt-2">
+        You set their initial password and share it with them.
+      </p>
+    </Panel>
+  );
+};

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import {
   updateSettlementSchedule,
 } from "@/services/settlementScheduleService";
 import { AccessorialRatesCard } from "@/components/settings/AccessorialRatesCard";
+import { TeamCard } from "@/components/settings/TeamCard";
 import { Panel } from "@/components/ui/Panel";
 
 const money = (n: number) =>
@@ -124,6 +125,8 @@ const SettingsPage = () => {
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
       <h1 className="text-3xl font-condensed">Settings</h1>
+
+      {localStorage.getItem("role") === "admin" && <TeamCard />}
 
       <Panel className="mt-6 max-w-[680px] p-5">
         <h2 className="text-lg font-medium text-light">Settlement schedule</h2>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -44,6 +44,8 @@ api.interceptors.response.use(
       if (hadToken && !isAuthAttempt) {
         localStorage.removeItem("token");
         localStorage.removeItem("user_id");
+        localStorage.removeItem("role");
+        localStorage.removeItem("display_name");
         window.location.href = "/login";
       }
     }

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -14,9 +14,11 @@ export const userLogin = async (credentials: Credentials) => {
       password: password,
     });
 
-    // Store user_id and token in localStorage
+    // Store user_id, token, and identity (role/name) in localStorage
     localStorage.setItem("user_id", response.data.user.user_id);
     localStorage.setItem("token", response.data.token);
+    localStorage.setItem("role", response.data.user.role ?? "admin");
+    localStorage.setItem("display_name", response.data.user.display_name ?? "");
 
     const data = {
       success: true,
@@ -49,9 +51,11 @@ export const userSignup = async (credentials: Credentials) => {
       password: password,
     });
 
-    // Store user_id and token in localStorage
+    // Store user_id, token, and identity (role/name) in localStorage
     localStorage.setItem("user_id", response.data.user.user_id);
     localStorage.setItem("token", response.data.token);
+    localStorage.setItem("role", response.data.user.role ?? "admin");
+    localStorage.setItem("display_name", response.data.user.display_name ?? "");
 
     const data = {
       success: true,

--- a/frontend/src/services/teamService.ts
+++ b/frontend/src/services/teamService.ts
@@ -1,0 +1,24 @@
+import api from "./api";
+
+export interface TeamMember {
+  user_id: string;
+  email: string;
+  role: string;
+  display_name: string | null;
+  created_at: string;
+}
+
+// The account's team (owner + dispatchers). Admin only — 403 otherwise.
+export const getTeam = async (): Promise<TeamMember[]> => {
+  const res = await api.get("/users");
+  return res.data.team;
+};
+
+export const createDispatcher = async (data: {
+  email: string;
+  password: string;
+  display_name: string;
+}): Promise<TeamMember> => {
+  const res = await api.post("/users", data);
+  return res.data.user;
+};


### PR DESCRIPTION
Phase 1 of #277 — delegated multi-user access. A user is an account **owner (admin)** or a **dispatcher** tied to an owner via `parent_user_id`.

## What
- **migration 047** (applied dev + prod): `role` (admin|dispatcher), `parent_user_id`, `display_name` on `users`; existing users default to **admin/owner**.
- **Auth resolves account vs identity** — token carries `{ user_id, account_id, role }`; `requireAuth` sets `req.user.user_id = account_id` (so all 24 data services keep scoping unchanged) and `self_id` = the logged-in person. **Backward-compatible**: old tokens fall back to owner/admin; the sliding session (#242) preserves and upgrades the claims.
- **Admin-only team routes** — `GET /users` (the account's team), `POST /users` (create a dispatcher; **role + parent forced server-side**, no privilege escalation).
- **Settings → Team card** (admin only) to create Brandie's login; frontend stores role/display_name, clears on logout.

## Security fix
The old `/users` routes exposed **every user's email unauthenticated** and allowed **modify/delete of any user by id** with no auth. Removed.

## Notes
- After deploy, log out + back in once so the local `admin` role is stored and the Team card appears (existing sessions predate it).
- 309 tests, strict build clean, backend syntax checked. Live auth flow best confirmed post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)