### PR TITLE
feat: sidebar — single-open accordion, Money group, and icons

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.105.2",
+  "version": "1.106.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1,5 +1,17 @@
 import { useState, useEffect } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  LayoutDashboard,
+  Target,
+  Package,
+  Truck,
+  Wallet,
+  ShieldCheck,
+  Trophy,
+  BookOpen,
+  type LucideIcon,
+} from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
@@ -20,16 +32,21 @@ import { isDispatcher } from "@/lib/roles";
 // `adminOnly` items are owner-only; a dispatcher's nav filters them out (and the
 // route guard bounces her if she types the URL). Keep these flags in lockstep
 // with ADMIN_ONLY_PREFIXES in lib/roles.
-type Leaf = { to: string; label: string; adminOnly?: boolean };
-type Group = { label: string; children: Leaf[] };
+type Child = { to: string; label: string; adminOnly?: boolean };
+type Leaf = Child & { icon: LucideIcon };
+type Group = { label: string; icon: LucideIcon; children: Child[] };
 type Entry = Leaf | Group;
 const isGroup = (e: Entry): e is Group => "children" in e;
 
+// Top level stays short: two quick actions, three grouped areas, three flat
+// references. The Money group is entirely owner pages, so it disappears for a
+// dispatcher once the admin children filter out.
 const nav: Entry[] = [
-  { to: "/dashboard", label: "Dashboard" },
-  { to: "/score", label: "Score a Load" },
+  { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { to: "/score", label: "Score a Load", icon: Target },
   {
     label: "Freight",
+    icon: Package,
     children: [
       { to: "/loads", label: "Loads" },
       { to: "/trips", label: "Trips" },
@@ -40,6 +57,7 @@ const nav: Entry[] = [
   },
   {
     label: "Fleet",
+    icon: Truck,
     children: [
       { to: "/trucks", label: "Trucks" },
       { to: "/trailers", label: "Trailers" },
@@ -48,13 +66,19 @@ const nav: Entry[] = [
       { to: "/fuel-entries", label: "Fuel", adminOnly: true },
     ],
   },
-  { to: "/compliance", label: "Compliance" },
-  { to: "/expenses", label: "Expenses", adminOnly: true },
-  { to: "/per-diem", label: "Per Diem", adminOnly: true },
-  { to: "/recap", label: "Recap", adminOnly: true },
-  { to: "/garage", label: "Garage", adminOnly: true },
-  { to: "/trophy-room", label: "Trophy Room", adminOnly: true },
-  { to: "/guide", label: "Guide" },
+  {
+    label: "Money",
+    icon: Wallet,
+    children: [
+      { to: "/expenses", label: "Expenses", adminOnly: true },
+      { to: "/per-diem", label: "Per Diem", adminOnly: true },
+      { to: "/recap", label: "Recap", adminOnly: true },
+      { to: "/garage", label: "Garage", adminOnly: true },
+    ],
+  },
+  { to: "/compliance", label: "Compliance", icon: ShieldCheck },
+  { to: "/trophy-room", label: "Trophy Room", icon: Trophy, adminOnly: true },
+  { to: "/guide", label: "Guide", icon: BookOpen },
 ];
 
 // A dispatcher sees only the non-adminOnly items; empty groups drop out.
@@ -66,7 +90,9 @@ const navFor = (dispatcher: boolean): Entry[] => {
         ? { ...e, children: e.children.filter((c) => !c.adminOnly) }
         : e,
     )
-    .filter((e) => (isGroup(e) ? e.children.length > 0 : !e.adminOnly));
+    .filter((e) =>
+      isGroup(e) ? e.children.length > 0 : !(e as Leaf).adminOnly,
+    );
 };
 
 const AppSidebar = () => {
@@ -75,6 +101,9 @@ const AppSidebar = () => {
   const navItems = navFor(dispatcher);
   const active = (to: string) =>
     pathname === to || pathname.startsWith(to + "/");
+  const groupOf = (items: Entry[]): string | null =>
+    items.find((e) => isGroup(e) && e.children.some((c) => active(c.to)))
+      ?.label ?? null;
 
   // On a phone the sidebar is an off-canvas sheet; tapping a destination should
   // dismiss it so the page is visible, instead of leaving it covering the screen.
@@ -84,21 +113,18 @@ const AppSidebar = () => {
     if (isMobile) setOpenMobile(false);
   };
 
-  // A group starts open if it holds the current route; navigating into a group
-  // opens it, but manual toggles of the others are preserved.
-  const [open, setOpen] = useState<Record<string, boolean>>(() => {
-    const init: Record<string, boolean> = {};
-    for (const e of navItems)
-      if (isGroup(e)) init[e.label] = e.children.some((c) => active(c.to));
-    return init;
-  });
-
+  // Single-open accordion: at most one group is expanded, and it's the one
+  // holding the current page. Navigating snaps the open group to the new route
+  // (a flat page closes them all), so the list never sprawls.
+  const [openGroup, setOpenGroup] = useState<string | null>(() =>
+    groupOf(navItems),
+  );
   useEffect(() => {
-    for (const e of navItems)
-      if (isGroup(e) && e.children.some((c) => active(c.to)))
-        setOpen((o) => ({ ...o, [e.label]: true }));
+    setOpenGroup(groupOf(navItems));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
+  const toggleGroup = (label: string) =>
+    setOpenGroup((cur) => (cur === label ? null : label));
 
   const linkCls = (to: string) =>
     active(to)
@@ -108,7 +134,9 @@ const AppSidebar = () => {
   return (
     <Sidebar>
       <SidebarHeader>
-        <div className="p-4 font-bold text-sidebar-foreground text-xl">Dash</div>
+        <div className="p-4 font-bold text-sidebar-foreground text-xl">
+          Dash
+        </div>
       </SidebarHeader>
 
       <SidebarContent>
@@ -118,19 +146,20 @@ const AppSidebar = () => {
               isGroup(e) ? (
                 <SidebarMenuItem key={e.label}>
                   <SidebarMenuButton
-                    onClick={() =>
-                      setOpen((o) => ({ ...o, [e.label]: !o[e.label] }))
-                    }
+                    onClick={() => toggleGroup(e.label)}
                     className="!bg-transparent hover:!bg-transparent justify-between !text-sidebar-foreground"
                   >
-                    <span>{e.label}</span>
-                    {open[e.label] ? (
+                    <span className="flex items-center gap-2.5">
+                      <e.icon size={16} className="shrink-0" />
+                      {e.label}
+                    </span>
+                    {openGroup === e.label ? (
                       <ChevronDown size={16} />
                     ) : (
                       <ChevronRight size={16} />
                     )}
                   </SidebarMenuButton>
-                  {open[e.label] && (
+                  {openGroup === e.label && (
                     <SidebarMenuSub>
                       {e.children.map((c) => (
                         <SidebarMenuSubItem key={c.to}>
@@ -160,8 +189,9 @@ const AppSidebar = () => {
                     <Link
                       to={e.to}
                       onClick={closeOnNav}
-                      className={linkCls(e.to)}
+                      className={`flex items-center gap-2.5 ${linkCls(e.to)}`}
                     >
+                      <e.icon size={16} className="shrink-0" />
                       {e.label}
                     </Link>
                   </SidebarMenuButton>


### PR DESCRIPTION
Two nav UX problems: it was long (11 top-level items), and expanded groups stayed open independently — opening both Freight and Fleet put ~22 rows on screen, rough in the mobile sheet.

## Changes
- **Single-open accordion** — at most one group expanded, and it's the one holding the current page. Toggling a group closes the others; navigating snaps the open group to the new route (a flat page closes them all). Replaces the old multi-open `Record<string, boolean>`.
- **New "Money" group** — folds the owner pages (Expenses, Per Diem, Recap, Garage) off the top level → **8 top-level items instead of 11**. Entirely admin children, so it disappears for a dispatcher (`navFor` drops empty groups) — Brandie's nav gets shorter too.
- **Icons** — one lucide icon per top-level item + group; sub-items stay text-only and indented.

Mobile auto-close (`setOpenMobile` on nav) unchanged.

## Verification
Driven in the browser at desktop and 375px: 8-item top level with icons, Money group present, and single-open confirmed (opening Fleet collapsed Freight). Mobile sheet clean and still auto-closes on tap. Build + lint clean, 361 tests.

`v1.106.0` — additive UX, minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)