### PR TITLE
feat: dispatcher view — role-tailored nav, guarded routes, dispatch board (#277 Phase 2)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.96.0",
+  "version": "1.97.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 
 import AppLayout from "@/layouts/AppLayout";
 import ProtectedRoute from "@/components/ProtectedRoute";
+import AdminRoute from "@/components/AdminRoute";
 
 import LoginPage from "@/pages/LoginPage";
 import DashboardPage from "@/pages/DashboardPage";
@@ -52,7 +53,6 @@ const App = () => {
           <Route path="/loads/:load_id" element={<LoadDetailPage />} />
           <Route path="/trips" element={<TripsPage />} />
           <Route path="/score" element={<ScoreLoadPage />} />
-          <Route path="/garage" element={<GaragePage />} />
           <Route
             path="/lanes"
             element={
@@ -67,16 +67,10 @@ const App = () => {
               </Suspense>
             }
           />
-          <Route path="/expenses" element={<ExpensesPage />} />
-          <Route path="/per-diem" element={<PerDiemPage />} />
           <Route path="/maintenance" element={<MaintenancePage />} />
           <Route path="/compliance" element={<CompliancePage />} />
-          <Route path="/recap" element={<RecapPage />} />
-          <Route path="/trophy-room" element={<TrophyHallPage />} />
-          <Route path="/trophy-studio" element={<TrophyStudioPage />} />
           <Route path="/agents" element={<AgentsPage />} />
           <Route path="/agents/:agent_id" element={<AgentDetailPage />} />
-          <Route path="/fuel-entries" element={<FuelEntriesPage />} />
           <Route path="/trucks" element={<TrucksPage />} />
           <Route path="/trucks/:id" element={<TruckDetailPage />} />
           <Route path="/drivers" element={<DriversPage />} />
@@ -86,7 +80,18 @@ const App = () => {
           <Route path="/facilities" element={<FacilitiesPage />} />
           <Route path="/facilities/:id" element={<FacilityDetailPage />} />
           <Route path="/guide" element={<GuidePage />} />
-          <Route path="/settings" element={<SettingsPage />} />
+
+          {/* Owner-only — a dispatcher is redirected to /dashboard (see roles.ts) */}
+          <Route element={<AdminRoute />}>
+            <Route path="/expenses" element={<ExpensesPage />} />
+            <Route path="/per-diem" element={<PerDiemPage />} />
+            <Route path="/recap" element={<RecapPage />} />
+            <Route path="/garage" element={<GaragePage />} />
+            <Route path="/trophy-room" element={<TrophyHallPage />} />
+            <Route path="/trophy-studio" element={<TrophyStudioPage />} />
+            <Route path="/fuel-entries" element={<FuelEntriesPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
+          </Route>
         </Route>
       </Route>
 

--- a/frontend/src/components/AdminRoute.tsx
+++ b/frontend/src/components/AdminRoute.tsx
@@ -1,0 +1,9 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { isDispatcher } from "@/lib/roles";
+
+// Wraps owner-only routes. A dispatcher who lands here (typed URL, stale link,
+// bookmark) is bounced to her dashboard. Frontend view boundary — see lib/roles.
+const AdminRoute = () =>
+  isDispatcher() ? <Navigate to="/dashboard" replace /> : <Outlet />;
+
+export default AdminRoute;

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -14,8 +14,12 @@ import {
   SidebarMenuSubButton,
 } from "@/components/ui/sidebar";
 import { Link, useLocation } from "react-router-dom";
+import { isDispatcher } from "@/lib/roles";
 
-type Leaf = { to: string; label: string };
+// `adminOnly` items are owner-only; a dispatcher's nav filters them out (and the
+// route guard bounces her if she types the URL). Keep these flags in lockstep
+// with ADMIN_ONLY_PREFIXES in lib/roles.
+type Leaf = { to: string; label: string; adminOnly?: boolean };
 type Group = { label: string; children: Leaf[] };
 type Entry = Leaf | Group;
 const isGroup = (e: Entry): e is Group => "children" in e;
@@ -40,20 +44,34 @@ const nav: Entry[] = [
       { to: "/trailers", label: "Trailers" },
       { to: "/drivers", label: "Drivers" },
       { to: "/maintenance", label: "Maintenance" },
-      { to: "/fuel-entries", label: "Fuel" },
+      { to: "/fuel-entries", label: "Fuel", adminOnly: true },
     ],
   },
   { to: "/compliance", label: "Compliance" },
-  { to: "/expenses", label: "Expenses" },
-  { to: "/per-diem", label: "Per Diem" },
-  { to: "/recap", label: "Recap" },
-  { to: "/garage", label: "Garage" },
-  { to: "/trophy-room", label: "Trophy Room" },
+  { to: "/expenses", label: "Expenses", adminOnly: true },
+  { to: "/per-diem", label: "Per Diem", adminOnly: true },
+  { to: "/recap", label: "Recap", adminOnly: true },
+  { to: "/garage", label: "Garage", adminOnly: true },
+  { to: "/trophy-room", label: "Trophy Room", adminOnly: true },
   { to: "/guide", label: "Guide" },
 ];
 
+// A dispatcher sees only the non-adminOnly items; empty groups drop out.
+const navFor = (dispatcher: boolean): Entry[] => {
+  if (!dispatcher) return nav;
+  return nav
+    .map((e) =>
+      isGroup(e)
+        ? { ...e, children: e.children.filter((c) => !c.adminOnly) }
+        : e,
+    )
+    .filter((e) => (isGroup(e) ? e.children.length > 0 : !e.adminOnly));
+};
+
 const AppSidebar = () => {
   const { pathname } = useLocation();
+  const dispatcher = isDispatcher();
+  const navItems = navFor(dispatcher);
   const active = (to: string) =>
     pathname === to || pathname.startsWith(to + "/");
 
@@ -61,13 +79,13 @@ const AppSidebar = () => {
   // opens it, but manual toggles of the others are preserved.
   const [open, setOpen] = useState<Record<string, boolean>>(() => {
     const init: Record<string, boolean> = {};
-    for (const e of nav)
+    for (const e of navItems)
       if (isGroup(e)) init[e.label] = e.children.some((c) => active(c.to));
     return init;
   });
 
   useEffect(() => {
-    for (const e of nav)
+    for (const e of navItems)
       if (isGroup(e) && e.children.some((c) => active(c.to)))
         setOpen((o) => ({ ...o, [e.label]: true }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -87,7 +105,7 @@ const AppSidebar = () => {
       <SidebarContent>
         <SidebarGroup>
           <SidebarMenu>
-            {nav.map((e) =>
+            {navItems.map((e) =>
               isGroup(e) ? (
                 <SidebarMenuItem key={e.label}>
                   <SidebarMenuButton
@@ -138,11 +156,13 @@ const AppSidebar = () => {
       </SidebarContent>
 
       <SidebarFooter>
-        <div className="px-4 pt-2">
-          <Link to="/settings" className={`text-sm ${linkCls("/settings")}`}>
-            Settings
-          </Link>
-        </div>
+        {!dispatcher && (
+          <div className="px-4 pt-2">
+            <Link to="/settings" className={`text-sm ${linkCls("/settings")}`}>
+              Settings
+            </Link>
+          </div>
+        )}
         <div className="px-4 pb-4 pt-1 text-sm text-muted-foreground">
           v{__APP_VERSION__}
         </div>

--- a/frontend/src/components/dashboard/TopAgents.tsx
+++ b/frontend/src/components/dashboard/TopAgents.tsx
@@ -9,6 +9,9 @@ interface Props {
   agents: AgentRevenue[];
   honors: Map<string, AgentHonors>;
   standings: Map<string, LiveStanding>;
+  // "revenue" (owner view) shows net $ per agent; "loads" (dispatch view) shows
+  // volume only, so the board carries no owner-dollar figures.
+  mode?: "revenue" | "loads";
 }
 
 const fmtK = (n: number): string => `$${(n / 1000).toFixed(1)}k`;
@@ -51,7 +54,12 @@ const Pulse = () => (
   />
 );
 
-export const TopAgents = ({ agents, honors, standings }: Props) => (
+export const TopAgents = ({
+  agents,
+  honors,
+  standings,
+  mode = "revenue",
+}: Props) => (
   <div
     className="relative overflow-hidden rounded-2xl border-2 p-4"
     style={{ background: "#10151f", borderColor: "#e8940a" }}
@@ -127,12 +135,18 @@ export const TopAgents = ({ agents, honors, standings }: Props) => (
                     color: first ? "#f5b03a" : i < 3 ? "#e8eef7" : "#9daabb",
                   }}
                 >
-                  {fmtK(agent.revenue)}
+                  {mode === "loads" ? agent.loadCount : fmtK(agent.revenue)}
                 </span>
-                {i < 3 && (
+                {mode === "loads" ? (
                   <span className="block text-[10px] text-muted-text">
-                    {agent.loadCount} loads
+                    loads
                   </span>
+                ) : (
+                  i < 3 && (
+                    <span className="block text-[10px] text-muted-text">
+                      {agent.loadCount} loads
+                    </span>
+                  )
                 )}
               </span>
             </>

--- a/frontend/src/lib/metrics/dashboard.test.ts
+++ b/frontend/src/lib/metrics/dashboard.test.ts
@@ -15,6 +15,8 @@ import {
   getUpcomingLoads,
   getRecentDeliveredLoads,
   getOutstandingSummary,
+  getDeadheadTrend,
+  getDetentionOwed,
 } from "./dashboard";
 
 // ---- typed factories: override only the fields a test cares about ----
@@ -1510,5 +1512,97 @@ describe("getOutstandingLoads", () => {
     // Revenue computed
     expect(result[0].revenue).toBe(4637); // 3400 + 612 + 625
     expect(result[1].revenue).toBe(2844); // 2283 + 411 + 150
+  });
+});
+
+// ---- DEADHEAD TREND ---- (clock frozen 2026-06-22 → 90-day window = Mar 24 →)
+describe("getDeadheadTrend", () => {
+  it("computes this month vs the trailing 90-day average", () => {
+    const loads = [
+      // June (this month): window 500, loaded 400 → 100 empty
+      makeLoad({
+        delivery_date: "2026-06-10T04:00:00.000Z",
+        odometer_start: 100000,
+        odometer_end: 100500,
+        loaded_miles: 400,
+      }),
+      // April (in the 90-day window, NOT this month): window 300, loaded 300
+      makeLoad({
+        delivery_date: "2026-04-15T04:00:00.000Z",
+        odometer_start: 90000,
+        odometer_end: 90300,
+        loaded_miles: 300,
+      }),
+      // February (older than 90 days): all empty, must be EXCLUDED from both
+      makeLoad({
+        delivery_date: "2026-02-10T04:00:00.000Z",
+        odometer_start: 80000,
+        odometer_end: 81000,
+        loaded_miles: 0,
+      }),
+    ];
+
+    const result = getDeadheadTrend(loads, []);
+    // June only: 100/500
+    expect(result.thisMonth).toBeCloseTo(0.2, 5);
+    // June + April (Feb excluded): total 800, loaded 700 → 100/800
+    expect(result.rolling90).toBeCloseTo(0.125, 5);
+  });
+
+  it("returns null on each side when its window has no qualifying miles", () => {
+    const result = getDeadheadTrend([], []);
+    expect(result.thisMonth).toBeNull();
+    expect(result.rolling90).toBeNull();
+  });
+});
+
+// ---- DETENTION OWED ---- (hours past free time, still uncollected)
+describe("getDetentionOwed", () => {
+  it("sums hours + loads for uncollected detention, longest first", () => {
+    const loads = [
+      // 5h dwell, 2h free → 180 min owed
+      makeLoad({
+        load_id: "A",
+        load_number: "A1",
+        shipper_in: "08:00",
+        shipper_out: "13:00",
+        detention_paid: false,
+      }),
+      // 2h30 dwell, 2h free → 30 min owed
+      makeLoad({
+        load_id: "B",
+        load_number: "B1",
+        receiver_in: "10:00",
+        receiver_out: "12:30",
+        detention_paid: false,
+      }),
+      // detention ran but already collected → excluded
+      makeLoad({
+        load_id: "C",
+        load_number: "C1",
+        shipper_in: "08:00",
+        shipper_out: "13:00",
+        detention_paid: true,
+      }),
+      // dwell inside free time → no detention → excluded
+      makeLoad({
+        load_id: "D",
+        load_number: "D1",
+        shipper_in: "08:00",
+        shipper_out: "09:00",
+        detention_paid: false,
+      }),
+    ];
+
+    const result = getDetentionOwed(loads, 2);
+    expect(result.loadCount).toBe(2);
+    expect(result.totalMinutes).toBe(210); // 180 + 30
+    expect(result.items.map((i) => i.load_number)).toEqual(["A1", "B1"]); // sorted desc
+    expect(result.items[0].minutes).toBe(180);
+  });
+
+  it("returns an empty summary when nothing is owed", () => {
+    const result = getDetentionOwed([], 2);
+    expect(result).toEqual({ loadCount: 0, totalMinutes: 0, items: [] });
   });
 });

--- a/frontend/src/lib/metrics/dashboard.ts
+++ b/frontend/src/lib/metrics/dashboard.ts
@@ -1,6 +1,7 @@
 import type { Load } from "@/types/load";
 import type { Trip } from "@/types/trip";
 import { loadRevenue } from "./rateTargets";
+import { detentionOwed, detentionMinutes } from "@/lib/detention";
 import { median } from "./stats";
 
 // Revenue = the owner-op's NET take (their company gross), via loadRevenue —
@@ -92,50 +93,24 @@ export interface MonthlyDeadhead {
   lastMonth: number | null;
 }
 
-// Deadhead % for a single UTC month. Empty miles = delivered loads' odometer
-// windows minus their loaded miles, PLUS every qualifying trip's full odometer
-// window (trips are 100% non-revenue). Payment status is irrelevant — only
-// load_status "delivered" ran (cancelled/tonu did not); all trip purposes count.
-// Both loads and trips need both odometer readings. Returns null when the month
-// has no qualifying miles at all.
-const deadheadForMonth = (
-  loads: Load[],
-  trips: Trip[],
-  year: number,
-  month: number,
-): number | null => {
-  const monthLoads = loads.filter(
-    (load) =>
-      load.load_status === "delivered" &&
-      load.odometer_start != null &&
-      load.odometer_end != null &&
-      load.delivery_date &&
-      new Date(load.delivery_date).getUTCFullYear() === year &&
-      new Date(load.delivery_date).getUTCMonth() === month,
-  );
-
-  const monthTrips = trips.filter(
-    (trip) =>
-      trip.odometer_start != null &&
-      trip.odometer_end != null &&
-      trip.trip_date &&
-      new Date(trip.trip_date).getUTCFullYear() === year &&
-      new Date(trip.trip_date).getUTCMonth() === month,
-  );
-
-  const loadWindow = monthLoads.reduce(
+// The deadhead math over a pre-filtered set of loads + trips. Empty miles =
+// delivered loads' odometer windows minus their loaded miles, PLUS every trip's
+// full odometer window (trips are 100% non-revenue). Returns null when there are
+// no qualifying miles at all. Callers do the date filtering.
+const deadheadOverSets = (loads: Load[], trips: Trip[]): number | null => {
+  const loadWindow = loads.reduce(
     (sum, load) =>
       sum + (Number(load.odometer_end) - Number(load.odometer_start)),
     0,
   );
-  const tripWindow = monthTrips.reduce(
+  const tripWindow = trips.reduce(
     (sum, trip) =>
       sum + (Number(trip.odometer_end) - Number(trip.odometer_start)),
     0,
   );
   const totalMiles = loadWindow + tripWindow;
 
-  const loadedMiles = monthLoads.reduce(
+  const loadedMiles = loads.reduce(
     (sum, load) => sum + Number(load.loaded_miles),
     0,
   );
@@ -143,6 +118,56 @@ const deadheadForMonth = (
   if (totalMiles === 0) return null;
 
   return (totalMiles - loadedMiles) / totalMiles;
+};
+
+// A load counts toward deadhead only if it delivered and has both odometer
+// readings; a trip needs both readings. (Payment status is irrelevant — only
+// load_status "delivered" ran; all trip purposes count.)
+const deadheadLoad = (load: Load): boolean =>
+  load.load_status === "delivered" &&
+  load.odometer_start != null &&
+  load.odometer_end != null &&
+  !!load.delivery_date;
+const deadheadTrip = (trip: Trip): boolean =>
+  trip.odometer_start != null && trip.odometer_end != null && !!trip.trip_date;
+
+// Deadhead % for a single UTC month.
+const deadheadForMonth = (
+  loads: Load[],
+  trips: Trip[],
+  year: number,
+  month: number,
+): number | null =>
+  deadheadOverSets(
+    loads.filter(
+      (l) =>
+        deadheadLoad(l) &&
+        new Date(l.delivery_date as string).getUTCFullYear() === year &&
+        new Date(l.delivery_date as string).getUTCMonth() === month,
+    ),
+    trips.filter(
+      (t) =>
+        deadheadTrip(t) &&
+        new Date(t.trip_date as string).getUTCFullYear() === year &&
+        new Date(t.trip_date as string).getUTCMonth() === month,
+    ),
+  );
+
+// Deadhead % over a [startMs, endMs) window (UTC ms), by delivery/trip date.
+const deadheadForWindow = (
+  loads: Load[],
+  trips: Trip[],
+  startMs: number,
+  endMs: number,
+): number | null => {
+  const inWin = (iso: string): boolean => {
+    const t = new Date(iso).getTime();
+    return t >= startMs && t < endMs;
+  };
+  return deadheadOverSets(
+    loads.filter((l) => deadheadLoad(l) && inWin(l.delivery_date as string)),
+    trips.filter((t) => deadheadTrip(t) && inWin(t.trip_date as string)),
+  );
 };
 
 // This month's deadhead % and last month's, for the KPI comparison.
@@ -165,6 +190,68 @@ export const getMonthlyDeadhead = (
       prev.getUTCFullYear(),
       prev.getUTCMonth(),
     ),
+  };
+};
+
+// Dispatch view: this calendar month's deadhead % vs the trailing 90-day
+// average (the baseline). Lower is leaner. Either side is null when its window
+// has no qualifying miles yet.
+export interface DeadheadTrend {
+  thisMonth: number | null;
+  rolling90: number | null;
+}
+
+export const getDeadheadTrend = (
+  loads: Load[],
+  trips: Trip[],
+  now: Date = new Date(Date.now()),
+): DeadheadTrend => {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const monthStart = Date.UTC(year, month, 1);
+  const nextMonth = Date.UTC(year, month + 1, 1);
+  const end = now.getTime();
+  const start = end - 90 * 24 * 60 * 60 * 1000;
+
+  return {
+    thisMonth: deadheadForWindow(loads, trips, monthStart, nextMonth),
+    rolling90: deadheadForWindow(loads, trips, start, end),
+  };
+};
+
+// Dispatch view: open detention to chase — loads that ran past free time and
+// aren't marked collected. Hours (not dollars) since the rate isn't known until
+// the settlement lands. Sorted longest-dwell first.
+export interface DetentionItem {
+  load_id: string;
+  load_number: string;
+  lane: string;
+  minutes: number;
+}
+export interface DetentionOwed {
+  loadCount: number;
+  totalMinutes: number;
+  items: DetentionItem[];
+}
+
+export const getDetentionOwed = (
+  loads: Load[],
+  freeHours: number,
+): DetentionOwed => {
+  const items = loads
+    .filter((l) => detentionOwed(l, freeHours))
+    .map((l) => ({
+      load_id: l.load_id,
+      load_number: l.load_number,
+      lane: `${l.origin_market} → ${l.delivery_market}`,
+      minutes: detentionMinutes(l, freeHours),
+    }))
+    .sort((a, b) => b.minutes - a.minutes);
+
+  return {
+    loadCount: items.length,
+    totalMinutes: items.reduce((sum, i) => sum + i.minutes, 0),
+    items,
   };
 };
 
@@ -342,12 +429,12 @@ export interface AgentRevenue {
 
 // Two guards, two failure modes: `windowDays` drops stale agents (a great load
 // six months ago falls out of the window); `minLoads` drops one-offs (a single
-// lucky run doesn't rank). loadCount is returned so the ranking self-explains.
-export const getTopAgentsByRevenue = (
+// lucky run doesn't rank). loadCount + revenue are both returned so either
+// ranking self-explains.
+const collectRecentAgents = (
   loads: Load[],
-  windowDays = 90,
-  minLoads = 2,
-  limit = 5,
+  windowDays: number,
+  minLoads: number,
 ): AgentRevenue[] => {
   const cutoff = Date.now() - windowDays * 86_400_000;
   const recent = loads.filter(
@@ -374,10 +461,30 @@ export const getTopAgentsByRevenue = (
       loadCount: agentLoads.length,
     });
   }
-
-  ranked.sort((a, b) => b.revenue - a.revenue);
-  return ranked.slice(0, limit);
+  return ranked;
 };
+
+export const getTopAgentsByRevenue = (
+  loads: Load[],
+  windowDays = 90,
+  minLoads = 2,
+  limit = 5,
+): AgentRevenue[] =>
+  collectRecentAgents(loads, windowDays, minLoads)
+    .sort((a, b) => b.revenue - a.revenue)
+    .slice(0, limit);
+
+// Dispatch view: same podium, ranked by LOAD COUNT (volume) not net revenue —
+// so the leaderboard carries no owner-dollar figures. Ties break on revenue.
+export const getTopAgentsByVolume = (
+  loads: Load[],
+  windowDays = 90,
+  minLoads = 2,
+  limit = 5,
+): AgentRevenue[] =>
+  collectRecentAgents(loads, windowDays, minLoads)
+    .sort((a, b) => b.loadCount - a.loadCount || b.revenue - a.revenue)
+    .slice(0, limit);
 
 // ---- UPCOMING LOADS ---- (booked / in-transit, soonest pickup first)
 export interface UpcomingLoad {

--- a/frontend/src/lib/roles.ts
+++ b/frontend/src/lib/roles.ts
@@ -1,0 +1,28 @@
+// Role helpers for the delegated-access model (#277). The owner is `admin`;
+// a dispatcher logs in under the owner's account. This is a FRONTEND view
+// boundary (Phase 2) — it tailors what a dispatcher sees, it is NOT hard
+// security. The API still scopes every request to the account, so the owner's
+// data is reachable by the dispatcher's token; we simply don't route her there.
+
+export const getRole = (): string => localStorage.getItem("role") ?? "admin";
+
+export const isDispatcher = (): boolean => getRole() === "dispatcher";
+
+// Routes only the owner/admin opens. A dispatcher who lands on one (typed URL,
+// stale link) is bounced to her dashboard. Keep this in lockstep with the
+// `adminOnly` flags in AppSidebar so the nav and the guard never disagree.
+export const ADMIN_ONLY_PREFIXES = [
+  "/expenses",
+  "/per-diem",
+  "/recap",
+  "/garage",
+  "/trophy-room",
+  "/trophy-studio",
+  "/fuel-entries",
+  "/settings",
+];
+
+export const isAdminOnlyPath = (pathname: string): boolean =>
+  ADMIN_ONLY_PREFIXES.some(
+    (p) => pathname === p || pathname.startsWith(p + "/"),
+  );

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -39,6 +39,8 @@ import { AlertBanners } from "@/components/dashboard/AlertBanners";
 import { TopAgents } from "@/components/dashboard/TopAgents";
 import { WhatsNext } from "@/components/dashboard/WhatsNext";
 import { RecentLoads } from "@/components/dashboard/RecentLoads";
+import { isDispatcher } from "@/lib/roles";
+import DispatchDashboard from "./DispatchDashboard";
 
 // helpers
 const formatCurrency = (n: number | null): string =>
@@ -61,7 +63,7 @@ const computeDelta = (current: number | null, previous: number | null) => {
   };
 };
 
-const DashboardPage = () => {
+const OwnerDashboard = () => {
   const [refreshKey] = useState(0);
   const {
     loads,
@@ -241,5 +243,11 @@ const DashboardPage = () => {
     </div>
   );
 };
+
+// The owner sees the full financial dashboard; a dispatcher gets her own
+// operational board (no net revenue / RPM / P&L). Role is fixed for the
+// session, so the branch is stable across renders.
+const DashboardPage = () =>
+  isDispatcher() ? <DispatchDashboard /> : <OwnerDashboard />;
 
 export default DashboardPage;

--- a/frontend/src/pages/DispatchDashboard.tsx
+++ b/frontend/src/pages/DispatchDashboard.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Zap } from "lucide-react";
+import { useLoads } from "@/hooks/useLoads";
+import { useTrips } from "@/hooks/useTrips";
+import { useRateTargets } from "@/hooks/useRateTargets";
+import { useMaintenanceAlerts } from "@/hooks/useMaintenanceAlerts";
+import { useComplianceAlerts } from "@/hooks/useComplianceAlerts";
+import { KpiCard } from "@/components/KpiCard";
+import { Panel } from "@/components/ui/Panel";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AlertBanners } from "@/components/dashboard/AlertBanners";
+import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
+import { GrindMeter } from "@/components/dashboard/GrindMeter";
+import { TopAgents } from "@/components/dashboard/TopAgents";
+import { WhatsNext } from "@/components/dashboard/WhatsNext";
+import {
+  getLoadsMonthly,
+  getTopAgentsByVolume,
+  getUpcomingLoads,
+  getDeadheadTrend,
+  getDetentionOwed,
+} from "@/lib/metrics/dashboard";
+import {
+  computeHonors,
+  currentQuarterStandings,
+} from "@/lib/metrics/agentLeaderboard";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import { fmtDuration } from "@/lib/stopTimes";
+import { DEADHEAD_TARGET } from "@/lib/constants/targets";
+
+const formatPercent = (ratio: number | null): string =>
+  ratio === null ? "—" : `${(ratio * 100).toFixed(1)}%`;
+
+// Detention headline as decimal hours ("12.5h") — the dollar isn't known until
+// the settlement lands, so we only ever show time.
+const hoursLabel = (minutes: number): string =>
+  minutes === 0 ? "0h" : `${(minutes / 60).toFixed(1)}h`;
+
+const computeDelta = (current: number | null, previous: number | null) => {
+  if (current === null || previous === null || previous === 0) return null;
+  const percent = ((current - previous) / previous) * 100;
+  return {
+    percent,
+    direction: percent >= 0 ? ("up" as const) : ("down" as const),
+  };
+};
+
+// Brandie's board — operational only. No net revenue, RPM, or P&L; gross pace
+// (which she books) stays via the rate card. Detention is hours, not dollars.
+const DispatchDashboard = () => {
+  const { loads, isLoading: loadsLoading, error: loadsError } = useLoads(0);
+  const { trips, isLoading: tripsLoading, error: tripsError } = useTrips(0);
+  const targets = useRateTargets(loads);
+  const alerts = [...useMaintenanceAlerts(loads), ...useComplianceAlerts()];
+
+  // Free-time setting drives what counts as detention (same source as Loads).
+  const [freeHours, setFreeHours] = useState(3);
+  useEffect(() => {
+    getSettlementSchedule()
+      .then((s) => setFreeHours(s.detention_free_hours))
+      .catch(() => {});
+  }, []);
+
+  const isLoading = loadsLoading || tripsLoading;
+  const error = loadsError || tripsError;
+
+  if (isLoading)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <Skeleton className="h-8 w-48 mb-6" />
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-24" style={{ borderRadius: 13 }} />
+          ))}
+        </div>
+        <Skeleton className="h-28 mt-6" style={{ borderRadius: 13 }} />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
+          <Skeleton className="h-56" style={{ borderRadius: 13 }} />
+          <Skeleton className="h-56" style={{ borderRadius: 13 }} />
+        </div>
+      </div>
+    );
+
+  if (error)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen">
+        <p className="text-destructive">{error}</p>
+      </div>
+    );
+
+  const now = new Date();
+  const bookedCount = loads.filter((l) => l.load_status === "booked").length;
+  const inTransitCount = loads.filter(
+    (l) => l.load_status === "in_transit",
+  ).length;
+  const loadsMonthly = getLoadsMonthly(loads);
+  const loadsDelta = computeDelta(loadsMonthly.thisMonth, loadsMonthly.lastMonth);
+  const detention = getDetentionOwed(loads, freeHours);
+  const deadhead = getDeadheadTrend(loads, trips, now);
+  // Leaner than the 90-day baseline (or the target when there's no baseline yet)
+  // reads green; drifting above it reads red so she catches it early.
+  const deadheadBaseline = deadhead.rolling90 ?? DEADHEAD_TARGET;
+  const deadheadStatus =
+    deadhead.thisMonth === null
+      ? "neutral"
+      : deadhead.thisMonth <= deadheadBaseline
+        ? "good"
+        : "bad";
+  const topAgents = getTopAgentsByVolume(loads);
+  const agentHonors = computeHonors(loads, now);
+  const agentStandings = currentQuarterStandings(loads, now);
+  const upcoming = getUpcomingLoads(loads);
+  const displayName = localStorage.getItem("display_name") || "Dispatch";
+
+  return (
+    <div className="p-6 bg-iron text-light min-h-screen font-body">
+      <div className="flex items-center justify-between mb-6 gap-3">
+        <div>
+          <h1 className="font-comic text-3xl" style={{ color: "#f5b03a" }}>
+            DISPATCH BOARD
+          </h1>
+          <p className="text-xs text-muted-text mt-0.5">{displayName}</p>
+        </div>
+        <Link
+          to="/score"
+          className="inline-flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm font-semibold whitespace-nowrap hover:opacity-90"
+          style={{ background: "#e8940a", color: "#10151f" }}
+        >
+          <Zap size={15} /> Score a Load
+        </Link>
+      </div>
+
+      <AlertBanners alerts={alerts} />
+
+      {/* KPI STRIP — operational only */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+        <KpiCard label="Booked" value={String(bookedCount)} subtext="on the board" />
+        <KpiCard label="In transit" value={String(inTransitCount)} />
+        <KpiCard
+          label="Loads · MTD"
+          value={String(loadsMonthly.thisMonth)}
+          delta={loadsDelta}
+        />
+        <KpiCard
+          label="Detention owed"
+          value={hoursLabel(detention.totalMinutes)}
+          subtext={
+            detention.loadCount === 0
+              ? "nothing to chase"
+              : `${detention.loadCount} load${
+                  detention.loadCount === 1 ? "" : "s"
+                } · settles on the statement`
+          }
+        />
+        <KpiCard
+          label="Deadhead · MTD"
+          value={formatPercent(deadhead.thisMonth)}
+          status={deadheadStatus}
+          subtext={`90-day avg ${formatPercent(deadhead.rolling90)}`}
+        />
+      </div>
+
+      {/* Booking floor + gross pace (gross is hers; net/RPM stay owner-only) */}
+      <div className="mt-6">
+        <RateTargetsCard targets={targets} />
+      </div>
+
+      {/* The grind — weekly target-beating streak (no dollar figures) */}
+      <div className="mt-6">
+        <GrindMeter loads={loads} />
+      </div>
+
+      {/* What's next + detention to chase */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
+        <Panel className="p-4">
+          <p className="text-xs uppercase tracking-wider text-muted-text mb-2">
+            What's next · booked
+          </p>
+          <WhatsNext loads={upcoming} />
+        </Panel>
+        <Panel className="p-4">
+          <p
+            className="text-xs uppercase tracking-wider mb-2"
+            style={{ color: "#f5b03a" }}
+          >
+            Detention to collect
+          </p>
+          {detention.items.length === 0 ? (
+            <p className="text-muted-text text-sm">Nothing owed right now.</p>
+          ) : (
+            <>
+              {detention.items.slice(0, 5).map((it) => (
+                <Link
+                  key={it.load_id}
+                  to={`/loads/${it.load_id}`}
+                  className="flex justify-between text-sm py-1.5 border-t border-steel first:border-t-0 hover:opacity-80"
+                >
+                  <span className="text-light truncate">
+                    #{it.load_number} · {it.lane}
+                  </span>
+                  <span
+                    className="whitespace-nowrap ml-2 font-semibold"
+                    style={{ color: "#f5b03a" }}
+                  >
+                    {fmtDuration(it.minutes) ?? "—"}
+                  </span>
+                </Link>
+              ))}
+              <p className="text-[10px] text-muted-text mt-2">
+                Mark paid on the load once it hits a settlement.
+              </p>
+            </>
+          )}
+        </Panel>
+      </div>
+
+      {/* Top agents — ranked by volume, no owner dollars */}
+      <div className="mt-6">
+        <TopAgents
+          agents={topAgents}
+          honors={agentHonors}
+          standings={agentStandings}
+          mode="loads"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DispatchDashboard;

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -830,6 +830,55 @@ const GuidePage = () => (
           each agent's own page.
         </p>
       </Section>
+
+      <div
+        className="my-6 border-t"
+        style={{ borderColor: "#22304a" }}
+        aria-hidden="true"
+      />
+      <h2 className="font-condensed text-2xl mb-3" style={{ color: AMBER_HI }}>
+        Team &amp; roles
+      </h2>
+
+      <Section title="Adding a dispatcher">
+        <p className="text-sm text-muted-text">
+          As the owner (an <span className="text-light">admin</span>), you can add
+          a <span className="text-light">dispatcher</span> to your account from{" "}
+          <Link to="/settings" className="text-status-info-text hover:underline">
+            Settings → Team
+          </Link>
+          . They sign in with their own email and password, but everything they
+          see is your account's data — same loads, agents, and trucks. It's one
+          shared operation, with a login of their own.
+        </p>
+      </Section>
+
+      <Section title="What a dispatcher sees">
+        <p className="text-sm text-muted-text">
+          A dispatcher's menu is trimmed to the day-to-day: the Dispatch board,
+          Score a Load, Loads, Trips, Lanes, Agents, Facilities, the fleet
+          (Trucks, Trailers, Drivers), Maintenance, Compliance, and this Guide.
+          The money pages — Expenses, Per&nbsp;Diem, Recap, Fuel, Garage, Trophy
+          Room, and Settings — stay owner-only, so the P&amp;L is yours alone.
+        </p>
+      </Section>
+
+      <Section title="The Dispatch board">
+        <p className="text-sm text-muted-text">
+          A dispatcher's dashboard leads with the operational picture instead of
+          the money: how many loads are <span className="text-light">booked</span>{" "}
+          and <span className="text-light">in transit</span>, loads delivered this
+          month, <span className="text-light">detention owed</span>, and{" "}
+          <span className="text-light">deadhead</span> this month against a rolling
+          90-day average. Detention is shown in{" "}
+          <span className="text-light">hours</span>, not dollars — the rate per
+          hour isn't settled until it lands on your statement, so the board tracks
+          the wait you're owed and lets you mark it paid once collected. It keeps
+          the rate ladder (the floor to book above), the grind streak, what's
+          next, a detention chase-list, and the top-agents leaderboard ranked by
+          loads. Net revenue, RPM, and profit never appear.
+        </p>
+      </Section>
     </div>
   </div>
 );


### PR DESCRIPTION
## Phase 2 of the multi-user epic (#277) — the dispatcher view

Gives a dispatcher (Brandie) her own operational experience under the owner's account. Boundary is a **frontend view boundary** (the API still scopes every request to the account, per the chosen approach). The owner dashboard is untouched.

### What's in it
- **`roles.ts`** — one source of truth for role + admin-only route prefixes, shared by the sidebar and the guard.
- **Filtered sidebar** — a dispatcher's nav drops Expenses, Per Diem, Recap, Garage, Trophy Room, Fuel, and the Settings link; empty groups collapse out.
- **`AdminRoute`** — a dispatcher who types an owner-only URL is redirected to `/dashboard`.
- **Dispatch board** — operational only: Booked / In transit / Loads MTD / **Detention owed (hours, not dollars — the rate settles on the statement)** / **Deadhead MTD vs rolling 90-day**, plus the rate ladder + gross pace, the grind streak, what's-next, a detention chase-list (drills per load), and the Top Agents leaderboard ranked by volume. No net revenue, RPM, or P&L.
- **New metrics** — `getDetentionOwed`, `getDeadheadTrend`, `getTopAgentsByVolume`, with unit tests (edge/null cases covered).
- **`TopAgents`** gains a `loads` mode so the leaderboard carries no owner dollars.
- **Guide** — new "Team & roles" section.

### Verify
- Strict production build clean; **313/313 tests pass** (+4 new).
- Detention/deadhead are pure client-side logic over already-fetched loads/trips — no new SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)