### PR TITLE
feat: dispatcher achievements — medals + patches (#277 Phase 3b-1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.99.2",
+  "version": "1.100.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/awards/DispatcherPatchBoard.tsx
+++ b/frontend/src/components/awards/DispatcherPatchBoard.tsx
@@ -1,0 +1,77 @@
+import type { GrindPatch } from "@/lib/awards/dispatcherAwards";
+import { awardIcon } from "./awardIcons";
+
+// The grind board — dispatcher patches that climb toward milestones. Earned
+// (lit, amber, with its badge + progress) sort ahead of locked (grayed).
+const Emblem = ({ p }: { p: GrindPatch }) => {
+  const Icon = awardIcon(p.icon);
+  return (
+    <div style={{ width: 96, textAlign: "center", position: "relative", opacity: p.earned ? 1 : 0.5 }}>
+      <div
+        style={{
+          width: 70,
+          height: 70,
+          borderRadius: "50%",
+          margin: "0 auto",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: p.earned ? "#2a1e0e" : "#141a26",
+          border: `3px solid ${p.earned ? "#e8940a" : "#2a3550"}`,
+        }}
+      >
+        <Icon size={28} style={{ color: p.earned ? "#f5b03a" : "#5b6b82" }} />
+      </div>
+      {p.earned && (
+        <span
+          className="font-comic"
+          style={{
+            position: "absolute",
+            top: -3,
+            left: "50%",
+            transform: "translateX(-50%)",
+            background: "#e8940a",
+            color: "#120f08",
+            borderRadius: 99,
+            fontSize: 11,
+            padding: "0 7px",
+            border: "2px solid #10151f",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {p.badge}
+        </span>
+      )}
+      <div style={{ fontSize: 10.5, color: p.earned ? "#c8d0dc" : "#7a869a", marginTop: 6, lineHeight: 1.15 }}>
+        {p.name}
+      </div>
+      <div style={{ fontSize: 8.5, color: "#9daabb" }}>{p.hint}</div>
+      {p.earned && p.progress < 1 && (
+        <div style={{ height: 3, borderRadius: 2, background: "#232c3f", marginTop: 4, overflow: "hidden" }}>
+          <div style={{ height: "100%", width: `${p.progress * 100}%`, background: "#e8940a" }} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const DispatcherPatchBoard = ({ patches }: { patches: GrindPatch[] }) => {
+  const sorted = [...patches].sort(
+    (a, b) => (b.earned ? 1 : 0) - (a.earned ? 1 : 0) || b.reached - a.reached,
+  );
+  return (
+    <div>
+      <div className="flex items-baseline gap-2 mb-3">
+        <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
+          PATCHES
+        </span>
+        <span className="text-[11px] text-muted-text">the grind · they climb as she books</span>
+      </div>
+      <div className="flex gap-3 flex-wrap">
+        {sorted.map((p) => (
+          <Emblem key={p.key} p={p} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/playercard/DispatcherCard.tsx
+++ b/frontend/src/components/playercard/DispatcherCard.tsx
@@ -3,12 +3,15 @@ import { Headset } from "lucide-react";
 import type { DispatcherCard as CardData } from "@/lib/metrics/dispatcherCard";
 import { RANK_TIERS } from "@/lib/metrics/dispatcherCard";
 import type { Grade } from "@/lib/metrics/playerCard";
+import type { Medal } from "@/lib/awards/medals";
+import { MedalBadge } from "@/components/awards/MedalBadge";
 
 interface Props {
   name: string;
   business?: string;
   avatar: ReactNode;
   card: CardData;
+  medals?: Medal[]; // earned rare-feat medals, worn by the name
 }
 
 // Compact gross: "$0", "$840", "$12.4k", "$487k".
@@ -59,7 +62,7 @@ const Stat = ({
   </div>
 );
 
-export const DispatcherCard = ({ name, business, avatar, card }: Props) => {
+export const DispatcherCard = ({ name, business, avatar, card, medals }: Props) => {
   const grade = card.seasonGrade ? GRADE_META[card.seasonGrade] : null;
   const stars =
     "★".repeat(card.rank.index + 1) +
@@ -99,6 +102,14 @@ export const DispatcherCard = ({ name, business, avatar, card }: Props) => {
           {business && (
             <div className="text-[11px] mt-1" style={{ color: "#9daabb" }}>
               {business}
+            </div>
+          )}
+
+          {medals && medals.length > 0 && (
+            <div className="flex gap-1 flex-wrap mt-2">
+              {medals.map((m) => (
+                <MedalBadge key={m.key} medal={m} />
+              ))}
             </div>
           )}
 

--- a/frontend/src/hooks/useDispatcherAwardPops.ts
+++ b/frontend/src/hooks/useDispatcherAwardPops.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect } from "react";
+import { newAwards, type Award } from "@/lib/metrics/awards";
+import {
+  dispatcherEarnedAwards,
+  type DispatcherAwardInput,
+} from "@/lib/awards/dispatcherAwards";
+
+// The dispatcher's awards keep their OWN per-device seen store, separate from the
+// driver's — so a device that already baselined the driver set doesn't flood a
+// dispatcher with every award at once (and vice-versa). Pass a fully-loaded input
+// (null until the rate ladder is ready) so the baseline is computed from complete
+// data.
+const KEY = "dash.dispatch.awards.v1";
+interface Store {
+  baselined: boolean;
+  seen: string[];
+}
+const read = (): Store => {
+  try {
+    const s = JSON.parse(localStorage.getItem(KEY) || "");
+    if (s && Array.isArray(s.seen)) return { baselined: !!s.baselined, seen: s.seen };
+  } catch {
+    /* fresh device */
+  }
+  return { baselined: false, seen: [] };
+};
+const write = (s: Store) => {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(s));
+  } catch {
+    /* storage disabled — pops just won't persist */
+  }
+};
+
+export const useDispatcherAwardPops = (
+  input: DispatcherAwardInput | null,
+): Award[] => {
+  const [pops, setPops] = useState<Award[]>([]);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (!input || input.loads.length === 0 || done) return;
+    setDone(true);
+
+    const earned = dispatcherEarnedAwards(input);
+    const currentIds = earned.map((a) => a.id);
+    const store = read();
+
+    if (!store.baselined) {
+      write({ baselined: true, seen: currentIds }); // silent day-one baseline
+      return;
+    }
+    const fresh = newAwards(earned, new Set(store.seen));
+    if (fresh.length > 0) {
+      write({ baselined: true, seen: [...new Set([...store.seen, ...currentIds])] });
+      setPops(fresh);
+    }
+  }, [input, done]);
+
+  return pops;
+};

--- a/frontend/src/lib/awards/dispatcherAwards.test.ts
+++ b/frontend/src/lib/awards/dispatcherAwards.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { RateLadder } from "@/lib/metrics/rateTargets";
+import type { ScoreBasis } from "@/lib/metrics/loadScore";
+import {
+  dispatcherMedals,
+  dispatcherPatches,
+  dispatcherEarnedAwards,
+  type DispatcherAwardInput,
+} from "./dispatcherAwards";
+
+const baseLoad: Load = {
+  load_id: "L",
+  load_number: "1",
+  load_type: "standard flatbed",
+  load_status: "delivered",
+  broker_id: "b",
+  broker: "B",
+  agent_id: "a1",
+  agent: "A",
+  agent_email: null,
+  pickup_date: "2026-06-10T04:00:00.000Z",
+  origin_market_id: "m",
+  origin_city: "X",
+  origin_state: "TX",
+  origin_market: "M",
+  destination_market_id: "m2",
+  destination_city: "Y",
+  destination_state: "TN",
+  delivery_market: "M2",
+  delivery_date: "2026-06-12T04:00:00.000Z",
+  deadhead_miles: 0,
+  loaded_miles: 1000,
+  linehaul: "5000",
+  fuel_surcharge: "0",
+  total_accessorials: "0",
+  commodity: null,
+  odometer_start: null,
+  odometer_end: null,
+  payment_status: "paid",
+  booked_by: "me",
+  detention_paid: false,
+  created_at: "",
+  updated_at: "",
+};
+const mk = (o: Partial<Load>): Load => ({ ...baseLoad, ...o });
+
+const ladder: RateLadder = { walkAway: 4, minimum: 4.5, target: 5, strong: 6 };
+// A basis where break-even ≈ $1/driven-mile, so a $10/mi load scores a STEAL.
+const scoreBasis: ScoreBasis = { costPerDrivenMile: 1, payTake: 1 };
+
+const input = (loads: Load[]): DispatcherAwardInput => ({
+  loads,
+  userId: "me",
+  ladder,
+  scoreBasis,
+  freeHours: 2,
+  streak: 0,
+});
+
+// A steal-quality load: $10/mi gross, no deadhead.
+const stealLoad = (over: Partial<Load>) =>
+  mk({ loaded_miles: 1000, linehaul: "10000", deadhead_miles: 0, ...over });
+
+describe("dispatcherMedals", () => {
+  it("tiers a rare feat on how many times earned, scoped to her non-cancelled loads", () => {
+    const loads = [
+      ...Array.from({ length: 5 }, (_, i) => stealLoad({ load_id: `S${i}` })),
+      stealLoad({ load_id: "OTHER", booked_by: "someone-else" }), // excluded
+      stealLoad({ load_id: "CX", load_status: "cancelled" }), // excluded
+    ];
+    const steal = dispatcherMedals(input(loads)).find((m) => m.key === "disp-steal")!;
+    expect(steal.tier).toBe(2); // 5 steals → tiers [1,5,15] → II
+  });
+
+  it("Big Week tiers on the best single week's load count", () => {
+    // 12 loads, all same week → best week = 12 → tiers [5,10,15] → II
+    const loads = Array.from({ length: 12 }, (_, i) => mk({ load_id: `W${i}` }));
+    const bw = dispatcherMedals(input(loads)).find((m) => m.key === "disp-big-week")!;
+    expect(bw.tier).toBe(2);
+  });
+});
+
+describe("dispatcherPatches", () => {
+  it("counts the grind and reports milestone progress", () => {
+    const loads = Array.from({ length: 30 }, (_, i) => mk({ load_id: `D${i}` }));
+    const deal = dispatcherPatches(input(loads)).find((p) => p.key === "disp-deal-closer")!;
+    expect(deal.earned).toBe(true);
+    expect(deal.badge).toBe("×30");
+    expect(deal.reached).toBe(1); // ≥25, <75 → 1 milestone
+  });
+
+  it("only counts her bookings", () => {
+    const loads = [
+      mk({ load_id: "A", booked_by: "me" }),
+      mk({ load_id: "B", booked_by: "other" }),
+      mk({ load_id: "C", booked_by: "me", load_status: "cancelled" }),
+    ];
+    const deal = dispatcherPatches(input(loads)).find((p) => p.key === "disp-deal-closer")!;
+    expect(deal.badge).toBe("×1"); // only the one non-cancelled load she booked
+  });
+});
+
+describe("dispatcherEarnedAwards", () => {
+  it("emits medal (tier) and patch (milestone) ids for the pop system", () => {
+    const loads = Array.from({ length: 30 }, (_, i) => stealLoad({ load_id: `S${i}` }));
+    const ids = dispatcherEarnedAwards(input(loads)).map((a) => a.id);
+    // 30 steals → tier III (≥15)
+    expect(ids).toContain("medal:disp-steal:3");
+    // 30 loads booked → Deal Closer milestone 1
+    expect(ids).toContain("patch:disp-deal-closer:1");
+  });
+
+  it("returns nothing before anything is earned", () => {
+    expect(dispatcherEarnedAwards(input([]))).toEqual([]);
+  });
+});

--- a/frontend/src/lib/awards/dispatcherAwards.ts
+++ b/frontend/src/lib/awards/dispatcherAwards.ts
@@ -1,0 +1,244 @@
+// Dispatcher achievements — scoped to ONE person via booked_by, everything on
+// GROSS (never net; see agents/lanes principle). Two kinds, mirroring the driver
+// system's mechanics so they render and POP the same way:
+//   • MEDALS  = rare, hard feats (tiered on how many times earned)
+//   • PATCHES = the everyday grind (a value that climbs; celebrates at milestones)
+import type { Load } from "@/types/load";
+import { loadGross, type RateLadder } from "@/lib/metrics/rateTargets";
+import { scoreLoad, type ScoreBasis } from "@/lib/metrics/loadScore";
+import { onTimeStatus, detentionMinutes } from "@/lib/detention";
+import { tiered, type Medal } from "./medals";
+import type { Award } from "@/lib/metrics/awards";
+import { DEADHEAD_TARGET } from "@/lib/constants/targets";
+
+export interface DispatcherAwardInput {
+  loads: Load[];
+  userId: string;
+  ladder: RateLadder;
+  scoreBasis: ScoreBasis;
+  freeHours: number;
+  streak: number; // best booking streak in weeks (from the grind)
+}
+
+// A grind patch for display: a value that climbs toward milestones.
+export interface GrindPatch {
+  key: string;
+  name: string;
+  icon: string;
+  earned: boolean;
+  badge: string; // "×150", "$487k", "6 wk"
+  hint: string;
+  progress: number; // 0..1 toward the next milestone
+  reached: number; // milestones crossed — encodes the pop id (so it pops at tiers)
+}
+
+const clamp = (n: number) => Math.max(0, Math.min(1, n));
+const cnt = (n: number) => `${Math.round(n)}`;
+const kMoney = (n: number) =>
+  n >= 1000 ? `$${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k` : `$${Math.round(n)}`;
+
+// Superload by the common cross-state thresholds (16' wide/high, 150' long, 200k lb).
+const isSuperload = (l: Load): boolean =>
+  (Number(l.width_in) || 0) >= 192 ||
+  (Number(l.height_in) || 0) >= 192 ||
+  (Number(l.length_in) || 0) >= 1800 ||
+  (Number(l.weight) || 0) >= 200_000;
+
+const rpm = (l: Load): number => {
+  const miles = Number(l.loaded_miles) || 0;
+  return miles > 0 ? loadGross(l) / miles : 0;
+};
+const deadheadPct = (l: Load): number | null => {
+  const loaded = Number(l.loaded_miles) || 0;
+  const dead = Number(l.deadhead_miles) || 0;
+  const tot = loaded + dead;
+  return tot > 0 ? dead / tot : null;
+};
+const bothOnTime = (l: Load): boolean =>
+  onTimeStatus(l.pickup_appt_start, l.pickup_appt_end, l.shipper_in) === "on-time" &&
+  onTimeStatus(l.delivery_appt_start, l.delivery_appt_end, l.receiver_in) === "on-time";
+
+const weekKey = (iso: string): string => {
+  const d = new Date(iso.slice(0, 10) + "T00:00:00Z");
+  const monday = new Date(d);
+  monday.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+  return monday.toISOString().slice(0, 10);
+};
+
+// All the raw tallies, computed once.
+interface Stats {
+  loadsBooked: number;
+  gross: number;
+  rateHawk: number;
+  detentionLoads: number;
+  topAgentLoads: number;
+  clockwork: number;
+  quickTurn: number;
+  oversize: number;
+  lean: number;
+  steal: number;
+  doubleUp: number;
+  superload: number;
+  whale: number;
+  perfectWeeks: number;
+  grandSlam: number;
+  bestWeekLoads: number;
+}
+
+const computeStats = (input: DispatcherAwardInput): Stats => {
+  const { loads, userId, ladder, scoreBasis, freeHours } = input;
+  const mine = loads.filter((l) => l.booked_by === userId && l.load_status !== "cancelled");
+  const delivered = mine.filter((l) => l.load_status === "delivered");
+  const target = ladder.target ?? Infinity;
+  const walkAway = ladder.walkAway ?? Infinity;
+
+  const isSteal = (l: Load): boolean =>
+    scoreLoad(
+      {
+        rate: loadGross(l),
+        loadedMiles: Number(l.loaded_miles) || 0,
+        deadheadMiles: Number(l.deadhead_miles) || 0,
+      },
+      scoreBasis,
+    ).verdict === "steal";
+
+  // Deepest single-agent relationship.
+  const byAgent = new Map<string, number>();
+  for (const l of mine) byAgent.set(l.agent_id, (byAgent.get(l.agent_id) ?? 0) + 1);
+  const topAgentLoads = byAgent.size ? Math.max(...byAgent.values()) : 0;
+
+  // Quick turns: consecutive runs where the next pickup lands ≤ 1 day after the
+  // prior delivery.
+  const chron = [...delivered]
+    .filter((l) => l.delivery_date && l.pickup_date)
+    .sort((a, b) => (a.delivery_date! < b.delivery_date! ? -1 : 1));
+  let quickTurn = 0;
+  for (let i = 1; i < chron.length; i++) {
+    const prevDel = Date.parse(chron[i - 1].delivery_date!.slice(0, 10) + "T00:00:00Z");
+    const nextPick = Date.parse(chron[i].pickup_date.slice(0, 10) + "T00:00:00Z");
+    if (nextPick >= prevDel && nextPick - prevDel <= 86_400_000) quickTurn++;
+  }
+
+  // Weekly buckets (of booked loads) for Big Week + Perfect Week.
+  const weeks = new Map<string, Load[]>();
+  for (const l of delivered)
+    if (l.delivery_date) {
+      const k = weekKey(l.delivery_date);
+      (weeks.get(k) ?? weeks.set(k, []).get(k)!).push(l);
+    }
+  let bestWeekLoads = 0;
+  let perfectWeeks = 0;
+  for (const w of weeks.values()) {
+    if (w.length > bestWeekLoads) bestWeekLoads = w.length;
+    if (w.length > 0 && w.every((l) => rpm(l) >= target)) perfectWeeks++;
+  }
+
+  return {
+    loadsBooked: mine.length,
+    gross: mine.reduce((s, l) => s + loadGross(l), 0),
+    rateHawk: mine.filter((l) => rpm(l) >= target).length,
+    detentionLoads: delivered.filter(
+      (l) => l.detention_paid && detentionMinutes(l, freeHours) > 0,
+    ).length,
+    topAgentLoads,
+    clockwork: delivered.filter(bothOnTime).length,
+    quickTurn,
+    oversize: mine.filter((l) => l.load_type === "oversize").length,
+    lean: delivered.filter((l) => {
+      const d = deadheadPct(l);
+      return d != null && d <= DEADHEAD_TARGET;
+    }).length,
+    steal: mine.filter(isSteal).length,
+    doubleUp: mine.filter((l) => rpm(l) >= 2 * walkAway).length,
+    superload: mine.filter(isSuperload).length,
+    whale: mine.filter((l) => loadGross(l) >= 10_000).length,
+    perfectWeeks,
+    grandSlam: delivered.filter(
+      (l) => isSteal(l) && bothOnTime(l) && (deadheadPct(l) ?? 1) <= 0.1,
+    ).length,
+    bestWeekLoads,
+  };
+};
+
+// ---- MEDALS (rare feats, tiered on times earned) ----
+export const dispatcherMedals = (input: DispatcherAwardInput): Medal[] => {
+  const s = computeStats(input);
+  return [
+    tiered("disp-steal", "Steal", "crown", [1, 5, 15], s.steal, cnt),
+    tiered("disp-double-up", "Double-Up", "coins", [1, 3, 10], s.doubleUp, cnt),
+    tiered("disp-whale", "Whale", "package", [1, 3, 10], s.whale, cnt),
+    tiered("disp-superload", "Superload", "mountain", [1, 2, 5], s.superload, cnt),
+    tiered("disp-perfect-week", "Perfect Week", "medal", [1, 3, 10], s.perfectWeeks, cnt),
+    tiered("disp-grand-slam", "Grand Slam", "trophy", [1, 2, 5], s.grandSlam, cnt),
+    tiered("disp-big-week", "Big Week", "stack-2", [5, 10, 15], s.bestWeekLoads, (n) => `${Math.round(n)} loads`),
+  ];
+};
+
+// ---- PATCHES (the grind, milestone-based) ----
+const grindPatch = (
+  key: string,
+  name: string,
+  icon: string,
+  value: number,
+  milestones: number[],
+  fmt: (n: number) => string,
+): GrindPatch => {
+  let reached = 0;
+  for (const m of milestones) if (value >= m) reached++;
+  const next = reached < milestones.length ? milestones[reached] : null;
+  const prev = reached > 0 ? milestones[reached - 1] : 0;
+  return {
+    key,
+    name,
+    icon,
+    earned: value > 0,
+    badge: fmt(value),
+    hint: next != null ? `next: ${fmt(next)}` : "maxed out",
+    progress: next != null ? clamp((value - prev) / (next - prev)) : 1,
+    reached,
+  };
+};
+
+export const dispatcherPatches = (input: DispatcherAwardInput): GrindPatch[] => {
+  const s = computeStats(input);
+  const x = (n: number) => `×${Math.round(n)}`;
+  return [
+    grindPatch("disp-deal-closer", "Deal Closer", "package", s.loadsBooked, [25, 75, 150, 300], x),
+    grindPatch("disp-rainmaker", "Rainmaker", "cash", s.gross, [100_000, 350_000, 750_000], kMoney),
+    grindPatch("disp-rate-hawk", "Rate Hawk", "feather", s.rateHawk, [15, 50, 125], x),
+    grindPatch("disp-iron-booker", "Iron Booker", "flame", input.streak, [4, 8, 12], (n) => `${Math.round(n)} wk`),
+    grindPatch("disp-bounty", "Bounty Hunter", "coins", s.detentionLoads, [3, 10, 25], x),
+    grindPatch("disp-right-hand", "Right Hand", "users", s.topAgentLoads, [10, 25, 50], x),
+    grindPatch("disp-clockwork", "Clockwork", "gauge", s.clockwork, [25, 75, 200], x),
+    grindPatch("disp-quick-turn", "Quick Turn", "arrows-horizontal", s.quickTurn, [15, 50, 125], x),
+    grindPatch("disp-oversize", "Oversize Ace", "truck", s.oversize, [5, 15, 40], x),
+    grindPatch("disp-lean", "Lean Machine", "route", s.lean, [25, 75, 200], x),
+  ];
+};
+
+// ---- AWARDS (for the pop celebration) ----
+// Medals pop on tier-up; grind patches pop when a new MILESTONE is crossed
+// (the id encodes `reached`, not the raw count — so no per-load spam).
+export const dispatcherEarnedAwards = (input: DispatcherAwardInput): Award[] => {
+  const out: Award[] = [];
+  for (const m of dispatcherMedals(input))
+    if (m.tier > 0)
+      out.push({
+        id: `medal:${m.key}:${m.tier}`,
+        tier: "medal",
+        name: `${m.name} ${m.tierLabel}`,
+        detail: m.hint,
+        icon: m.icon,
+        medalTier: m.tier,
+      });
+  for (const p of dispatcherPatches(input))
+    if (p.reached > 0)
+      out.push({
+        id: `patch:${p.key}:${p.reached}`,
+        tier: "patch",
+        name: `${p.name} ${p.badge}`,
+        detail: p.hint,
+        icon: p.icon,
+      });
+  return out;
+};

--- a/frontend/src/pages/DispatchDashboard.tsx
+++ b/frontend/src/pages/DispatchDashboard.tsx
@@ -6,6 +6,9 @@ import { useTrips } from "@/hooks/useTrips";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { useMaintenanceAlerts } from "@/hooks/useMaintenanceAlerts";
 import { useComplianceAlerts } from "@/hooks/useComplianceAlerts";
+import { useGrind } from "@/hooks/useGrind";
+import { useDispatcherAwardPops } from "@/hooks/useDispatcherAwardPops";
+import { AwardPopHost } from "@/components/comic/AwardPopHost";
 import { KpiCard } from "@/components/KpiCard";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AlertBanners } from "@/components/dashboard/AlertBanners";
@@ -61,6 +64,27 @@ const DispatchDashboard = () => {
       .catch(() => {});
   }, []);
 
+  // Her achievements pop the same way the driver's do — computed from her own
+  // bookings, celebrated on her board. Gated on the rate ladder being ready so
+  // the day-one baseline is built from complete data.
+  const grind = useGrind(loads);
+  const selfId = localStorage.getItem("user_id") ?? "";
+  const awardInput =
+    selfId && targets.bookingLadder.walkAway != null
+      ? {
+          loads,
+          userId: selfId,
+          ladder: targets.bookingLadder,
+          scoreBasis: {
+            costPerDrivenMile: targets.basis.costPerTotalMile,
+            payTake: targets.basis.payTake,
+          },
+          freeHours,
+          streak: grind?.bestStreak ?? 0,
+        }
+      : null;
+  const pops = useDispatcherAwardPops(awardInput);
+
   const isLoading = loadsLoading || tripsLoading;
   const error = loadsError || tripsError;
 
@@ -112,6 +136,8 @@ const DispatchDashboard = () => {
 
   return (
     <div className="p-6 bg-iron text-light min-h-screen font-body">
+      <AwardPopHost pops={pops} />
+
       <div className="flex items-center justify-between mb-6 gap-3">
         <div>
           <h1 className="font-comic text-3xl" style={{ color: "#f5b03a" }}>

--- a/frontend/src/pages/DispatcherPage.tsx
+++ b/frontend/src/pages/DispatcherPage.tsx
@@ -2,25 +2,44 @@ import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
+import { useGrind } from "@/hooks/useGrind";
 import { getUser, type TeamMember } from "@/services/teamService";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
 import { getDispatcherCard, RANK_TIERS } from "@/lib/metrics/dispatcherCard";
+import {
+  dispatcherMedals,
+  dispatcherPatches,
+  type DispatcherAwardInput,
+} from "@/lib/awards/dispatcherAwards";
 import { DispatcherCard } from "@/components/playercard/DispatcherCard";
+import { DispatcherPatchBoard } from "@/components/awards/DispatcherPatchBoard";
+import { MedalBadge } from "@/components/awards/MedalBadge";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { Skeleton } from "@/components/ui/skeleton";
 
-// Achievement tiers land in 3b; the shells sit here so the page reads complete.
-const COMING = [
-  { icon: "🦅", label: "Rate Hawk" },
-  { icon: "💰", label: "Detention Bounty" },
-  { icon: "🤝", label: "Deal Closer" },
-  { icon: "🔥", label: "Iron Booker" },
-];
+const LockedMedal = ({ name }: { name: string }) => (
+  <div style={{ width: 46, textAlign: "center", opacity: 0.4 }}>
+    <div
+      style={{
+        width: 36,
+        height: 36,
+        borderRadius: "50%",
+        margin: "11px auto 0",
+        background: "#141a26",
+        border: "2px solid #2a3550",
+      }}
+    />
+    <div style={{ fontSize: 8.5, color: "#7a869a", marginTop: 4, lineHeight: 1.1 }}>
+      {name}
+    </div>
+  </div>
+);
 
 const DispatcherPage = () => {
   const { id = "" } = useParams();
   const { loads, isLoading: loadsLoading, error } = useLoads(0);
   const targets = useRateTargets(loads);
+  const grind = useGrind(loads);
 
   const [member, setMember] = useState<TeamMember | null>(null);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
@@ -78,6 +97,21 @@ const DispatcherPage = () => {
   );
   const name = member.display_name || member.email;
 
+  const awardInput: DispatcherAwardInput = {
+    loads,
+    userId: id,
+    ladder: targets.bookingLadder,
+    scoreBasis: {
+      costPerDrivenMile: targets.basis.costPerTotalMile,
+      payTake: targets.basis.payTake,
+    },
+    freeHours,
+    streak: grind?.bestStreak ?? 0,
+  };
+  const medals = dispatcherMedals(awardInput);
+  const patches = dispatcherPatches(awardInput);
+  const earnedMedals = medals.filter((m) => m.tier > 0);
+
   const avatar = (
     <EntityAvatar
       kind="user"
@@ -88,6 +122,9 @@ const DispatcherPage = () => {
       onUpdated={(u) => setAvatarUrl(u)}
     />
   );
+
+  const panel = "rounded-2xl border p-4 mt-4";
+  const panelStyle = { background: "#141a26", borderColor: "#2a3347" };
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -101,13 +138,11 @@ const DispatcherPage = () => {
           business="Delgado Trucking Services · Dispatcher"
           avatar={avatar}
           card={card}
+          medals={earnedMedals}
         />
 
-        {/* Career ladder — horizontal progression */}
-        <div
-          className="rounded-2xl border p-4 mt-4"
-          style={{ background: "#141a26", borderColor: "#2a3347" }}
-        >
+        {/* Career ladder */}
+        <div className={panel} style={panelStyle}>
           <p className="text-[10px] uppercase tracking-widest text-muted-text mb-3">
             Career ladder
           </p>
@@ -146,28 +181,30 @@ const DispatcherPage = () => {
           </div>
         </div>
 
-        {/* Achievements — 3b */}
-        <div
-          className="rounded-2xl border p-4 mt-4"
-          style={{ background: "#141a26", borderColor: "#2a3347" }}
-        >
-          <p className="text-[10px] uppercase tracking-widest text-muted-text mb-3">
-            Achievements <span className="text-[#5f6b80]">· coming soon</span>
-          </p>
-          <div className="flex gap-2 flex-wrap opacity-60">
-            {COMING.map((a) => (
-              <span
-                key={a.label}
-                className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5"
-                style={{ background: "#1a2033", border: "1px dashed #3a4a66" }}
-              >
-                <span>{a.icon}</span>
-                <span className="text-[11px]" style={{ color: "#9daabb" }}>
-                  {a.label}
-                </span>
-              </span>
-            ))}
+        {/* Medals — rare feats */}
+        <div className={panel} style={panelStyle}>
+          <div className="flex items-baseline gap-2 mb-3">
+            <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
+              MEDALS
+            </span>
+            <span className="text-[11px] text-muted-text">
+              rare feats · can't be ground out
+            </span>
           </div>
+          <div className="flex gap-2 flex-wrap">
+            {medals.map((m) =>
+              m.tier > 0 ? (
+                <MedalBadge key={m.key} medal={m} />
+              ) : (
+                <LockedMedal key={m.key} name={m.name} />
+              ),
+            )}
+          </div>
+        </div>
+
+        {/* Patches — the grind */}
+        <div className={panel} style={panelStyle}>
+          <DispatcherPatchBoard patches={patches} />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -921,6 +921,21 @@ const GuidePage = () => (
           . Everything on the card is gross, never net.
         </p>
       </Section>
+
+      <Section title="Dispatcher achievements — patches &amp; medals">
+        <p className="text-sm text-muted-text">
+          Her page carries two kinds of earned awards, and they pop the same way
+          the driver's do. <span className="text-light">Patches</span> are the
+          everyday grind — Deal Closer, Rainmaker, Rate Hawk, Clockwork (on-time),
+          Quick Turn, Oversize Ace, Lean Machine, Bounty Hunter, Right Hand, Iron
+          Booker — each climbs a ×count and celebrates at milestones as she books.{" "}
+          <span className="text-light">Medals</span> are the rare, hard feats you
+          can't just grind out — Steal (a load the scorer rates a steal), Double-Up
+          (2× break-even), Superload, Whale (a huge single load), Perfect Week,
+          Grand&nbsp;Slam (a steal that's on-time with under 10% deadhead), and Big
+          Week. All of it is scored off her own bookings, on gross.
+        </p>
+      </Section>
     </div>
   </div>
 );


### PR DESCRIPTION
## Multi-user Phase 3b-1 — dispatcher achievements

Gives the dispatcher earned awards that fire and render the same way the driver's do, scoped to her own bookings (`booked_by`), all on gross.

- **`dispatcherAwards.ts`** — 7 rare-feat **medals** (Steal, Double-Up, Whale, Superload, Perfect Week, Grand Slam, Big Week — tiered on times earned) + 10 grind **patches** (Deal Closer, Rainmaker, Rate Hawk, Iron Booker, Bounty Hunter, Right Hand, Clockwork, Quick Turn, Oversize Ace, Lean Machine — climb to milestones). Reuses `loadGross`, `scoreLoad`, on-time/detention, streak. +6 tests.
- **Card** wears her earned medallions; **page** shows the full medals shelf (earned/locked) + the patch board.
- **`useDispatcherAwardPops`** — its own per-device seen store (no cross-flood with the driver set), silent day-one baseline; grind patches pop at milestones, not every load. `AwardPopHost` on her board celebrates like the driver's.
- Guide: "Dispatcher achievements" section.

### Deferred to 3b-2
Backhaul Boss + the month/quarter/year season cards.

### Verify
Strict build clean; **330/330 tests** (+6). Compute unit-tested: attribution-scoping, medal tiering, patch milestones, pop ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)