### PR TITLE
feat: trips capture start/end location; prefill from truck's last-known spot

### DIFF
--- a/backend/db/migrations/051_trip_location.sql
+++ b/backend/db/migrations/051_trip_location.sql
@@ -1,0 +1,11 @@
+-- Trips now record WHERE the truck went, not just how far. start_/end_ city+state
+-- let a completed trip advance the truck's last-known location — loads and fuel
+-- already stamp it; trips were the blind spot (deadhead home, repositioning).
+-- All nullable: existing trips have none, and a quick trip can still be logged
+-- bare. ALTER only (no new table) → no RLS statement required.
+
+ALTER TABLE trips
+  ADD COLUMN IF NOT EXISTS start_city VARCHAR(50),
+  ADD COLUMN IF NOT EXISTS start_state CHAR(2),
+  ADD COLUMN IF NOT EXISTS end_city VARCHAR(50),
+  ADD COLUMN IF NOT EXISTS end_state CHAR(2);

--- a/backend/src/routes/tripRoutes.js
+++ b/backend/src/routes/tripRoutes.js
@@ -4,6 +4,7 @@ import {
   getTrips,
   getTrip,
   getLatestOdometer,
+  getLastKnownLocation,
   createTrip,
   patchTrip,
   deleteTrip,
@@ -49,6 +50,31 @@ router.get("/latest-odometer", async (req, res) => {
     return res.status(200).json({
       message: "Latest odometer retrieved successfully",
       latest_odometer,
+    });
+  } catch (err) {
+    if (err.type === "validation") {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+// ---- GET LAST KNOWN LOCATION ----
+// Also before "/:id" so Express doesn't match it as a trip id.
+
+router.get("/last-known-location", async (req, res) => {
+  try {
+    const user_id = req.user.user_id;
+
+    const location = await getLastKnownLocation(user_id);
+
+    return res.status(200).json({
+      message: "Last known location retrieved successfully",
+      location,
     });
   } catch (err) {
     if (err.type === "validation") {

--- a/backend/src/services/tripServices.js
+++ b/backend/src/services/tripServices.js
@@ -32,6 +32,10 @@ export async function getTrips(user_id) {
             odometer_start,
             odometer_end,
             is_estimated,
+            start_city,
+            start_state,
+            end_city,
+            end_state,
             trips.created_at,
             trips.updated_at
         FROM trips
@@ -67,6 +71,10 @@ export async function getTrip(user_id, trip_id) {
             odometer_start,
             odometer_end,
             is_estimated,
+            start_city,
+            start_state,
+            end_city,
+            end_state,
             trips.created_at,
             trips.updated_at
         FROM trips
@@ -105,6 +113,41 @@ export async function getLatestOdometer(user_id) {
   return result.rows[0].latest_odometer; // number | null
 }
 
+// ---- GET LAST KNOWN LOCATION SERVICE ----
+// Where the truck currently sits, derived from the records that already stamp a
+// location: a delivered load ends at its destination, a fuel stop at the pump,
+// a trip at its end. The highest odometer among them is the furthest — and
+// therefore latest — point the truck reached, so its city/state is "now".
+// Trips were the blind spot until they carried an end city/state (migration 051).
+// Maintenance is deliberately excluded — its location is free text, not a clean
+// city/state. Used to prefill a new trip's start location. Returns null when no
+// located record exists yet. Global across trucks, like getLatestOdometer.
+export async function getLastKnownLocation(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+
+  const query = `
+        SELECT city, state FROM (
+            SELECT destination_city AS city, destination_state AS state, odometer_end AS odo
+                FROM loads
+                WHERE user_id = $1 AND odometer_end IS NOT NULL
+            UNION ALL
+            SELECT fuel_city AS city, fuel_state AS state, odometer_reading AS odo
+                FROM fuel_entries
+                WHERE user_id = $1
+            UNION ALL
+            SELECT end_city AS city, end_state AS state, odometer_end AS odo
+                FROM trips
+                WHERE user_id = $1 AND odometer_end IS NOT NULL AND end_city IS NOT NULL
+        ) located
+        ORDER BY odo DESC NULLS LAST
+        LIMIT 1;
+    `;
+
+  const result = await db.query(query, [user_id]);
+
+  return result.rows[0] ?? null; // { city, state } | null
+}
+
 // ---- CREATE TRIP SERVICE ----
 export async function createTrip(user_id, data) {
   // Reject missing user_id
@@ -119,6 +162,10 @@ export async function createTrip(user_id, data) {
     "odometer_start",
     "odometer_end",
     "is_estimated",
+    "start_city",
+    "start_state",
+    "end_city",
+    "end_state",
   ];
 
   for (const field in data) {
@@ -195,6 +242,10 @@ export async function patchTrip(user_id, trip_id, data) {
     "trip_date",
     "odometer_start",
     "odometer_end",
+    "start_city",
+    "start_state",
+    "end_city",
+    "end_state",
   ];
 
   // Throw error if data contains invalid field(s)

--- a/backend/src/utils/validation/tripsValidation.js
+++ b/backend/src/utils/validation/tripsValidation.js
@@ -5,7 +5,32 @@
  * trip_date, odometer_start, odometer_end, is_estimated
  */
 
+// Location is optional; when present, a city is a short string and a state is a
+// 2-letter code. null/undefined skip (the field just isn't set).
+const cityRule = (field) => (value, errors) => {
+  if (value == null) return;
+  if (typeof value !== "string") {
+    errors.push(`${field} must be a string`);
+    return;
+  }
+  if (value.length > 50) errors.push(`${field} must be 50 characters or fewer`);
+};
+
+const stateRule = (field) => (value, errors) => {
+  if (value == null) return;
+  if (typeof value !== "string") {
+    errors.push(`${field} must be a string`);
+    return;
+  }
+  if (value.trim().length !== 2)
+    errors.push(`${field} must be a 2-letter state code`);
+};
+
 const rules = {
+  start_city: cityRule("start_city"),
+  start_state: stateRule("start_state"),
+  end_city: cityRule("end_city"),
+  end_state: stateRule("end_state"),
   trip_date: (value, errors) => {
     // Check if date is a string
     if (typeof value !== "string") {

--- a/backend/src/utils/validation/tripsValidation.test.js
+++ b/backend/src/utils/validation/tripsValidation.test.js
@@ -1,0 +1,61 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  validateTripCreate,
+  validateTripPatch,
+} from "./tripsValidation.js";
+
+// A minimal valid create payload; individual tests override the location fields.
+const base = { trip_date: "2026-07-24", trip_purpose: "home" };
+
+describe("trip location validation", () => {
+  test("accepts a full start + end city/state", () => {
+    const errors = validateTripCreate({
+      ...base,
+      start_city: "Irving",
+      start_state: "TX",
+      end_city: "Laredo",
+      end_state: "TX",
+    });
+    assert.deepEqual(errors, []);
+  });
+
+  test("location is optional — a bare trip passes", () => {
+    assert.deepEqual(validateTripCreate(base), []);
+  });
+
+  test("null/undefined location fields are skipped, not errors", () => {
+    const errors = validateTripCreate({
+      ...base,
+      start_city: null,
+      end_state: undefined,
+    });
+    assert.deepEqual(errors, []);
+  });
+
+  test("rejects a state that isn't 2 letters", () => {
+    const errors = validateTripCreate({ ...base, end_state: "Texas" });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /end_state must be a 2-letter state code/);
+  });
+
+  test("rejects a city longer than 50 characters", () => {
+    const errors = validateTripCreate({ ...base, start_city: "x".repeat(51) });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /start_city must be 50 characters or fewer/);
+  });
+
+  test("rejects a non-string city", () => {
+    const errors = validateTripCreate({ ...base, start_city: 123 });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /start_city must be a string/);
+  });
+
+  test("patch validates location the same way", () => {
+    assert.deepEqual(validateTripPatch({ end_city: "Dallas", end_state: "TX" }), []);
+    assert.match(
+      validateTripPatch({ start_state: "T" })[0],
+      /start_state must be a 2-letter state code/,
+    );
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.108.1",
+  "version": "1.109.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/TripForm.tsx
+++ b/frontend/src/components/TripForm.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect } from "react";
 import type { TripInput } from "@/types/tripInput";
-import { createTrip, getLatestOdometer } from "@/services/tripsService";
+import {
+  createTrip,
+  getLatestOdometer,
+  getLastKnownLocation,
+} from "@/services/tripsService";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -34,6 +38,10 @@ const TripForm = ({ onSuccess, onClose }: TripFormProps) => {
     odometer_start: undefined,
     odometer_end: undefined,
     is_estimated: true,
+    start_city: "",
+    start_state: "",
+    end_city: "",
+    end_state: "",
   });
 
   const [error, setError] = useState<string | null>(null);
@@ -51,6 +59,25 @@ const TripForm = ({ onSuccess, onClose }: TripFormProps) => {
         }
       })
       .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Prefill the START location with the truck's last known spot (the end of the
+  // most recent load/fuel/trip), so a trip begins where the truck actually is.
+  // Non-fatal, same as the odometer prefill: no data → fields stay blank.
+  useEffect(() => {
+    let active = true;
+    getLastKnownLocation().then((loc) => {
+      if (active && loc) {
+        setFormData((prev) => ({
+          ...prev,
+          start_city: loc.city ?? "",
+          start_state: loc.state ?? "",
+        }));
+      }
+    });
     return () => {
       active = false;
     };
@@ -76,9 +103,23 @@ const TripForm = ({ onSuccess, onClose }: TripFormProps) => {
       return;
     }
 
+    // Blank location fields → omit (stored NULL, not ""); states normalized to
+    // an uppercase 2-letter code so the location model matches cleanly.
+    const clean = (v?: string) => {
+      const t = v?.trim();
+      return t ? t : undefined;
+    };
+
     setSubmitting(true);
     try {
-      await createTrip({ ...formData, trip_purpose: purpose });
+      await createTrip({
+        ...formData,
+        trip_purpose: purpose,
+        start_city: clean(formData.start_city),
+        start_state: clean(formData.start_state)?.toUpperCase(),
+        end_city: clean(formData.end_city),
+        end_state: clean(formData.end_state)?.toUpperCase(),
+      });
       onSuccess();
       onClose();
     } catch (e) {
@@ -134,6 +175,53 @@ const TripForm = ({ onSuccess, onClose }: TripFormProps) => {
               </SelectGroup>
             </SelectContent>
           </Select>
+        </div>
+
+        {/* Start location — where the truck currently sits */}
+        <div>
+          <Label htmlFor="start_city">Start City</Label>
+          <Input
+            name="start_city"
+            id="start_city"
+            onChange={handleChange}
+            value={formData.start_city ?? ""}
+          />
+          <p className="text-xs text-muted-text mt-1">
+            Prefilled from your last known location.
+          </p>
+        </div>
+
+        {/* Start state */}
+        <div>
+          <Label htmlFor="start_state">Start State</Label>
+          <Input
+            name="start_state"
+            id="start_state"
+            onChange={handleChange}
+            value={formData.start_state ?? ""}
+          />
+        </div>
+
+        {/* End location — where the truck ends up (feeds its next last-known spot) */}
+        <div>
+          <Label htmlFor="end_city">End City</Label>
+          <Input
+            name="end_city"
+            id="end_city"
+            onChange={handleChange}
+            value={formData.end_city ?? ""}
+          />
+        </div>
+
+        {/* End state */}
+        <div>
+          <Label htmlFor="end_state">End State</Label>
+          <Input
+            name="end_state"
+            id="end_state"
+            onChange={handleChange}
+            value={formData.end_state ?? ""}
+          />
         </div>
 
         {/* Odometer start */}

--- a/frontend/src/lib/metrics/dashboard.test.ts
+++ b/frontend/src/lib/metrics/dashboard.test.ts
@@ -68,6 +68,10 @@ const baseTrip: Trip = {
   odometer_start: null,
   odometer_end: null,
   is_estimated: true,
+  start_city: null,
+  start_state: null,
+  end_city: null,
+  end_state: null,
   created_at: "",
   updated_at: "",
 };

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -749,7 +749,11 @@ const GuidePage = () => {
             <Why>
               Non-revenue trips (running home, to the shop) count as 100% empty
               — their whole odometer window is deadhead. Lower is better; every
-              empty mile is cost with no revenue against it.
+              empty mile is cost with no revenue against it. Logging a trip's{" "}
+              <span className="text-light">start and end city</span> keeps the
+              truck's last-known location current, so the next trip prefills
+              where the truck actually sits — loads and fuel already stamp it,
+              trips were the blind spot.
             </Why>
           </Metric>
 

--- a/frontend/src/pages/TripsPage.tsx
+++ b/frontend/src/pages/TripsPage.tsx
@@ -3,6 +3,21 @@ import { useTrips } from "@/hooks/useTrips";
 import TripForm from "@/components/TripForm";
 import { formatDate } from "@/lib/format";
 import { Button } from "@/components/ui/button";
+import type { Trip } from "@/types/trip";
+
+// "Irving, TX" from a city/state pair; falls back to whichever is present.
+const place = (city: string | null, state: string | null): string | null => {
+  if (city && state) return `${city}, ${state}`;
+  return state || city || null;
+};
+
+// "Irving, TX → Laredo, TX" for the trips table, or a dash when neither end is set.
+const tripRoute = (trip: Trip): string => {
+  const from = place(trip.start_city, trip.start_state);
+  const to = place(trip.end_city, trip.end_state);
+  if (!from && !to) return "—";
+  return `${from ?? "?"} → ${to ?? "?"}`;
+};
 
 // Components
 import {
@@ -56,6 +71,7 @@ const TripsPage = () => {
               <TableHead>Trip #</TableHead>
               <TableHead>Date</TableHead>
               <TableHead>Purpose</TableHead>
+              <TableHead>Route</TableHead>
               <TableHead>OD Start</TableHead>
               <TableHead>OD End</TableHead>
             </TableRow>
@@ -68,6 +84,7 @@ const TripsPage = () => {
                 </TableCell>
                 <TableCell>{formatDate(trip.trip_date)}</TableCell>
                 <TableCell>{trip.trip_purpose}</TableCell>
+                <TableCell>{tripRoute(trip)}</TableCell>
                 <TableCell>{trip.odometer_start}</TableCell>
                 <TableCell>{trip.odometer_end}</TableCell>
               </TableRow>

--- a/frontend/src/services/tripsService.ts
+++ b/frontend/src/services/tripsService.ts
@@ -36,3 +36,22 @@ export const getLatestOdometer = async (): Promise<number | null> => {
     throw new Error("Unable to fetch latest odometer");
   }
 };
+
+export interface LastKnownLocation {
+  city: string | null;
+  state: string | null;
+}
+
+// Where the truck currently sits, derived from the latest located record
+// (delivered load, fuel stop, or trip). Prefills a new trip's start location.
+// Non-fatal: a failure just leaves the field blank, so it swallows errors and
+// returns null rather than throwing.
+export const getLastKnownLocation =
+  async (): Promise<LastKnownLocation | null> => {
+    try {
+      const response = await api.get("/trips/last-known-location");
+      return response.data.location ?? null;
+    } catch {
+      return null;
+    }
+  };

--- a/frontend/src/types/trip.ts
+++ b/frontend/src/types/trip.ts
@@ -13,6 +13,12 @@ export interface Trip {
   odometer_start: number | null;
   odometer_end: number | null;
   is_estimated: boolean;
+  // Where the truck started and ended this trip. Null when not recorded; the
+  // end feeds the truck's last-known location.
+  start_city: string | null;
+  start_state: string | null;
+  end_city: string | null;
+  end_state: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/types/tripInput.ts
+++ b/frontend/src/types/tripInput.ts
@@ -6,4 +6,8 @@ export interface TripInput {
   odometer_start?: number;
   odometer_end?: number;
   is_estimated?: boolean;
+  start_city?: string;
+  start_state?: string;
+  end_city?: string;
+  end_state?: string;
 }


### PR DESCRIPTION
Trips were the one movement type that didn't stamp a location, so the truck's last-known position went stale the moment it deadheaded home or repositioned. This closes that gap and turns it into a prefill.

## What changed
- **Migration 051** — `start_city/state` + `end_city/state` on `trips`, all nullable (existing trips and quick entries stay valid). Applied to dev + prod ahead of merge.
- **`getLastKnownLocation`** — derives the truck's current spot from the highest-odometer record that carries a location, across **loads + fuel + trips**. Maintenance is excluded (free-text location, not clean city/state).
- **Trip form** — Start city/state prefill from last-known location, mirroring the existing odometer prefill; blanks omit (stored NULL), states normalize to uppercase 2-letter.
- **Trips list** — new Route column (`Start → End`).
- **Guide** — Deadhead section notes how trips now keep the truck's location current.
- Odometer stays the single source of truth for actual miles; this only powers the location estimate.

## Verified
- Strict build clean; **370 frontend + 18 backend tests** (7 new pin the city/state validation).
- Last-known query run against **real prod data** → returns **Ferris, TX**, the delivered load at the highest odometer (587,694). Ordering logic confirmed.

Bumped to **v1.109.0** (feat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)