### PR TITLE
feat: smart city autocomplete on all city fields + city cleanup

### DIFF
--- a/backend/db/migrations/052_trim_city_values.sql
+++ b/backend/db/migrations/052_trim_city_values.sql
@@ -1,0 +1,39 @@
+-- One-time hygiene: strip stray whitespace from city values and normalize state
+-- codes (trim + uppercase) that accumulated before city autocomplete existed —
+-- e.g. "Ferris " / "Canfield " that were fragmenting lane and agent grouping.
+-- Idempotent (re-running is a no-op); no schema change, so no RLS statement.
+
+UPDATE loads SET origin_city = TRIM(origin_city)
+  WHERE origin_city <> TRIM(origin_city);
+UPDATE loads SET destination_city = TRIM(destination_city)
+  WHERE destination_city <> TRIM(destination_city);
+UPDATE loads SET origin_state = UPPER(TRIM(origin_state))
+  WHERE origin_state <> UPPER(TRIM(origin_state));
+UPDATE loads SET destination_state = UPPER(TRIM(destination_state))
+  WHERE destination_state <> UPPER(TRIM(destination_state));
+
+UPDATE trips SET start_city = TRIM(start_city)
+  WHERE start_city IS NOT NULL AND start_city <> TRIM(start_city);
+UPDATE trips SET end_city = TRIM(end_city)
+  WHERE end_city IS NOT NULL AND end_city <> TRIM(end_city);
+UPDATE trips SET start_state = UPPER(TRIM(start_state))
+  WHERE start_state IS NOT NULL AND start_state <> UPPER(TRIM(start_state));
+UPDATE trips SET end_state = UPPER(TRIM(end_state))
+  WHERE end_state IS NOT NULL AND end_state <> UPPER(TRIM(end_state));
+
+UPDATE fuel_entries SET fuel_city = TRIM(fuel_city)
+  WHERE fuel_city IS NOT NULL AND fuel_city <> TRIM(fuel_city);
+UPDATE fuel_entries SET fuel_state = UPPER(TRIM(fuel_state))
+  WHERE fuel_state IS NOT NULL AND fuel_state <> UPPER(TRIM(fuel_state));
+
+-- Facilities carry UNIQUE(user_id, name, city, state). Only clean rows whose
+-- trimmed value wouldn't collide with an existing facility (skip the rare dup).
+UPDATE facilities f SET city = TRIM(city), state = UPPER(TRIM(state))
+  WHERE (city <> TRIM(city) OR state <> UPPER(TRIM(state)))
+    AND NOT EXISTS (
+      SELECT 1 FROM facilities g
+      WHERE g.user_id = f.user_id AND g.facility_id <> f.facility_id
+        AND g.name = f.name
+        AND g.city = TRIM(f.city)
+        AND g.state = UPPER(TRIM(f.state))
+    );

--- a/backend/src/routes/routingRoutes.js
+++ b/backend/src/routes/routingRoutes.js
@@ -1,11 +1,24 @@
 import express from "express";
 import { requireAuth } from "../middleware/requireAuth.js";
 import { loadMiles, routeGeo } from "../services/routingService.js";
+import { citySuggest } from "../services/hereProvider.js";
 import { getLoad } from "../services/loadServices.js";
 import { precedingLocation } from "../services/tripServices.js";
 
 const router = express.Router();
 router.use(requireAuth);
+
+// ---- CITY AUTOCOMPLETE ----
+// Typeahead suggestions for a city field. Non-fatal: any failure returns an
+// empty list, so the dropdown just goes quiet and the user types normally.
+router.get("/city-suggest", async (req, res) => {
+  try {
+    const suggestions = await citySuggest(req.query.q);
+    return res.status(200).json({ suggestions });
+  } catch {
+    return res.status(200).json({ suggestions: [] });
+  }
+});
 
 // ---- SCORE-A-LOAD MILEAGE ----
 // Body: { truckNow?, pickup, delivery, dims? } where a place is { city, state }

--- a/backend/src/services/hereProvider.js
+++ b/backend/src/services/hereProvider.js
@@ -9,6 +9,7 @@
 
 const GEOCODE_URL = "https://geocode.search.hereapi.com/v1/geocode";
 const ROUTER_URL = "https://router.hereapi.com/v8/routes";
+const AUTOCOMPLETE_URL = "https://autocomplete.search.hereapi.com/v1/autocomplete";
 
 // ---- unit conversions (pure) ----
 export const metersToMiles = (m) => m / 1609.344;
@@ -89,4 +90,45 @@ export const routeMiles = async (from, to, dims) => {
   if (!res.ok) throw new Error(`HERE route failed (${res.status})`);
   const meters = parseRouteMeters(await res.json());
   return meters == null ? null : metersToMiles(meters);
+};
+
+// ---- city autocomplete ----
+
+// Pure: HERE autocomplete response → up to `limit` city suggestions
+// [{ city, state, label }]. Keeps any US result that resolves to a city + a
+// 2-letter state, de-duped by "CITY,ST" (so a street and its city collapse to
+// one city suggestion). Robust whether or not the request filtered by type.
+export const parseCitySuggestions = (json, limit = 6) => {
+  const items = json?.items;
+  if (!Array.isArray(items)) return [];
+  const out = [];
+  const seen = new Set();
+  for (const it of items) {
+    const a = it?.address;
+    const city = a?.city?.trim();
+    const state = a?.stateCode?.trim()?.toUpperCase();
+    if (!city || !state || state.length !== 2) continue;
+    const key = `${city.toUpperCase()},${state}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ city, state, label: `${city}, ${state}` });
+    if (out.length >= limit) break;
+  }
+  return out;
+};
+
+// City typeahead suggestions for a partial query (US cities). [] when
+// unconfigured or the query is too short to be worth a call.
+export const citySuggest = async (q) => {
+  if (!hasKey() || !q || q.trim().length < 2) return [];
+  const params = new URLSearchParams({
+    q: q.trim(),
+    in: "countryCode:USA",
+    types: "city",
+    limit: "10",
+    apiKey: process.env.HERE_API_KEY,
+  });
+  const res = await fetch(`${AUTOCOMPLETE_URL}?${params}`);
+  if (!res.ok) throw new Error(`HERE autocomplete failed (${res.status})`);
+  return parseCitySuggestions(await res.json());
 };

--- a/backend/src/services/hereProvider.test.js
+++ b/backend/src/services/hereProvider.test.js
@@ -6,6 +6,7 @@ import {
   poundsToKg,
   parseGeocode,
   parseRouteMeters,
+  parseCitySuggestions,
 } from "./hereProvider.js";
 
 describe("unit conversions", () => {
@@ -54,5 +55,49 @@ describe("parseRouteMeters", () => {
   test("null when a section is missing its length (don't trust a partial total)", () => {
     const json = { routes: [{ sections: [{ summary: { length: 1000 } }, { summary: {} }] }] };
     assert.equal(parseRouteMeters(json), null);
+  });
+});
+
+describe("parseCitySuggestions", () => {
+  test("maps city + stateCode to {city, state, label}", () => {
+    const json = {
+      items: [
+        { address: { city: "Dallas", stateCode: "TX" } },
+        { address: { city: "Dalton", stateCode: "GA" } },
+      ],
+    };
+    assert.deepEqual(parseCitySuggestions(json), [
+      { city: "Dallas", state: "TX", label: "Dallas, TX" },
+      { city: "Dalton", state: "GA", label: "Dalton, GA" },
+    ]);
+  });
+
+  test("trims junk, uppercases the state, and de-dupes by city+state", () => {
+    const json = {
+      items: [
+        { address: { city: "Ferris ", stateCode: "tx" } },
+        { address: { city: "Ferris", stateCode: "TX" } }, // dup after trim/upper
+        { address: { city: "123 Main St", stateCode: "TX" } }, // a street resolving to a city we already have? no — different "city"
+      ],
+    };
+    const out = parseCitySuggestions(json);
+    assert.deepEqual(out[0], { city: "Ferris", state: "TX", label: "Ferris, TX" });
+    // the second Ferris is deduped
+    assert.equal(out.filter((s) => s.city === "Ferris").length, 1);
+  });
+
+  test("skips items without a usable city + 2-letter state; caps at the limit", () => {
+    const json = {
+      items: [
+        { address: { city: "Austin", stateCode: "TX" } },
+        { address: { stateCode: "TX" } }, // no city
+        { address: { city: "Nowhere", stateCode: "Texas" } }, // bad state
+        { title: "junk" },
+      ],
+    };
+    assert.deepEqual(parseCitySuggestions(json, 6), [
+      { city: "Austin", state: "TX", label: "Austin, TX" },
+    ]);
+    assert.deepEqual(parseCitySuggestions({}), []);
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.112.0",
+  "version": "1.113.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/CityAutocomplete.tsx
+++ b/frontend/src/components/CityAutocomplete.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef, useState } from "react";
+import { getCitySuggestions, type CitySuggestion } from "@/services/routingService";
+
+interface CityAutocompleteProps {
+  value: string;
+  onType: (city: string) => void; // free typing — parent updates the city only
+  onSelect: (city: string, state: string) => void; // a suggestion was picked
+  placeholder?: string;
+  id?: string;
+  inputClassName?: string;
+  inputStyle?: React.CSSProperties;
+}
+
+// A city text field with a HERE-backed typeahead. Picking a suggestion fills a
+// clean, canonical "City, ST" (via onSelect); typing is always allowed (onType).
+// The parent owns the value and styling; this owns the dropdown behavior.
+const CityAutocomplete = ({
+  value,
+  onType,
+  onSelect,
+  placeholder = "City",
+  id,
+  inputClassName,
+  inputStyle,
+}: CityAutocompleteProps) => {
+  const [suggestions, setSuggestions] = useState<CitySuggestion[]>([]);
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(-1);
+  const focused = useRef(false);
+  const skipNext = useRef(false); // suppress the fetch triggered by a pick/prefill
+
+  // Debounced fetch as the user types (only while focused, only 2+ chars).
+  useEffect(() => {
+    if (!focused.current) return;
+    if (skipNext.current) {
+      skipNext.current = false;
+      return;
+    }
+    const q = value.trim();
+    if (q.length < 2) {
+      setSuggestions([]);
+      setOpen(false);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      const s = await getCitySuggestions(q);
+      if (!focused.current) return;
+      setSuggestions(s);
+      setOpen(s.length > 0);
+      setActive(-1);
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [value]);
+
+  const pick = (s: CitySuggestion) => {
+    skipNext.current = true;
+    onSelect(s.city, s.state);
+    setOpen(false);
+    setSuggestions([]);
+    setActive(-1);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (!open || suggestions.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive((a) => Math.min(a + 1, suggestions.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((a) => Math.max(a - 1, 0));
+    } else if (e.key === "Enter" && active >= 0) {
+      e.preventDefault();
+      pick(suggestions[active]);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div style={{ position: "relative" }}>
+      <input
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        autoComplete="off"
+        className={inputClassName}
+        style={inputStyle}
+        onChange={(e) => onType(e.target.value)}
+        onFocus={() => {
+          focused.current = true;
+          if (suggestions.length) setOpen(true);
+        }}
+        onBlur={() => {
+          focused.current = false;
+          // Delay so an onMouseDown pick registers before the list closes.
+          setTimeout(() => setOpen(false), 150);
+        }}
+        onKeyDown={onKeyDown}
+        role="combobox"
+        aria-expanded={open}
+        aria-autocomplete="list"
+      />
+      {open && suggestions.length > 0 && (
+        <ul
+          role="listbox"
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: "calc(100% + 4px)",
+            zIndex: 30,
+            margin: 0,
+            padding: 4,
+            listStyle: "none",
+            background: "#141b28",
+            border: "1px solid #2a3347",
+            borderRadius: 9,
+            maxHeight: 220,
+            overflowY: "auto",
+            boxShadow: "0 8px 24px rgba(0,0,0,0.35)",
+          }}
+        >
+          {suggestions.map((s, i) => (
+            <li
+              key={s.label}
+              role="option"
+              aria-selected={i === active}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                pick(s);
+              }}
+              onMouseEnter={() => setActive(i)}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "8px 10px",
+                borderRadius: 6,
+                cursor: "pointer",
+                fontSize: 14,
+                color: "#f4f7fb",
+                background: i === active ? "#20293a" : "transparent",
+              }}
+            >
+              <span style={{ color: "#5f6b80", fontSize: 12 }}>◈</span>
+              <span>
+                {s.city}, <span style={{ color: "#9fb0c9" }}>{s.state}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default CityAutocomplete;

--- a/frontend/src/components/FacilityCreateForm.tsx
+++ b/frontend/src/components/FacilityCreateForm.tsx
@@ -3,7 +3,8 @@ import type { Facility, FacilityKind } from "@/types/facility";
 import { createFacility } from "@/services/facilitiesService";
 import { findDuplicate, facilityLabel } from "@/lib/facilityMatch";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Input, inputClass } from "@/components/ui/input";
+import CityAutocomplete from "@/components/CityAutocomplete";
 import { Label } from "@/components/ui/label";
 
 interface Props {
@@ -103,7 +104,18 @@ export const FacilityCreateForm = ({
       )}
 
       <div className="flex gap-2">
-        <Input placeholder="City" value={city} onChange={(e) => setCity(e.target.value)} />
+        <div className="flex-1">
+          <CityAutocomplete
+            value={city}
+            onType={setCity}
+            onSelect={(c, s) => {
+              setCity(c);
+              setState(s);
+            }}
+            placeholder="City"
+            inputClassName={inputClass}
+          />
+        </div>
         <Input
           placeholder="ST"
           maxLength={2}

--- a/frontend/src/components/LoadForm.tsx
+++ b/frontend/src/components/LoadForm.tsx
@@ -29,7 +29,8 @@ import { toInches, toFeetInches, isOverWidth, formatInches } from "@/lib/dimensi
 // UI Component Imports
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Input, inputClass } from "@/components/ui/input";
+import CityAutocomplete from "@/components/CityAutocomplete";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -883,12 +884,21 @@ const LoadForm = ({
             {/* Origin City field */}
             <div>
               <Label htmlFor="origin_city">Origin City</Label>
-              <Input
-                name="origin_city"
+              <CityAutocomplete
                 id="origin_city"
-                onChange={handleChange}
                 value={formData.origin_city}
-              ></Input>
+                onType={(city) =>
+                  setFormData((f) => ({ ...f, origin_city: city }))
+                }
+                onSelect={(city, state) =>
+                  setFormData((f) => ({
+                    ...f,
+                    origin_city: city,
+                    origin_state: state,
+                  }))
+                }
+                inputClassName={inputClass}
+              />
             </div>
             {/* Origin State field name */}
             <div>
@@ -942,12 +952,21 @@ const LoadForm = ({
             {/* Destination City field */}
             <div>
               <Label htmlFor="destination_city">Destination City</Label>
-              <Input
-                name="destination_city"
+              <CityAutocomplete
                 id="destination_city"
-                onChange={handleChange}
                 value={formData.destination_city}
-              ></Input>
+                onType={(city) =>
+                  setFormData((f) => ({ ...f, destination_city: city }))
+                }
+                onSelect={(city, state) =>
+                  setFormData((f) => ({
+                    ...f,
+                    destination_city: city,
+                    destination_state: state,
+                  }))
+                }
+                inputClassName={inputClass}
+              />
             </div>
             {/* Destination State field */}
             <div>

--- a/frontend/src/components/TripForm.tsx
+++ b/frontend/src/components/TripForm.tsx
@@ -7,7 +7,8 @@ import {
 } from "@/services/tripsService";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Input, inputClass } from "@/components/ui/input";
+import CityAutocomplete from "@/components/CityAutocomplete";
 import { Panel } from "@/components/ui/Panel";
 import { Label } from "@/components/ui/label";
 import {
@@ -180,11 +181,14 @@ const TripForm = ({ onSuccess, onClose }: TripFormProps) => {
         {/* Start location — where the truck currently sits */}
         <div>
           <Label htmlFor="start_city">Start City</Label>
-          <Input
-            name="start_city"
+          <CityAutocomplete
             id="start_city"
-            onChange={handleChange}
             value={formData.start_city ?? ""}
+            onType={(city) => setFormData((prev) => ({ ...prev, start_city: city }))}
+            onSelect={(city, state) =>
+              setFormData((prev) => ({ ...prev, start_city: city, start_state: state }))
+            }
+            inputClassName={inputClass}
           />
           <p className="text-xs text-muted-text mt-1">
             Prefilled from your last known location.
@@ -205,11 +209,14 @@ const TripForm = ({ onSuccess, onClose }: TripFormProps) => {
         {/* End location — where the truck ends up (feeds its next last-known spot) */}
         <div>
           <Label htmlFor="end_city">End City</Label>
-          <Input
-            name="end_city"
+          <CityAutocomplete
             id="end_city"
-            onChange={handleChange}
             value={formData.end_city ?? ""}
+            onType={(city) => setFormData((prev) => ({ ...prev, end_city: city }))}
+            onSelect={(city, state) =>
+              setFormData((prev) => ({ ...prev, end_city: city, end_state: state }))
+            }
+            inputClassName={inputClass}
           />
         </div>
 

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -2,17 +2,20 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+// The base input styling, exported so other controls (e.g. CityAutocomplete's
+// text field) can match the shared Input exactly.
+export const inputClass = cn(
+  "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+  "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+  "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+)
+
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
     <input
       type={type}
       data-slot="input"
-      className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className
-      )}
+      className={cn(inputClass, className)}
       {...props}
     />
   )

--- a/frontend/src/pages/ScoreLoadPage.tsx
+++ b/frontend/src/pages/ScoreLoadPage.tsx
@@ -12,6 +12,7 @@ import {
 import { getLastKnownLocation } from "@/services/tripsService";
 import { toInches, classifyOversize } from "@/lib/dimensions";
 import MissionMap from "@/components/MissionMap";
+import CityAutocomplete from "@/components/CityAutocomplete";
 
 const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const rpm = (n: number | null) => (n != null ? `$${n.toFixed(2)}` : "—");
@@ -97,11 +98,11 @@ const PlaceRow = ({
   <div className="flex gap-2 mb-2.5">
     <div className="flex-[3]">
       <Lbl>{label}</Lbl>
-      <input
-        style={txt}
+      <CityAutocomplete
         value={place.city}
-        placeholder="City"
-        onChange={(e) => onChange({ ...place, city: e.target.value })}
+        onType={(city) => onChange({ ...place, city })}
+        onSelect={(city, state) => onChange({ city, state })}
+        inputStyle={txt}
       />
     </div>
     <div className="flex-1">

--- a/frontend/src/services/routingService.ts
+++ b/frontend/src/services/routingService.ts
@@ -5,6 +5,26 @@ export interface Place {
   state: string;
 }
 
+export interface CitySuggestion {
+  city: string;
+  state: string;
+  label: string; // "Dallas, TX"
+}
+
+// City typeahead suggestions for a partial query. Non-fatal → [] on any failure,
+// so the dropdown just stays quiet and the field types normally.
+export const getCitySuggestions = async (
+  q: string,
+): Promise<CitySuggestion[]> => {
+  if (!q || q.trim().length < 2) return [];
+  try {
+    const res = await api.get("/routing/city-suggest", { params: { q } });
+    return res.data.suggestions ?? [];
+  } catch {
+    return [];
+  }
+};
+
 // Travel dimensions in inches + gross pounds; drives HERE's oversize routing.
 export interface LoadDims {
   widthIn?: number | null;


### PR DESCRIPTION
Typeahead on every city input — Scorer (pickup/delivery), load form (origin/destination), trip form (start/end), and facility form. Type a few letters, pick a real "City, ST", and it fills a clean canonical value in both fields. Free typing still works.

## What changed
- **`CityAutocomplete`** — debounced, keyboard-navigable combobox. Parent owns value + styling (`inputClass` now exported from `ui/input` so the field matches the shared Input exactly).
- **Backend proxy** — `hereProvider.citySuggest` + `parseCitySuggestions` (US cities; trims, uppercases the state, de-dupes by city+state), exposed at `GET /routing/city-suggest`. Non-fatal: any failure returns `[]`, so the dropdown just goes quiet.
- **Migration 052 — one-time cleanup** of existing city/state junk (stray spaces, lowercase states) that was fragmenting lane/agent grouping. Idempotent; facilities guarded against their `UNIQUE(user_id,name,city,state)`. **Applied to dev + prod — fixed 27 loads + 21 facilities, 0 junk left.**

## Verified
- Rendered locally: the dropdown positions/styles correctly, and picking "Dallas, TX" filled city `Dallas` + state `TX` and closed. (screenshots in thread)
- Strict build clean; **380 frontend + 29 backend tests** (suggestion parser unit-tested).
- Live HERE autocomplete format is the one piece only exercisable with the prod key — first confirmed by typing in a field once deployed.

**v1.113.0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)