### PR TITLE
fix: stop delivered loads scrolling the page sideways on mobile

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.107.0",
+  "version": "1.107.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -10,8 +10,13 @@ const AppLayout = () => {
           <AppSidebar />
 
           {/* min-w-0 lets wide tables scroll inside their card instead of
-              forcing the whole page to scroll sideways on a phone. */}
-          <main className="flex-1 min-w-0 overflow-y-auto bg-background text-foreground">
+              forcing the whole page to scroll sideways on a phone; overflow-x-hidden
+              is the hard floor — nothing (e.g. the rotated rubber-stamp, whose
+              transform sits outside flex layout) can scroll the whole page
+              sideways. Wide content that must scroll keeps its own overflow-x-auto
+              scroller, so this only clips true page-level overflow, never a table.
+              overflow-y stays auto, so vertical scroll and sticky children work. */}
+          <main className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden bg-background text-foreground">
             <div className="p-3 border-b border-border">
               <SidebarTrigger />
             </div>


### PR DESCRIPTION
The load-detail page still slid left-right on a phone for stamped loads (delivered / paid / cancelled), even after the v1.104.0 header wrap fix.

## Root cause
The `RubberStamp` slam animation holds `transform: rotate(-12deg) scale(1)` (and starts at `scale(2.6)`). **CSS transforms don't participate in flex layout** — so `flex-wrap` laid the stamp out at its normal size while its rotated/scaled visual box still pushed past the viewport. Only stamped loads overflowed, which is why the earlier wrap didn't catch it.

## Fix
Add `overflow-x-hidden` to the main scroll container in `AppLayout`. It was already `overflow-y-auto` with a comment that the page shouldn't scroll sideways — this makes that a hard floor. Wide tables keep their own `overflow-x-auto` scrollers, so only true page-level overflow is clipped; `overflow-y` stays auto so vertical scroll and sticky children keep working.

## Verification (in the browser)
- Injected a `rotate(-12deg) scale(2.6)` DELIVERED stamp at the right edge → page **cannot** scroll sideways (`canPageScrollSideways: false`).
- Vertical scroll still works.
- Guide's sticky rail still pins on scroll (top 181 → 24px = its `top-6` offset) — confirming `overflow-x-hidden` didn't break sticky.

Build + 361 tests green. `v1.107.1` — corrective, patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)