### PR TITLE
fix: mission map — use point: not multiPoint: for single markers

### DIFF
--- a/backend/src/services/hereProvider.js
+++ b/backend/src/services/hereProvider.js
@@ -137,7 +137,9 @@ export const buildMapImageUrl = ({
     overlays.push(`line:${geom};color=%23${l.color};width=${l.width}`);
   }
   for (const p of points) {
-    overlays.push(`multiPoint:${p.lat},${p.lng};color=%23${p.color};size=large`);
+    // A single pin is `point:` — `multiPoint:` is for a set and 400s on one pair
+    // (confirmed against the live API). Color is accepted; `size` is not passed.
+    overlays.push(`point:${p.lat},${p.lng};color=%23${p.color}`);
   }
   // Overlay values are already URL-safe (polyline is [A-Za-z0-9-_], plus digits,
   // '.', ':', ';', ','); the color '#' is the only reserved char, emitted as %23.

--- a/backend/src/services/hereProvider.test.js
+++ b/backend/src/services/hereProvider.test.js
@@ -83,7 +83,9 @@ describe("buildMapImageUrl", () => {
     assert.ok(url.startsWith("https://image.maps.hereapi.com/mia/v3/base/mc/overlay:padding=40/640x300/png"));
     assert.ok(url.includes("apiKey=K"));
     assert.ok(url.includes("overlay=line:ABC;color=%23f5b03a;width=5"));
-    assert.ok(url.includes("overlay=multiPoint:32.5,-96.6;color=%234ade80;size=large"));
+    // a single pin is `point:` (not `multiPoint:`, which 400s on one pair)
+    assert.ok(url.includes("overlay=point:32.5,-96.6;color=%234ade80"));
+    assert.ok(!url.includes("multiPoint"));
     // the raw '#' must never appear (it would truncate the URL at the fragment)
     assert.ok(!url.includes("#"));
   });

--- a/backend/src/services/routingService.js
+++ b/backend/src/services/routingService.js
@@ -73,37 +73,46 @@ export async function renderRouteMap({ deadheadOrigin, pickup, delivery } = {}) 
         : null,
     ]);
     if (pk && dl) {
-      const lines = [];
       const points = [];
-
-      // Deadhead leg first so the loaded haul draws on top of it.
-      if (dh) {
-        const dhPolys = await routePolylines(dh, pk);
-        if (dhPolys)
-          for (const p of dhPolys)
-            lines.push({ polyline: p, color: C_DEADHEAD, width: 4 });
-        else
-          lines.push({ coords: [dh.lat, dh.lng, pk.lat, pk.lng], color: C_DEADHEAD, width: 4 });
-        points.push({ lat: dh.lat, lng: dh.lng, color: C_DH_ORIGIN });
-      }
-
-      const loadedPolys = await routePolylines(pk, dl);
-      if (loadedPolys)
-        for (const p of loadedPolys)
-          lines.push({ polyline: p, color: C_LOADED, width: 5 });
-      else
-        lines.push({ coords: [pk.lat, pk.lng, dl.lat, dl.lng], color: C_LOADED, width: 5 });
+      if (dh) points.push({ lat: dh.lat, lng: dh.lng, color: C_DH_ORIGIN });
       points.push({ lat: pk.lat, lng: pk.lng, color: C_START });
       points.push({ lat: dl.lat, lng: dl.lng, color: C_OBJECTIVE });
 
-      const url = buildMapImageUrl({
-        apiKey: process.env.HERE_API_KEY,
-        width: 640,
-        height: 300,
-        lines,
-        points,
-      });
-      image = await fetchMapDataUri(url);
+      // Straight raw-coord segments — the confirmed-working fallback.
+      const straight = [];
+      if (dh)
+        straight.push({ coords: [dh.lat, dh.lng, pk.lat, pk.lng], color: C_DEADHEAD, width: 4 });
+      straight.push({ coords: [pk.lat, pk.lng, dl.lat, dl.lng], color: C_LOADED, width: 5 });
+
+      // Road-route geometry — the nicer primary, per leg (polyline when HERE
+      // returns it, otherwise that leg's straight segment).
+      const road = [];
+      if (dh) {
+        const p = await routePolylines(dh, pk);
+        if (p) for (const pl of p) road.push({ polyline: pl, color: C_DEADHEAD, width: 4 });
+        else road.push({ coords: [dh.lat, dh.lng, pk.lat, pk.lng], color: C_DEADHEAD, width: 4 });
+      }
+      const lp = await routePolylines(pk, dl);
+      if (lp) for (const pl of lp) road.push({ polyline: pl, color: C_LOADED, width: 5 });
+      else road.push({ coords: [pk.lat, pk.lng, dl.lat, dl.lng], color: C_LOADED, width: 5 });
+
+      // Try the road route; if its image request fails (rejected polyline, URL
+      // too long), fall back to plain straight lines so a map still renders.
+      for (const lines of [road, straight]) {
+        try {
+          const url = buildMapImageUrl({
+            apiKey: process.env.HERE_API_KEY,
+            width: 640,
+            height: 300,
+            lines,
+            points,
+          });
+          image = await fetchMapDataUri(url);
+          if (image) break;
+        } catch {
+          // try the next line style
+        }
+      }
     }
   } catch {
     image = null;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.111.0",
+  "version": "1.111.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Every mission map came back blank. The Map Image v3 request was 400ing because each pin was emitted as `multiPoint:lat,lng` — but `multiPoint` is for a *set* of points and rejects a single pair (`"expected latitude1,longitude1,...latitudeN,longitudeN"`). A single marker is `point:`.

Confirmed against the live HERE API: the corrected URL (`point:` markers, line overlay unchanged) returns **200 image/png**. The line overlay, geocoding, image proxy, and `<img>` wiring were all already correct — it was purely the marker keyword.

Also hardens `renderRouteMap`: it now tries the road-route polylines first, then falls back to plain **straight-line raw coordinates** (the format proven to work) if HERE rejects the polyline or the URL runs too long — so a map renders either way.

Backend 30 tests green (URL-builder test now locks the `point:` format); frontend build clean.

Patch — **v1.111.1** (v1.111.0 shipped the feature broken; this makes it render). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)