### PR TITLE
fix: weekly pace counts the in-transit load you're currently under

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.100.0",
+  "version": "1.100.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/rateTargets.test.ts
+++ b/frontend/src/lib/metrics/rateTargets.test.ts
@@ -220,6 +220,21 @@ describe("getWeekBookedGross", () => {
     ];
     expect(getWeekBookedGross(loads, start, end)).toBeCloseTo(6000, 5);
   });
+
+  it("dates a not-yet-delivered load by its pickup day (the load you're under)", () => {
+    const loads = [
+      load({ delivery_date: "2026-07-08", load_status: "delivered", linehaul: "1000" }),
+      // in-transit, no delivery_date yet, but picked up this week — must count
+      load({
+        delivery_date: null,
+        pickup_date: "2026-07-10",
+        load_status: "in_transit",
+        linehaul: "5000",
+      }),
+    ];
+    expect(getWeekBookedGross(loads, start, end)).toBeCloseTo(6000, 5); // committed sees both
+    expect(getWeekEarnedGross(loads, start, end)).toBeCloseTo(1000, 5); // earned, delivered only
+  });
 });
 
 describe("getWeekEarnedGross", () => {

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -214,14 +214,19 @@ export const payWeekRange = (
   return { start, end };
 };
 
-// Non-cancelled loads delivering in [start, end) — booked, in-transit, and
-// delivered all count, so mid-week reflects committed + earned freight.
+// Non-cancelled loads that fall in [start, end) — booked, in-transit, and
+// delivered all count, so mid-week reflects committed + earned freight. Date a
+// load by its delivery day when there is one (planned or actual), else by its
+// pickup day — otherwise the in-transit load you're currently under (no delivery
+// date yet) drops out of the committed pipeline entirely.
 const loadsInWeek = (loads: Load[], start: Date, end: Date): Load[] =>
   loads.filter((l) => {
-    if (l.load_status === "cancelled" || !l.delivery_date) return false;
-    const dd = new Date(l.delivery_date);
+    if (l.load_status === "cancelled") return false;
+    const ref = l.delivery_date ?? l.pickup_date;
+    if (!ref) return false;
+    const rd = new Date(ref);
     const day = new Date(
-      Date.UTC(dd.getUTCFullYear(), dd.getUTCMonth(), dd.getUTCDate()),
+      Date.UTC(rd.getUTCFullYear(), rd.getUTCMonth(), rd.getUTCDate()),
     );
     return day >= start && day < end;
   });


### PR DESCRIPTION
**Bug:** `loadsInWeek` dated every load by `delivery_date` and dropped any load without one. An in-transit load has no delivery date yet, so it fell out of the week's **committed** pipeline — the rate/pace card showed only delivered gross (the load Jason was under wasn't counted).

**Fix:** a load is now dated by its `delivery_date` when present (planned or actual), else by its `pickup_date`. The load you're currently under lands in this week's committed total; **earned** (delivered only) is unchanged. Same fix flows through the grind's committed number; the streak (earned-based) is unaffected.

Build clean, 331/331 tests (+1 reproducing the no-delivery-date in-transit case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)