### PR TITLE
fix: last-month revenue rolls into December in January

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.103.0",
+  "version": "1.103.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/dashboard.test.ts
+++ b/frontend/src/lib/metrics/dashboard.test.ts
@@ -863,6 +863,41 @@ describe("getRevenueLastMonth", () => {
 
     expect(result).toBe(7124);
   });
+
+  it("rolls back to December of the prior year in January", () => {
+    // The bug: in January, `getUTCMonth() - 1` is -1 (no month) AND the year
+    // filter demanded the current year, so December's revenue read as $0 and
+    // the month-over-month delta broke for all of January.
+    vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+    const loads = [
+      // December 2025 — this is "last month" and must count.
+      {
+        load_status: "delivered",
+        delivery_date: "2025-12-20T05:00:00.000Z",
+        linehaul: "3000.00",
+        fuel_surcharge: "500.00",
+        total_accessorials: "0",
+      },
+      // January 2026 — current month, must NOT count as last month.
+      {
+        load_status: "delivered",
+        delivery_date: "2026-01-05T05:00:00.000Z",
+        linehaul: "9999.00",
+        fuel_surcharge: "0.00",
+        total_accessorials: "0",
+      },
+      // November 2025 — a month too early, excluded.
+      {
+        load_status: "delivered",
+        delivery_date: "2025-11-15T05:00:00.000Z",
+        linehaul: "1000.00",
+        fuel_surcharge: "0.00",
+        total_accessorials: "0",
+      },
+    ];
+
+    expect(getRevenueLastMonth(loads as any)).toBe(3500);
+  });
 });
 
 // ---- GET REVENUE YTD ----

--- a/frontend/src/lib/metrics/dashboard.ts
+++ b/frontend/src/lib/metrics/dashboard.ts
@@ -34,14 +34,21 @@ export const getRevenueMTD = (loads: Load[]): number | null => {
 
 // ---- GET LAST MONTHS REVENUE ----
 export const getRevenueLastMonth = (loads: Load[]): number | null => {
-  const now = new Date();
+  const now = new Date(Date.now());
+  // First of last month in UTC. Deriving the (year, month) pair this way handles
+  // the January → December rollover — `now.getUTCMonth() - 1` alone is -1 every
+  // January, which no month matches, so last-month revenue read empty and the
+  // month-over-month delta broke for the whole of January.
+  const prev = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+  const prevYear = prev.getUTCFullYear();
+  const prevMonth = prev.getUTCMonth();
 
   const filteredLoads = loads.filter(
     (load) =>
       load.delivery_date &&
       load.load_status === "delivered" &&
-      new Date(load.delivery_date).getUTCFullYear() === now.getUTCFullYear() &&
-      new Date(load.delivery_date).getUTCMonth() === now.getUTCMonth() - 1,
+      new Date(load.delivery_date).getUTCFullYear() === prevYear &&
+      new Date(load.delivery_date).getUTCMonth() === prevMonth,
   );
 
   const grossRev = getLoadRevenue(filteredLoads);


### PR DESCRIPTION
## The bug

`getRevenueLastMonth` filtered on `getUTCMonth() === now.getUTCMonth() - 1` while also demanding the current year. Every January that inner month is `-1` — which no month equals — and December lives in the prior year anyway, so the function returned `$0` for all of January.

## The symptom

That value feeds the Net-revenue-MTD delta (`computeDelta(mtd, lastMonth)`), and `computeDelta` returns `null` when the previous month is `0`. So for the whole of January the KPI's month-over-month chip **silently vanished** instead of comparing against December — wrong-by-omission, the quiet kind of break that erodes trust in the numbers.

## The fix

Derive the previous `(year, month)` with `Date.UTC(year, month - 1, 1)`, the same rollover-safe pattern `getMonthlyDeadhead` already uses. Behavior is byte-identical for every non-January month.

## Test

Clock frozen to Jan 15 2026: December 2025 counts, January 2026 (current) doesn't, November 2025 (a month too early) doesn't. The existing June-dated test still passes, proving no other month shifted. 355 tests green, build clean.

`v1.103.1` — corrective, patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)