### PR TITLE
feat: Load Scorer routes real miles via HERE, with oversize-aware routing

### DIFF
--- a/backend/src/routes/routingRoutes.js
+++ b/backend/src/routes/routingRoutes.js
@@ -1,0 +1,29 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import { loadMiles } from "../services/routingService.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+// ---- SCORE-A-LOAD MILEAGE ----
+// Body: { truckNow?, pickup, delivery, dims? } where a place is { city, state }
+// and dims is { widthIn, heightIn, lengthIn, grossWeightLb }. Returns loaded +
+// deadhead miles, either of which may be null (no route, unconfigured key, or a
+// bad geocode) — the Scorer treats null as "type it yourself".
+router.post("/load-miles", async (req, res) => {
+  try {
+    const { truckNow, pickup, delivery, dims } = req.body ?? {};
+    const miles = await loadMiles({ truckNow, pickup, delivery, dims });
+    return res.status(200).json({
+      message: "Load miles computed",
+      ...miles,
+    });
+  } catch (err) {
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -28,6 +28,7 @@ import complianceRouter from "./routes/complianceRoutes.js";
 import trophyRouter from "./routes/trophyRoutes.js";
 import settlementScheduleRouter from "./routes/settlementScheduleRoutes.js";
 import accessorialRateRouter from "./routes/accessorialRateRoutes.js";
+import routingRouter from "./routes/routingRoutes.js";
 
 const app = express();
 
@@ -77,6 +78,7 @@ app.use("/trailers", trailerRouter);
 app.use("/avatars", avatarRouter);
 app.use("/settlement-schedule", settlementScheduleRouter);
 app.use("/accessorial-rates", accessorialRateRouter);
+app.use("/routing", routingRouter);
 
 app.get("/", (req, res) => {
   res.send("Home Page");

--- a/backend/src/services/hereProvider.js
+++ b/backend/src/services/hereProvider.js
@@ -1,0 +1,92 @@
+// HERE Technologies routing adapter. Isolated on purpose: the rest of the app
+// talks to routingService, which talks to this — so swapping providers (Google,
+// PC*Miler) is a one-file change. Server-side only, so the key never reaches the
+// browser; everything degrades to null when HERE_API_KEY is unset.
+//
+// HERE speaks metric: routes come back in METERS, and vehicle dimensions go out
+// in CENTIMETERS, gross weight in KILOGRAMS. We convert at this boundary so the
+// rest of the app stays in the units it already uses (miles, inches, pounds).
+
+const GEOCODE_URL = "https://geocode.search.hereapi.com/v1/geocode";
+const ROUTER_URL = "https://router.hereapi.com/v8/routes";
+
+// ---- unit conversions (pure) ----
+export const metersToMiles = (m) => m / 1609.344;
+export const inchesToCm = (inch) => Math.round(inch * 2.54);
+export const poundsToKg = (lb) => Math.round(lb * 0.45359237);
+
+// ---- pure parsers (unit-tested; no key needed) ----
+
+// HERE geocode response → { lat, lng } of the top hit, or null when nothing
+// matched or the shape is off.
+export const parseGeocode = (json) => {
+  const pos = json?.items?.[0]?.position;
+  if (!pos || typeof pos.lat !== "number" || typeof pos.lng !== "number")
+    return null;
+  return { lat: pos.lat, lng: pos.lng };
+};
+
+// HERE route response → total METERS across every section, or null when there's
+// no usable route (a section missing its length means we can't trust the total).
+export const parseRouteMeters = (json) => {
+  const sections = json?.routes?.[0]?.sections;
+  if (!Array.isArray(sections) || sections.length === 0) return null;
+  let meters = 0;
+  for (const s of sections) {
+    const len = s?.summary?.length;
+    if (typeof len !== "number") return null;
+    meters += len;
+  }
+  return meters;
+};
+
+const hasKey = () => !!process.env.HERE_API_KEY;
+
+// city/state → { lat, lng }, cached for the process (a city center doesn't move).
+// null when unconfigured, blank, or no match.
+const geoCache = new Map();
+export const geocode = async (city, state) => {
+  if (!hasKey() || !city || !state) return null;
+  const key = `${city.trim()}, ${state.trim()}`.toUpperCase();
+  if (geoCache.has(key)) return geoCache.get(key);
+
+  const params = new URLSearchParams({
+    q: `${city.trim()}, ${state.trim()}, USA`,
+    apiKey: process.env.HERE_API_KEY,
+    limit: "1",
+  });
+  const res = await fetch(`${GEOCODE_URL}?${params}`);
+  if (!res.ok) throw new Error(`HERE geocode failed (${res.status})`);
+  const coords = parseGeocode(await res.json());
+  geoCache.set(key, coords);
+  return coords;
+};
+
+// Driving miles between two { lat, lng } points as a truck. Optional dims
+// (inches + gross pounds) turn on PHYSICAL restrictions — the oversize routing
+// that reroutes around low bridges, narrow roads, and weight-limited segments.
+// null when unconfigured or no route.
+export const routeMiles = async (from, to, dims) => {
+  if (!hasKey() || !from || !to) return null;
+
+  const params = new URLSearchParams({
+    transportMode: "truck",
+    origin: `${from.lat},${from.lng}`,
+    destination: `${to.lat},${to.lng}`,
+    return: "summary",
+    apiKey: process.env.HERE_API_KEY,
+  });
+
+  if (dims) {
+    if (dims.widthIn) params.set("vehicle[width]", String(inchesToCm(dims.widthIn)));
+    if (dims.heightIn) params.set("vehicle[height]", String(inchesToCm(dims.heightIn)));
+    if (dims.lengthIn) params.set("vehicle[length]", String(inchesToCm(dims.lengthIn)));
+    if (dims.grossWeightLb)
+      params.set("vehicle[grossWeight]", String(poundsToKg(dims.grossWeightLb)));
+  }
+
+  const res = await fetch(`${ROUTER_URL}?${params}`);
+  if (!res.ok) throw new Error(`HERE route failed (${res.status})`);
+  const meters = parseRouteMeters(await res.json());
+  return meters == null ? null : metersToMiles(meters);
+};

--- a/backend/src/services/hereProvider.test.js
+++ b/backend/src/services/hereProvider.test.js
@@ -1,0 +1,58 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  metersToMiles,
+  inchesToCm,
+  poundsToKg,
+  parseGeocode,
+  parseRouteMeters,
+} from "./hereProvider.js";
+
+describe("unit conversions", () => {
+  test("meters → miles", () => {
+    assert.equal(metersToMiles(1609.344), 1);
+    assert.ok(Math.abs(metersToMiles(100000) - 62.137) < 0.01);
+  });
+
+  test("inches → centimeters (HERE wants cm, rounded)", () => {
+    assert.equal(inchesToCm(144), 366); // 12'0" wide → 366 cm
+    assert.equal(inchesToCm(162), 411); // 13'6" tall
+  });
+
+  test("pounds → kilograms (HERE wants kg, rounded)", () => {
+    assert.equal(poundsToKg(80000), 36287);
+    assert.equal(poundsToKg(0), 0);
+  });
+});
+
+describe("parseGeocode", () => {
+  test("pulls lat/lng from the top hit", () => {
+    const json = { items: [{ position: { lat: 32.53, lng: -96.66 } }] };
+    assert.deepEqual(parseGeocode(json), { lat: 32.53, lng: -96.66 });
+  });
+
+  test("null when no items or malformed", () => {
+    assert.equal(parseGeocode({ items: [] }), null);
+    assert.equal(parseGeocode({}), null);
+    assert.equal(parseGeocode({ items: [{ position: { lat: "x", lng: 1 } }] }), null);
+  });
+});
+
+describe("parseRouteMeters", () => {
+  test("sums section lengths", () => {
+    const json = {
+      routes: [{ sections: [{ summary: { length: 1000 } }, { summary: { length: 500 } }] }],
+    };
+    assert.equal(parseRouteMeters(json), 1500);
+  });
+
+  test("null when no route", () => {
+    assert.equal(parseRouteMeters({ routes: [] }), null);
+    assert.equal(parseRouteMeters({}), null);
+  });
+
+  test("null when a section is missing its length (don't trust a partial total)", () => {
+    const json = { routes: [{ sections: [{ summary: { length: 1000 } }, { summary: {} }] }] };
+    assert.equal(parseRouteMeters(json), null);
+  });
+});

--- a/backend/src/services/routingService.js
+++ b/backend/src/services/routingService.js
@@ -1,0 +1,32 @@
+// Load-scoring mileage, provider-agnostic. Talks to hereProvider today; swap that
+// import to change providers. Everything here is an ESTIMATE for scoring a load
+// before it runs — the odometer stays the single source of truth once it does.
+import { geocode, routeMiles } from "./hereProvider.js";
+
+// One leg's miles: geocode both ends, then route between them with the load's
+// dims. Self-contained try/catch so a failure on one leg never sinks the other
+// or the whole request — the Scorer just falls back to manual entry for it.
+async function legMiles(from, to, dims) {
+  try {
+    if (!from?.city || !from?.state || !to?.city || !to?.state) return null;
+    const [a, b] = await Promise.all([
+      geocode(from.city, from.state),
+      geocode(to.city, to.state),
+    ]);
+    if (!a || !b) return null;
+    const mi = await routeMiles(a, b, dims);
+    return mi == null ? null : Math.round(mi * 10) / 10;
+  } catch {
+    return null;
+  }
+}
+
+// The two legs of a scored load: loaded (pickup → delivery) and, when we know
+// where the truck is, deadhead (truck → pickup). Either can be null.
+export async function loadMiles({ truckNow, pickup, delivery, dims } = {}) {
+  const [loadedMiles, deadheadMiles] = await Promise.all([
+    legMiles(pickup, delivery, dims),
+    truckNow ? legMiles(truckNow, pickup, dims) : Promise.resolve(null),
+  ]);
+  return { loadedMiles, deadheadMiles };
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.109.0",
+  "version": "1.110.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/dimensions.test.ts
+++ b/frontend/src/lib/dimensions.test.ts
@@ -5,6 +5,7 @@ import {
   formatInches,
   formatLoadDims,
   isOverWidth,
+  classifyOversize,
 } from "./dimensions";
 
 describe("toInches / toFeetInches", () => {
@@ -66,5 +67,36 @@ describe("isOverWidth", () => {
     expect(isOverWidth(96)).toBe(false);
     expect(isOverWidth(null)).toBe(false);
     expect(isOverWidth(undefined)).toBe(false);
+  });
+});
+
+describe("classifyOversize", () => {
+  it("legal when everything is within limits", () => {
+    const v = classifyOversize({ widthIn: 102, heightIn: 162, lengthIn: 636, grossWeightLb: 80000 });
+    expect(v.oversize).toBe(false);
+    expect(v.reasons).toEqual([]);
+  });
+
+  it("legal when nothing is entered", () => {
+    expect(classifyOversize({}).oversize).toBe(false);
+  });
+
+  it("flags over-width and names it", () => {
+    const v = classifyOversize({ widthIn: 144 }); // 12'0"
+    expect(v.oversize).toBe(true);
+    expect(v.reasons).toEqual([`width 12'0" over 8'6"`]);
+  });
+
+  it("flags every dimension that's over, in order", () => {
+    const v = classifyOversize({ widthIn: 144, heightIn: 168, lengthIn: 700, grossWeightLb: 92000 });
+    expect(v.oversize).toBe(true);
+    expect(v.reasons).toHaveLength(4);
+    expect(v.reasons[1]).toBe(`height 14'0" over 13'6"`);
+    expect(v.reasons[3]).toBe("92,000 lb over 80,000 lb");
+  });
+
+  it("is exclusive at the limit — exactly legal is not oversize", () => {
+    expect(classifyOversize({ widthIn: 102, grossWeightLb: 80000 }).oversize).toBe(false);
+    expect(classifyOversize({ widthIn: 103 }).oversize).toBe(true);
   });
 });

--- a/frontend/src/lib/dimensions.ts
+++ b/frontend/src/lib/dimensions.ts
@@ -43,3 +43,43 @@ export const formatLoadDims = (
 export const LEGAL_WIDTH_IN = 102;
 export const isOverWidth = (width_in?: number | null): boolean =>
   width_in != null && width_in > LEGAL_WIDTH_IN;
+
+// Federal defaults for the other three. These compare against TRAVEL figures —
+// total height is deck + load, length is overall, weight is gross (truck +
+// trailer + load) — not cargo-only numbers. Real limits vary by state; these are
+// the routine no-permit thresholds, good enough to flag "this needs a permit".
+export const LEGAL_HEIGHT_IN = 162; // 13'6"
+export const LEGAL_LENGTH_IN = 636; // 53' overall
+export const LEGAL_GROSS_LB = 80000; // gross vehicle weight
+
+export interface TravelDims {
+  widthIn?: number | null;
+  heightIn?: number | null; // total travel height (deck + load)
+  lengthIn?: number | null; // overall
+  grossWeightLb?: number | null; // truck + trailer + load
+}
+
+export interface OversizeVerdict {
+  oversize: boolean;
+  reasons: string[]; // e.g. ["width 12'0\" over 8'6\""] — one per dimension over
+}
+
+// Legal-vs-oversize from a load's travel dimensions. Any dimension over its limit
+// makes the load oversize, and each contributes a plain-language reason naming
+// the offender. Blank dimensions are skipped — a load with nothing entered reads
+// legal. Mirrors the width-first honesty above: width is the surest flag, the
+// rest lean on the federal defaults.
+export const classifyOversize = (d: TravelDims): OversizeVerdict => {
+  const reasons: string[] = [];
+  if (d.widthIn != null && d.widthIn > LEGAL_WIDTH_IN)
+    reasons.push(`width ${formatInches(d.widthIn)} over ${formatInches(LEGAL_WIDTH_IN)}`);
+  if (d.heightIn != null && d.heightIn > LEGAL_HEIGHT_IN)
+    reasons.push(`height ${formatInches(d.heightIn)} over ${formatInches(LEGAL_HEIGHT_IN)}`);
+  if (d.lengthIn != null && d.lengthIn > LEGAL_LENGTH_IN)
+    reasons.push(`length ${formatInches(d.lengthIn)} over ${formatInches(LEGAL_LENGTH_IN)}`);
+  if (d.grossWeightLb != null && d.grossWeightLb > LEGAL_GROSS_LB)
+    reasons.push(
+      `${d.grossWeightLb.toLocaleString("en-US")} lb over ${LEGAL_GROSS_LB.toLocaleString("en-US")} lb`,
+    );
+  return { oversize: reasons.length > 0, reasons };
+};

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -589,7 +589,7 @@ const GuidePage = () => {
 
           <Metric
             title="Load Scorer — Take It or Leave It"
-            answers="Punch a rate, loaded miles, and deadhead into the Score a Load page and get an instant verdict on whether the load's worth taking."
+            answers="Enter a rate, pickup, and delivery — the miles come back routed, deadhead measured from where your truck sits — for an instant verdict on whether the load's worth taking."
             sources={[{ label: "Score a Load", to: "/score" }]}
           >
             <Formula>
@@ -611,6 +611,17 @@ const GuidePage = () => {
               <span style={{ color: "#e8940a" }}>MEH</span> under +35%,{" "}
               <span style={{ color: "#4ade80" }}>TAKE IT</span> at +35%,{" "}
               <span style={{ color: "#fbbf24" }}>STEAL</span> at +60%.
+            </Why>
+            <Why>
+              Miles come from truck routing (HERE), not a straight line — the
+              deadhead starts from your{" "}
+              <span className="text-light">last-known location</span> (your last
+              delivery, fuel stop, or trip). Enter the load's dimensions and it
+              flags <span className="text-light">legal vs oversize</span> and
+              routes an oversize load around the clearances it can't make, so the
+              miles are honest. It's an estimate for the decision; the odometer is
+              still truth once you run it. Every mile field stays editable if you'd
+              rather type your own.
             </Why>
           </Metric>
 

--- a/frontend/src/pages/ScoreLoadPage.tsx
+++ b/frontend/src/pages/ScoreLoadPage.tsx
@@ -1,8 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect, useMemo, type ReactNode } from "react";
 import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { scoreLoad, VERDICT_META } from "@/lib/metrics/loadScore";
 import { RATE_TIERS } from "@/lib/constants/targets";
+import { getLoadMiles, type Place } from "@/services/routingService";
+import { getLastKnownLocation } from "@/services/tripsService";
+import { toInches, classifyOversize } from "@/lib/dimensions";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const rpm = (n: number | null) => (n != null ? `$${n.toFixed(2)}` : "—");
@@ -16,6 +19,12 @@ const markerPct = (pct: number | null, allIn: number | null, be: number | null):
     return 50 + ((pct - RATE_TIERS.target) / (RATE_TIERS.strong - RATE_TIERS.target)) * 25; // TAKE
   return 75 + Math.min(1, (pct - RATE_TIERS.strong) / 0.4) * 25; // STEAL
 };
+
+const box = (accent?: boolean) => ({
+  background: "#161d2b",
+  border: `1px solid ${accent ? "#85500b" : "#2a3347"}`,
+  borderRadius: 9,
+});
 
 const Field = ({
   label,
@@ -32,10 +41,7 @@ const Field = ({
   suffix?: string;
   prefix?: string;
 }) => (
-  <div
-    className="flex items-center justify-between rounded-[9px] px-3 py-2.5"
-    style={{ background: "#161d2b", border: `1px solid ${accent ? "#85500b" : "#2a3347"}` }}
-  >
+  <div className="flex items-center justify-between px-3 py-2.5" style={box(accent)}>
     <span className="text-xs" style={{ color: accent ? "#f5b03a" : "#9fb0c9" }}>
       {label}
     </span>
@@ -55,12 +61,180 @@ const Field = ({
   </div>
 );
 
+const Lbl = ({ children, accent }: { children: ReactNode; accent?: boolean }) => (
+  <div className="text-[11px] mb-1" style={{ color: accent ? "#f5b03a" : "#9fb0c9" }}>
+    {children}
+  </div>
+);
+
+const txt = {
+  background: "#161d2b",
+  border: "1px solid #2a3347",
+  borderRadius: 8,
+  padding: "8px 10px",
+  color: "#f4f7fb",
+  fontSize: 14,
+  width: "100%",
+  outline: "none",
+} as const;
+
+// City + 2-letter state pair.
+const PlaceRow = ({
+  label,
+  place,
+  onChange,
+}: {
+  label: string;
+  place: Place;
+  onChange: (p: Place) => void;
+}) => (
+  <div className="flex gap-2 mb-2.5">
+    <div className="flex-[3]">
+      <Lbl>{label}</Lbl>
+      <input
+        style={txt}
+        value={place.city}
+        placeholder="City"
+        onChange={(e) => onChange({ ...place, city: e.target.value })}
+      />
+    </div>
+    <div className="flex-1">
+      <Lbl>ST</Lbl>
+      <input
+        style={txt}
+        value={place.state}
+        placeholder="ST"
+        maxLength={2}
+        onChange={(e) => onChange({ ...place, state: e.target.value })}
+      />
+    </div>
+  </div>
+);
+
+type FtIn = { ft: string; in: string };
+const dimToIn = (d: FtIn): number | null =>
+  d.ft === "" && d.in === "" ? null : toInches(Number(d.ft) || 0, Number(d.in) || 0);
+
+// Compact feet + inches field for one dimension.
+const DimField = ({
+  label,
+  val,
+  onChange,
+  accent,
+}: {
+  label: string;
+  val: FtIn;
+  onChange: (v: FtIn) => void;
+  accent?: boolean;
+}) => (
+  <div className="flex-1">
+    <Lbl accent={accent}>{label}</Lbl>
+    <div className="flex items-center px-2 py-2" style={box(accent)}>
+      <input
+        type="number"
+        inputMode="numeric"
+        value={val.ft}
+        placeholder="0"
+        onChange={(e) => onChange({ ...val, ft: e.target.value })}
+        className="w-7 bg-transparent text-right outline-none"
+        style={{ color: "#f4f7fb", fontSize: 13 }}
+      />
+      <span className="text-[11px] text-muted-text mx-0.5">'</span>
+      <input
+        type="number"
+        inputMode="numeric"
+        value={val.in}
+        placeholder="0"
+        onChange={(e) => onChange({ ...val, in: e.target.value })}
+        className="w-7 bg-transparent text-right outline-none"
+        style={{ color: "#f4f7fb", fontSize: 13 }}
+      />
+      <span className="text-[11px] text-muted-text ml-0.5">"</span>
+    </div>
+  </div>
+);
+
 const ScoreLoadPage = () => {
   const { loads } = useLoads(0);
   const targets = useRateTargets(loads);
+
   const [rate, setRate] = useState("");
+  const [truckNow, setTruckNow] = useState<Place>({ city: "", state: "" });
+  const [pickup, setPickup] = useState<Place>({ city: "", state: "" });
+  const [delivery, setDelivery] = useState<Place>({ city: "", state: "" });
+  const [wt, setWt] = useState("");
+  const [len, setLen] = useState<FtIn>({ ft: "", in: "" });
+  const [wid, setWid] = useState<FtIn>({ ft: "", in: "" });
+  const [hgt, setHgt] = useState<FtIn>({ ft: "", in: "" });
   const [loaded, setLoaded] = useState("");
   const [deadhead, setDeadhead] = useState("");
+  const [routing, setRouting] = useState(false);
+  const [routeErr, setRouteErr] = useState(false);
+
+  // Prefill "Truck now" (the deadhead origin) with the truck's last-known
+  // location. Non-fatal — no data just leaves it blank to fill by hand.
+  useEffect(() => {
+    let active = true;
+    getLastKnownLocation().then((loc) => {
+      if (active && loc && (loc.city || loc.state))
+        setTruckNow({ city: loc.city ?? "", state: loc.state ?? "" });
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const dims = useMemo(
+    () => ({
+      widthIn: dimToIn(wid),
+      heightIn: dimToIn(hgt),
+      lengthIn: dimToIn(len),
+      grossWeightLb: wt === "" ? null : Number(wt) || null,
+    }),
+    [wid, hgt, len, wt],
+  );
+  const dimsKey = JSON.stringify(dims);
+  const anyDim =
+    dims.widthIn != null ||
+    dims.heightIn != null ||
+    dims.lengthIn != null ||
+    dims.grossWeightLb != null;
+  const oversize = useMemo(() => classifyOversize(dims), [dims]);
+
+  const pickupReady = !!(pickup.city && pickup.state);
+  const deliveryReady = !!(delivery.city && delivery.state);
+
+  // Auto-route once pickup + delivery are both complete. Debounced so we hit HERE
+  // once the typing settles, not per keystroke. Re-runs when the route or the
+  // dims change; a manual edit to the mile fields doesn't (they're not deps), so
+  // an override sticks until the route itself changes.
+  useEffect(() => {
+    if (!pickupReady || !deliveryReady) return;
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setRouting(true);
+      setRouteErr(false);
+      const res = await getLoadMiles({
+        truckNow: truckNow.city && truckNow.state ? truckNow : null,
+        pickup,
+        delivery,
+        dims: anyDim ? dims : undefined,
+      });
+      if (cancelled) return;
+      setRouting(false);
+      if (res.loadedMiles == null && res.deadheadMiles == null) {
+        setRouteErr(true);
+        return;
+      }
+      if (res.loadedMiles != null) setLoaded(String(res.loadedMiles));
+      if (res.deadheadMiles != null) setDeadhead(String(res.deadheadMiles));
+    }, 600);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pickup.city, pickup.state, delivery.city, delivery.state, truckNow.city, truckNow.state, dimsKey]);
 
   const entered = rate !== "" && loaded !== "";
   const score = scoreLoad(
@@ -76,26 +250,102 @@ const ScoreLoadPage = () => {
   );
   const meta = score.verdict ? VERDICT_META[score.verdict] : null;
 
+  const routeNote = routing
+    ? "routing…"
+    : routeErr
+      ? "couldn't route — type the miles in"
+      : loaded
+        ? "routed · edit to override"
+        : "enter pickup + delivery to route";
+
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
       <div
         className="mx-auto"
-        style={{ maxWidth: 400, background: "#10151f", border: "1px solid #2a3347", borderRadius: 16, padding: 18 }}
+        style={{ maxWidth: 420, background: "#10151f", border: "1px solid #2a3347", borderRadius: 16, padding: 18 }}
       >
         <div className="text-[17px] font-semibold uppercase tracking-wide" style={{ color: "#f4f7fb" }}>
           Score a Load
         </div>
         <div className="text-[11px] text-muted-text mt-0.5 mb-3.5">Punch it in at the phone.</div>
 
-        <div className="flex flex-col gap-2.5">
+        <div className="mb-2.5">
           <Field label="Rate" value={rate} onChange={setRate} prefix="$" />
-          <div className="flex gap-2.5">
-            <div className="flex-1">
-              <Field label="Loaded" value={loaded} onChange={setLoaded} suffix="mi" />
+        </div>
+
+        <div
+          className="flex items-center gap-2 px-3 py-2 mb-3"
+          style={{ background: "#141b28", border: "1px solid #24304a", borderRadius: 9 }}
+        >
+          <span className="text-[11px] text-muted-text">Truck now</span>
+          <input
+            className="flex-[3] bg-transparent outline-none text-sm"
+            style={{ color: "#f4f7fb" }}
+            value={truckNow.city}
+            placeholder="last stop"
+            onChange={(e) => setTruckNow({ ...truckNow, city: e.target.value })}
+          />
+          <input
+            className="w-8 bg-transparent outline-none text-sm text-right"
+            style={{ color: "#f4f7fb" }}
+            value={truckNow.state}
+            placeholder="ST"
+            maxLength={2}
+            onChange={(e) => setTruckNow({ ...truckNow, state: e.target.value })}
+          />
+        </div>
+
+        <PlaceRow label="Pickup" place={pickup} onChange={setPickup} />
+        <PlaceRow label="Delivery" place={delivery} onChange={setDelivery} />
+
+        <div className="text-[10px] uppercase tracking-wide mt-1 mb-1.5" style={{ color: "#5f6b80" }}>
+          Load size <span className="normal-case" style={{ color: "#4a5566" }}>— leave blank if legal</span>
+        </div>
+        <div className="mb-2">
+          <Field label="Gross wt" value={wt} onChange={setWt} suffix="lb" />
+        </div>
+        <div className="flex gap-2 mb-3">
+          <DimField label="Length" val={len} onChange={setLen} />
+          <DimField label="Width" val={wid} onChange={setWid} accent={oversize.reasons.some((r) => r.startsWith("width"))} />
+          <DimField label="Height" val={hgt} onChange={setHgt} />
+        </div>
+
+        {anyDim &&
+          (oversize.oversize ? (
+            <div
+              className="flex items-start gap-2 px-3 py-2 mb-3"
+              style={{ background: "#241a06", border: "1px solid #85500b", borderRadius: 9 }}
+            >
+              <span className="text-sm font-semibold tracking-wide" style={{ color: "#f5b03a" }}>
+                OVERSIZE
+              </span>
+              <span className="text-[11px] mt-0.5" style={{ color: "#c99a52" }}>
+                {oversize.reasons.join(" · ")}
+              </span>
             </div>
-            <div className="flex-1">
-              <Field label="Deadhead" value={deadhead} onChange={setDeadhead} accent suffix="mi" />
+          ) : (
+            <div
+              className="flex items-center gap-2 px-3 py-2 mb-3"
+              style={{ background: "#0f2018", border: "1px solid #1a5c3a", borderRadius: 9 }}
+            >
+              <span className="text-sm font-semibold tracking-wide" style={{ color: "#4ade80" }}>
+                LEGAL
+              </span>
+              <span className="text-[11px]" style={{ color: "#5f8a6e" }}>
+                within legal limits — no permit
+              </span>
             </div>
+          ))}
+
+        <div className="text-[10px] mb-1" style={{ color: routeErr ? "#e8940a" : "#5f6b80" }}>
+          {routeNote}
+        </div>
+        <div className="flex gap-2.5 mb-1">
+          <div className="flex-1">
+            <Field label="Loaded" value={loaded} onChange={setLoaded} suffix="mi" />
+          </div>
+          <div className="flex-1">
+            <Field label="Deadhead" value={deadhead} onChange={setDeadhead} accent suffix="mi" />
           </div>
         </div>
 
@@ -105,7 +355,7 @@ const ScoreLoadPage = () => {
           </p>
         ) : !entered ? (
           <p className="text-xs text-muted-text mt-6 text-center">
-            Enter a rate and loaded miles to get a verdict.
+            Enter a rate and route to get a verdict.
           </p>
         ) : (
           <>

--- a/frontend/src/services/routingService.ts
+++ b/frontend/src/services/routingService.ts
@@ -1,0 +1,39 @@
+import api from "./api";
+
+export interface Place {
+  city: string;
+  state: string;
+}
+
+// Travel dimensions in inches + gross pounds; drives HERE's oversize routing.
+export interface LoadDims {
+  widthIn?: number | null;
+  heightIn?: number | null;
+  lengthIn?: number | null;
+  grossWeightLb?: number | null;
+}
+
+export interface LoadMiles {
+  loadedMiles: number | null;
+  deadheadMiles: number | null;
+}
+
+// Routed miles for a scored load — loaded (pickup → delivery) and deadhead
+// (truck → pickup). Non-fatal: any failure returns nulls so the Scorer just
+// keeps its typed-in miles. An estimate; the odometer is truth once it runs.
+export const getLoadMiles = async (body: {
+  truckNow?: Place | null;
+  pickup: Place;
+  delivery: Place;
+  dims?: LoadDims;
+}): Promise<LoadMiles> => {
+  try {
+    const res = await api.post("/routing/load-miles", body);
+    return {
+      loadedMiles: res.data.loadedMiles ?? null,
+      deadheadMiles: res.data.deadheadMiles ?? null,
+    };
+  } catch {
+    return { loadedMiles: null, deadheadMiles: null };
+  }
+};


### PR DESCRIPTION
The Scorer stops asking you to type miles.

## What changed
- **Cities in, miles out.** Enter rate + pickup + delivery; HERE returns loaded (pickup→delivery) and deadhead (truck→pickup) miles. Auto-routes once both ends are complete (debounced).
- **Deadhead from where the truck sits.** The deadhead origin auto-seeds from the last-known location shipped earlier (delivered load / fuel / trip).
- **Legal vs oversize.** Enter dimensions and it classifies (reusing `isOverWidth` + federal defaults for height/length/gross), names the offender, and passes the dims to HERE so an oversize load routes around clearances it can't make.
- **Provider-agnostic.** HERE lives in `hereProvider.js` alone (swappable for Google/PC*Miler); `routingService.js` orchestrates. Server-side so the key never reaches the browser; degrades to null → manual entry on any failure. cm/kg/meters converted at the boundary.
- Odometer stays the single source of truth; this is the pre-book estimate only. Every mile field stays editable.

## Verified
- Strict build clean; **375 frontend + 26 backend tests** — new coverage for the HERE geocode/route parsers, cm/kg/mile conversions, and the oversize classifier.
- Rendered live: OVERSIZE badge fires correctly; routing-failure degrades to "couldn't route — type the miles in" with fields editable.
- A *successful* live route needs prod auth + the `HERE_API_KEY` on Railway, so the deploy is its first real exercise.

No migration. Scorer-only this pass; auto-filling new loads is the next step. Bumped to **v1.110.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)