### PR TITLE
fix: truck "Loads hauled" counts delivered, not delivered-and-paid

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.105.1",
+  "version": "1.105.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/truckMetrics.test.ts
+++ b/frontend/src/lib/metrics/truckMetrics.test.ts
@@ -55,3 +55,30 @@ describe("computeTruckMetrics — days-based utilization", () => {
     expect(m.homeDays).toBe(0); // 01-06 is under load, not a home gap
   });
 });
+
+describe("computeTruckMetrics — loads hauled vs earned", () => {
+  const truck = { in_service_date: "2026-01-01", current_odometer: 0 } as Truck;
+  const unpaid = (pickup: string, delivery: string): Load =>
+    ({ ...load(pickup, delivery), payment_status: "invoiced" }) as Load;
+
+  it("counts loads HAULED as delivered — paid or not", () => {
+    const loads = [
+      load("2026-01-05", "2026-01-07"), // delivered + paid
+      load("2026-01-10", "2026-01-12"), // delivered + paid
+      unpaid("2026-01-15", "2026-01-17"), // delivered, NOT paid yet
+    ];
+    const m = run(truck, loads, []);
+    expect(m.loads).toBe(3); // all three were hauled
+    // Revenue still counts only the two paid loads.
+    expect(m.netRevenue).toBeCloseTo(2000, 2); // 2 × $1000, not 3
+  });
+
+  it("excludes cancelled/booked/in-transit from loads hauled", () => {
+    const loads = [
+      load("2026-01-05", "2026-01-07"), // delivered
+      { ...load("2026-01-10", "2026-01-12"), load_status: "cancelled" } as Load,
+      { ...load("2026-01-15", "2026-01-17"), load_status: "booked" } as Load,
+    ];
+    expect(run(truck, loads, []).loads).toBe(1);
+  });
+});

--- a/frontend/src/lib/metrics/truckMetrics.ts
+++ b/frontend/src/lib/metrics/truckMetrics.ts
@@ -60,6 +60,9 @@ export const computeTruckMetrics = (
   const earned = truckLoads.filter(
     (l) => l.load_status === "delivered" && l.payment_status === "paid",
   );
+  // Loads HAULED is delivered (paid or not) — payment status doesn't change
+  // whether the truck ran the load.
+  const delivered = truckLoads.filter((l) => l.load_status === "delivered");
   const netRevenue = earned.reduce((s, l) => s + loadRevenue(l), 0);
   const totalMiles = earned.reduce((s, l) => s + loadMiles(l), 0);
 
@@ -133,7 +136,7 @@ export const computeTruckMetrics = (
     milesPerMonth: monthsInService ? totalMiles / monthsInService : null,
     totalMiles,
     netRevenue,
-    loads: earned.length,
+    loads: delivered.length,
   };
 };
 

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -143,6 +143,13 @@ const TruckDetailPage = () => {
       ),
     [truckLoads],
   );
+  // "Loads hauled" is about work run, so it's delivered — paid or not. A load you
+  // delivered but haven't been paid for yet was still hauled. (Revenue stays on
+  // earnedLoads: you've only earned money on the paid ones.)
+  const deliveredLoads = useMemo(
+    () => truckLoads.filter((l) => l.load_status === "delivered"),
+    [truckLoads],
+  );
 
   // Latest odometer, derived from the app: stored value + newest load + newest
   // trip + newest service reading + newest fuel fill-up (fuel is usually freshest).
@@ -368,7 +375,7 @@ const TruckDetailPage = () => {
         </Link>
         <Panel className="p-4">
           <p className="text-xs text-muted-text mb-1">Loads hauled</p>
-          <p className="text-2xl font-condensed">{earnedLoads.length}</p>
+          <p className="text-2xl font-condensed">{deliveredLoads.length}</p>
         </Panel>
         <Panel className="p-4">
           <p className="text-xs text-muted-text mb-1">Net revenue · all time</p>
@@ -378,11 +385,11 @@ const TruckDetailPage = () => {
 
       <Panel className="p-4 mt-4">
         <p className="text-xs text-muted-text mb-2">Recent loads</p>
-        {earnedLoads.length === 0 ? (
+        {deliveredLoads.length === 0 ? (
           <p className="text-sm text-muted-text">None on this truck yet.</p>
         ) : (
           <div className="text-sm divide-y divide-steel">
-            {earnedLoads.slice(0, 6).map((l) => (
+            {deliveredLoads.slice(0, 6).map((l) => (
               <div key={l.load_id} className="py-2 flex justify-between">
                 <span>
                   {l.origin_market} → {l.delivery_market}


### PR DESCRIPTION
Jason flagged the Trucks page showing "40-something" (49) loads as inaccurate. Traced it: "Loads hauled" was counting delivered **AND paid**, so a load he delivered but hasn't been paid for yet went uncounted. Payment status has nothing to do with whether the truck hauled the load — and the label says "hauled."

## Fix
- **TruckDetailPage**: "Loads hauled" count + Recent-loads list now use `deliveredLoads` (delivered, paid or not). Revenue keeps `earnedLoads` (delivered+paid) — you've only *earned* on the paid ones. Reads the honest "50 hauled, earned on 49."
- **computeTruckMetrics.loads** → delivered count, so the fleet-comparison table agrees.

## Not touched (confirmed correct with Jason)
The driver card's oversize count stays **delivered (13)**. His website counts all 16 oversize — including a **cancelled** load that was never hauled. 13 is the right "hauled" number; `loadTypeMix` already uses delivered. The equipment mix was never wrong.

## Verification
Prod: delivered on the truck = **50**, delivered+paid = **49** — exactly the intended split. Build clean, 361 tests (2 new: a delivered-unpaid load counts as hauled but not toward revenue; cancelled/booked/in-transit excluded).

`v1.105.2` — corrective, patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)