### PR TITLE
feat: Dispatcher Card + per-load booking attribution (#277 Phase 3a)

### DIFF
--- a/backend/db/migrations/048_dispatcher_attribution.sql
+++ b/backend/db/migrations/048_dispatcher_attribution.sql
@@ -1,0 +1,20 @@
+-- 048: dispatcher attribution + user avatars (multi-user Phase 3a)
+--
+-- `booked_by` records WHO booked each load, so a dispatcher's card can count
+-- only the loads they personally booked (Jason and Brandie both book; she should
+-- get credit for hers). New loads default booked_by to the logged-in creator;
+-- existing loads are attributed to the account owner, who booked all history.
+--
+-- loads.user_id is the ACCOUNT id under delegated access (= the owner/admin's
+-- user_id), so `booked_by = user_id` backfills every existing load to the owner.
+ALTER TABLE loads
+  ADD COLUMN IF NOT EXISTS booked_by uuid REFERENCES users(user_id) ON DELETE SET NULL;
+
+UPDATE loads SET booked_by = user_id WHERE booked_by IS NULL;
+
+-- A user's own avatar (their dispatcher card + team pages) — same idea as the
+-- trucks/drivers/trailers avatar_url, but keyed to the login.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_url varchar(500);
+
+-- No RLS statement: this migration only ALTERs existing tables (loads + users
+-- already have RLS enabled); the convention only requires ENABLE on new tables.

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -62,6 +62,7 @@ router.post("/login", async (req, res) => {
         email: user.email,
         role: user.role,
         display_name: user.display_name,
+        avatar_url: user.avatar_url,
       },
       token: accessToken,
     });

--- a/backend/src/routes/avatarRoutes.js
+++ b/backend/src/routes/avatarRoutes.js
@@ -20,7 +20,7 @@ const handleError = (res, err) => {
 router.post("/:kind/:id/generate", async (req, res) => {
   try {
     const result = await generateAvatar(
-      req.user.user_id,
+      req.user,
       req.params.kind,
       req.params.id,
       req.body?.variant,
@@ -44,7 +44,7 @@ router.post(
       if (!req.body || !req.body.length)
         return res.status(400).json({ error: "No image in request body" });
       const result = await uploadAvatar(
-        req.user.user_id,
+        req.user,
         req.params.kind,
         req.params.id,
         req.body,

--- a/backend/src/routes/loadRoutes.js
+++ b/backend/src/routes/loadRoutes.js
@@ -69,7 +69,7 @@ router.post("/", async (req, res) => {
     const user_id = req.user.user_id;
     const data = req.body;
 
-    const load = await createLoad(user_id, data);
+    const load = await createLoad(user_id, data, req.user.self_id);
 
     return res.status(201).json({
       message: "Load created successfully",

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -1,6 +1,10 @@
 import express from "express";
 import { requireAuth } from "../middleware/requireAuth.js";
-import { createDispatcher, listAccountUsers } from "../services/userServices.js";
+import {
+  createDispatcher,
+  listAccountUsers,
+  getTeamMember,
+} from "../services/userServices.js";
 
 const router = express.Router();
 
@@ -15,6 +19,23 @@ router.get("/", requireAuth, adminOnly, async (req, res) => {
   try {
     const team = await listAccountUsers(req.user.account_id);
     return res.status(200).json({ team });
+  } catch (err) {
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: err.message });
+  }
+});
+
+// ---- GET one account member ---- for their dispatcher card/page. A user may
+// fetch their own identity; an admin may fetch any member of their account.
+router.get("/:id", requireAuth, async (req, res) => {
+  try {
+    const targetId = req.params.id;
+    if (targetId !== req.user.self_id && req.user.role !== "admin")
+      return res.status(403).json({ error: "Forbidden" });
+    const user = await getTeamMember(req.user.account_id, targetId);
+    if (!user) return res.status(404).json({ error: "User not found" });
+    return res.status(200).json({ user });
   } catch (err) {
     return res
       .status(500)

--- a/backend/src/services/avatarService.js
+++ b/backend/src/services/avatarService.js
@@ -38,6 +38,15 @@ const buildPrompt = (kind, row, variant) => {
       "truck driver, baseball cap, work shirt, confident calm expression."
     );
   }
+  // user — the dispatcher behind the desk (role-relevant, not a driver).
+  if (kind === "user") {
+    const g = variant === "female" ? "woman" : variant === "male" ? "man" : "person";
+    return (
+      `${STYLE}. Head and shoulders avatar portrait of a ${g} freight dispatcher ` +
+      "at a command desk wearing a phone headset, glowing load-board and route " +
+      "map monitors behind, confident friendly expression."
+    );
+  }
   // trailer — reflect the actual type, and force a STANDALONE trailer (flux
   // otherwise draws a flatbed body truck).
   const len = row.length_ft ? `${row.length_ft} foot ` : "";
@@ -89,44 +98,68 @@ export const uploadToStorage = async (path, buffer, contentType) => {
   return `${SUPABASE_URL}/storage/v1/object/public/${BUCKET}/${path}`;
 };
 
-const setAvatarUrl = async (kind, user_id, id, url) => {
+const isValidKind = (kind) => kind === "user" || !!ENTITY[kind];
+
+const setAvatarUrl = async (kind, auth, id, url) => {
+  if (kind === "user") {
+    await db.query(`UPDATE users SET avatar_url = $1 WHERE user_id = $2`, [
+      url,
+      id,
+    ]);
+    return;
+  }
   const { table, idCol } = ENTITY[kind];
   await db.query(
     `UPDATE ${table} SET avatar_url = $1, updated_at = NOW()
      WHERE ${idCol} = $2 AND user_id = $3`,
-    [url, id, user_id],
+    [url, id, auth.account_id],
   );
 };
 
-const getEntity = async (kind, user_id, id) => {
+// Resolve the target row AND authorize. Entities belong to the account (user_id
+// = account). A `user` avatar is the person's own (id === self_id) or, for an
+// admin, any member of their account.
+const resolveTarget = async (kind, auth, id) => {
+  if (kind === "user") {
+    if (id !== auth.self_id && auth.role !== "admin")
+      throw new NotFoundError("user not found");
+    const r = await db.query(
+      `SELECT * FROM users
+        WHERE user_id = $1 AND (user_id = $2 OR parent_user_id = $2)`,
+      [id, auth.account_id],
+    );
+    if (r.rowCount === 0) throw new NotFoundError("user not found");
+    return r.rows[0];
+  }
   const { table, idCol } = ENTITY[kind];
   const r = await db.query(
     `SELECT * FROM ${table} WHERE ${idCol} = $1 AND user_id = $2`,
-    [id, user_id],
+    [id, auth.account_id],
   );
   if (r.rowCount === 0) throw new NotFoundError(`${kind} not found`);
   return r.rows[0];
 };
 
-// Generate a themed avatar, store it, and set the entity's avatar_url.
-export const generateAvatar = async (user_id, kind, id, variant) => {
-  if (!ENTITY[kind]) throw new ValidationError("Invalid avatar kind");
-  const row = await getEntity(kind, user_id, id);
+// Generate a themed avatar, store it, and set the target's avatar_url.
+// `auth` is req.user ({ account_id, self_id, role }).
+export const generateAvatar = async (auth, kind, id, variant) => {
+  if (!isValidKind(kind)) throw new ValidationError("Invalid avatar kind");
+  const row = await resolveTarget(kind, auth, id);
   const imageUrl = await falGenerate(buildPrompt(kind, row, variant));
   const buffer = Buffer.from(await (await fetch(imageUrl)).arrayBuffer());
   const path = `${kind}/${id}.jpg`;
   const publicUrl = await uploadToStorage(path, buffer, "image/jpeg");
-  await setAvatarUrl(kind, user_id, id, publicUrl);
+  await setAvatarUrl(kind, auth, id, publicUrl);
   return { avatar_url: publicUrl };
 };
 
-// Store a user-uploaded image (buffer) and set the entity's avatar_url.
-export const uploadAvatar = async (user_id, kind, id, buffer, contentType) => {
-  if (!ENTITY[kind]) throw new ValidationError("Invalid avatar kind");
-  await getEntity(kind, user_id, id); // ownership check
+// Store a user-uploaded image (buffer) and set the target's avatar_url.
+export const uploadAvatar = async (auth, kind, id, buffer, contentType) => {
+  if (!isValidKind(kind)) throw new ValidationError("Invalid avatar kind");
+  await resolveTarget(kind, auth, id); // ownership / authorization check
   const ext = contentType === "image/png" ? "png" : contentType === "image/webp" ? "webp" : "jpg";
   const path = `${kind}/${id}-upload.${ext}`;
   const publicUrl = await uploadToStorage(path, buffer, contentType);
-  await setAvatarUrl(kind, user_id, id, publicUrl);
+  await setAvatarUrl(kind, auth, id, publicUrl);
   return { avatar_url: publicUrl };
 };

--- a/backend/src/services/loadServices.js
+++ b/backend/src/services/loadServices.js
@@ -89,6 +89,7 @@ export async function getLoads(user_id) {
             loads.truck_id,
             loads.driver_id,
             loads.trailer_id,
+            loads.booked_by,
             loads.created_at AS created_at,
             loads.updated_at AS updated_at
         FROM loads
@@ -200,6 +201,7 @@ export async function getLoad(user_id, load_id) {
             l.truck_id,
             l.driver_id,
             l.trailer_id,
+            l.booked_by,
             trk.unit_number AS truck_unit,
             drv.first_name || ' ' || drv.last_name AS driver_name,
             trl.unit_number AS trailer_unit,
@@ -234,7 +236,10 @@ export async function getLoad(user_id, load_id) {
 }
 
 // ---- CREATE LOAD SERVICE ----
-export async function createLoad(user_id, data) {
+// `self_id` is the logged-in person; a load's booker defaults to them so the
+// dispatcher who enters it gets the credit. The client may override booked_by
+// (e.g. the owner crediting a dispatcher for a load they sourced).
+export async function createLoad(user_id, data, self_id) {
   // Reject missing user_id
   if (!user_id) throw new ValidationError("Missing user_id");
 
@@ -282,6 +287,7 @@ export async function createLoad(user_id, data) {
     "truck_id",
     "driver_id",
     "trailer_id",
+    "booked_by",
   ];
 
   for (const field in data) {
@@ -295,13 +301,16 @@ export async function createLoad(user_id, data) {
 
   if (errors.length > 0) throw new ValidationError("Validation failed", errors);
 
-  let fields = ["user_id"];
-  let values = [user_id];
-  let placeholders = ["$1"];
+  // Booker: explicit override, else the logged-in creator.
+  const booker = data.booked_by ?? self_id ?? user_id;
+  let fields = ["user_id", "booked_by"];
+  let values = [user_id, booker];
+  let placeholders = ["$1", "$2"];
 
-  let index = 2;
+  let index = 3;
 
   for (const field in data) {
+    if (field === "booked_by") continue; // seeded above
     if (data[field] !== undefined) {
       fields.push(field);
       values.push(data[field]);
@@ -371,6 +380,7 @@ export async function patchLoad(user_id, load_id, data) {
     "truck_id",
     "driver_id",
     "trailer_id",
+    "booked_by",
   ];
 
   // Throw error if data contains invalid field(s)

--- a/backend/src/services/userServices.js
+++ b/backend/src/services/userServices.js
@@ -47,7 +47,7 @@ export async function validateUser(email, password) {
   // fetch user row
   const result = await db.query(
     `
-    SELECT user_id, email, password_hash, role, parent_user_id, display_name
+    SELECT user_id, email, password_hash, role, parent_user_id, display_name, avatar_url
     FROM users
     WHERE email = $1
     `,
@@ -74,6 +74,7 @@ export async function validateUser(email, password) {
     role: user.role,
     parent_user_id: user.parent_user_id,
     display_name: user.display_name,
+    avatar_url: user.avatar_url,
   };
 }
 
@@ -103,11 +104,24 @@ export async function createDispatcher(accountId, { email, password, display_nam
 // ---- LIST an account's team ---- (owner + its dispatchers; safe fields only)
 export async function listAccountUsers(accountId) {
   const result = await db.query(
-    `SELECT user_id, email, role, display_name, created_at
+    `SELECT user_id, email, role, display_name, avatar_url, created_at
        FROM users
       WHERE user_id = $1 OR parent_user_id = $1
       ORDER BY (user_id = $1) DESC, created_at`,
     [accountId],
   );
   return result.rows;
+}
+
+// ---- FETCH one account member ---- (for a team member's dispatcher page).
+// Scoped to the account, so only the owner + its dispatchers are reachable.
+// The route decides WHO may ask (self, or an admin viewing the team).
+export async function getTeamMember(accountId, targetId) {
+  const result = await db.query(
+    `SELECT user_id, email, role, display_name, avatar_url, created_at
+       FROM users
+      WHERE user_id = $1 AND (user_id = $2 OR parent_user_id = $2)`,
+    [targetId, accountId],
+  );
+  return result.rows[0] ?? null;
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.98.0",
+  "version": "1.99.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import { LoadDetailPage } from "@/pages/LoadDetailPage";
 import { SwatchesPage } from "@/pages/SwatchesPage";
 import SignupPage from "@/pages/SignupPage";
 import GuidePage from "@/pages/GuidePage";
+import DispatcherPage from "@/pages/DispatcherPage";
 import CompliancePage from "@/pages/CompliancePage";
 import RecapPage from "@/pages/RecapPage";
 import TrophyHallPage from "@/pages/TrophyHallPage";
@@ -80,6 +81,7 @@ const App = () => {
           <Route path="/facilities" element={<FacilitiesPage />} />
           <Route path="/facilities/:id" element={<FacilityDetailPage />} />
           <Route path="/guide" element={<GuidePage />} />
+          <Route path="/dispatcher/:id" element={<DispatcherPage />} />
 
           {/* Owner-only — a dispatcher is redirected to /dashboard (see roles.ts) */}
           <Route element={<AdminRoute />}>

--- a/frontend/src/components/LoadForm.tsx
+++ b/frontend/src/components/LoadForm.tsx
@@ -9,6 +9,7 @@ import type { Trailer } from "@/types/trailer";
 import { getTrucks } from "@/services/trucksService";
 import { getDrivers } from "@/services/driversService";
 import { getTrailers } from "@/services/trailersService";
+import { getTeam, type TeamMember } from "@/services/teamService";
 import { QuickAddBroker } from "./QuickAddBroker";
 import { QuickAddAgent } from "./QuickAddAgent";
 import { QuickAddMarket } from "./QuickAddMarket";
@@ -169,6 +170,7 @@ const LoadForm = ({
           truck_id: initialData.truck_id ?? null,
           driver_id: initialData.driver_id ?? null,
           trailer_id: initialData.trailer_id ?? null,
+          booked_by: initialData.booked_by ?? null,
         }
       : {
           load_number: "",
@@ -211,6 +213,8 @@ const LoadForm = ({
           truck_id: null,
           driver_id: null,
           trailer_id: null,
+          // Default credit to the creator; the owner can reassign below.
+          booked_by: localStorage.getItem("user_id") ?? null,
         },
   );
 
@@ -218,6 +222,15 @@ const LoadForm = ({
   const [agentList, setAgentList] = useState<Agent[]>(agents);
   const [marketList, setMarketList] = useState<Market[]>(markets);
   const [facilityList, setFacilityList] = useState<Facility[]>(facilities);
+
+  // Booking credit: the owner (admin) can attribute a load to a dispatcher. A
+  // dispatcher's loads auto-credit to them (server default), so no picker for her.
+  const selfId = localStorage.getItem("user_id");
+  const isAdmin = localStorage.getItem("role") === "admin";
+  const [team, setTeam] = useState<TeamMember[]>([]);
+  useEffect(() => {
+    if (isAdmin) getTeam().then(setTeam).catch(() => {});
+  }, [isAdmin]);
 
   const [trucks, setTrucks] = useState<Truck[]>([]);
   const [drivers, setDrivers] = useState<Driver[]>([]);
@@ -464,6 +477,32 @@ const LoadForm = ({
                 </SelectContent>
               </Select>
             </div>
+            {/* Booked by — owner only; credits a dispatcher for the booking */}
+            {isAdmin && team.length > 1 && (
+              <div>
+                <Label htmlFor="booked_by">Booked by</Label>
+                <Select
+                  value={formData.booked_by ?? ""}
+                  onValueChange={(v) =>
+                    setFormData({ ...formData, booked_by: v })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Who booked it" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {team.map((m) => (
+                        <SelectItem key={m.user_id} value={m.user_id}>
+                          {(m.display_name || m.email) +
+                            (m.user_id === selfId ? " (you)" : "")}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
             {/* Broker selects */}
             <div className="flex gap-2 items-end">
               <div className="flex-1">

--- a/frontend/src/components/dashboard/MyDispatcherCard.tsx
+++ b/frontend/src/components/dashboard/MyDispatcherCard.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import type { Load } from "@/types/load";
+import type { RateLadder } from "@/lib/metrics/rateTargets";
+import { getUser, type TeamMember } from "@/services/teamService";
+import { getDispatcherCard } from "@/lib/metrics/dispatcherCard";
+import { DispatcherCard } from "@/components/playercard/DispatcherCard";
+import { AvatarFallback } from "@/components/fleet/AvatarFallback";
+
+// The logged-in dispatcher's own card at the top of her board. Static avatar
+// (editing lives on her page); the whole card links there.
+export const MyDispatcherCard = ({
+  loads,
+  ladder,
+  freeHours,
+}: {
+  loads: Load[];
+  ladder: RateLadder;
+  freeHours: number;
+}) => {
+  const selfId = localStorage.getItem("user_id") ?? "";
+  const [me, setMe] = useState<TeamMember | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    if (selfId)
+      getUser(selfId)
+        .then((u) => active && setMe(u))
+        .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [selfId]);
+
+  if (!selfId) return null;
+
+  const card = getDispatcherCard(loads, selfId, ladder, freeHours, new Date());
+  const name = me?.display_name || "Dispatcher";
+  const avatar = me?.avatar_url ? (
+    <img
+      src={me.avatar_url}
+      alt={name}
+      className="w-20 h-20 rounded-full object-cover border-2"
+      style={{ borderColor: "#e8940a" }}
+    />
+  ) : (
+    <div
+      className="w-20 h-20 rounded-full overflow-hidden border-2"
+      style={{ borderColor: "#e8940a" }}
+    >
+      <AvatarFallback kind="user" />
+    </div>
+  );
+
+  return (
+    <Link
+      to={`/dispatcher/${selfId}`}
+      className="block max-w-md hover:opacity-95"
+      title="Your dispatcher card"
+    >
+      <DispatcherCard
+        name={name}
+        business="Delgado Trucking Services · Dispatcher"
+        avatar={avatar}
+        card={card}
+      />
+    </Link>
+  );
+};

--- a/frontend/src/components/playercard/DispatcherCard.tsx
+++ b/frontend/src/components/playercard/DispatcherCard.tsx
@@ -1,0 +1,167 @@
+import type { ReactNode } from "react";
+import type { DispatcherCard as CardData } from "@/lib/metrics/dispatcherCard";
+import type { Grade } from "@/lib/metrics/playerCard";
+
+interface Props {
+  name: string;
+  business?: string;
+  avatar: ReactNode;
+  card: CardData;
+}
+
+// Compact gross: "$0", "$840", "$12.4k", "$487k".
+const gross = (n: number): string => {
+  if (n < 1000) return `$${Math.round(n)}`;
+  const k = n / 1000;
+  return `$${k < 100 ? k.toFixed(1) : Math.round(k)}k`;
+};
+const rpm = (n: number | null): string => (n == null ? "—" : `$${n.toFixed(2)}`);
+const hrs = (min: number): string => `${(min / 60).toFixed(1)}h`;
+const pct = (r: number | null): string => (r == null ? "—" : `${Math.round(r * 100)}%`);
+
+const GRADE_META: Record<Grade, { label: string; bg: string; border: string; fg: string }> = {
+  strong: { label: "STRONG", bg: "#10241a", border: "#1d6e50", fg: "#4ade80" },
+  target: { label: "ON TARGET", bg: "#10241a", border: "#1d6e50", fg: "#4ade80" },
+  minimum: { label: "COVERING", bg: "#2a1f0a", border: "#85500b", fg: "#f5b03a" },
+  below: { label: "BELOW FLOOR", bg: "#2a1414", border: "#7a2d2d", fg: "#f87171" },
+};
+
+const Stat = ({
+  label,
+  value,
+  sub,
+  span,
+  accent,
+}: {
+  label: string;
+  value: string;
+  sub?: ReactNode;
+  span?: boolean;
+  accent?: boolean;
+}) => (
+  <div
+    className="rounded-lg px-2.5 py-2"
+    style={{
+      background: "#1c2333",
+      gridColumn: span ? "span 2" : undefined,
+      border: accent ? "1px solid #85500b" : undefined,
+    }}
+  >
+    <div
+      className="text-[8px] tracking-wide"
+      style={{ color: accent ? "#f5b03a" : "#7d8ba3" }}
+    >
+      {label}
+    </div>
+    <div className="font-comic text-[22px]" style={{ color: accent ? "#f5b03a" : "#f4f7fb" }}>
+      {value}
+    </div>
+    {sub && <div className="text-[9px]" style={{ color: "#7d8ba3" }}>{sub}</div>}
+  </div>
+);
+
+export const DispatcherCard = ({ name, business, avatar, card }: Props) => {
+  const grade = card.seasonGrade ? GRADE_META[card.seasonGrade] : null;
+  const over = card.overBreakEven;
+  const overNode =
+    over == null ? (
+      <span style={{ color: "#7d8ba3" }}>no rated loads yet</span>
+    ) : (
+      <span style={{ color: over >= 0 ? "#4ade80" : "#f87171" }}>
+        {over >= 0 ? "▲" : "▼"} ${Math.abs(over).toFixed(2)}{" "}
+        {over >= 0 ? "over" : "under"} break-even
+      </span>
+    );
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-2xl border-2 p-4"
+      style={{ background: "linear-gradient(160deg,#161d2b,#10151f)", borderColor: "#e8940a" }}
+    >
+      <div
+        className="absolute top-0 right-0 w-32 h-32 pointer-events-none"
+        style={{
+          backgroundImage: "radial-gradient(#e8940a 1.3px, transparent 1.4px)",
+          backgroundSize: "8px 8px",
+          opacity: 0.1,
+        }}
+      />
+
+      {/* header */}
+      <div className="relative flex gap-3.5 items-center">
+        <div className="shrink-0">{avatar}</div>
+        <div className="min-w-0 flex-1">
+          <div className="font-comic text-3xl leading-none" style={{ color: "#f5b03a" }}>
+            {name}
+          </div>
+          {business && (
+            <div className="text-[10px] mt-1" style={{ color: "#9daabb" }}>
+              {business}
+            </div>
+          )}
+          <div
+            className="inline-flex items-center gap-1 mt-1.5 rounded-full px-2.5 py-0.5"
+            style={{ background: "rgba(232,148,10,0.14)", border: "1px solid #7a4718" }}
+          >
+            <span className="text-[10px]">⭐</span>
+            <span className="text-[10px] font-semibold tracking-wide" style={{ color: "#f5b03a" }}>
+              {card.rank.name.toUpperCase()}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* rank progress */}
+      <div className="relative mt-3">
+        <div className="flex justify-between text-[8.5px] mb-1" style={{ color: "#7d8ba3" }}>
+          <span>{card.rank.name.toUpperCase()}</span>
+          <span>
+            {card.rank.next
+              ? `${card.rank.next.name.toUpperCase()} · ${card.rank.toNext} loads to go`
+              : "TOP RANK"}
+          </span>
+        </div>
+        <div className="h-1.5 rounded" style={{ background: "#232c3f" }}>
+          <div
+            className="h-1.5 rounded"
+            style={{ width: `${Math.round(card.rank.pct * 100)}%`, background: "linear-gradient(90deg,#e8940a,#f5b03a)" }}
+          />
+        </div>
+      </div>
+
+      {/* season grade */}
+      {grade && (
+        <div className="relative flex items-center gap-1.5 mt-3">
+          <span className="text-[9px] tracking-widest" style={{ color: "#7d8ba3" }}>
+            THIS SEASON
+          </span>
+          <span
+            className="font-comic text-[13px] tracking-wide rounded px-2 py-0.5"
+            style={{ background: grade.bg, border: `1px solid ${grade.border}`, color: grade.fg }}
+          >
+            {grade.label}
+          </span>
+        </div>
+      )}
+
+      {/* stats */}
+      <div className="relative grid grid-cols-2 gap-2 mt-3">
+        <Stat
+          label="LOADS BOOKED"
+          value={String(card.loadsBookedLifetime)}
+          sub={`${card.loadsBookedMonth} this month`}
+        />
+        <Stat label="GROSS BOOKED" value={gross(card.grossBooked)} sub="lifetime" />
+        <Stat
+          label="AVG BOOKED RATE · $/MI"
+          value={rpm(card.avgBookedRate)}
+          sub={overNode}
+          span
+          accent
+        />
+        <Stat label="DETENTION COLLECTED" value={hrs(card.detentionCollectedMin)} />
+        <Stat label="ON-TIME" value={pct(card.onTimePct)} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/settings/TeamCard.tsx
+++ b/frontend/src/components/settings/TeamCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { UserPlus } from "lucide-react";
+import { Link } from "react-router-dom";
+import { UserPlus, ChevronRight } from "lucide-react";
 import { Panel } from "@/components/ui/Panel";
 import {
   getTeam,
@@ -57,19 +58,45 @@ export const TeamCard = () => {
       </p>
 
       <div className="mt-4 divide-y divide-steel">
-        {team.map((m) => (
-          <div key={m.user_id} className="flex items-center justify-between py-2">
-            <div className="min-w-0">
-              <span className="text-sm text-light">{m.display_name || m.email}</span>
-              {m.display_name && (
-                <span className="text-xs text-muted-text ml-2">{m.email}</span>
-              )}
+        {team.map((m) => {
+          const inner = (
+            <>
+              <div className="min-w-0">
+                <span className="text-sm text-light">
+                  {m.display_name || m.email}
+                </span>
+                {m.display_name && (
+                  <span className="text-xs text-muted-text ml-2">{m.email}</span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <span className="text-[11px] px-2 py-0.5 rounded-full bg-steel text-muted-text">
+                  {m.role === "admin" ? "Owner · Admin" : "Dispatcher"}
+                </span>
+                {m.role === "dispatcher" && (
+                  <ChevronRight size={15} className="text-muted-text" />
+                )}
+              </div>
+            </>
+          );
+          // A dispatcher's row opens their card/page; the owner has the driver card.
+          return m.role === "dispatcher" ? (
+            <Link
+              key={m.user_id}
+              to={`/dispatcher/${m.user_id}`}
+              className="flex items-center justify-between py-2 hover:opacity-80"
+            >
+              {inner}
+            </Link>
+          ) : (
+            <div
+              key={m.user_id}
+              className="flex items-center justify-between py-2"
+            >
+              {inner}
             </div>
-            <span className="text-[11px] px-2 py-0.5 rounded-full bg-steel text-muted-text shrink-0">
-              {m.role === "admin" ? "Owner · Admin" : "Dispatcher"}
-            </span>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-2">

--- a/frontend/src/lib/metrics/dispatcherCard.test.ts
+++ b/frontend/src/lib/metrics/dispatcherCard.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Load } from "@/types/load";
+import type { RateLadder } from "./rateTargets";
+import { getDispatcherCard, dispatchRank } from "./dispatcherCard";
+
+const baseLoad: Load = {
+  load_id: "L",
+  load_number: "1",
+  load_type: "standard flatbed",
+  load_status: "delivered",
+  broker_id: "b",
+  broker: "B",
+  agent_id: "a",
+  agent: "A",
+  agent_email: null,
+  pickup_date: "2026-06-10T04:00:00.000Z",
+  origin_market_id: "m",
+  origin_city: "X",
+  origin_state: "TX",
+  origin_market: "M",
+  destination_market_id: "m2",
+  destination_city: "Y",
+  destination_state: "TN",
+  delivery_market: "M2",
+  delivery_date: "2026-06-12T04:00:00.000Z",
+  deadhead_miles: 0,
+  loaded_miles: 0,
+  linehaul: "0",
+  fuel_surcharge: "0",
+  total_accessorials: "0",
+  commodity: null,
+  odometer_start: null,
+  odometer_end: null,
+  payment_status: "paid",
+  booked_by: "me",
+  detention_paid: false,
+  created_at: "",
+  updated_at: "",
+};
+const mk = (o: Partial<Load>): Load => ({ ...baseLoad, ...o });
+
+const ladder: RateLadder = {
+  walkAway: 4.0,
+  minimum: 4.5,
+  target: 5.0,
+  strong: 6.0,
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-22T12:00:00Z"));
+});
+afterEach(() => vi.useRealTimers());
+
+describe("getDispatcherCard", () => {
+  it("scopes to the user's real bookings; gross + avg rate over break-even", () => {
+    const loads = [
+      // mine: 1000 mi @ $5000 gross → $5.00/mi
+      mk({ load_id: "A", loaded_miles: 1000, linehaul: "5000" }),
+      // mine: 1000 mi @ $4400 gross → $4.40/mi
+      mk({ load_id: "B", load_status: "booked", loaded_miles: 1000, linehaul: "4400" }),
+      // someone else's booking → excluded
+      mk({ load_id: "C", booked_by: "other", loaded_miles: 1000, linehaul: "9999" }),
+      // mine but cancelled → not counted
+      mk({ load_id: "D", load_status: "cancelled", loaded_miles: 1000, linehaul: "9999" }),
+    ];
+
+    const card = getDispatcherCard(loads, "me", ladder, 2, new Date());
+    expect(card.loadsBookedLifetime).toBe(2);
+    expect(card.loadsBookedMonth).toBe(2); // both pick up in June
+    expect(card.grossBooked).toBe(9400);
+    expect(card.avgBookedRate).toBeCloseTo(4.7, 5); // 9400 / 2000
+    expect(card.overBreakEven).toBeCloseTo(0.7, 5); // 4.70 − 4.00
+  });
+
+  it("detention collected counts only paid detention", () => {
+    const loads = [
+      // 5h dwell, 2h free → 180 min; collected
+      mk({ load_id: "E", shipper_in: "08:00", shipper_out: "13:00", detention_paid: true }),
+      // detention ran but not yet collected → excluded
+      mk({ load_id: "F", shipper_in: "08:00", shipper_out: "13:00", detention_paid: false }),
+    ];
+    const card = getDispatcherCard(loads, "me", ladder, 2, new Date());
+    expect(card.detentionCollectedMin).toBe(180);
+  });
+
+  it("is all-zero when the user has booked nothing", () => {
+    const loads = [mk({ booked_by: "other", loaded_miles: 500, linehaul: "3000" })];
+    const card = getDispatcherCard(loads, "me", ladder, 2, new Date());
+    expect(card.loadsBookedLifetime).toBe(0);
+    expect(card.grossBooked).toBe(0);
+    expect(card.avgBookedRate).toBeNull();
+    expect(card.overBreakEven).toBeNull();
+    expect(card.rank.name).toBe("Rookie Dispatcher");
+  });
+});
+
+describe("dispatchRank", () => {
+  it("climbs tiers on lifetime loads booked", () => {
+    expect(dispatchRank(0).name).toBe("Rookie Dispatcher");
+    expect(dispatchRank(24).name).toBe("Rookie Dispatcher");
+    expect(dispatchRank(25).name).toBe("Load Wrangler");
+    expect(dispatchRank(80).name).toBe("Freight Closer");
+    expect(dispatchRank(500).name).toBe("Dispatch Legend");
+  });
+
+  it("reports progress toward the next tier; tops out at Legend", () => {
+    const r = dispatchRank(50); // Load Wrangler [25, 75)
+    expect(r.next?.name).toBe("Freight Closer");
+    expect(r.toNext).toBe(25); // 75 − 50
+    expect(r.pct).toBeCloseTo(0.5, 5); // (50−25)/(75−25)
+
+    const top = dispatchRank(600);
+    expect(top.next).toBeNull();
+    expect(top.toNext).toBe(0);
+    expect(top.pct).toBe(1);
+  });
+});

--- a/frontend/src/lib/metrics/dispatcherCard.ts
+++ b/frontend/src/lib/metrics/dispatcherCard.ts
@@ -1,0 +1,125 @@
+// Dispatcher-card math — the booking game, scoped to ONE person via booked_by.
+// Everything a dispatcher is graded on is GROSS (the market value they book),
+// never net; net is Jason's operational result, not theirs. Pure; `now` is
+// passed in so it's testable.
+import type { Load } from "@/types/load";
+import { loadGross, type RateLadder } from "./rateTargets";
+import { detentionMinutes } from "@/lib/detention";
+import { agentStops, scoreStops } from "./stopScore";
+import { rpmGrade, type Grade } from "./playerCard";
+
+// Career ranks climb on lifetime loads booked — the dispatcher's analogue of the
+// driver's lifetime miles.
+export const RANK_TIERS = [
+  { min: 0, name: "Rookie Dispatcher" },
+  { min: 25, name: "Load Wrangler" },
+  { min: 75, name: "Freight Closer" },
+  { min: 200, name: "Rate Hawk" },
+  { min: 500, name: "Dispatch Legend" },
+];
+
+export interface DispatchRank {
+  name: string;
+  index: number;
+  count: number;
+  next: { name: string; min: number } | null;
+  toNext: number; // loads to the next tier
+  pct: number; // progress within the current tier, 0..1
+}
+
+export const dispatchRank = (loadsBooked: number): DispatchRank => {
+  let i = 0;
+  for (let t = 0; t < RANK_TIERS.length; t++) {
+    if (loadsBooked >= RANK_TIERS[t].min) i = t;
+  }
+  const cur = RANK_TIERS[i];
+  const next = i < RANK_TIERS.length - 1 ? RANK_TIERS[i + 1] : null;
+  const toNext = next ? Math.max(0, next.min - loadsBooked) : 0;
+  const span = next ? next.min - cur.min : 1;
+  const pct = next ? Math.min(1, (loadsBooked - cur.min) / span) : 1;
+  return {
+    name: cur.name,
+    index: i,
+    count: loadsBooked,
+    next: next ? { name: next.name, min: next.min } : null,
+    toNext,
+    pct,
+  };
+};
+
+export interface DispatcherCard {
+  loadsBookedLifetime: number;
+  loadsBookedMonth: number;
+  grossBooked: number;
+  avgBookedRate: number | null; // gross $/loaded-mile she books
+  breakEven: number | null; // the ladder floor (per loaded mile)
+  overBreakEven: number | null; // avgBookedRate − breakEven
+  detentionCollectedMin: number; // detention hours she chased down and got paid
+  onTimePct: number | null;
+  rank: DispatchRank;
+  seasonGrade: Grade | null;
+}
+
+// A "real" booking is any of her loads that didn't cancel — she still did the
+// work of booking a load that later fell through isn't counted against her, but
+// a cancelled load isn't freight, so it doesn't count for her either.
+const isReal = (l: Load) => l.load_status !== "cancelled";
+
+const grossPerMile = (loads: Load[]): number | null => {
+  const withMiles = loads.filter((l) => Number(l.loaded_miles) > 0);
+  const miles = withMiles.reduce((s, l) => s + Number(l.loaded_miles), 0);
+  if (miles <= 0) return null;
+  return withMiles.reduce((s, l) => s + loadGross(l), 0) / miles;
+};
+
+export const getDispatcherCard = (
+  loads: Load[],
+  userId: string,
+  ladder: RateLadder,
+  freeHours: number,
+  now: Date,
+): DispatcherCard => {
+  const mine = loads.filter((l) => l.booked_by === userId && isReal(l));
+
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const inThisMonth = (iso: string | null | undefined) =>
+    !!iso &&
+    new Date(iso).getUTCFullYear() === year &&
+    new Date(iso).getUTCMonth() === month;
+
+  const avgBookedRate = grossPerMile(mine);
+  const breakEven = ladder.walkAway;
+  const overBreakEven =
+    avgBookedRate != null && breakEven != null
+      ? avgBookedRate - breakEven
+      : null;
+
+  const detentionCollectedMin = mine
+    .filter((l) => l.detention_paid)
+    .reduce((s, l) => s + detentionMinutes(l, freeHours), 0);
+
+  // On-time only over loads that actually ran.
+  const delivered = mine.filter((l) => l.load_status === "delivered");
+  const onTimePct = scoreStops(agentStops(delivered, freeHours)).onTimePct;
+
+  // Season grade = recent (90-day) booking rate graded against the ladder.
+  const cutoff = now.getTime() - 90 * 86_400_000;
+  const recent = mine.filter(
+    (l) => l.pickup_date && new Date(l.pickup_date).getTime() >= cutoff,
+  );
+  const seasonGrade = rpmGrade(grossPerMile(recent), ladder);
+
+  return {
+    loadsBookedLifetime: mine.length,
+    loadsBookedMonth: mine.filter((l) => inThisMonth(l.pickup_date)).length,
+    grossBooked: mine.reduce((s, l) => s + loadGross(l), 0),
+    avgBookedRate,
+    breakEven,
+    overBreakEven,
+    detentionCollectedMin,
+    onTimePct,
+    rank: dispatchRank(mine.length),
+    seasonGrade,
+  };
+};

--- a/frontend/src/pages/DispatchDashboard.tsx
+++ b/frontend/src/pages/DispatchDashboard.tsx
@@ -14,6 +14,7 @@ import { GrindMeter } from "@/components/dashboard/GrindMeter";
 import { TopAgents } from "@/components/dashboard/TopAgents";
 import { DispatchLoadsTable } from "@/components/dashboard/DispatchLoadsTable";
 import { DispatchAgentsTable } from "@/components/dashboard/DispatchAgentsTable";
+import { MyDispatcherCard } from "@/components/dashboard/MyDispatcherCard";
 import {
   getLoadsMonthly,
   getTopAgentsByRevenue,
@@ -126,6 +127,15 @@ const DispatchDashboard = () => {
         >
           <Zap size={15} /> Score a Load
         </Link>
+      </div>
+
+      {/* Her card — the first thing she sees; taps through to her page */}
+      <div className="mb-6">
+        <MyDispatcherCard
+          loads={loads}
+          ladder={targets.bookingLadder}
+          freeHours={freeHours}
+        />
       </div>
 
       <AlertBanners alerts={alerts} />

--- a/frontend/src/pages/DispatcherPage.tsx
+++ b/frontend/src/pages/DispatcherPage.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useLoads } from "@/hooks/useLoads";
+import { useRateTargets } from "@/hooks/useRateTargets";
+import { getUser, type TeamMember } from "@/services/teamService";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import { getDispatcherCard, RANK_TIERS } from "@/lib/metrics/dispatcherCard";
+import { DispatcherCard } from "@/components/playercard/DispatcherCard";
+import { EntityAvatar } from "@/components/fleet/EntityAvatar";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Panel } from "@/components/ui/Panel";
+
+const DispatcherPage = () => {
+  const { id = "" } = useParams();
+  const { loads, isLoading: loadsLoading, error } = useLoads(0);
+  const targets = useRateTargets(loads);
+
+  const [member, setMember] = useState<TeamMember | null>(null);
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [freeHours, setFreeHours] = useState(3);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    getUser(id)
+      .then((u) => {
+        if (!active) return;
+        setMember(u);
+        setAvatarUrl(u.avatar_url);
+      })
+      .catch(() => active && setNotFound(true));
+    getSettlementSchedule()
+      .then((s) => active && setFreeHours(s.detention_free_hours))
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [id]);
+
+  const isAdmin = localStorage.getItem("role") === "admin";
+  const backTo = isAdmin ? "/settings" : "/dashboard";
+
+  if (notFound)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <p className="text-muted-text">Dispatcher not found.</p>
+      </div>
+    );
+
+  if (loadsLoading || !member)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <Skeleton className="h-4 w-24 mb-4" />
+        <Skeleton className="h-80 max-w-md" style={{ borderRadius: 16 }} />
+      </div>
+    );
+
+  if (error)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen">
+        <p className="text-destructive">{error}</p>
+      </div>
+    );
+
+  const card = getDispatcherCard(
+    loads,
+    id,
+    targets.bookingLadder,
+    freeHours,
+    new Date(),
+  );
+  const name = member.display_name || member.email;
+
+  const avatar = (
+    <EntityAvatar
+      kind="user"
+      id={id}
+      avatarUrl={avatarUrl}
+      size={80}
+      allowVariant
+      onUpdated={(u) => setAvatarUrl(u)}
+    />
+  );
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <Link to={backTo} className="text-xs text-muted-text hover:text-light">
+        ← Back
+      </Link>
+
+      <div className="mt-3 max-w-md">
+        <DispatcherCard
+          name={name}
+          business="Delgado Trucking Services · Dispatcher"
+          avatar={avatar}
+          card={card}
+        />
+
+        {/* Career ladder — progression through the ranks */}
+        <Panel className="p-4 mt-4">
+          <p className="text-xs uppercase tracking-wider text-muted-text mb-3">
+            Career ladder
+          </p>
+          <div className="flex flex-col gap-2">
+            {RANK_TIERS.map((tier, i) => {
+              const reached = card.rank.count >= tier.min;
+              const current = i === card.rank.index;
+              return (
+                <div key={tier.name} className="flex items-center gap-3">
+                  <span
+                    className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] shrink-0"
+                    style={{
+                      background: current
+                        ? "#e8940a"
+                        : reached
+                          ? "#7a4718"
+                          : "#232c3f",
+                      color: current ? "#10151f" : reached ? "#f5b03a" : "#5f6b80",
+                    }}
+                  >
+                    {i + 1}
+                  </span>
+                  <span
+                    className="flex-1 text-sm"
+                    style={{
+                      color: current ? "#f5b03a" : reached ? "#cdd8e8" : "#5f6b80",
+                      fontWeight: current ? 600 : 400,
+                    }}
+                  >
+                    {tier.name}
+                  </span>
+                  <span className="text-[11px] text-muted-text">
+                    {tier.min}+ loads
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          <p className="text-[10px] text-muted-text mt-3">
+            {card.rank.next
+              ? `${card.rank.toNext} more ${
+                  card.rank.toNext === 1 ? "load" : "loads"
+                } to reach ${card.rank.next.name}.`
+              : "Top rank reached — legend status."}
+          </p>
+        </Panel>
+
+        <p className="text-[11px] text-muted-text mt-4 text-center">
+          Achievements &amp; goals coming soon.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default DispatcherPage;

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -894,6 +894,33 @@ const GuidePage = () => (
           is what the agent and the lane actually delivered.
         </p>
       </Section>
+
+      <Section title="The Dispatcher Card">
+        <p className="text-sm text-muted-text">
+          Every dispatcher has their own card — an avatar, a{" "}
+          <span className="text-light">career rank</span> that climbs on lifetime
+          loads booked (Rookie Dispatcher → Load Wrangler → Freight Closer → Rate
+          Hawk → Dispatch Legend), a season grade, and five booking stats:{" "}
+          <span className="text-light">loads booked</span>,{" "}
+          <span className="text-light">gross booked</span>, the{" "}
+          <span className="text-light">average booked rate</span> against your
+          break-even floor, <span className="text-light">detention collected</span>,
+          and <span className="text-light">on-time %</span>. It sits at the top of
+          the dispatch board and opens to a full page with the rank ladder.
+        </p>
+        <p className="text-sm text-muted-text mt-3">
+          The card counts only the loads a person actually booked. Every load
+          records a <span className="text-light">"Booked by"</span> — it defaults
+          to whoever enters it, so a dispatcher's own loads credit to them
+          automatically. As the owner you'll see a Booked-by picker on the load
+          form to hand credit to a dispatcher for a load you entered, and you can
+          open any teammate's card from{" "}
+          <Link to="/settings" className="text-status-info-text hover:underline">
+            Settings → Team
+          </Link>
+          . Everything on the card is gross, never net.
+        </p>
+      </Section>
     </div>
   </div>
 );

--- a/frontend/src/services/avatarsService.ts
+++ b/frontend/src/services/avatarsService.ts
@@ -1,6 +1,6 @@
 import api from "./api";
 
-export type AvatarKind = "truck" | "driver" | "trailer";
+export type AvatarKind = "truck" | "driver" | "trailer" | "user";
 
 // Generate a themed avatar server-side (fal → Supabase Storage). `variant` is
 // the driver gender ('male' | 'female'); ignored for truck/trailer.

--- a/frontend/src/services/patchLoadService.ts
+++ b/frontend/src/services/patchLoadService.ts
@@ -4,6 +4,7 @@ import type { Load } from "@/types/load";
 interface PatchLoadInput {
   load_status?: string;
   payment_status?: string;
+  booked_by?: string | null;
 }
 
 export const patchLoad = async (

--- a/frontend/src/services/teamService.ts
+++ b/frontend/src/services/teamService.ts
@@ -5,6 +5,7 @@ export interface TeamMember {
   email: string;
   role: string;
   display_name: string | null;
+  avatar_url: string | null;
   created_at: string;
 }
 
@@ -12,6 +13,13 @@ export interface TeamMember {
 export const getTeam = async (): Promise<TeamMember[]> => {
   const res = await api.get("/users");
   return res.data.team;
+};
+
+// One account member's identity, for their dispatcher card/page. A user may
+// fetch their own; an admin may fetch any member of the account.
+export const getUser = async (id: string): Promise<TeamMember> => {
+  const res = await api.get(`/users/${id}`);
+  return res.data.user;
 };
 
 export const createDispatcher = async (data: {

--- a/frontend/src/types/LoadInput.ts
+++ b/frontend/src/types/LoadInput.ts
@@ -39,4 +39,7 @@ export interface LoadInput {
   truck_id?: string | null;
   driver_id?: string | null;
   trailer_id?: string | null;
+  // Who gets booking credit — a user's self_id. Defaults to the creator
+  // server-side; the owner may set it to credit a dispatcher.
+  booked_by?: string | null;
 }

--- a/frontend/src/types/load.ts
+++ b/frontend/src/types/load.ts
@@ -63,6 +63,9 @@ export interface Load {
   truck_id?: string | null;
   driver_id?: string | null;
   trailer_id?: string | null;
+  // The user (self_id) who booked this load — powers the dispatcher card's
+  // per-person credit. Defaults to the creator; editable to reassign credit.
+  booked_by?: string | null;
   // Joined labels, present on the single-load fetch (getLoad) only.
   truck_unit?: string | null;
   driver_name?: string | null;


### PR DESCRIPTION
## Multi-user Phase 3a — the Dispatcher Card

Gives a dispatcher their own identity surface (card, page, avatar) so booking becomes a game they can climb. Built on real per-load attribution — both Jason and Brandie book, and each gets credit for their own.

### Attribution (migration 048, applied dev + prod)
- `loads.booked_by` (uuid → users) records who booked each load. New loads default to the logged-in creator; existing loads backfilled to the account owner. `users.avatar_url` added.
- `createLoad` defaults `booked_by = self_id`, accepts an override. Owner-only **"Booked by"** picker on the load form (create + edit) to credit a dispatcher.

### Card + page (all gross, never net)
- `getDispatcherCard`: loads booked, gross booked, avg booked rate vs break-even, detention collected, on-time %, career rank (lifetime loads booked), season grade — scoped to one person via `booked_by`. +5 unit tests.
- `DispatcherCard` (per the approved mock); `MyDispatcherCard` at the top of the dispatch board → taps to `/dispatcher/:id` (card + rank ladder).

### Identity + avatar
- `GET /users/:id` (self, or admin viewing a team member) returns identity incl `avatar_url`; team list + login carry it.
- Avatar service gains a role-themed `user` kind (dispatcher-at-the-desk prompt), authorized self-or-admin, stored on `users.avatar_url`.
- Settings → Team rows open each dispatcher's card.

### Verify
- Strict build clean; **321/321 tests** (+5). `getTeamMember` account-scoping checked against prod; backend syntax-checked.
- Migration verified: 57 prod loads all attributed to the owner, Brandie starts at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)