### PR TITLE
fix: validate token expiry before rendering protected routes (mobile kick)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.99.1",
+  "version": "1.99.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,9 +1,14 @@
 import { Navigate, Outlet } from "react-router-dom";
+import { isTokenValid, clearSession } from "@/lib/auth";
 
 const ProtectedRoute = () => {
   const token = localStorage.getItem("token");
 
-  if (!token) {
+  // Validate expiry, not just presence — otherwise a stale token renders the
+  // page and then gets 401-bounced ("loads, then kicks to login"). A dead token
+  // is cleared so we don't keep retrying it.
+  if (!isTokenValid(token)) {
+    if (token) clearSession();
     return <Navigate to="/login" replace />;
   }
 

--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { isTokenValid } from "./auth";
+
+// Build a JWT-shaped token (header.payload.signature) with a base64url payload.
+const mk = (payload: object): string => {
+  const b64 = btoa(JSON.stringify(payload))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `h.${b64}.s`;
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-16T12:00:00Z"));
+});
+afterEach(() => vi.useRealTimers());
+
+describe("isTokenValid", () => {
+  const now = Math.floor(Date.parse("2026-07-16T12:00:00Z") / 1000);
+
+  it("accepts a token whose exp is still in the future", () => {
+    expect(isTokenValid(mk({ exp: now + 3600 }))).toBe(true);
+  });
+
+  it("rejects an expired token", () => {
+    expect(isTokenValid(mk({ exp: now - 1 }))).toBe(false);
+  });
+
+  it("rejects null, empty, garbage, and exp-less tokens", () => {
+    expect(isTokenValid(null)).toBe(false);
+    expect(isTokenValid("")).toBe(false);
+    expect(isTokenValid("not-a-jwt")).toBe(false);
+    expect(isTokenValid(mk({ user_id: "x" }))).toBe(false);
+  });
+});

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,26 @@
+// Client-side session helpers. We only read the JWT's expiry here — signature
+// verification is the server's job. The point is to avoid rendering a protected
+// page on a dead token and then getting 401-bounced ("loads, then kicks to
+// login"), which is what happens on mobile after the app sits idle past the
+// token's 1h lifetime.
+
+export const isTokenValid = (token: string | null): token is string => {
+  if (!token) return false;
+  try {
+    const seg = token.split(".")[1];
+    const b64 = seg.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64.length % 4 ? b64 + "=".repeat(4 - (b64.length % 4)) : b64;
+    const payload = JSON.parse(atob(padded));
+    return typeof payload.exp === "number" && payload.exp * 1000 > Date.now();
+  } catch {
+    return false;
+  }
+};
+
+// Drop everything a session keeps, in one place.
+export const clearSession = () => {
+  localStorage.removeItem("token");
+  localStorage.removeItem("user_id");
+  localStorage.removeItem("role");
+  localStorage.removeItem("display_name");
+};

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { clearSession } from "@/lib/auth";
 
 // Create a centralized axios instance
 const api = axios.create({
@@ -42,10 +43,7 @@ api.interceptors.response.use(
       const url = error.config?.url || "";
       const isAuthAttempt = url.includes("/auth/login") || url.includes("/auth/signup");
       if (hadToken && !isAuthAttempt) {
-        localStorage.removeItem("token");
-        localStorage.removeItem("user_id");
-        localStorage.removeItem("role");
-        localStorage.removeItem("display_name");
+        clearSession();
         window.location.href = "/login";
       }
     }


### PR DESCRIPTION
## The "loads then kicks me to login" mobile bug

On mobile the app sits idle past the token's 1h lifetime. On reopen, `ProtectedRoute` only checked that a token **existed**, so it rendered the page, fired a request with the stale token, got a 401, cleared the token, and bounced to `/login`.

### Fix
- `lib/auth.isTokenValid` decodes the JWT's `exp` client-side (no signature check — that's the server's job) so a dead token never renders a protected page.
- `ProtectedRoute` validates expiry, not just presence, and clears a dead token → an expired session goes straight to a clean login instead of flashing the dashboard and bouncing.
- `clearSession` centralizes localStorage cleanup; the api 401 handler reuses it.
- 3 unit tests (valid / expired / garbage).

### Diagnosis
Probed the deployed backend: valid tokens verify, bad tokens 401, CORS ok — so this was purely client-side session hygiene. Reproduced against the live app: a bad token in storage renders the dashboard, then the first request 401s and bounces to `/login`.

Build clean, 324/324 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)