### PR TITLE
fix: unrecorded (0) deadhead no longer sets a false best-deadhead record

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.100.1",
+  "version": "1.100.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/awards/dispatcherAwards.test.ts
+++ b/frontend/src/lib/awards/dispatcherAwards.test.ts
@@ -90,6 +90,15 @@ describe("dispatcherPatches", () => {
     expect(deal.reached).toBe(1); // ≥25, <75 → 1 milestone
   });
 
+  it("Lean Machine ignores loads with unrecorded (0) deadhead", () => {
+    const loads = [
+      mk({ load_id: "R", loaded_miles: 1000, deadhead_miles: 50 }), // ~4.8% → lean
+      mk({ load_id: "U", loaded_miles: 1000, deadhead_miles: 0 }), // unrecorded → not lean
+    ];
+    const lean = dispatcherPatches(input(loads)).find((p) => p.key === "disp-lean")!;
+    expect(lean.badge).toBe("×1"); // only the recorded low-deadhead load
+  });
+
   it("only counts her bookings", () => {
     const loads = [
       mk({ load_id: "A", booked_by: "me" }),

--- a/frontend/src/lib/awards/dispatcherAwards.ts
+++ b/frontend/src/lib/awards/dispatcherAwards.ts
@@ -49,8 +49,11 @@ const rpm = (l: Load): number => {
   return miles > 0 ? loadGross(l) / miles : 0;
 };
 const deadheadPct = (l: Load): number | null => {
-  const loaded = Number(l.loaded_miles) || 0;
   const dead = Number(l.deadhead_miles) || 0;
+  // A 0/blank deadhead is unrecorded, not truly zero — real deadhead is never
+  // exactly 0. Return null so it can't masquerade as a "lean" or slam-worthy load.
+  if (dead <= 0) return null;
+  const loaded = Number(l.loaded_miles) || 0;
   const tot = loaded + dead;
   return tot > 0 ? dead / tot : null;
 };

--- a/frontend/src/lib/metrics/playerCard.test.ts
+++ b/frontend/src/lib/metrics/playerCard.test.ts
@@ -198,6 +198,16 @@ describe("personalBests", () => {
     expect(pb.lowestDeadheadPct).toBeCloseTo(150 / 1650, 3);
     expect(pb.bestMpg).toBeCloseTo(6.483, 2);
   });
+
+  it("ignores a week with an unrecorded (0) deadhead load — no false 0% best", () => {
+    const loads = [
+      mkLoad({ load_id: "a", delivery_date: "2026-05-12", loaded_miles: 1000, deadhead_miles: 100 }),
+      // 0 deadhead = unrecorded, not truly zero → this week can't set the record
+      mkLoad({ load_id: "z", delivery_date: "2026-06-15", loaded_miles: 900, deadhead_miles: 0 }),
+    ];
+    const pb = personalBests(loads, fuel, NOW);
+    expect(pb.lowestDeadheadPct).toBeCloseTo(100 / 1100, 4); // NOT 0
+  });
 });
 
 describe("earnedTrophies", () => {

--- a/frontend/src/lib/metrics/playerCard.ts
+++ b/frontend/src/lib/metrics/playerCard.ts
@@ -240,14 +240,21 @@ export const personalBests = (
     (l) => l.load_status === "delivered" && l.delivery_date,
   );
 
-  const weeks = new Map<string, { rev: number; count: number; loaded: number; dead: number }>();
+  const weeks = new Map<
+    string,
+    { rev: number; count: number; loaded: number; dead: number; deadheadKnown: boolean }
+  >();
   for (const l of delivered) {
     const k = weekKey(l.delivery_date!);
-    const w = weeks.get(k) ?? { rev: 0, count: 0, loaded: 0, dead: 0 };
+    const w = weeks.get(k) ?? { rev: 0, count: 0, loaded: 0, dead: 0, deadheadKnown: true };
     w.rev += loadRevenue(l);
     w.count += 1;
     w.loaded += Number(l.loaded_miles || 0);
-    w.dead += Number(l.deadhead_miles || 0);
+    const dh = Number(l.deadhead_miles || 0);
+    w.dead += dh;
+    // One load with a 0/blank deadhead makes the whole week's deadhead unreliable
+    // (real deadhead is never exactly 0), so that week can't set a "best" record.
+    if (dh <= 0) w.deadheadKnown = false;
     weeks.set(k, w);
   }
 
@@ -258,7 +265,7 @@ export const personalBests = (
     if (bestWeekRevenue == null || w.rev > bestWeekRevenue) bestWeekRevenue = w.rev;
     if (mostLoadsInWeek == null || w.count > mostLoadsInWeek) mostLoadsInWeek = w.count;
     const t = w.loaded + w.dead;
-    if (t > 0) {
+    if (w.deadheadKnown && t > 0) {
       const dh = w.dead / t;
       if (lowestDeadheadPct == null || dh < lowestDeadheadPct) lowestDeadheadPct = dh;
     }


### PR DESCRIPTION
**Bug:** a delivered load with `deadhead_miles = 0` (unrecorded — real deadhead is never exactly 0) made its week read as **0% deadhead**, which became a false "best deadhead yet" record. Same flaw would have counted it as a Lean Machine / Grand-Slam-worthy load on the dispatcher side.

**Fix:** treat a 0/blank deadhead as *unknown*, not *zero*.
- `personalBests`: a week containing any 0/blank-deadhead load can't set the lowest-deadhead record.
- `dispatcherAwards`: a 0/blank deadhead returns `null` → can't count as lean or qualify for Grand Slam.

Verified against prod (48/49 delivered loads have deadhead recorded; the one 0 was poisoning the record). Build clean, 333/333 tests (+2 reproducing both cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)