### PR TITLE
feat: mobile polish — sidebar auto-close + fix header overflow across detail pages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.103.1",
+  "version": "1.104.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -12,6 +12,7 @@ import {
   SidebarMenuSub,
   SidebarMenuSubItem,
   SidebarMenuSubButton,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { Link, useLocation } from "react-router-dom";
 import { isDispatcher } from "@/lib/roles";
@@ -75,6 +76,14 @@ const AppSidebar = () => {
   const active = (to: string) =>
     pathname === to || pathname.startsWith(to + "/");
 
+  // On a phone the sidebar is an off-canvas sheet; tapping a destination should
+  // dismiss it so the page is visible, instead of leaving it covering the screen.
+  // On desktop the rail is permanent, so this is a no-op there.
+  const { isMobile, setOpenMobile } = useSidebar();
+  const closeOnNav = () => {
+    if (isMobile) setOpenMobile(false);
+  };
+
   // A group starts open if it holds the current route; navigating into a group
   // opens it, but manual toggles of the others are preserved.
   const [open, setOpen] = useState<Record<string, boolean>>(() => {
@@ -129,7 +138,11 @@ const AppSidebar = () => {
                             asChild
                             className="!bg-transparent hover:!bg-transparent"
                           >
-                            <Link to={c.to} className={linkCls(c.to)}>
+                            <Link
+                              to={c.to}
+                              onClick={closeOnNav}
+                              className={linkCls(c.to)}
+                            >
                               {c.label}
                             </Link>
                           </SidebarMenuSubButton>
@@ -144,7 +157,11 @@ const AppSidebar = () => {
                     asChild
                     className="!bg-transparent hover:!bg-transparent"
                   >
-                    <Link to={e.to} className={linkCls(e.to)}>
+                    <Link
+                      to={e.to}
+                      onClick={closeOnNav}
+                      className={linkCls(e.to)}
+                    >
                       {e.label}
                     </Link>
                   </SidebarMenuButton>
@@ -158,7 +175,11 @@ const AppSidebar = () => {
       <SidebarFooter>
         {!dispatcher && (
           <div className="px-4 pt-2">
-            <Link to="/settings" className={`text-sm ${linkCls("/settings")}`}>
+            <Link
+              to="/settings"
+              onClick={closeOnNav}
+              className={`text-sm ${linkCls("/settings")}`}
+            >
               Settings
             </Link>
           </div>

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -167,13 +167,13 @@ const AgentDetailPage = () => {
         ← Agents
       </Link>
 
-      <div className="flex justify-between items-start mt-3 mb-6 gap-4">
-        <div className="flex gap-4 items-center">
+      <div className="flex flex-col gap-4 mt-3 mb-6 sm:flex-row sm:justify-between sm:items-start">
+        <div className="flex gap-4 items-center min-w-0">
           <div className="size-16 rounded-full bg-steel border-2 border-amber flex items-center justify-center font-condensed font-semibold text-2xl text-amber-light shrink-0">
             {agent.first_name.charAt(0)}
             {agent.last_name.charAt(0)}
           </div>
-          <div>
+          <div className="min-w-0">
             <h1 className="text-3xl font-condensed leading-none">
               {agent.first_name} {agent.last_name}
             </h1>
@@ -191,7 +191,7 @@ const AgentDetailPage = () => {
             )}
           </div>
         </div>
-        <div className="text-right shrink-0">
+        <div className="shrink-0 sm:text-right">
           <RatingStamp rating={agent.rating} />
           <div className="mt-3">
             <button

--- a/frontend/src/pages/DispatchDashboard.tsx
+++ b/frontend/src/pages/DispatchDashboard.tsx
@@ -138,7 +138,7 @@ const DispatchDashboard = () => {
     <div className="p-6 bg-iron text-light min-h-screen font-body">
       <AwardPopHost pops={pops} />
 
-      <div className="flex items-center justify-between mb-6 gap-3">
+      <div className="flex flex-wrap items-center justify-between mb-6 gap-x-3 gap-y-2">
         <div>
           <h1 className="font-comic text-3xl" style={{ color: "#f5b03a" }}>
             DISPATCH BOARD

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -55,9 +55,9 @@ const Spec = ({
   label: string;
   value: string | null | undefined;
 }) => (
-  <div>
+  <div className="min-w-0">
     <p className="text-xs text-muted-text">{label}</p>
-    <p className="text-sm">{value ? value : "—"}</p>
+    <p className="text-sm break-words">{value ? value : "—"}</p>
   </div>
 );
 

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -195,8 +195,8 @@ const ExpensesPage = () => {
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-condensed">
+      <div className="flex flex-wrap justify-between items-center gap-3 mb-6">
+        <h1 className="text-3xl font-condensed min-w-0">
           Expenses
           {selected?.period_label ? ` · ${selected.period_label}` : ""}
         </h1>

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -404,9 +404,9 @@ export const LoadDetailPage = () => {
         ← Loads
       </Link>
 
-      <div className="flex justify-between items-start mt-3 mb-6">
-        <div>
-          <div className="flex items-center gap-3">
+      <div className="flex flex-col gap-3 mt-3 mb-6 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
             <h1 className="text-3xl font-condensed">{load.load_number}</h1>
             <StatusBadge value={load.load_status} />
             <StatusBadge value={load.payment_status} />
@@ -416,7 +416,7 @@ export const LoadDetailPage = () => {
             {load.broker} · {load.agent} · {capitalize(load.load_type)}
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 shrink-0">
           <button
             onClick={() => setShowEditForm(true)}
             className="bg-steel text-light px-3 py-1.5 rounded text-sm flex items-center gap-1"

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -75,9 +75,9 @@ const Spec = ({
   label: string;
   value: string | number | null | undefined;
 }) => (
-  <div>
+  <div className="min-w-0">
     <p className="text-xs text-muted-text">{label}</p>
-    <p className="text-sm">
+    <p className="text-sm break-words">
       {value === null || value === undefined || value === "" ? "—" : value}
     </p>
   </div>


### PR DESCRIPTION
Two things that bit on a phone, plus the class of bug behind one of them.

## Reported

- **Load-detail header scrolled the whole page sideways.** The load number + two status badges + the DELIVERED rubber stamp + Edit/Delete buttons sat in one non-wrapping ~450px row on a 375px screen. Now the header stacks (`flex-col` → `sm:flex-row`) and the badge/stamp row wraps. Desktop unchanged. (The rubber stamp added recently is what tipped it over.)
- **Sidebar stayed open after tapping a nav link.** On mobile the rail is an off-canvas sheet; nav links now call `setOpenMobile(false)` so tapping a destination dismisses it. No-op on desktop, where the rail is permanent.

## Audit — same pattern elsewhere, fixed

A sweep of every page found the same overflow shape on the other detail headers:

- **Agent detail header** — avatar + name + rating stamp + Edit → stack/wrap.
- **Dispatch board header** and **Expenses header** — `flex-wrap` so title + action button reflow.
- **Truck / Driver `Spec` cells** — `break-words` + `min-w-0` so a long email or VIN breaks instead of pushing the page.

## Left alone (deliberately)

Audit rated these low and they don't cause horizontal scroll: a few `grid-cols-3` tiles that already fit, and small 3-column tables that cramp but don't overflow. Confirmed safe: every wide data table (Loads, Trucks, Trailers, Fuel, …) already scrolls inside its card, and the detail hero cards already stack on mobile.

## Verification

Sidebar auto-close verified live in a 375px viewport (opened the sheet, tapped a link, it dismissed). Build clean, 355 tests green. The header layout fixes are on data-backed pages, so they're structural (build-confirmed) — visible live after deploy.

`v1.104.0` — sidebar auto-close is new behavior, minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)