### PR TITLE
feat: dispatch board restructure — searchable loads/agents tables + gross Top Agents

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.97.0",
+  "version": "1.98.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/DispatchAgentsTable.tsx
+++ b/frontend/src/components/dashboard/DispatchAgentsTable.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { Search, ChevronLeft, ChevronRight, Trophy } from "lucide-react";
+import type { Load } from "@/types/load";
+import { Panel } from "@/components/ui/Panel";
+import { getAgentGrossTable } from "@/lib/metrics/dashboard";
+
+const PAGE = 10;
+const MEDAL = ["🥇", "🥈", "🥉"];
+
+type Sort = "gross" | "loads" | "name";
+
+const fmtK = (n: number): string => `$${(n / 1000).toFixed(1)}k`;
+
+export const DispatchAgentsTable = ({ loads }: { loads: Load[] }) => {
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<Sort>("gross");
+  const [page, setPage] = useState(0);
+
+  useEffect(() => setPage(0), [search, sort]);
+
+  // Gross-ranked directory of every agent with a delivered load.
+  const table = useMemo(() => getAgentGrossTable(loads), [loads]);
+  const leader = table[0];
+
+  const sorted = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const rows = table.filter((a) => !q || a.agent.toLowerCase().includes(q));
+    const by =
+      sort === "loads"
+        ? (a: typeof rows[number], b: typeof rows[number]) =>
+            b.loadCount - a.loadCount || b.revenue - a.revenue
+        : sort === "name"
+          ? (a: typeof rows[number], b: typeof rows[number]) =>
+              a.agent.localeCompare(b.agent)
+          : (a: typeof rows[number], b: typeof rows[number]) =>
+              b.revenue - a.revenue;
+    return [...rows].sort(by);
+  }, [table, search, sort]);
+
+  const pages = Math.max(1, Math.ceil(sorted.length / PAGE));
+  const clamped = Math.min(page, pages - 1);
+  const start = clamped * PAGE;
+  const shown = sorted.slice(start, start + PAGE);
+
+  // Medals only read as a rank when the list is gross-sorted from the top.
+  const rankMark = (idx: number): string =>
+    sort === "gross" && idx < 3 ? MEDAL[idx] : String(idx + 1);
+
+  const SortHead = ({ label, col, align }: { label: string; col: Sort; align?: string }) => (
+    <button
+      onClick={() => setSort(col)}
+      className={`uppercase tracking-wide ${align ?? ""}`}
+      style={{ color: sort === col ? "#f5b03a" : undefined }}
+    >
+      {label}
+      {sort === col ? " ▾" : ""}
+    </button>
+  );
+
+  return (
+    <Panel className="p-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
+          AGENTS
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2 bg-[#141a26] border border-[#2a3347] rounded-md px-2.5 py-1.5 mb-2.5">
+        <Search size={13} className="text-muted-text shrink-0" />
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search agent name"
+          className="bg-transparent outline-none text-sm text-light placeholder:text-muted-text w-full"
+        />
+      </div>
+
+      {leader && (
+        <Link
+          to={`/agents/${leader.agentId}`}
+          className="block rounded-lg px-2.5 py-1.5 mb-2.5 hover:opacity-90"
+          style={{ background: "#241a0d", border: "1px solid #7a4718" }}
+        >
+          <div className="flex items-center justify-between">
+            <span
+              className="text-[10px] flex items-center gap-1"
+              style={{ color: "#f5b03a" }}
+            >
+              <Trophy size={11} /> TOP BY GROSS
+            </span>
+            <span className="text-[10px] text-muted-text">
+              {leader.loadCount} loads
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span
+              className="font-comic text-base truncate"
+              style={{ color: "#f5b03a" }}
+            >
+              {leader.agent}
+            </span>
+            <span className="font-comic text-base" style={{ color: "#f5b03a" }}>
+              {fmtK(leader.revenue)}
+            </span>
+          </div>
+        </Link>
+      )}
+
+      <div className="grid grid-cols-[22px_1fr_40px_52px] text-[10px] text-muted-text px-1 pb-1.5 border-b border-steel">
+        <span>#</span>
+        <SortHead label="Agent" col="name" />
+        <SortHead label="Loads" col="loads" align="text-right" />
+        <SortHead label="Gross" col="gross" align="text-right" />
+      </div>
+
+      {shown.length === 0 ? (
+        <p className="text-muted-text text-sm py-4 text-center">
+          No agents match.
+        </p>
+      ) : (
+        shown.map((a, i) => (
+          <Link
+            key={a.agentId}
+            to={`/agents/${a.agentId}`}
+            className="grid grid-cols-[22px_1fr_40px_52px] items-center text-[11px] py-1.5 px-1 border-b border-[#202838] last:border-b-0 hover:opacity-80"
+          >
+            <span>{rankMark(start + i)}</span>
+            <span className="text-light truncate underline">{a.agent}</span>
+            <span className="text-right text-muted-text">{a.loadCount}</span>
+            <span className="text-right" style={{ color: "#cdd8e8" }}>
+              {fmtK(a.revenue)}
+            </span>
+          </Link>
+        ))
+      )}
+
+      <div className="flex items-center justify-between mt-2.5">
+        <span className="text-[11px] text-muted-text">
+          {sorted.length === 0
+            ? "0 agents"
+            : `${start + 1}–${start + shown.length} of ${sorted.length}`}
+        </span>
+        <div className="flex gap-1.5">
+          <button
+            onClick={() => setPage(clamped - 1)}
+            disabled={clamped === 0}
+            className="w-6 h-5 rounded flex items-center justify-center disabled:opacity-30"
+            style={{ background: "#232c3f", color: "#cdd8e8" }}
+            aria-label="Previous page"
+          >
+            <ChevronLeft size={13} />
+          </button>
+          <button
+            onClick={() => setPage(clamped + 1)}
+            disabled={clamped >= pages - 1}
+            className="w-6 h-5 rounded flex items-center justify-center disabled:opacity-30"
+            style={{ background: "#232c3f", color: "#cdd8e8" }}
+            aria-label="Next page"
+          >
+            <ChevronRight size={13} />
+          </button>
+        </div>
+      </div>
+    </Panel>
+  );
+};

--- a/frontend/src/components/dashboard/DispatchLoadsTable.tsx
+++ b/frontend/src/components/dashboard/DispatchLoadsTable.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { Search, ChevronLeft, ChevronRight, Truck } from "lucide-react";
+import type { Load } from "@/types/load";
+import { Panel } from "@/components/ui/Panel";
+import { detentionOwed, detentionMinutes } from "@/lib/detention";
+import { fmtDuration } from "@/lib/stopTimes";
+
+const PAGE = 10;
+
+type Filter = "all" | "booked" | "in_transit" | "delivered" | "detention";
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "booked", label: "Booked" },
+  { key: "in_transit", label: "In transit" },
+  { key: "delivered", label: "Delivered" },
+  { key: "detention", label: "Detention" },
+];
+
+const STATUS_COLOR: Record<string, string> = {
+  booked: "#8fb9ff",
+  in_transit: "#4ade80",
+  delivered: "#9daabb",
+  cancelled: "#f87171",
+  tonu: "#f5c37a",
+};
+const STATUS_LABEL: Record<string, string> = {
+  booked: "booked",
+  in_transit: "in transit",
+  delivered: "delivered",
+  cancelled: "cancelled",
+  tonu: "TONU",
+};
+
+const lane = (l: Load): string => `${l.origin_market} → ${l.delivery_market}`;
+
+// Format in UTC to dodge the local-timezone day-shift on date-only strings.
+const fmtDate = (iso: string | null | undefined): string =>
+  !iso
+    ? "—"
+    : new Date(iso).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      });
+
+// The date that matters for the row: delivered → when it delivered, otherwise
+// when it picks up.
+const rowDate = (l: Load): string | null | undefined =>
+  l.load_status === "delivered" ? l.delivery_date : l.pickup_date;
+
+const StatusChip = ({ status }: { status: string }) => (
+  <span style={{ color: STATUS_COLOR[status] ?? "#9daabb" }}>
+    {STATUS_LABEL[status] ?? status}
+  </span>
+);
+
+export const DispatchLoadsTable = ({
+  loads,
+  freeHours,
+}: {
+  loads: Load[];
+  freeHours: number;
+}) => {
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<Filter>("all");
+  const [page, setPage] = useState(0);
+
+  // Any change to what's shown snaps back to the first page.
+  useEffect(() => setPage(0), [search, filter]);
+
+  // The one (or few) loads on the road right now — pulled out on top.
+  const active = useMemo(
+    () => loads.filter((l) => l.load_status === "in_transit"),
+    [loads],
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const searchMatch = (l: Load) =>
+      !q ||
+      [
+        l.load_number,
+        l.broker,
+        l.agent,
+        l.origin_market,
+        l.delivery_market,
+        l.origin_city,
+        l.origin_state,
+        l.destination_city,
+        l.destination_state,
+      ]
+        .join(" ")
+        .toLowerCase()
+        .includes(q);
+    const statusMatch = (l: Load) =>
+      filter === "all"
+        ? true
+        : filter === "detention"
+          ? detentionOwed(l, freeHours)
+          : l.load_status === filter;
+
+    return loads
+      .filter((l) => searchMatch(l) && statusMatch(l))
+      .sort((a, b) =>
+        (rowDate(b) ?? "").localeCompare(rowDate(a) ?? ""),
+      );
+  }, [loads, search, filter, freeHours]);
+
+  const pages = Math.max(1, Math.ceil(filtered.length / PAGE));
+  const clamped = Math.min(page, pages - 1);
+  const start = clamped * PAGE;
+  const shown = filtered.slice(start, start + PAGE);
+
+  return (
+    <Panel className="p-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
+          LOADS
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2 bg-[#141a26] border border-[#2a3347] rounded-md px-2.5 py-1.5 mb-2.5">
+        <Search size={13} className="text-muted-text shrink-0" />
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search # · lane · city"
+          className="bg-transparent outline-none text-sm text-light placeholder:text-muted-text w-full"
+        />
+      </div>
+
+      {active.length > 0 && (
+        <div className="mb-2.5 flex flex-col gap-1.5">
+          {active.slice(0, 2).map((l) => (
+            <Link
+              key={l.load_id}
+              to={`/loads/${l.load_id}`}
+              className="block rounded-lg px-2.5 py-1.5 hover:opacity-90"
+              style={{ background: "#132234", border: "1px solid #2b5a8c" }}
+            >
+              <div className="flex items-center justify-between">
+                <span
+                  className="text-[10px] flex items-center gap-1"
+                  style={{ color: "#60a5fa" }}
+                >
+                  <Truck size={11} /> ON THE ROAD
+                </span>
+                <span className="text-[10px] text-muted-text">
+                  del {fmtDate(l.delivery_date)}
+                </span>
+              </div>
+              <div className="text-sm text-light truncate">
+                #{l.load_number} · {lane(l)}
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      <div className="flex gap-1.5 flex-wrap mb-2">
+        {FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setFilter(f.key)}
+            className="rounded-full px-2.5 py-0.5 text-[11px]"
+            style={
+              filter === f.key
+                ? { background: "#e8940a", color: "#10151f", fontWeight: 600 }
+                : { background: "#232c3f", color: "#cdd8e8" }
+            }
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-[46px_1fr_66px_46px] text-[10px] text-muted-text uppercase tracking-wide px-1 pb-1.5 border-b border-steel">
+        <span>Load</span>
+        <span>Lane</span>
+        <span>Status</span>
+        <span className="text-right">Date</span>
+      </div>
+
+      {shown.length === 0 ? (
+        <p className="text-muted-text text-sm py-4 text-center">
+          No loads match.
+        </p>
+      ) : (
+        shown.map((l) => {
+          const owed = detentionOwed(l, freeHours);
+          return (
+            <Link
+              key={l.load_id}
+              to={`/loads/${l.load_id}`}
+              className="grid grid-cols-[46px_1fr_66px_46px] items-center text-[11px] py-1.5 px-1 border-b border-[#202838] last:border-b-0 hover:opacity-80"
+            >
+              <span style={{ color: "#8fb9ff" }} className="underline">
+                #{l.load_number}
+              </span>
+              <span className="text-light truncate flex items-center gap-1.5">
+                <span className="truncate">{lane(l)}</span>
+                {owed && (
+                  <span
+                    className="shrink-0 rounded px-1 text-[9px]"
+                    style={{ background: "#7a4718", color: "#f5c37a" }}
+                  >
+                    {fmtDuration(detentionMinutes(l, freeHours))}
+                  </span>
+                )}
+              </span>
+              <span className="text-[11px]">
+                <StatusChip status={l.load_status} />
+              </span>
+              <span className="text-right text-muted-text">
+                {fmtDate(rowDate(l))}
+              </span>
+            </Link>
+          );
+        })
+      )}
+
+      <div className="flex items-center justify-between mt-2.5">
+        <span className="text-[11px] text-muted-text">
+          {filtered.length === 0
+            ? "0 loads"
+            : `${start + 1}–${start + shown.length} of ${filtered.length}`}
+        </span>
+        <div className="flex gap-1.5">
+          <button
+            onClick={() => setPage(clamped - 1)}
+            disabled={clamped === 0}
+            className="w-6 h-5 rounded flex items-center justify-center disabled:opacity-30"
+            style={{ background: "#232c3f", color: "#cdd8e8" }}
+            aria-label="Previous page"
+          >
+            <ChevronLeft size={13} />
+          </button>
+          <button
+            onClick={() => setPage(clamped + 1)}
+            disabled={clamped >= pages - 1}
+            className="w-6 h-5 rounded flex items-center justify-center disabled:opacity-30"
+            style={{ background: "#232c3f", color: "#cdd8e8" }}
+            aria-label="Next page"
+          >
+            <ChevronRight size={13} />
+          </button>
+        </div>
+      </div>
+    </Panel>
+  );
+};

--- a/frontend/src/components/dashboard/TopAgents.tsx
+++ b/frontend/src/components/dashboard/TopAgents.tsx
@@ -9,11 +9,10 @@ interface Props {
   agents: AgentRevenue[];
   honors: Map<string, AgentHonors>;
   standings: Map<string, LiveStanding>;
-  // "revenue" (owner view) shows net $ per agent; "loads" (dispatch view) shows
-  // volume only, so the board carries no owner-dollar figures.
-  mode?: "revenue" | "loads";
 }
 
+// agent.revenue is GROSS (see getTopAgentsByRevenue) — agents are graded on the
+// market value they bring, the same way on every dashboard.
 const fmtK = (n: number): string => `$${(n / 1000).toFixed(1)}k`;
 
 // Gold, silver, bronze for the podium (index 0/1/2).
@@ -54,12 +53,7 @@ const Pulse = () => (
   />
 );
 
-export const TopAgents = ({
-  agents,
-  honors,
-  standings,
-  mode = "revenue",
-}: Props) => (
+export const TopAgents = ({ agents, honors, standings }: Props) => (
   <div
     className="relative overflow-hidden rounded-2xl border-2 p-4"
     style={{ background: "#10151f", borderColor: "#e8940a" }}
@@ -79,7 +73,7 @@ export const TopAgents = ({
         TOP AGENTS
       </span>
       <span className="flex-1" />
-      <span className="text-[10px] text-muted-text">90 days</span>
+      <span className="text-[10px] text-muted-text">gross · 90 days</span>
     </div>
 
     {agents.length === 0 ? (
@@ -135,19 +129,11 @@ export const TopAgents = ({
                     color: first ? "#f5b03a" : i < 3 ? "#e8eef7" : "#9daabb",
                   }}
                 >
-                  {mode === "loads" ? agent.loadCount : fmtK(agent.revenue)}
+                  {fmtK(agent.revenue)}
                 </span>
-                {mode === "loads" ? (
-                  <span className="block text-[10px] text-muted-text">
-                    loads
-                  </span>
-                ) : (
-                  i < 3 && (
-                    <span className="block text-[10px] text-muted-text">
-                      {agent.loadCount} loads
-                    </span>
-                  )
-                )}
+                <span className="block text-[10px] text-muted-text">
+                  {agent.loadCount} loads
+                </span>
               </span>
             </>
           );

--- a/frontend/src/lib/metrics/dashboard.test.ts
+++ b/frontend/src/lib/metrics/dashboard.test.ts
@@ -17,6 +17,7 @@ import {
   getOutstandingSummary,
   getDeadheadTrend,
   getDetentionOwed,
+  getAgentGrossTable,
 } from "./dashboard";
 
 // ---- typed factories: override only the fields a test cares about ----
@@ -258,6 +259,43 @@ describe("getTopAgentsByRevenue", () => {
       makeLoad({ agent_id: id, agent: id, delivery_date: "2026-06-11T04:00:00.000Z" }),
     ]);
     expect(getTopAgentsByRevenue(loads, 90, 2, 2)).toHaveLength(2);
+  });
+
+  it("uses GROSS, not net — an agent isn't penalized for Jason's cut", () => {
+    // gross = linehaul + fsc + accessorials = 1250/load; net_revenue (700) must
+    // NOT be what's summed.
+    const grossLoad = {
+      linehaul: "1000",
+      fuel_surcharge: "200",
+      total_accessorials: "50",
+      net_revenue: "700",
+    };
+    const loads = [
+      makeLoad({ agent_id: "g", agent: "Gus", delivery_date: "2026-06-10T04:00:00.000Z", ...grossLoad }),
+      makeLoad({ agent_id: "g", agent: "Gus", delivery_date: "2026-06-12T04:00:00.000Z", ...grossLoad }),
+    ];
+    const top = getTopAgentsByRevenue(loads, 90, 2, 5);
+    expect(top[0].revenue).toBe(2500); // 2 × 1250 gross, not 2 × 700 net
+  });
+});
+
+describe("getAgentGrossTable", () => {
+  it("lists every agent with a delivered load, gross + count, gross-sorted", () => {
+    const loads = [
+      makeLoad({ agent_id: "a1", agent: "Ann", linehaul: "1000", delivery_date: "2026-06-10T04:00:00.000Z" }),
+      makeLoad({ agent_id: "a2", agent: "Bob", linehaul: "400", delivery_date: "2026-06-01T04:00:00.000Z" }),
+      makeLoad({ agent_id: "a2", agent: "Bob", linehaul: "400", delivery_date: "2026-06-05T04:00:00.000Z" }),
+      // booked → excluded (no realized gross yet)
+      makeLoad({ agent_id: "a3", agent: "Cid", load_status: "booked", linehaul: "9999" }),
+    ];
+    const table = getAgentGrossTable(loads);
+    expect(table.map((r) => r.agent)).toEqual(["Ann", "Bob"]); // 1000 > 800
+    expect(table[1].loadCount).toBe(2);
+    expect(table[1].revenue).toBe(800);
+  });
+
+  it("returns an empty list when no loads are delivered", () => {
+    expect(getAgentGrossTable([])).toEqual([]);
   });
 });
 

--- a/frontend/src/lib/metrics/dashboard.ts
+++ b/frontend/src/lib/metrics/dashboard.ts
@@ -1,6 +1,6 @@
 import type { Load } from "@/types/load";
 import type { Trip } from "@/types/trip";
-import { loadRevenue } from "./rateTargets";
+import { loadRevenue, loadGross } from "./rateTargets";
 import { detentionOwed, detentionMinutes } from "@/lib/detention";
 import { median } from "./stats";
 
@@ -419,18 +419,25 @@ export const getLoadsMonthly = (loads: Load[]): MonthlyLoadCount => {
   };
 };
 
-// ---- TOP AGENTS BY REVENUE ---- (delivered loads, grouped by agent)
+// ---- TOP AGENTS BY GROSS ---- (delivered loads, grouped by agent)
+// `revenue` here is the agent's total GROSS (the full customer rate). Agents are
+// graded on the market value they bring, NOT Jason's net — net would penalize a
+// good booking for his deadhead/cost, which the agent doesn't control. Gross is
+// used for agents/lanes/targets app-wide (owner dashboard too). Assets stay net.
 export interface AgentRevenue {
   agentId: string;
   agent: string;
-  revenue: number;
+  revenue: number; // GROSS
   loadCount: number;
 }
 
+const agentGross = (loads: Load[]): number =>
+  loads.reduce((sum, l) => sum + loadGross(l), 0);
+
 // Two guards, two failure modes: `windowDays` drops stale agents (a great load
 // six months ago falls out of the window); `minLoads` drops one-offs (a single
-// lucky run doesn't rank). loadCount + revenue are both returned so either
-// ranking self-explains.
+// lucky run doesn't rank). loadCount + gross are both returned so the ranking
+// self-explains.
 const collectRecentAgents = (
   loads: Load[],
   windowDays: number,
@@ -457,7 +464,7 @@ const collectRecentAgents = (
     ranked.push({
       agentId,
       agent: agentLoads[0].agent,
-      revenue: getLoadRevenue(agentLoads) ?? 0,
+      revenue: agentGross(agentLoads),
       loadCount: agentLoads.length,
     });
   }
@@ -474,17 +481,29 @@ export const getTopAgentsByRevenue = (
     .sort((a, b) => b.revenue - a.revenue)
     .slice(0, limit);
 
-// Dispatch view: same podium, ranked by LOAD COUNT (volume) not net revenue —
-// so the leaderboard carries no owner-dollar figures. Ties break on revenue.
-export const getTopAgentsByVolume = (
-  loads: Load[],
-  windowDays = 90,
-  minLoads = 2,
-  limit = 5,
-): AgentRevenue[] =>
-  collectRecentAgents(loads, windowDays, minLoads)
-    .sort((a, b) => b.loadCount - a.loadCount || b.revenue - a.revenue)
-    .slice(0, limit);
+// The full agent directory for the dispatch Agents table: every agent with a
+// delivered load, lifetime load count + gross, sorted by gross. The component
+// searches / re-sorts / paginates this.
+export const getAgentGrossTable = (loads: Load[]): AgentRevenue[] => {
+  const byAgent = new Map<string, Load[]>();
+  for (const load of loads) {
+    if (load.load_status !== "delivered") continue;
+    const bucket = byAgent.get(load.agent_id);
+    if (bucket) bucket.push(load);
+    else byAgent.set(load.agent_id, [load]);
+  }
+
+  const rows: AgentRevenue[] = [];
+  for (const [agentId, agentLoads] of byAgent) {
+    rows.push({
+      agentId,
+      agent: agentLoads[0].agent,
+      revenue: agentGross(agentLoads),
+      loadCount: agentLoads.length,
+    });
+  }
+  return rows.sort((a, b) => b.revenue - a.revenue);
+};
 
 // ---- UPCOMING LOADS ---- (booked / in-transit, soonest pickup first)
 export interface UpcomingLoad {

--- a/frontend/src/pages/DispatchDashboard.tsx
+++ b/frontend/src/pages/DispatchDashboard.tsx
@@ -7,17 +7,16 @@ import { useRateTargets } from "@/hooks/useRateTargets";
 import { useMaintenanceAlerts } from "@/hooks/useMaintenanceAlerts";
 import { useComplianceAlerts } from "@/hooks/useComplianceAlerts";
 import { KpiCard } from "@/components/KpiCard";
-import { Panel } from "@/components/ui/Panel";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AlertBanners } from "@/components/dashboard/AlertBanners";
 import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
 import { GrindMeter } from "@/components/dashboard/GrindMeter";
 import { TopAgents } from "@/components/dashboard/TopAgents";
-import { WhatsNext } from "@/components/dashboard/WhatsNext";
+import { DispatchLoadsTable } from "@/components/dashboard/DispatchLoadsTable";
+import { DispatchAgentsTable } from "@/components/dashboard/DispatchAgentsTable";
 import {
   getLoadsMonthly,
-  getTopAgentsByVolume,
-  getUpcomingLoads,
+  getTopAgentsByRevenue,
   getDeadheadTrend,
   getDetentionOwed,
 } from "@/lib/metrics/dashboard";
@@ -26,7 +25,6 @@ import {
   currentQuarterStandings,
 } from "@/lib/metrics/agentLeaderboard";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
-import { fmtDuration } from "@/lib/stopTimes";
 import { DEADHEAD_TARGET } from "@/lib/constants/targets";
 
 const formatPercent = (ratio: number | null): string =>
@@ -107,10 +105,9 @@ const DispatchDashboard = () => {
       : deadhead.thisMonth <= deadheadBaseline
         ? "good"
         : "bad";
-  const topAgents = getTopAgentsByVolume(loads);
+  const topAgents = getTopAgentsByRevenue(loads);
   const agentHonors = computeHonors(loads, now);
   const agentStandings = currentQuarterStandings(loads, now);
-  const upcoming = getUpcomingLoads(loads);
   const displayName = localStorage.getItem("display_name") || "Dispatch";
 
   return (
@@ -161,67 +158,24 @@ const DispatchDashboard = () => {
         />
       </div>
 
-      {/* Booking floor + gross pace (gross is hers; net/RPM stay owner-only) */}
-      <div className="mt-6">
+      {/* Booking floor + gross pace | the grind (gross is hers; net/RPM owner-only) */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6 items-start">
         <RateTargetsCard targets={targets} />
-      </div>
-
-      {/* The grind — weekly target-beating streak (no dollar figures) */}
-      <div className="mt-6">
         <GrindMeter loads={loads} />
       </div>
 
-      {/* What's next + detention to chase */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
-        <Panel className="p-4">
-          <p className="text-xs uppercase tracking-wider text-muted-text mb-2">
-            What's next · booked
-          </p>
-          <WhatsNext loads={upcoming} />
-        </Panel>
-        <Panel className="p-4">
-          <p
-            className="text-xs uppercase tracking-wider mb-2"
-            style={{ color: "#f5b03a" }}
-          >
-            Detention to collect
-          </p>
-          {detention.items.length === 0 ? (
-            <p className="text-muted-text text-sm">Nothing owed right now.</p>
-          ) : (
-            <>
-              {detention.items.slice(0, 5).map((it) => (
-                <Link
-                  key={it.load_id}
-                  to={`/loads/${it.load_id}`}
-                  className="flex justify-between text-sm py-1.5 border-t border-steel first:border-t-0 hover:opacity-80"
-                >
-                  <span className="text-light truncate">
-                    #{it.load_number} · {it.lane}
-                  </span>
-                  <span
-                    className="whitespace-nowrap ml-2 font-semibold"
-                    style={{ color: "#f5b03a" }}
-                  >
-                    {fmtDuration(it.minutes) ?? "—"}
-                  </span>
-                </Link>
-              ))}
-              <p className="text-[10px] text-muted-text mt-2">
-                Mark paid on the load once it hits a settlement.
-              </p>
-            </>
-          )}
-        </Panel>
+      {/* The workhorses — searchable, paginated loads + agents */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6 items-start">
+        <DispatchLoadsTable loads={loads} freeHours={freeHours} />
+        <DispatchAgentsTable loads={loads} />
       </div>
 
-      {/* Top agents — ranked by volume, no owner dollars */}
+      {/* Top agents — ranked by gross, same card as the owner dashboard */}
       <div className="mt-6">
         <TopAgents
           agents={topAgents}
           honors={agentHonors}
           standings={agentStandings}
-          mode="loads"
         />
       </div>
     </div>

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -873,10 +873,25 @@ const GuidePage = () => (
           90-day average. Detention is shown in{" "}
           <span className="text-light">hours</span>, not dollars — the rate per
           hour isn't settled until it lands on your statement, so the board tracks
-          the wait you're owed and lets you mark it paid once collected. It keeps
-          the rate ladder (the floor to book above), the grind streak, what's
-          next, a detention chase-list, and the top-agents leaderboard ranked by
-          loads. Net revenue, RPM, and profit never appear.
+          the wait you're owed and lets you mark it paid once collected. Below the
+          rate ladder and the grind streak sit two searchable, paginated tables —{" "}
+          <span className="text-light">Loads</span> (with the load on the road
+          pulled out on top, and filters for booked / in&#8209;transit / delivered
+          / detention) and <span className="text-light">Agents</span> — then the
+          Top&nbsp;Agents leaderboard. Net revenue, RPM, and profit never appear.
+        </p>
+      </Section>
+
+      <Section title="Agents &amp; lanes are graded on gross">
+        <p className="text-sm text-muted-text">
+          Everywhere an <span className="text-light">agent</span> or a{" "}
+          <span className="text-light">lane</span> is ranked — the Top&nbsp;Agents
+          leaderboard on either dashboard, the Agents table — the number is{" "}
+          <span className="text-light">gross</span> revenue (the full customer
+          rate), not net. An agent who books a strong load did their job; they
+          shouldn't be marked down because a deadhead leg or a cost of yours thinned
+          the net. Net is your operational result and lives on the owner side; gross
+          is what the agent and the lane actually delivered.
         </p>
       </Section>
     </div>


### PR DESCRIPTION
## Dispatch board restructure (#277)

Reorganizes the dispatcher's board around two browsable tables and fixes the agent metric basis.

### Layout (below the KPI strip)
1. Rate ladder + gross pace │ The Grind
2. **Loads table** │ **Agents table** — searchable + paginated (10/page)
3. Top Agents leaderboard

- **Loads table**: search (#, lane, city — like the Loads page), the in-transit load pulled out on top, filter chips (booked / in-transit / delivered / detention with hrs-owed chips), rows drill to the load.
- **Agents table**: search by name, sortable by gross / loads / name, top-by-gross leader pulled out, rows drill to the agent.
- **Dropped** the redundant What's Next + Detention-to-collect panels — the loads table's Booked/Detention filters cover them.

### Agents/lanes/targets graded on GROSS, app-wide
An agent or lane is measured by the market value they deliver, not Jason's net — net would penalize a strong booking for his deadhead/cost, which the agent doesn't control.
- `getTopAgentsByRevenue` now sums **gross** (`loadGross`), not net — on **both** dashboards. Removed `getTopAgentsByVolume` and the `TopAgents` `mode` prop; the leaderboard shows gross + load count everywhere.
- New `getAgentGrossTable` (full agent directory) backs the Agents table.

### Verify
- Strict build clean; **316/316 tests pass** (+3: proves gross-not-net is summed; directory + empty cases).
- Pure client-side over already-fetched loads — no new SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)