### PR TITLE
feat: mission map — self-rendered geo route over faint state borders

### DIFF
--- a/backend/src/routes/routingRoutes.js
+++ b/backend/src/routes/routingRoutes.js
@@ -1,6 +1,6 @@
 import express from "express";
 import { requireAuth } from "../middleware/requireAuth.js";
-import { loadMiles, renderRouteMap } from "../services/routingService.js";
+import { loadMiles, routeGeo } from "../services/routingService.js";
 import { getLoad } from "../services/loadServices.js";
 import { precedingLocation } from "../services/tripServices.js";
 
@@ -28,21 +28,30 @@ router.post("/load-miles", async (req, res) => {
   }
 });
 
-// ---- MISSION MAP FOR A SAVED LOAD ----
-// Renders the load's haul, with the deadhead leg chained from wherever the truck
-// sat before it. Returns { image: dataURI | null }; null just means "show the
-// text route" — a missing map never errors the page.
-router.get("/load-map/:loadId", async (req, res) => {
+// ---- MISSION MAP DATA FOR A SAVED LOAD ----
+// Geocoded pickup/delivery (+ the load's loaded miles) for the mission map. The
+// deadhead leg is included ONLY once the load is active (in_transit/delivered) —
+// on a booked load the deadhead origin isn't real yet, so it's omitted. Returns
+// null coords when a city won't geocode; the page falls back to the text route.
+router.get("/load-route/:loadId", async (req, res) => {
   try {
     const user_id = req.user.user_id;
     const load = await getLoad(user_id, req.params.loadId);
-    const deadheadOrigin = await precedingLocation(user_id, load);
-    const image = await renderRouteMap({
+    const active =
+      load.load_status === "in_transit" || load.load_status === "delivered";
+    const deadheadOrigin = active
+      ? await precedingLocation(user_id, load)
+      : null;
+    const geo = await routeGeo({
       deadheadOrigin,
       pickup: { city: load.origin_city, state: load.origin_state },
       delivery: { city: load.destination_city, state: load.destination_state },
     });
-    return res.status(200).json({ message: "Load map", image });
+    return res.status(200).json({
+      message: "Load route",
+      ...geo,
+      loadedMiles: Number(load.loaded_miles) || null,
+    });
   } catch (err) {
     if (err.type === "not_found") {
       return res.status(err.statusCode).json({ error: err.message });
@@ -54,17 +63,13 @@ router.get("/load-map/:loadId", async (req, res) => {
   }
 });
 
-// ---- MISSION MAP FOR A SCORED (not-yet-saved) LOAD ----
+// ---- MISSION MAP DATA FOR A SCORED (not-yet-saved) LOAD ----
 // Body: { truckNow?, pickup, delivery }. Deadhead leg drawn from truckNow.
-router.post("/map", async (req, res) => {
+router.post("/route", async (req, res) => {
   try {
     const { truckNow, pickup, delivery } = req.body ?? {};
-    const image = await renderRouteMap({
-      deadheadOrigin: truckNow,
-      pickup,
-      delivery,
-    });
-    return res.status(200).json({ message: "Route map", image });
+    const geo = await routeGeo({ deadheadOrigin: truckNow, pickup, delivery });
+    return res.status(200).json({ message: "Route", ...geo });
   } catch (err) {
     return res.status(500).json({
       error: "Internal Server Error",

--- a/backend/src/services/hereProvider.js
+++ b/backend/src/services/hereProvider.js
@@ -9,7 +9,6 @@
 
 const GEOCODE_URL = "https://geocode.search.hereapi.com/v1/geocode";
 const ROUTER_URL = "https://router.hereapi.com/v8/routes";
-const MAP_IMAGE_URL = "https://image.maps.hereapi.com/mia/v3/base/mc";
 
 // ---- unit conversions (pure) ----
 export const metersToMiles = (m) => m / 1609.344;
@@ -90,68 +89,4 @@ export const routeMiles = async (from, to, dims) => {
   if (!res.ok) throw new Error(`HERE route failed (${res.status})`);
   const meters = parseRouteMeters(await res.json());
   return meters == null ? null : metersToMiles(meters);
-};
-
-// ---- static route map (for the "mission map") ----
-
-// HERE route response → the flexible polyline(s), one per section, for drawing
-// the route on a static map. null when there's no geometry.
-export const parseRoutePolylines = (json) => {
-  const sections = json?.routes?.[0]?.sections;
-  if (!Array.isArray(sections)) return null;
-  const polys = sections.map((s) => s?.polyline).filter(Boolean);
-  return polys.length ? polys : null;
-};
-
-// The route's drawable geometry (flexible polylines) between two points. Plain
-// truck mode — the map line is illustrative, so we skip dims here for speed and
-// robustness (the Scorer's MILES are where dims matter). null when no route.
-export const routePolylines = async (from, to) => {
-  if (!hasKey() || !from || !to) return null;
-  const params = new URLSearchParams({
-    transportMode: "truck",
-    origin: `${from.lat},${from.lng}`,
-    destination: `${to.lat},${to.lng}`,
-    return: "polyline",
-    apiKey: process.env.HERE_API_KEY,
-  });
-  const res = await fetch(`${ROUTER_URL}?${params}`);
-  if (!res.ok) throw new Error(`HERE route(polyline) failed (${res.status})`);
-  return parseRoutePolylines(await res.json());
-};
-
-// Pure: assemble a Map Image v3 URL. `lines` = [{ polyline | coords[], color,
-// width }], `points` = [{ lat, lng, color }] (colors are 6-hex, no '#'). HERE's
-// overlay syntax needs ':' ';' ',' kept literal, so we build the query by hand
-// and only encode the color '#' as %23. `overlay:padding` auto-fits the view.
-export const buildMapImageUrl = ({
-  apiKey,
-  width = 640,
-  height = 300,
-  lines = [],
-  points = [],
-}) => {
-  const overlays = [];
-  for (const l of lines) {
-    const geom = l.polyline ? l.polyline : l.coords.join(",");
-    overlays.push(`line:${geom};color=%23${l.color};width=${l.width}`);
-  }
-  for (const p of points) {
-    // A single pin is `point:` — `multiPoint:` is for a set and 400s on one pair
-    // (confirmed against the live API). Color is accepted; `size` is not passed.
-    overlays.push(`point:${p.lat},${p.lng};color=%23${p.color}`);
-  }
-  // Overlay values are already URL-safe (polyline is [A-Za-z0-9-_], plus digits,
-  // '.', ':', ';', ','); the color '#' is the only reserved char, emitted as %23.
-  const qs = overlays.map((o) => `overlay=${o}`).join("&");
-  return `${MAP_IMAGE_URL}/overlay:padding=40/${width}x${height}/png?apiKey=${apiKey}&${qs}`;
-};
-
-// Fetch a Map Image URL and return it as a base64 PNG data URI — so it rides
-// authenticated JSON to the browser and the key never leaves the server.
-export const fetchMapDataUri = async (url) => {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`HERE map image failed (${res.status})`);
-  const buf = Buffer.from(await res.arrayBuffer());
-  return `data:image/png;base64,${buf.toString("base64")}`;
 };

--- a/backend/src/services/hereProvider.test.js
+++ b/backend/src/services/hereProvider.test.js
@@ -6,8 +6,6 @@ import {
   poundsToKg,
   parseGeocode,
   parseRouteMeters,
-  parseRoutePolylines,
-  buildMapImageUrl,
 } from "./hereProvider.js";
 
 describe("unit conversions", () => {
@@ -56,45 +54,5 @@ describe("parseRouteMeters", () => {
   test("null when a section is missing its length (don't trust a partial total)", () => {
     const json = { routes: [{ sections: [{ summary: { length: 1000 } }, { summary: {} }] }] };
     assert.equal(parseRouteMeters(json), null);
-  });
-});
-
-describe("parseRoutePolylines", () => {
-  test("collects a polyline per section", () => {
-    const json = { routes: [{ sections: [{ polyline: "AAA" }, { polyline: "BBB" }] }] };
-    assert.deepEqual(parseRoutePolylines(json), ["AAA", "BBB"]);
-  });
-
-  test("null when there's no geometry", () => {
-    assert.equal(parseRoutePolylines({ routes: [{ sections: [{}] }] }), null);
-    assert.equal(parseRoutePolylines({}), null);
-  });
-});
-
-describe("buildMapImageUrl", () => {
-  test("builds a v3 URL with size, line + point overlays, and %23-encoded color", () => {
-    const url = buildMapImageUrl({
-      apiKey: "K",
-      width: 640,
-      height: 300,
-      lines: [{ polyline: "ABC", color: "f5b03a", width: 5 }],
-      points: [{ lat: 32.5, lng: -96.6, color: "4ade80" }],
-    });
-    assert.ok(url.startsWith("https://image.maps.hereapi.com/mia/v3/base/mc/overlay:padding=40/640x300/png"));
-    assert.ok(url.includes("apiKey=K"));
-    assert.ok(url.includes("overlay=line:ABC;color=%23f5b03a;width=5"));
-    // a single pin is `point:` (not `multiPoint:`, which 400s on one pair)
-    assert.ok(url.includes("overlay=point:32.5,-96.6;color=%234ade80"));
-    assert.ok(!url.includes("multiPoint"));
-    // the raw '#' must never appear (it would truncate the URL at the fragment)
-    assert.ok(!url.includes("#"));
-  });
-
-  test("falls back to raw coords for a line when no polyline", () => {
-    const url = buildMapImageUrl({
-      apiKey: "K",
-      lines: [{ coords: [1, 2, 3, 4], color: "6f7a8c", width: 4 }],
-    });
-    assert.ok(url.includes("overlay=line:1,2,3,4;color=%236f7a8c;width=4"));
   });
 });

--- a/backend/src/services/routingService.js
+++ b/backend/src/services/routingService.js
@@ -1,13 +1,7 @@
-// Load-scoring mileage, provider-agnostic. Talks to hereProvider today; swap that
-// import to change providers. Everything here is an ESTIMATE for scoring a load
-// before it runs — the odometer stays the single source of truth once it does.
-import {
-  geocode,
-  routeMiles,
-  routePolylines,
-  buildMapImageUrl,
-  fetchMapDataUri,
-} from "./hereProvider.js";
+// Load-scoring mileage + route geometry, provider-agnostic. Talks to hereProvider
+// today; swap that import to change providers. Everything here is an ESTIMATE for
+// scoring/visualizing a load — the odometer stays the single source of truth.
+import { geocode, routeMiles } from "./hereProvider.js";
 
 // One leg's miles: geocode both ends, then route between them with the load's
 // dims. Self-contained try/catch so a failure on one leg never sinks the other
@@ -37,91 +31,25 @@ export async function loadMiles({ truckNow, pickup, delivery, dims } = {}) {
   return { loadedMiles, deadheadMiles };
 }
 
-// ---- the "mission map" ----
-
-// Map colors (6-hex, no '#') — the paid haul in amber, the empty leg in gray,
-// pickup green, destination red, and a faint pin where the deadhead began.
-const C_LOADED = "f5b03a";
-const C_DEADHEAD = "6f7a8c";
-const C_START = "4ade80";
-const C_OBJECTIVE = "f87171";
-const C_DH_ORIGIN = "8b98a9";
-
-// Tiny bounded cache: a route's rendered image doesn't change, so don't re-hit
-// HERE for the same haul. Keyed by the three places; oldest evicted past cap.
-const mapCache = new Map();
-const MAP_CACHE_CAP = 60;
-
-// A rendered route-map data URI (PNG) for a load: the loaded haul
-// (pickup→delivery) and, when we know where the truck came from, the deadhead
-// leg into the pickup. null on any failure — the caller shows the text route.
-export async function renderRouteMap({ deadheadOrigin, pickup, delivery } = {}) {
-  if (!process.env.HERE_API_KEY) return null;
-  if (!pickup?.city || !pickup?.state || !delivery?.city || !delivery?.state)
-    return null;
-
-  const key = JSON.stringify({ deadheadOrigin, pickup, delivery });
-  if (mapCache.has(key)) return mapCache.get(key);
-
-  let image = null;
-  try {
-    const [pk, dl, dh] = await Promise.all([
-      geocode(pickup.city, pickup.state),
-      geocode(delivery.city, delivery.state),
-      deadheadOrigin?.city && deadheadOrigin?.state
-        ? geocode(deadheadOrigin.city, deadheadOrigin.state)
-        : null,
-    ]);
-    if (pk && dl) {
-      const points = [];
-      if (dh) points.push({ lat: dh.lat, lng: dh.lng, color: C_DH_ORIGIN });
-      points.push({ lat: pk.lat, lng: pk.lng, color: C_START });
-      points.push({ lat: dl.lat, lng: dl.lng, color: C_OBJECTIVE });
-
-      // Straight raw-coord segments — the confirmed-working fallback.
-      const straight = [];
-      if (dh)
-        straight.push({ coords: [dh.lat, dh.lng, pk.lat, pk.lng], color: C_DEADHEAD, width: 4 });
-      straight.push({ coords: [pk.lat, pk.lng, dl.lat, dl.lng], color: C_LOADED, width: 5 });
-
-      // Road-route geometry — the nicer primary, per leg (polyline when HERE
-      // returns it, otherwise that leg's straight segment).
-      const road = [];
-      if (dh) {
-        const p = await routePolylines(dh, pk);
-        if (p) for (const pl of p) road.push({ polyline: pl, color: C_DEADHEAD, width: 4 });
-        else road.push({ coords: [dh.lat, dh.lng, pk.lat, pk.lng], color: C_DEADHEAD, width: 4 });
-      }
-      const lp = await routePolylines(pk, dl);
-      if (lp) for (const pl of lp) road.push({ polyline: pl, color: C_LOADED, width: 5 });
-      else road.push({ coords: [pk.lat, pk.lng, dl.lat, dl.lng], color: C_LOADED, width: 5 });
-
-      // Try the road route; if its image request fails (rejected polyline, URL
-      // too long), fall back to plain straight lines so a map still renders.
-      for (const lines of [road, straight]) {
-        try {
-          const url = buildMapImageUrl({
-            apiKey: process.env.HERE_API_KEY,
-            width: 640,
-            height: 300,
-            lines,
-            points,
-          });
-          image = await fetchMapDataUri(url);
-          if (image) break;
-        } catch {
-          // try the next line style
-        }
-      }
+// ---- route geometry for the "mission map" ----
+// Geocode each end to { lat, lng, city, state } so the frontend can draw the
+// route AND the faint state borders in one coordinate space. A point that won't
+// geocode (or a null deadhead — e.g. a booked load) comes back null; the map
+// falls back to the text route when pickup/delivery can't resolve.
+export async function routeGeo({ deadheadOrigin, pickup, delivery } = {}) {
+  const geo = async (p) => {
+    if (!p?.city || !p?.state) return null;
+    try {
+      const c = await geocode(p.city, p.state);
+      return c ? { lat: c.lat, lng: c.lng, city: p.city.trim(), state: p.state.trim() } : null;
+    } catch {
+      return null;
     }
-  } catch {
-    image = null;
-  }
-
-  if (image) {
-    mapCache.set(key, image);
-    if (mapCache.size > MAP_CACHE_CAP)
-      mapCache.delete(mapCache.keys().next().value);
-  }
-  return image;
+  };
+  const [pickupGeo, deliveryGeo, deadheadGeo] = await Promise.all([
+    geo(pickup),
+    geo(delivery),
+    geo(deadheadOrigin),
+  ]);
+  return { pickup: pickupGeo, delivery: deliveryGeo, deadhead: deadheadGeo };
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.94.0",
+  "version": "1.111.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.94.0",
+      "version": "1.111.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "axios": "^1.13.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.111.1",
+  "version": "1.112.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/MissionMap.tsx
+++ b/frontend/src/components/MissionMap.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo, useState } from "react";
+import { makeProjector, geoPath, type LngLat } from "@/lib/geoProject";
+import type { GeoPoint } from "@/services/routingService";
+
+interface MissionMapProps {
+  pickup: GeoPoint;
+  delivery: GeoPoint;
+  deadhead?: GeoPoint | null; // omit/null → no deadhead leg (e.g. a booked load)
+  loadedMiles?: number | null;
+  deadheadMiles?: number | null;
+  height?: number;
+}
+
+type Feat = { geometry: { type: string; coordinates: unknown } };
+
+// Load the US states once for the whole app, lazily — a ~115KB dataset that has
+// no business in the main bundle. Failures degrade to no borders (route only).
+let statesPromise: Promise<Feat[]> | null = null;
+const loadStates = (): Promise<Feat[]> => {
+  if (!statesPromise) {
+    statesPromise = Promise.all([
+      import("us-atlas/states-10m.json"),
+      import("topojson-client"),
+    ])
+      .then(([topoMod, tj]) => {
+        const topo = ((topoMod as { default?: unknown }).default ??
+          topoMod) as { objects: { states: unknown } };
+        const feature = (tj as { feature: (t: unknown, o: unknown) => { features: Feat[] } }).feature;
+        return feature(topo, topo.objects.states).features;
+      })
+      .catch(() => []);
+  }
+  return statesPromise;
+};
+
+const label = (city: string, state: string) => `${city}, ${state}`;
+
+const MissionMap = ({
+  pickup,
+  delivery,
+  deadhead,
+  loadedMiles,
+  deadheadMiles,
+  height = 300,
+}: MissionMapProps) => {
+  const [states, setStates] = useState<Feat[]>([]);
+  useEffect(() => {
+    let active = true;
+    loadStates().then((f) => active && setStates(f));
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const W = 860;
+  const H = height;
+
+  const project = useMemo(() => {
+    const pts: LngLat[] = [
+      { lng: pickup.lng, lat: pickup.lat },
+      { lng: delivery.lng, lat: delivery.lat },
+    ];
+    if (deadhead) pts.push({ lng: deadhead.lng, lat: deadhead.lat });
+    // Extra padding leaves room for the reticle crosshair + labels at the edges.
+    return makeProjector(pts, W, H, 46);
+  }, [pickup, delivery, deadhead, H]);
+
+  const statePaths = useMemo(
+    () => states.map((f) => geoPath(f.geometry, project)).filter(Boolean),
+    [states, project],
+  );
+
+  const pk = project(pickup);
+  const dl = project(delivery);
+  const dh = deadhead ? project(deadhead) : null;
+  const clampY = (y: number) => Math.max(15, Math.min(H - 7, y));
+  // Keep labels inside the frame: a pin near an edge anchors its label inward.
+  const anchorFor = (x: number): "start" | "middle" | "end" =>
+    x < W * 0.16 ? "start" : x > W * 0.84 ? "end" : "middle";
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      style={{ width: "100%", borderRadius: 9, display: "block" }}
+      role="img"
+      aria-label={`Route from ${label(pickup.city, pickup.state)} to ${label(delivery.city, delivery.state)}`}
+    >
+      <rect width={W} height={H} fill="#0e1420" />
+
+      {/* Faint state borders, zoomed to the run. */}
+      {statePaths.map((d, i) => (
+        <path key={i} d={d} fill="#111d2c" stroke="#28384f" strokeWidth={1} strokeLinejoin="round" />
+      ))}
+
+      {/* Deadhead leg (empty) under the loaded haul. */}
+      {dh && (
+        <line x1={dh.x} y1={dh.y} x2={pk.x} y2={pk.y} stroke="#7c8899" strokeWidth={3} strokeDasharray="7 6" strokeLinecap="round" />
+      )}
+      {/* Loaded haul. */}
+      <line x1={pk.x} y1={pk.y} x2={dl.x} y2={dl.y} stroke="#f5b03a" strokeWidth={4} strokeLinecap="round" />
+
+      {/* Pins. */}
+      {dh && <circle cx={dh.x} cy={dh.y} r={6} fill="#8b98a9" />}
+      <circle cx={pk.x} cy={pk.y} r={8} fill="#4ade80" stroke="#0e1420" strokeWidth={2} />
+
+      {/* Objective — target reticle. */}
+      <circle cx={dl.x} cy={dl.y} r={13} fill="none" stroke="#f87171" strokeWidth={2.5} />
+      <circle cx={dl.x} cy={dl.y} r={4.5} fill="#f87171" />
+      <line x1={dl.x} y1={dl.y - 20} x2={dl.x} y2={dl.y - 13} stroke="#f87171" strokeWidth={2.5} />
+      <line x1={dl.x} y1={dl.y + 13} x2={dl.x} y2={dl.y + 20} stroke="#f87171" strokeWidth={2.5} />
+      <line x1={dl.x - 20} y1={dl.y} x2={dl.x - 13} y2={dl.y} stroke="#f87171" strokeWidth={2.5} />
+      <line x1={dl.x + 13} y1={dl.y} x2={dl.x + 20} y2={dl.y} stroke="#f87171" strokeWidth={2.5} />
+
+      {/* Labels. */}
+      <g fontFamily="system-ui" fontSize={13} fontWeight={600}>
+        <text x={pk.x} y={clampY(pk.y + 24)} fill="#eaf1f8" textAnchor={anchorFor(pk.x)}>
+          {label(pickup.city, pickup.state)}
+        </text>
+        <text x={dl.x} y={clampY(dl.y - 24)} fill="#eaf1f8" textAnchor={anchorFor(dl.x)}>
+          {label(delivery.city, delivery.state)}
+        </text>
+        {dh && (
+          <text x={dh.x} y={clampY(dh.y + 22)} fill="#8b98a9" textAnchor={anchorFor(dh.x)} fontWeight={400}>
+            {label(deadhead!.city, deadhead!.state)}
+          </text>
+        )}
+      </g>
+      <g fontFamily="system-ui" fontSize={11.5} fontWeight={600}>
+        {loadedMiles != null && (
+          <text x={(pk.x + dl.x) / 2} y={clampY((pk.y + dl.y) / 2 - 8)} fill="#f5b03a" textAnchor="middle">
+            {Math.round(loadedMiles).toLocaleString("en-US")} mi loaded
+          </text>
+        )}
+        {dh && deadheadMiles != null && (
+          <text x={(dh.x + pk.x) / 2} y={clampY((dh.y + pk.y) / 2 - 8)} fill="#8b98a9" textAnchor="middle" fontWeight={400}>
+            {Math.round(deadheadMiles).toLocaleString("en-US")} mi deadhead
+          </text>
+        )}
+      </g>
+    </svg>
+  );
+};
+
+export default MissionMap;

--- a/frontend/src/lib/geoProject.test.ts
+++ b/frontend/src/lib/geoProject.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { makeProjector, geoPath } from "./geoProject";
+
+describe("makeProjector", () => {
+  it("puts a single point at the center of the box", () => {
+    const p = makeProjector([{ lng: -96, lat: 39 }], 800, 300);
+    const { x, y } = p({ lng: -96, lat: 39 });
+    expect(x).toBeCloseTo(400, 0);
+    expect(y).toBeCloseTo(150, 0);
+  });
+
+  it("preserves compass orientation: east → larger x, north → smaller y", () => {
+    const pts = [
+      { lng: -96, lat: 32 }, // SW (Dallas-ish)
+      { lng: -84, lat: 34 }, // NE (Atlanta-ish)
+    ];
+    const proj = makeProjector(pts, 800, 300);
+    const sw = proj(pts[0]);
+    const ne = proj(pts[1]);
+    expect(ne.x).toBeGreaterThan(sw.x); // east is right
+    expect(ne.y).toBeLessThan(sw.y); // north is up
+  });
+
+  it("keeps every point inside the padded box", () => {
+    const pts = [
+      { lng: -122, lat: 47 },
+      { lng: -71, lat: 42 },
+      { lng: -96, lat: 30 },
+    ];
+    const pad = 26;
+    const proj = makeProjector(pts, 800, 320, pad);
+    for (const pt of pts) {
+      const { x, y } = proj(pt);
+      expect(x).toBeGreaterThanOrEqual(pad - 1);
+      expect(x).toBeLessThanOrEqual(800 - pad + 1);
+      expect(y).toBeGreaterThanOrEqual(pad - 1);
+      expect(y).toBeLessThanOrEqual(320 - pad + 1);
+    }
+  });
+});
+
+describe("geoPath", () => {
+  it("builds a closed SVG path from a Polygon", () => {
+    const proj = makeProjector([{ lng: 0, lat: 0 }], 100, 100);
+    const d = geoPath(
+      { type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+      proj,
+    );
+    expect(d.startsWith("M")).toBe(true);
+    expect(d.endsWith("Z")).toBe(true);
+    expect((d.match(/Z/g) || []).length).toBe(1);
+  });
+
+  it("handles MultiPolygon (one Z per ring) and ignores other types", () => {
+    const proj = makeProjector([{ lng: 0, lat: 0 }], 100, 100);
+    const d = geoPath(
+      {
+        type: "MultiPolygon",
+        coordinates: [
+          [[[0, 0], [1, 0], [0, 0]]],
+          [[[2, 2], [3, 2], [2, 2]]],
+        ],
+      },
+      proj,
+    );
+    expect((d.match(/Z/g) || []).length).toBe(2);
+    expect(geoPath({ type: "Point", coordinates: [0, 0] }, proj)).toBe("");
+  });
+});

--- a/frontend/src/lib/geoProject.ts
+++ b/frontend/src/lib/geoProject.ts
@@ -1,0 +1,89 @@
+// Tiny equirectangular projector for the mission map: fit a set of lng/lat points
+// into a WxH box, so the geocoded route AND the state-border outlines share one
+// coordinate space. Longitude is scaled by cos(midLat) so the map doesn't look
+// east-west stretched at US latitudes. Latitude flips (screen y grows down).
+// A minimum span keeps a short haul from zooming in absurdly.
+
+export interface LngLat {
+  lng: number;
+  lat: number;
+}
+export interface XY {
+  x: number;
+  y: number;
+}
+
+export interface Projector {
+  (p: LngLat): XY;
+}
+
+export const makeProjector = (
+  points: LngLat[],
+  width: number,
+  height: number,
+  pad = 26,
+  minSpanDeg = 2.2,
+): Projector => {
+  let minLng = Infinity,
+    maxLng = -Infinity,
+    minLat = Infinity,
+    maxLat = -Infinity;
+  for (const p of points) {
+    if (p.lng < minLng) minLng = p.lng;
+    if (p.lng > maxLng) maxLng = p.lng;
+    if (p.lat < minLat) minLat = p.lat;
+    if (p.lat > maxLat) maxLat = p.lat;
+  }
+  // Empty/degenerate guard — center on the point(s) with the min span.
+  if (!Number.isFinite(minLng)) {
+    minLng = -98;
+    maxLng = -98;
+    minLat = 39;
+    maxLat = 39;
+  }
+
+  const midLat = (minLat + maxLat) / 2;
+  const k = Math.cos((midLat * Math.PI) / 180) || 1; // lng compression at this latitude
+
+  // Enforce a minimum span (in degrees), expanding around the center.
+  const cLng = (minLng + maxLng) / 2;
+  const cLat = (minLat + maxLat) / 2;
+  const halfLng = Math.max((maxLng - minLng) / 2, minSpanDeg / 2 / (k || 1));
+  const halfLat = Math.max((maxLat - minLat) / 2, minSpanDeg / 2);
+
+  // Uniform scale that fits both axes into the padded box (letterboxed).
+  const spanX = halfLng * 2 * k; // adjusted-longitude span
+  const spanY = halfLat * 2;
+  const scale = Math.min((width - 2 * pad) / spanX, (height - 2 * pad) / spanY);
+
+  return (p: LngLat): XY => ({
+    x: width / 2 + (p.lng - cLng) * k * scale,
+    y: height / 2 - (p.lat - cLat) * scale, // flip: north is up
+  });
+};
+
+// A GeoJSON Polygon/MultiPolygon → an SVG path `d`, projected. Rings are
+// [ [lng,lat], ... ]. Unknown geometry types yield an empty string.
+type Ring = [number, number][];
+export const geoPath = (
+  geometry: { type: string; coordinates: unknown },
+  project: Projector,
+): string => {
+  const ringPath = (ring: Ring): string =>
+    ring
+      .map(([lng, lat], i) => {
+        const { x, y } = project({ lng, lat });
+        return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join("") + "Z";
+
+  if (geometry.type === "Polygon") {
+    return (geometry.coordinates as Ring[]).map(ringPath).join("");
+  }
+  if (geometry.type === "MultiPolygon") {
+    return (geometry.coordinates as Ring[][])
+      .flatMap((poly) => poly.map(ringPath))
+      .join("");
+  }
+  return "";
+};

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -12,7 +12,8 @@ import {
 } from "lucide-react";
 
 import { useLoad } from "@/hooks/useLoad";
-import { getLoadMap } from "@/services/routingService";
+import { getLoadRoute, type RouteGeo } from "@/services/routingService";
+import MissionMap from "@/components/MissionMap";
 import { formatLoadDims } from "@/lib/dimensions";
 import { useAccessorials } from "@/hooks/useAccessorials";
 import { useBrokers } from "@/hooks/useBrokers";
@@ -166,7 +167,7 @@ export const LoadDetailPage = () => {
   const [refreshKey, setRefreshKey] = useState(0);
   const [accRefreshKey, setAccRefreshKey] = useState(0);
   const { load, isLoading, error } = useLoad(refreshKey);
-  const [mapImage, setMapImage] = useState<string | null>(null);
+  const [route, setRoute] = useState<RouteGeo | null>(null);
   const { accessorials } = useAccessorials(accRefreshKey);
 
   const [newType, setNewType] = useState("");
@@ -232,13 +233,13 @@ export const LoadDetailPage = () => {
     }
   }, [load]);
 
-  // Fetch the mission map for this load (haul + deadhead leg). Non-fatal: null
-  // just leaves the text route to stand on its own.
+  // Fetch the mission-map geometry for this load. Non-fatal: an empty route just
+  // leaves the text route to stand on its own.
   useEffect(() => {
     if (!load?.load_id) return;
     let active = true;
-    getLoadMap(load.load_id).then((img) => {
-      if (active) setMapImage(img);
+    getLoadRoute(load.load_id).then((r) => {
+      if (active) setRoute(r);
     });
     return () => {
       active = false;
@@ -608,34 +609,37 @@ export const LoadDetailPage = () => {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-        <Panel className="p-4">
+        <Panel className="p-4 md:col-span-2">
           <p className={cardLbl}>Route</p>
-          {mapImage && (
-            <img
-              src={mapImage}
-              alt={`Route from ${load.origin_city} to ${load.destination_city}`}
-              className="w-full rounded-lg mb-3 border border-steel"
+          {route?.pickup && route?.delivery ? (
+            <MissionMap
+              pickup={route.pickup}
+              delivery={route.delivery}
+              deadhead={route.deadhead}
+              loadedMiles={route.loadedMiles}
+              height={300}
             />
+          ) : (
+            <div className="flex gap-3">
+              <div className="flex flex-col items-center pt-1.5">
+                <div className="w-2 h-2 rounded-full bg-muted-text" />
+                <div className="w-px flex-1 bg-steel min-h-[24px] my-1" />
+                <div className="w-2 h-2 rounded-full bg-amber" />
+              </div>
+              <div className="text-sm flex-1">
+                <p className="font-medium">
+                  {load.origin_city}, {load.origin_state}
+                </p>
+                <p className="text-xs text-muted-text mb-3">
+                  {load.origin_market}
+                </p>
+                <p className="font-medium">
+                  {load.destination_city}, {load.destination_state}
+                </p>
+                <p className="text-xs text-muted-text">{load.delivery_market}</p>
+              </div>
+            </div>
           )}
-          <div className="flex gap-3">
-            <div className="flex flex-col items-center pt-1.5">
-              <div className="w-2 h-2 rounded-full bg-muted-text" />
-              <div className="w-px flex-1 bg-steel min-h-[24px] my-1" />
-              <div className="w-2 h-2 rounded-full bg-amber" />
-            </div>
-            <div className="text-sm flex-1">
-              <p className="font-medium">
-                {load.origin_city}, {load.origin_state}
-              </p>
-              <p className="text-xs text-muted-text mb-3">
-                {load.origin_market}
-              </p>
-              <p className="font-medium">
-                {load.destination_city}, {load.destination_state}
-              </p>
-              <p className="text-xs text-muted-text">{load.delivery_market}</p>
-            </div>
-          </div>
         </Panel>
 
         <Panel className="p-4 border border-amber">

--- a/frontend/src/pages/ScoreLoadPage.tsx
+++ b/frontend/src/pages/ScoreLoadPage.tsx
@@ -3,9 +3,15 @@ import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { scoreLoad, VERDICT_META } from "@/lib/metrics/loadScore";
 import { RATE_TIERS } from "@/lib/constants/targets";
-import { getLoadMiles, getRouteMap, type Place } from "@/services/routingService";
+import {
+  getLoadMiles,
+  getScoreRoute,
+  type Place,
+  type RouteGeo,
+} from "@/services/routingService";
 import { getLastKnownLocation } from "@/services/tripsService";
 import { toInches, classifyOversize } from "@/lib/dimensions";
+import MissionMap from "@/components/MissionMap";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const rpm = (n: number | null) => (n != null ? `$${n.toFixed(2)}` : "—");
@@ -170,7 +176,7 @@ const ScoreLoadPage = () => {
   const [deadhead, setDeadhead] = useState("");
   const [routing, setRouting] = useState(false);
   const [routeErr, setRouteErr] = useState(false);
-  const [mapImage, setMapImage] = useState<string | null>(null);
+  const [route, setRoute] = useState<RouteGeo | null>(null);
 
   // Prefill "Truck now" (the deadhead origin) with the truck's last-known
   // location. Non-fatal — no data just leaves it blank to fill by hand.
@@ -225,18 +231,18 @@ const ScoreLoadPage = () => {
       setRouting(false);
       if (res.loadedMiles == null && res.deadheadMiles == null) {
         setRouteErr(true);
-        setMapImage(null);
+        setRoute(null);
         return;
       }
       if (res.loadedMiles != null) setLoaded(String(res.loadedMiles));
       if (res.deadheadMiles != null) setDeadhead(String(res.deadheadMiles));
       // The mission map for what was just entered (haul + deadhead leg).
-      getRouteMap({
+      getScoreRoute({
         truckNow: truckNow.city && truckNow.state ? truckNow : null,
         pickup,
         delivery,
-      }).then((img) => {
-        if (!cancelled) setMapImage(img);
+      }).then((r) => {
+        if (!cancelled) setRoute(r);
       });
     }, 600);
     return () => {
@@ -359,13 +365,17 @@ const ScoreLoadPage = () => {
           </div>
         </div>
 
-        {mapImage && (
-          <img
-            src={mapImage}
-            alt="Route map"
-            className="w-full rounded-[9px] mt-2.5 mb-1"
-            style={{ border: "1px solid #2a3347" }}
-          />
+        {route?.pickup && route?.delivery && (
+          <div className="mt-2.5 mb-1 rounded-[9px] overflow-hidden" style={{ border: "1px solid #2a3347" }}>
+            <MissionMap
+              pickup={route.pickup}
+              delivery={route.delivery}
+              deadhead={route.deadhead}
+              loadedMiles={loaded === "" ? null : Number(loaded)}
+              deadheadMiles={deadhead === "" ? null : Number(deadhead)}
+              height={440}
+            />
+          </div>
         )}
 
         {!targets.ready ? (

--- a/frontend/src/services/routingService.ts
+++ b/frontend/src/services/routingService.ts
@@ -38,29 +38,61 @@ export const getLoadMiles = async (body: {
   }
 };
 
-// The mission map (base64 PNG data URI) for a saved load — its haul plus the
-// deadhead leg chained from where the truck sat before it. null → show the text
-// route. Non-fatal.
-export const getLoadMap = async (loadId: string): Promise<string | null> => {
+// A geocoded point for the mission map.
+export interface GeoPoint {
+  lat: number;
+  lng: number;
+  city: string;
+  state: string;
+}
+
+export interface RouteGeo {
+  pickup: GeoPoint | null;
+  delivery: GeoPoint | null;
+  deadhead: GeoPoint | null; // null when unknown (booked load) or ungeocodable
+  loadedMiles: number | null;
+}
+
+const EMPTY_ROUTE: RouteGeo = {
+  pickup: null,
+  delivery: null,
+  deadhead: null,
+  loadedMiles: null,
+};
+
+// Mission-map geometry for a saved load: geocoded pickup/delivery, the deadhead
+// origin (only when the load is active), and the loaded miles. Non-fatal → an
+// empty route just leaves the text route standing.
+export const getLoadRoute = async (loadId: string): Promise<RouteGeo> => {
   try {
-    const res = await api.get(`/routing/load-map/${loadId}`);
-    return res.data.image ?? null;
+    const res = await api.get(`/routing/load-route/${loadId}`);
+    return {
+      pickup: res.data.pickup ?? null,
+      delivery: res.data.delivery ?? null,
+      deadhead: res.data.deadhead ?? null,
+      loadedMiles: res.data.loadedMiles ?? null,
+    };
   } catch {
-    return null;
+    return EMPTY_ROUTE;
   }
 };
 
-// The mission map for a scored (unsaved) load: deadhead (truckNow→pickup) +
-// loaded (pickup→delivery). null → no map. Non-fatal.
-export const getRouteMap = async (body: {
+// Mission-map geometry for a scored (unsaved) load: deadhead (truckNow→pickup)
+// and loaded (pickup→delivery). The Scorer supplies its own miles. Non-fatal.
+export const getScoreRoute = async (body: {
   truckNow?: Place | null;
   pickup: Place;
   delivery: Place;
-}): Promise<string | null> => {
+}): Promise<RouteGeo> => {
   try {
-    const res = await api.post("/routing/map", body);
-    return res.data.image ?? null;
+    const res = await api.post("/routing/route", body);
+    return {
+      pickup: res.data.pickup ?? null,
+      delivery: res.data.delivery ?? null,
+      deadhead: res.data.deadhead ?? null,
+      loadedMiles: null,
+    };
   } catch {
-    return null;
+    return EMPTY_ROUTE;
   }
 };


### PR DESCRIPTION
Reworks the mission map per feedback: drop HERE's detailed map tile for a stylized SVG dash draws itself.

## What changed
- **Faint US state borders** (us-atlas, lazy-loaded as its own ~37KB-gzip chunk) auto-zoomed to the route — enough to place the haul at a glance, no map detail.
- **Geo-placed route** on top: green pickup pin, red **target reticle** objective, gray dashed deadhead, amber loaded leg, city/state labels + distances. Fully themeable; no external tile to break.
- `geoProject.ts` — equirectangular fit-to-box projector (cos-lat corrected) so borders + pins share one coordinate space (unit-tested).
- Backend returns geocoded route **data** now (`routeGeo`) instead of a PNG: `GET /routing/load-route/:id`, `POST /routing/route`. The dead Map Image code is removed.
- **Load detail**: full-width ROUTE row; deadhead leg shown **only when the load is active** (booked → pickup → objective). Scorer keeps the deadhead (it's a what-if).

## Verified
- Rendered locally with a sample route (screenshots in the thread): faint SE-US borders, correct geo placement (Ferris TX → Abbeville SC → Ashburn VA), reticle, and edge-label clipping fixed.
- Strict build clean; **380 frontend + 26 backend tests**; states data confirmed to split into its own lazy chunk (main bundle unchanged).

No migration. **v1.112.0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)