### PR TITLE
feat: mission map — rendered route on load detail + Scorer

### DIFF
--- a/backend/src/routes/routingRoutes.js
+++ b/backend/src/routes/routingRoutes.js
@@ -1,6 +1,8 @@
 import express from "express";
 import { requireAuth } from "../middleware/requireAuth.js";
-import { loadMiles } from "../services/routingService.js";
+import { loadMiles, renderRouteMap } from "../services/routingService.js";
+import { getLoad } from "../services/loadServices.js";
+import { precedingLocation } from "../services/tripServices.js";
 
 const router = express.Router();
 router.use(requireAuth);
@@ -18,6 +20,51 @@ router.post("/load-miles", async (req, res) => {
       message: "Load miles computed",
       ...miles,
     });
+  } catch (err) {
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+// ---- MISSION MAP FOR A SAVED LOAD ----
+// Renders the load's haul, with the deadhead leg chained from wherever the truck
+// sat before it. Returns { image: dataURI | null }; null just means "show the
+// text route" — a missing map never errors the page.
+router.get("/load-map/:loadId", async (req, res) => {
+  try {
+    const user_id = req.user.user_id;
+    const load = await getLoad(user_id, req.params.loadId);
+    const deadheadOrigin = await precedingLocation(user_id, load);
+    const image = await renderRouteMap({
+      deadheadOrigin,
+      pickup: { city: load.origin_city, state: load.origin_state },
+      delivery: { city: load.destination_city, state: load.destination_state },
+    });
+    return res.status(200).json({ message: "Load map", image });
+  } catch (err) {
+    if (err.type === "not_found") {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+// ---- MISSION MAP FOR A SCORED (not-yet-saved) LOAD ----
+// Body: { truckNow?, pickup, delivery }. Deadhead leg drawn from truckNow.
+router.post("/map", async (req, res) => {
+  try {
+    const { truckNow, pickup, delivery } = req.body ?? {};
+    const image = await renderRouteMap({
+      deadheadOrigin: truckNow,
+      pickup,
+      delivery,
+    });
+    return res.status(200).json({ message: "Route map", image });
   } catch (err) {
     return res.status(500).json({
       error: "Internal Server Error",

--- a/backend/src/services/hereProvider.js
+++ b/backend/src/services/hereProvider.js
@@ -9,6 +9,7 @@
 
 const GEOCODE_URL = "https://geocode.search.hereapi.com/v1/geocode";
 const ROUTER_URL = "https://router.hereapi.com/v8/routes";
+const MAP_IMAGE_URL = "https://image.maps.hereapi.com/mia/v3/base/mc";
 
 // ---- unit conversions (pure) ----
 export const metersToMiles = (m) => m / 1609.344;
@@ -89,4 +90,66 @@ export const routeMiles = async (from, to, dims) => {
   if (!res.ok) throw new Error(`HERE route failed (${res.status})`);
   const meters = parseRouteMeters(await res.json());
   return meters == null ? null : metersToMiles(meters);
+};
+
+// ---- static route map (for the "mission map") ----
+
+// HERE route response → the flexible polyline(s), one per section, for drawing
+// the route on a static map. null when there's no geometry.
+export const parseRoutePolylines = (json) => {
+  const sections = json?.routes?.[0]?.sections;
+  if (!Array.isArray(sections)) return null;
+  const polys = sections.map((s) => s?.polyline).filter(Boolean);
+  return polys.length ? polys : null;
+};
+
+// The route's drawable geometry (flexible polylines) between two points. Plain
+// truck mode — the map line is illustrative, so we skip dims here for speed and
+// robustness (the Scorer's MILES are where dims matter). null when no route.
+export const routePolylines = async (from, to) => {
+  if (!hasKey() || !from || !to) return null;
+  const params = new URLSearchParams({
+    transportMode: "truck",
+    origin: `${from.lat},${from.lng}`,
+    destination: `${to.lat},${to.lng}`,
+    return: "polyline",
+    apiKey: process.env.HERE_API_KEY,
+  });
+  const res = await fetch(`${ROUTER_URL}?${params}`);
+  if (!res.ok) throw new Error(`HERE route(polyline) failed (${res.status})`);
+  return parseRoutePolylines(await res.json());
+};
+
+// Pure: assemble a Map Image v3 URL. `lines` = [{ polyline | coords[], color,
+// width }], `points` = [{ lat, lng, color }] (colors are 6-hex, no '#'). HERE's
+// overlay syntax needs ':' ';' ',' kept literal, so we build the query by hand
+// and only encode the color '#' as %23. `overlay:padding` auto-fits the view.
+export const buildMapImageUrl = ({
+  apiKey,
+  width = 640,
+  height = 300,
+  lines = [],
+  points = [],
+}) => {
+  const overlays = [];
+  for (const l of lines) {
+    const geom = l.polyline ? l.polyline : l.coords.join(",");
+    overlays.push(`line:${geom};color=%23${l.color};width=${l.width}`);
+  }
+  for (const p of points) {
+    overlays.push(`multiPoint:${p.lat},${p.lng};color=%23${p.color};size=large`);
+  }
+  // Overlay values are already URL-safe (polyline is [A-Za-z0-9-_], plus digits,
+  // '.', ':', ';', ','); the color '#' is the only reserved char, emitted as %23.
+  const qs = overlays.map((o) => `overlay=${o}`).join("&");
+  return `${MAP_IMAGE_URL}/overlay:padding=40/${width}x${height}/png?apiKey=${apiKey}&${qs}`;
+};
+
+// Fetch a Map Image URL and return it as a base64 PNG data URI — so it rides
+// authenticated JSON to the browser and the key never leaves the server.
+export const fetchMapDataUri = async (url) => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HERE map image failed (${res.status})`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  return `data:image/png;base64,${buf.toString("base64")}`;
 };

--- a/backend/src/services/hereProvider.test.js
+++ b/backend/src/services/hereProvider.test.js
@@ -6,6 +6,8 @@ import {
   poundsToKg,
   parseGeocode,
   parseRouteMeters,
+  parseRoutePolylines,
+  buildMapImageUrl,
 } from "./hereProvider.js";
 
 describe("unit conversions", () => {
@@ -54,5 +56,43 @@ describe("parseRouteMeters", () => {
   test("null when a section is missing its length (don't trust a partial total)", () => {
     const json = { routes: [{ sections: [{ summary: { length: 1000 } }, { summary: {} }] }] };
     assert.equal(parseRouteMeters(json), null);
+  });
+});
+
+describe("parseRoutePolylines", () => {
+  test("collects a polyline per section", () => {
+    const json = { routes: [{ sections: [{ polyline: "AAA" }, { polyline: "BBB" }] }] };
+    assert.deepEqual(parseRoutePolylines(json), ["AAA", "BBB"]);
+  });
+
+  test("null when there's no geometry", () => {
+    assert.equal(parseRoutePolylines({ routes: [{ sections: [{}] }] }), null);
+    assert.equal(parseRoutePolylines({}), null);
+  });
+});
+
+describe("buildMapImageUrl", () => {
+  test("builds a v3 URL with size, line + point overlays, and %23-encoded color", () => {
+    const url = buildMapImageUrl({
+      apiKey: "K",
+      width: 640,
+      height: 300,
+      lines: [{ polyline: "ABC", color: "f5b03a", width: 5 }],
+      points: [{ lat: 32.5, lng: -96.6, color: "4ade80" }],
+    });
+    assert.ok(url.startsWith("https://image.maps.hereapi.com/mia/v3/base/mc/overlay:padding=40/640x300/png"));
+    assert.ok(url.includes("apiKey=K"));
+    assert.ok(url.includes("overlay=line:ABC;color=%23f5b03a;width=5"));
+    assert.ok(url.includes("overlay=multiPoint:32.5,-96.6;color=%234ade80;size=large"));
+    // the raw '#' must never appear (it would truncate the URL at the fragment)
+    assert.ok(!url.includes("#"));
+  });
+
+  test("falls back to raw coords for a line when no polyline", () => {
+    const url = buildMapImageUrl({
+      apiKey: "K",
+      lines: [{ coords: [1, 2, 3, 4], color: "6f7a8c", width: 4 }],
+    });
+    assert.ok(url.includes("overlay=line:1,2,3,4;color=%236f7a8c;width=4"));
   });
 });

--- a/backend/src/services/routingService.js
+++ b/backend/src/services/routingService.js
@@ -1,7 +1,13 @@
 // Load-scoring mileage, provider-agnostic. Talks to hereProvider today; swap that
 // import to change providers. Everything here is an ESTIMATE for scoring a load
 // before it runs — the odometer stays the single source of truth once it does.
-import { geocode, routeMiles } from "./hereProvider.js";
+import {
+  geocode,
+  routeMiles,
+  routePolylines,
+  buildMapImageUrl,
+  fetchMapDataUri,
+} from "./hereProvider.js";
 
 // One leg's miles: geocode both ends, then route between them with the load's
 // dims. Self-contained try/catch so a failure on one leg never sinks the other
@@ -29,4 +35,84 @@ export async function loadMiles({ truckNow, pickup, delivery, dims } = {}) {
     truckNow ? legMiles(truckNow, pickup, dims) : Promise.resolve(null),
   ]);
   return { loadedMiles, deadheadMiles };
+}
+
+// ---- the "mission map" ----
+
+// Map colors (6-hex, no '#') — the paid haul in amber, the empty leg in gray,
+// pickup green, destination red, and a faint pin where the deadhead began.
+const C_LOADED = "f5b03a";
+const C_DEADHEAD = "6f7a8c";
+const C_START = "4ade80";
+const C_OBJECTIVE = "f87171";
+const C_DH_ORIGIN = "8b98a9";
+
+// Tiny bounded cache: a route's rendered image doesn't change, so don't re-hit
+// HERE for the same haul. Keyed by the three places; oldest evicted past cap.
+const mapCache = new Map();
+const MAP_CACHE_CAP = 60;
+
+// A rendered route-map data URI (PNG) for a load: the loaded haul
+// (pickup→delivery) and, when we know where the truck came from, the deadhead
+// leg into the pickup. null on any failure — the caller shows the text route.
+export async function renderRouteMap({ deadheadOrigin, pickup, delivery } = {}) {
+  if (!process.env.HERE_API_KEY) return null;
+  if (!pickup?.city || !pickup?.state || !delivery?.city || !delivery?.state)
+    return null;
+
+  const key = JSON.stringify({ deadheadOrigin, pickup, delivery });
+  if (mapCache.has(key)) return mapCache.get(key);
+
+  let image = null;
+  try {
+    const [pk, dl, dh] = await Promise.all([
+      geocode(pickup.city, pickup.state),
+      geocode(delivery.city, delivery.state),
+      deadheadOrigin?.city && deadheadOrigin?.state
+        ? geocode(deadheadOrigin.city, deadheadOrigin.state)
+        : null,
+    ]);
+    if (pk && dl) {
+      const lines = [];
+      const points = [];
+
+      // Deadhead leg first so the loaded haul draws on top of it.
+      if (dh) {
+        const dhPolys = await routePolylines(dh, pk);
+        if (dhPolys)
+          for (const p of dhPolys)
+            lines.push({ polyline: p, color: C_DEADHEAD, width: 4 });
+        else
+          lines.push({ coords: [dh.lat, dh.lng, pk.lat, pk.lng], color: C_DEADHEAD, width: 4 });
+        points.push({ lat: dh.lat, lng: dh.lng, color: C_DH_ORIGIN });
+      }
+
+      const loadedPolys = await routePolylines(pk, dl);
+      if (loadedPolys)
+        for (const p of loadedPolys)
+          lines.push({ polyline: p, color: C_LOADED, width: 5 });
+      else
+        lines.push({ coords: [pk.lat, pk.lng, dl.lat, dl.lng], color: C_LOADED, width: 5 });
+      points.push({ lat: pk.lat, lng: pk.lng, color: C_START });
+      points.push({ lat: dl.lat, lng: dl.lng, color: C_OBJECTIVE });
+
+      const url = buildMapImageUrl({
+        apiKey: process.env.HERE_API_KEY,
+        width: 640,
+        height: 300,
+        lines,
+        points,
+      });
+      image = await fetchMapDataUri(url);
+    }
+  } catch {
+    image = null;
+  }
+
+  if (image) {
+    mapCache.set(key, image);
+    if (mapCache.size > MAP_CACHE_CAP)
+      mapCache.delete(mapCache.keys().next().value);
+  }
+  return image;
 }

--- a/backend/src/services/tripServices.js
+++ b/backend/src/services/tripServices.js
@@ -148,6 +148,37 @@ export async function getLastKnownLocation(user_id) {
   return result.rows[0] ?? null; // { city, state } | null
 }
 
+// ---- WHERE THE TRUCK WAS BEFORE A GIVEN LOAD ----
+// The located record (a load's destination or a trip's end) with the greatest
+// odometer_end at or below this load's odometer_start — i.e. where the truck
+// sat just before it rolled on this load. Powers the deadhead leg on a load's
+// mission map. Falls back to the current last-known location when the load has
+// no start odometer yet (not run); null when nothing precedes it.
+export async function precedingLocation(user_id, load) {
+  if (!user_id || !load) return null;
+  const start = load.odometer_start;
+  if (start == null) return getLastKnownLocation(user_id);
+
+  const query = `
+        SELECT city, state FROM (
+            SELECT destination_city AS city, destination_state AS state, odometer_end AS odo
+                FROM loads
+                WHERE user_id = $1 AND load_id <> $2
+                  AND odometer_end IS NOT NULL AND odometer_end <= $3
+            UNION ALL
+            SELECT end_city AS city, end_state AS state, odometer_end AS odo
+                FROM trips
+                WHERE user_id = $1 AND end_city IS NOT NULL
+                  AND odometer_end IS NOT NULL AND odometer_end <= $3
+        ) prev
+        ORDER BY odo DESC
+        LIMIT 1;
+    `;
+
+  const result = await db.query(query, [user_id, load.load_id, start]);
+  return result.rows[0] ?? null; // { city, state } | null
+}
+
 // ---- CREATE TRIP SERVICE ----
 export async function createTrip(user_id, data) {
   // Reject missing user_id

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.110.0",
+  "version": "1.111.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 
 import { useLoad } from "@/hooks/useLoad";
+import { getLoadMap } from "@/services/routingService";
 import { formatLoadDims } from "@/lib/dimensions";
 import { useAccessorials } from "@/hooks/useAccessorials";
 import { useBrokers } from "@/hooks/useBrokers";
@@ -165,6 +166,7 @@ export const LoadDetailPage = () => {
   const [refreshKey, setRefreshKey] = useState(0);
   const [accRefreshKey, setAccRefreshKey] = useState(0);
   const { load, isLoading, error } = useLoad(refreshKey);
+  const [mapImage, setMapImage] = useState<string | null>(null);
   const { accessorials } = useAccessorials(accRefreshKey);
 
   const [newType, setNewType] = useState("");
@@ -229,6 +231,19 @@ export const LoadDetailPage = () => {
       setPaymentSel(load.payment_status);
     }
   }, [load]);
+
+  // Fetch the mission map for this load (haul + deadhead leg). Non-fatal: null
+  // just leaves the text route to stand on its own.
+  useEffect(() => {
+    if (!load?.load_id) return;
+    let active = true;
+    getLoadMap(load.load_id).then((img) => {
+      if (active) setMapImage(img);
+    });
+    return () => {
+      active = false;
+    };
+  }, [load?.load_id]);
 
   useEffect(() => {
     getAccessorialRates()
@@ -595,6 +610,13 @@ export const LoadDetailPage = () => {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
         <Panel className="p-4">
           <p className={cardLbl}>Route</p>
+          {mapImage && (
+            <img
+              src={mapImage}
+              alt={`Route from ${load.origin_city} to ${load.destination_city}`}
+              className="w-full rounded-lg mb-3 border border-steel"
+            />
+          )}
           <div className="flex gap-3">
             <div className="flex flex-col items-center pt-1.5">
               <div className="w-2 h-2 rounded-full bg-muted-text" />

--- a/frontend/src/pages/ScoreLoadPage.tsx
+++ b/frontend/src/pages/ScoreLoadPage.tsx
@@ -3,7 +3,7 @@ import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { scoreLoad, VERDICT_META } from "@/lib/metrics/loadScore";
 import { RATE_TIERS } from "@/lib/constants/targets";
-import { getLoadMiles, type Place } from "@/services/routingService";
+import { getLoadMiles, getRouteMap, type Place } from "@/services/routingService";
 import { getLastKnownLocation } from "@/services/tripsService";
 import { toInches, classifyOversize } from "@/lib/dimensions";
 
@@ -170,6 +170,7 @@ const ScoreLoadPage = () => {
   const [deadhead, setDeadhead] = useState("");
   const [routing, setRouting] = useState(false);
   const [routeErr, setRouteErr] = useState(false);
+  const [mapImage, setMapImage] = useState<string | null>(null);
 
   // Prefill "Truck now" (the deadhead origin) with the truck's last-known
   // location. Non-fatal — no data just leaves it blank to fill by hand.
@@ -224,10 +225,19 @@ const ScoreLoadPage = () => {
       setRouting(false);
       if (res.loadedMiles == null && res.deadheadMiles == null) {
         setRouteErr(true);
+        setMapImage(null);
         return;
       }
       if (res.loadedMiles != null) setLoaded(String(res.loadedMiles));
       if (res.deadheadMiles != null) setDeadhead(String(res.deadheadMiles));
+      // The mission map for what was just entered (haul + deadhead leg).
+      getRouteMap({
+        truckNow: truckNow.city && truckNow.state ? truckNow : null,
+        pickup,
+        delivery,
+      }).then((img) => {
+        if (!cancelled) setMapImage(img);
+      });
     }, 600);
     return () => {
       cancelled = true;
@@ -348,6 +358,15 @@ const ScoreLoadPage = () => {
             <Field label="Deadhead" value={deadhead} onChange={setDeadhead} accent suffix="mi" />
           </div>
         </div>
+
+        {mapImage && (
+          <img
+            src={mapImage}
+            alt="Route map"
+            className="w-full rounded-[9px] mt-2.5 mb-1"
+            style={{ border: "1px solid #2a3347" }}
+          />
+        )}
 
         {!targets.ready ? (
           <p className="text-xs text-muted-text mt-4 text-center">

--- a/frontend/src/services/routingService.ts
+++ b/frontend/src/services/routingService.ts
@@ -37,3 +37,30 @@ export const getLoadMiles = async (body: {
     return { loadedMiles: null, deadheadMiles: null };
   }
 };
+
+// The mission map (base64 PNG data URI) for a saved load — its haul plus the
+// deadhead leg chained from where the truck sat before it. null → show the text
+// route. Non-fatal.
+export const getLoadMap = async (loadId: string): Promise<string | null> => {
+  try {
+    const res = await api.get(`/routing/load-map/${loadId}`);
+    return res.data.image ?? null;
+  } catch {
+    return null;
+  }
+};
+
+// The mission map for a scored (unsaved) load: deadhead (truckNow→pickup) +
+// loaded (pickup→delivery). null → no map. Non-fatal.
+export const getRouteMap = async (body: {
+  truckNow?: Place | null;
+  pickup: Place;
+  delivery: Place;
+}): Promise<string | null> => {
+  try {
+    const res = await api.post("/routing/map", body);
+    return res.data.image ?? null;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
A static HERE map of the haul, on the load detail ROUTE panel and the Scorer.

## What changed
- Draws the **loaded leg** (pickup→delivery) and the **deadhead leg**. On a saved load the deadhead origin is chained from `precedingLocation` — the located record (load destination / trip end) just below the load's start odometer. On the Scorer it's the truck's current spot.
- **HERE provider:** `routePolylines`, a pure `buildMapImageUrl` (Map Image v3 overlay syntax — line + multiPoint, `%23` color), `fetchMapDataUri`.
- **`renderRouteMap`** composes both legs + pins, cached by route (bounded).
- **Endpoints:** `GET /routing/load-map/:id`, `POST /routing/map`. The PNG returns as a **base64 data URI over authenticated JSON** — key stays server-side, and a plain `<img>` (which can't send the auth header) still works.
- Graceful to null everywhere: no key, no geocode, no route, or an over-long URL → no image, and the text route stands. The page never breaks.

## Verified
- Strict build clean; **375 frontend + 30 backend tests** — polyline parsing and the exact v3 URL format (overlays, encoded color, no raw `#`).
- `precedingLocation` checked against **prod**: load 1469377's deadhead correctly originates at Columbus, MS.
- The live map render needs the Railway `HERE_API_KEY` + auth, so it first draws in-app.

No migration (uses the trip location columns already shipped). **v1.111.0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)