### PR TITLE
fix: remove the Clean Run patch + Best Deadhead record

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.104.0",
+  "version": "1.104.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/awards/RecordBook.tsx
+++ b/frontend/src/components/awards/RecordBook.tsx
@@ -10,10 +10,10 @@ export interface RecordChip {
 
 const kMoney = (n: number) => (n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${Math.round(n)}`);
 
-// The driver's five records → chips.
+// The driver's records → chips. (No deadhead record — it's a structural cost of
+// oversize work, not a personal best to chase; removed 2026-07-25.)
 export const driverRecordChips = (b: PersonalBests): RecordChip[] => [
   { icon: "trophy", color: "#f5b03a", value: b.bestWeekRevenue != null ? kMoney(b.bestWeekRevenue) : "—", label: "TOP WEEK" },
-  { icon: "gauge", color: "#4ade80", value: b.lowestDeadheadPct != null ? `${(b.lowestDeadheadPct * 100).toFixed(1)}%` : "—", label: "BEST DEADHEAD" },
   { icon: "flame", color: "#e8940a", value: b.bestMpg != null ? b.bestMpg.toFixed(1) : "—", label: "BEST TANK" },
   { icon: "package", color: "#f5b03a", value: b.biggestLoad != null ? kMoney(b.biggestLoad) : "—", label: "BIGGEST LOAD" },
   { icon: "stack", color: "#60a5fa", value: b.mostLoadsInWeek != null ? String(b.mostLoadsInWeek) : "—", label: "MOST / WEEK" },

--- a/frontend/src/lib/awards/patches.test.ts
+++ b/frontend/src/lib/awards/patches.test.ts
@@ -14,7 +14,7 @@ const L = (o: Record<string, unknown>): Load =>
   }) as unknown as Load;
 
 const find = (loads: Load[], key: string) =>
-  computePatches(loads, [], [] as FuelEntry[]).find((p) => p.key === key)!;
+  computePatches(loads, [] as FuelEntry[]).find((p) => p.key === key)!;
 
 describe("computePatches", () => {
   it("Trailblazer counts distinct states touched", () => {
@@ -58,7 +58,7 @@ describe("computePatches", () => {
 
   // ---- Operation-specific (open-deck) set ----
   const findOp = (loads: Load[], key: string, operation: string) =>
-    computePatches(loads, [], [] as FuelEntry[], operation).find((p) => p.key === key);
+    computePatches(loads, [] as FuelEntry[], operation).find((p) => p.key === key);
 
   it("gates the oversize set to open-deck operations", () => {
     const loads = [

--- a/frontend/src/lib/awards/patches.ts
+++ b/frontend/src/lib/awards/patches.ts
@@ -4,12 +4,10 @@
 // patch is derived from load data and takes the loads pre-filtered, so the same
 // function scopes to a driver, a truck, or a trailer just by what you pass in.
 import type { Load } from "@/types/load";
-import type { Trip } from "@/types/trip";
 import type { FuelEntry } from "@/types/fuelEntry";
 import { loadGross, loadRevenue } from "@/lib/metrics/rateTargets";
 import { formatInches } from "@/lib/dimensions";
 import { computeStack, type BarOpts } from "./adaptiveBar";
-import { deadheadPctOver } from "@/lib/metrics/deadhead";
 
 export interface Patch {
   key: string;
@@ -87,7 +85,6 @@ const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 
 export const computePatches = (
   loads: Load[],
-  trips: Trip[],
   _fuel: FuelEntry[],
   operation: string = "flatbed",
 ): Patch[] => {
@@ -113,26 +110,8 @@ export const computePatches = (
   const iron = computeStack(weeklyLoads, { n: 5, floor: 5 });
   out.push({ key: "iron-week", name: "Iron Week", icon: "barbell", count: iron.count, bar: iron.bar, unit: null, hint: `${Math.round(iron.bar)}+ loads in a week` });
 
-  // ---- Clean Run: adaptive over weekly deadhead %, lower is better ----
-  // Odometer-derived, with that week's non-revenue trips counted as fully empty.
-  // A week with nothing measurable scores 1 (worst) so it can never win a patch.
-  const tripsByWeek = new Map<string, Trip[]>();
-  for (const t of trips) {
-    if (!t.trip_date) continue;
-    const k = weekKey(t.trip_date);
-    const arr = tripsByWeek.get(k);
-    if (arr) arr.push(t);
-    else tripsByWeek.set(k, [t]);
-  }
-  const weeklyDeadhead = bucketed(
-    dl,
-    (l) => weekKey(l.delivery_date!),
-    (ls) =>
-      deadheadPctOver(ls, tripsByWeek.get(weekKey(ls[0].delivery_date!)) ?? []) ??
-      1,
-  );
-  const clean = computeStack(weeklyDeadhead, { n: 5, floor: 0.1, lowerIsBetter: true });
-  out.push({ key: "clean-run", name: "Clean Run", icon: "gauge", count: clean.count, bar: clean.bar, unit: "pct", hint: `a week under ${(clean.bar * 100).toFixed(0)}% deadhead` });
+  // (Deadhead is a structural cost of oversize work, not a feat to chase, so
+  // there's no weekly-deadhead patch — removed 2026-07-25 at Jason's call.)
 
   // ---- Trailblazer (structural): distinct states touched — the count IS the map ----
   const states = new Set<string>();
@@ -189,7 +168,6 @@ export const PATCH_GUIDE: { name: string; icon: string; how: string }[] = [
   { name: "Super Load", icon: "crown", how: "A true superload — 16' wide/high, 150' long, or 200k lb. A career milestone." },
   { name: "Rainmaker", icon: "coins", how: "A top-tier net month." },
   { name: "Iron Week", icon: "barbell", how: "One of your busiest pay-weeks by load count." },
-  { name: "Clean Run", icon: "gauge", how: "A week with your tightest deadhead." },
   { name: "Trailblazer", icon: "map-pin", how: "Deliver to a new state — the ×count is your states-conquered map." },
   { name: "Coast to Coast", icon: "arrows-horizontal", how: "A single run spanning the West and East coasts." },
   { name: "Doubleheader", icon: "layers-subtract", how: "Deliver two or more loads in one day." },

--- a/frontend/src/lib/metrics/awards.ts
+++ b/frontend/src/lib/metrics/awards.ts
@@ -108,12 +108,12 @@ export const earnedAwards = (i: AwardInputs): Award[] => {
   });
 
   // ---- Patches (stacked hard feat): fire when the ×count climbs ----
-  for (const p of computePatches(i.loads, i.trips, i.fuel))
+  for (const p of computePatches(i.loads, i.fuel))
     if (p.count > 0)
       out.push({ id: `patch:${p.key}:${p.count}`, tier: "patch", name: `${p.name} ×${p.count}`, detail: p.hint, icon: p.icon });
 
   // ---- Records (new personal best): fire when a best improves ----
-  const pb = personalBests(i.loads, i.trips, i.fuel, i.now);
+  const pb = personalBests(i.loads, i.fuel, i.now);
   const rec = (key: string, val: number | null, id: string, name: string, detail: string, icon: string) => {
     if (val != null) out.push({ id: `record:${key}:${id}`, tier: "record", name, detail, icon });
   };
@@ -121,7 +121,6 @@ export const earnedAwards = (i: AwardInputs): Award[] => {
   rec("best-tank", pb.bestMpg, `${(pb.bestMpg ?? 0).toFixed(1)}`, "New record — Best Tank", `${(pb.bestMpg ?? 0).toFixed(1)} mpg`, "flame");
   rec("biggest-load", pb.biggestLoad, `${Math.round(pb.biggestLoad ?? 0)}`, "New record — Biggest Load", money(pb.biggestLoad ?? 0), "package");
   rec("most-week", pb.mostLoadsInWeek, `${pb.mostLoadsInWeek ?? 0}`, "New record — Most in a Week", `${pb.mostLoadsInWeek ?? 0} loads`, "stack");
-  rec("best-deadhead", pb.lowestDeadheadPct, `${((pb.lowestDeadheadPct ?? 0) * 100).toFixed(1)}`, "New record — Best Deadhead", `${((pb.lowestDeadheadPct ?? 0) * 100).toFixed(1)}%`, "gauge");
 
   return out;
 };

--- a/frontend/src/lib/metrics/playerCard.test.ts
+++ b/frontend/src/lib/metrics/playerCard.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import type { Load } from "@/types/load";
 import type { ExpensePeriod } from "@/types/expense";
 import type { FuelEntry } from "@/types/fuelEntry";
-import type { Trip } from "@/types/trip";
 import {
   careerRank,
   marginGrade,
@@ -186,41 +185,17 @@ describe("personalBests", () => {
     { odometer_reading: 572503, gallons: 135.1, price_per_gallon: 4.322, fuel_date: "2026-05-30" },
   ] as unknown as FuelEntry[];
 
-  it("finds best week, biggest load, most loads/week, lowest deadhead", () => {
+  it("finds best week, biggest load, most loads/week", () => {
     const loads = [
       mkLoad({ load_id: "a", delivery_date: "2026-05-12", linehaul: "3200", loaded_miles: 1000, odometer_start: 570000, odometer_end: 571200 }),
       mkLoad({ load_id: "c", delivery_date: "2026-05-13", linehaul: "1000", loaded_miles: 500, odometer_start: 571200, odometer_end: 571800 }),
       mkLoad({ load_id: "b", delivery_date: "2026-06-15", linehaul: "2600", loaded_miles: 800, odometer_start: 572000, odometer_end: 573100 }),
     ];
-    const pb = personalBests(loads, [], fuel, NOW);
+    const pb = personalBests(loads, fuel, NOW);
     expect(pb.bestWeekRevenue).toBeCloseTo(4200, 2);
     expect(pb.mostLoadsInWeek).toBe(2);
     expect(pb.biggestLoad).toBeCloseTo(3200, 2);
-    expect(pb.lowestDeadheadPct).toBeCloseTo(300 / 1800, 4); // May week: 1800 run, 1500 loaded
     expect(pb.bestMpg).toBeCloseTo(6.483, 2);
-  });
-
-  it("ignores a week whose load never got odometer readings — no false best", () => {
-    const loads = [
-      mkLoad({ load_id: "a", delivery_date: "2026-05-12", loaded_miles: 1000, odometer_start: 570000, odometer_end: 571100 }),
-      // No odometer window = we don't know what it ran, so this week can't
-      // set a record (a planning-field 0 must never read as a flawless week).
-      mkLoad({ load_id: "z", delivery_date: "2026-06-15", loaded_miles: 900, deadhead_miles: 0 }),
-    ];
-    const pb = personalBests(loads, [], fuel, NOW);
-    expect(pb.lowestDeadheadPct).toBeCloseTo(100 / 1100, 4); // NOT 0
-  });
-
-  it("counts a non-revenue trip as fully empty miles in the week's deadhead", () => {
-    const loads = [
-      mkLoad({ load_id: "a", delivery_date: "2026-05-12", loaded_miles: 1000, odometer_start: 570000, odometer_end: 571100 }),
-    ];
-    // 400 mi run home empty that same week: 1500 run, 1000 loaded → 500 empty.
-    const trips = [
-      { trip_date: "2026-05-13", odometer_start: 571100, odometer_end: 571500 },
-    ] as unknown as Trip[];
-    const pb = personalBests(loads, trips, fuel, NOW);
-    expect(pb.lowestDeadheadPct).toBeCloseTo(500 / 1500, 4);
   });
 });
 

--- a/frontend/src/lib/metrics/playerCard.ts
+++ b/frontend/src/lib/metrics/playerCard.ts
@@ -6,7 +6,7 @@ import type { Load } from "@/types/load";
 import type { Trip } from "@/types/trip";
 import type { ExpensePeriod } from "@/types/expense";
 import type { FuelEntry } from "@/types/fuelEntry";
-import { deadheadPctOver, hasOdometerWindow } from "./deadhead";
+import { deadheadPctOver } from "./deadhead";
 import {
   loadRevenue,
   completeMonthsBefore,
@@ -235,7 +235,6 @@ export const getSeasonStats = (
 // ---------- personal bests (records) ----------
 export interface PersonalBests {
   bestWeekRevenue: number | null;
-  lowestDeadheadPct: number | null;
   bestMpg: number | null;
   biggestLoad: number | null;
   mostLoadsInWeek: number | null;
@@ -248,26 +247,8 @@ const weekKey = (iso: string): string => {
   return monday.toISOString().slice(0, 10);
 };
 
-// Group by pay-week key, skipping anything without a date to place it.
-const byWeek = <T,>(
-  items: T[],
-  dateOf: (x: T) => string | null | undefined,
-): Map<string, T[]> => {
-  const m = new Map<string, T[]>();
-  for (const it of items) {
-    const d = dateOf(it);
-    if (!d) continue;
-    const k = weekKey(d);
-    const arr = m.get(k);
-    if (arr) arr.push(it);
-    else m.set(k, [it]);
-  }
-  return m;
-};
-
 export const personalBests = (
   loads: Load[],
-  trips: Trip[],
   fuel: FuelEntry[],
   now: Date,
 ): PersonalBests => {
@@ -291,21 +272,6 @@ export const personalBests = (
     if (mostLoadsInWeek == null || w.count > mostLoadsInWeek) mostLoadsInWeek = w.count;
   }
 
-  // Lowest weekly deadhead, odometer-derived with trips counted as fully empty.
-  // A week only stands as a record if EVERY load in it ran with both readings —
-  // a partly-measured week would set a flattering record on incomplete data.
-  const loadWeeks = byWeek(delivered, (l) => l.delivery_date);
-  const tripWeeks = byWeek(trips, (t) => t.trip_date);
-  let lowestDeadheadPct: number | null = null;
-  for (const k of new Set([...loadWeeks.keys(), ...tripWeeks.keys()])) {
-    const ls = loadWeeks.get(k) ?? [];
-    if (ls.length > 0 && !ls.every(hasOdometerWindow)) continue;
-    const pct = deadheadPctOver(ls, tripWeeks.get(k) ?? []);
-    if (pct == null) continue;
-    if (lowestDeadheadPct == null || pct < lowestDeadheadPct)
-      lowestDeadheadPct = pct;
-  }
-
   const biggestLoad = delivered.reduce<number | null>((m, l) => {
     const r = loadRevenue(l);
     return m == null || r > m ? r : m;
@@ -313,7 +279,6 @@ export const personalBests = (
 
   return {
     bestWeekRevenue,
-    lowestDeadheadPct,
     bestMpg: fuelStats(fuel, now).bestMpg,
     biggestLoad,
     mostLoadsInWeek,

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -186,8 +186,8 @@ const DriverDetailPage = () => {
       utilGrade: utilizationGrade(utilization),
       windowRpm: basis.windowRpm,
       medals: earnedMedals(medals),
-      bests: personalBests(driverLoads, driverTrips, fuel, now),
-      patches: computePatches(driverLoads, driverTrips, fuel, operation),
+      bests: personalBests(driverLoads, fuel, now),
+      patches: computePatches(driverLoads, fuel, operation),
       // Equipment identity — oversize and heavy haul kept as separate disciplines.
       oversize: loadTypeMix(driverLoads, "oversize"),
       heavyHaul: loadTypeMix(driverLoads, "heavy haul"),


### PR DESCRIPTION
Deadhead is a structural cost of oversize freight (30-40% is normal), not a feat to chase — and a "week under 10% deadhead" achievement was actively misleading. It sat on the driver card with no date, so a real but one-off February week (5.1%, the only sub-10% week in 27) read like a claim about the *current* week — right when Jason was deep in a legitimate 42.6% week. His call: drop it rather than dress it up.

## Removed

- **Clean Run** driver patch (`patches.ts`) + its `PATCH_GUIDE` entry — so it also drops from the Guide's driver-patches list (which maps that array).
- **Best Deadhead** record: `lowestDeadheadPct` off `PersonalBests`, its Record Book chip, and its award-pop record in `awards.ts`.
- The now-unused `trips` arg to `computePatches` / `personalBests` and their dead `deadheadPctOver` / `hasOdometerWindow` imports.

## Untouched

- The dashboard deadhead KPI, the driver **season deadhead stat** (`getSeasonStats` keeps `trips`), and per-load deadhead on load detail — all still odometer-derived. Deadhead as a *measurement* stays; deadhead as a *trophy* is gone.
- The dispatcher **Lean Machine / Grand Slam** (Brandie's booking awards). Choosing low-deadhead loads is a real booking skill she controls — a different thing from grading the owner on freight already run.

## Notes

Existing per-device "seen" award stores keep stale `clean-run` / `best-deadhead` ids harmlessly — those ids never regenerate, so nothing re-pops.

Build clean, 353 tests green (two deadhead-record tests removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)