### PR TITLE
fix: fuel % should be of net, not gross

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.105.0",
+  "version": "1.105.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/fuel/FuelVsRevenueCard.tsx
+++ b/frontend/src/components/fuel/FuelVsRevenueCard.tsx
@@ -98,13 +98,13 @@ export const FuelVsRevenueCard = ({ data }: { data: FuelVsRevenue }) => {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4">
         <div className="rounded-md p-3" style={{ background: "#141a26" }}>
-          <p className="text-xs text-muted-text">Fuel · % of gross</p>
+          <p className="text-xs text-muted-text">Fuel · % of net</p>
           <p className="text-2xl font-condensed mt-1 text-light">
-            {m.fuelPctGross == null ? "—" : pct0(m.fuelPctGross)}
+            {m.fuelPctNet == null ? "—" : pct0(m.fuelPctNet)}
           </p>
           <p className="text-[11px] text-muted-text mt-0.5">
             {money0(m.fuelSpend)}
-            {m.gross > 0 ? ` of ${money0(m.gross)} gross` : ""}
+            {m.net > 0 ? ` of ${money0(m.net)} net` : ""}
           </p>
         </div>
 

--- a/frontend/src/lib/metrics/fuelRevenue.test.ts
+++ b/frontend/src/lib/metrics/fuelRevenue.test.ts
@@ -18,7 +18,8 @@ const fuel = (o: Partial<FuelEntry>): FuelEntry =>
     ...o,
   }) as FuelEntry;
 
-// loadGross falls back to linehaul + fuel_surcharge + total_accessorials.
+// loadRevenue uses net_revenue when present (what the business keeps after the
+// carrier's cut), else falls back to gross. Set net_revenue to exercise net.
 const load = (o: Partial<Load>): Load =>
   ({
     load_status: "delivered",
@@ -30,26 +31,28 @@ const load = (o: Partial<Load>): Load =>
   }) as unknown as Load;
 
 describe("fuelVsRevenue", () => {
-  it("computes fuel %-of-gross and surcharge coverage per month", () => {
+  it("computes fuel %-of-NET and surcharge coverage per month", () => {
     const entries = [
       fuel({ fuel_date: "2026-06-05", gallons: 100, price_per_gallon: 4 }), // $400
       fuel({ fuel_date: "2026-06-20", gallons: 100, price_per_gallon: 4 }), // $400 → June $800
     ];
     const loads = [
+      // gross would be 10000, but net (what the business keeps) is 7300.
       load({
         delivery_date: "2026-06-15",
         linehaul: "9000",
         fuel_surcharge: "1000",
-      }), // gross 10000, fsc 1000
+        net_revenue: "7300",
+      }),
     ];
     const r = fuelVsRevenue(entries, loads);
     expect(r.months).toHaveLength(1);
     const jun = r.months[0];
     expect(jun.month).toBe("2026-06");
     expect(jun.fuelSpend).toBeCloseTo(800, 2);
-    expect(jun.gross).toBeCloseTo(10000, 2);
+    expect(jun.net).toBeCloseTo(7300, 2); // NET, not the 10000 gross
     expect(jun.fsc).toBeCloseTo(1000, 2);
-    expect(jun.fuelPctGross).toBeCloseTo(0.08, 4); // 800 / 10000
+    expect(jun.fuelPctNet).toBeCloseTo(800 / 7300, 4); // 11.0%, not 8% of gross
     expect(jun.fscCoverage).toBeCloseTo(1.25, 4); // 1000 / 800 → surcharge covered fuel
     expect(r.latest?.month).toBe("2026-06");
   });
@@ -100,9 +103,9 @@ describe("fuelVsRevenue", () => {
     expect(r.latest).toBeNull();
   });
 
-  it("leaves %-of-gross null when a fuel month has no delivered revenue", () => {
+  it("leaves %-of-net null when a fuel month has no delivered revenue", () => {
     const r = fuelVsRevenue([fuel({ fuel_date: "2026-06-10" })], []);
-    expect(r.months[0].fuelPctGross).toBeNull();
+    expect(r.months[0].fuelPctNet).toBeNull();
     expect(r.months[0].fscCoverage).toBeCloseTo(0, 4); // fsc 0 / spend
   });
 });

--- a/frontend/src/lib/metrics/fuelRevenue.ts
+++ b/frontend/src/lib/metrics/fuelRevenue.ts
@@ -1,19 +1,22 @@
 import type { Load } from "@/types/load";
 import type { FuelEntry } from "@/types/fuelEntry";
-import { loadGross } from "./rateTargets";
+import { loadRevenue } from "./rateTargets";
 
 // Fuel against the money it relates to, per month. Two readings:
-//   • fuelPctGross  — fuel spend as a share of gross revenue (the cost view)
-//   • fscCoverage   — fuel-surcharge collected ÷ fuel spend; ≥1 means the
-//                     surcharge paid for the fuel, <1 means the gap comes out
-//                     of linehaul. This is the one that moves money for a BCO
-//                     who keeps 100% of FSC.
+//   • fuelPctNet   — fuel spend as a share of NET revenue (what the business
+//                    actually keeps after the carrier's cut). Net is the honest
+//                    denominator: fuel is paid out of net, not out of the full
+//                    customer rate that includes Landstar's slice.
+//   • fscCoverage  — fuel-surcharge collected ÷ fuel spend; ≥1 means the
+//                    surcharge paid for the fuel, <1 means the gap comes out
+//                    of linehaul. This is the one that moves money for a BCO
+//                    who keeps 100% of FSC.
 export interface FuelMonth {
   month: string; // "YYYY-MM"
   fuelSpend: number; // Σ gallons × price/gal that month
-  gross: number; // Σ gross revenue delivered that month
+  net: number; // Σ net revenue delivered that month (after the carrier's cut)
   fsc: number; // Σ fuel surcharge delivered that month
-  fuelPctGross: number | null; // null when no gross that month
+  fuelPctNet: number | null; // null when no net that month
   fscCoverage: number | null; // null when no fuel that month (never shown then)
 }
 
@@ -38,13 +41,15 @@ export const fuelVsRevenue = (
     spend.set(k, (spend.get(k) ?? 0) + dollars);
   }
 
-  // Gross + fuel surcharge per month, from delivered loads.
-  const gross = new Map<string, number>();
+  // Net revenue + fuel surcharge per month, from delivered loads. Net is via
+  // loadRevenue (the carrier's cut already taken out) — the money the fuel is
+  // actually paid from.
+  const net = new Map<string, number>();
   const fsc = new Map<string, number>();
   for (const l of loads) {
     if (l.load_status !== "delivered" || !l.delivery_date) continue;
     const k = monthKey(l.delivery_date);
-    gross.set(k, (gross.get(k) ?? 0) + loadGross(l));
+    net.set(k, (net.get(k) ?? 0) + loadRevenue(l));
     fsc.set(k, (fsc.get(k) ?? 0) + (Number(l.fuel_surcharge) || 0));
   }
 
@@ -55,14 +60,14 @@ export const fuelVsRevenue = (
     .sort()
     .map((k) => {
       const fuelSpend = spend.get(k) ?? 0;
-      const g = gross.get(k) ?? 0;
+      const n = net.get(k) ?? 0;
       const f = fsc.get(k) ?? 0;
       return {
         month: k,
         fuelSpend,
-        gross: g,
+        net: n,
         fsc: f,
-        fuelPctGross: g > 0 ? fuelSpend / g : null,
+        fuelPctNet: n > 0 ? fuelSpend / n : null,
         fscCoverage: fuelSpend > 0 ? f / fuelSpend : null,
       };
     });

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -799,25 +799,28 @@ const GuidePage = () => {
 
           <Metric
             title="Fuel vs revenue — is the surcharge covering your fuel?"
-            answers="Two reads on your fuel each month: what slice of gross it eats, and whether the fuel surcharge you collect still pays for it."
+            answers="Two reads on your fuel each month: what slice of your net it eats, and whether the fuel surcharge you collect still pays for it."
             sources={[{ label: "Fuel", to: "/fuel-entries" }]}
           >
             <Formula>
-              fuel · % of gross = fuel spend ÷ gross revenue
+              fuel · % of net = fuel spend ÷ net revenue
               <br />
               <span style={{ color: AMBER_HI }}>
                 surcharge covers = fuel surcharge collected ÷ fuel spend
               </span>
             </Formula>
             <Eg>
-              July: $4,080 fuel on $31,660 gross ={" "}
-              <span className="text-light">13%</span>. Surcharge collected was
+              July: $4,080 fuel on $23,883 net ={" "}
+              <span className="text-light">17%</span>. Surcharge collected was
               $2,857, so it covered <span className="text-light">70%</span> of
               the fuel — the missing $1,223 came out of linehaul.
             </Eg>
             <Why>
-              You keep 100% of the fuel surcharge, so it's meant to offset
-              diesel. When{" "}
+              It's measured against <span className="text-light">net</span>, not
+              gross, because you pay for fuel out of what your business actually
+              keeps — after Landstar's cut — not the full customer rate. (Gross
+              would read a flattering 13%; the honest number is 17%.) You keep
+              100% of the fuel surcharge, so it's meant to offset diesel: when{" "}
               <span className="text-light">surcharge covers ≥ 100%</span> the
               freight paid for its own fuel; under 100%, the gap eats into your
               linehaul. It's been slipping — the surcharge fell while diesel


### PR DESCRIPTION
Follow-up to #300. Jason's call, and he's right: fuel is paid out of **net** — what the business keeps after Landstar's cut — not the full customer gross that includes the carrier's slice. Measuring against gross understated the burden, and it contradicts the app's own rule (owner/asset economics use net; only agents and lanes use gross). I'd anchored on the industry benchmark instead of his money model.

## Change
- `fuelVsRevenue` takes revenue from `loadRevenue` (net) instead of `loadGross`.
- `FuelMonth.gross` / `fuelPctGross` → `net` / `fuelPctNet`; card reads **Fuel · % of net**.
- FSC coverage unchanged (FSC ÷ fuel spend — he keeps 100% of FSC).
- Guide updated: net formula, the 17% example, and why net is the honest basis.

## Effect
July fuel: **17.1% of net** vs the 12.9% of gross it showed before (net $23,883 at his 65% + 8% linehaul / 100% FSC settlement). Verified against prod.

Test now sets `net_revenue` (7300) distinct from gross (10000) to prove net is the denominator. 359 tests green, build clean.

`v1.105.1` — corrective, patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)