### PR TITLE
feat: Scorer estimated tolls + counter-rate ladder

### DIFF
--- a/backend/src/services/hereProvider.js
+++ b/backend/src/services/hereProvider.js
@@ -63,13 +63,22 @@ export const geocode = async (city, state) => {
   return coords;
 };
 
-// Driving miles between two { lat, lng } points as a truck. Optional dims
-// (inches + gross pounds) turn on PHYSICAL restrictions — the oversize routing
-// that reroutes around low bridges, narrow roads, and weight-limited segments.
-// null when unconfigured or no route.
+// Apply the load's dims to a routing request — HERE wants centimeters + kg.
+// Turns on PHYSICAL restrictions (the oversize reroute around low bridges,
+// narrow roads, weight limits) and, for tolls, the correct vehicle toll class.
+const setVehicleDims = (params, dims) => {
+  if (!dims) return;
+  if (dims.widthIn) params.set("vehicle[width]", String(inchesToCm(dims.widthIn)));
+  if (dims.heightIn) params.set("vehicle[height]", String(inchesToCm(dims.heightIn)));
+  if (dims.lengthIn) params.set("vehicle[length]", String(inchesToCm(dims.lengthIn)));
+  if (dims.grossWeightLb)
+    params.set("vehicle[grossWeight]", String(poundsToKg(dims.grossWeightLb)));
+};
+
+// Driving miles between two { lat, lng } points as a truck. null when
+// unconfigured or no route.
 export const routeMiles = async (from, to, dims) => {
   if (!hasKey() || !from || !to) return null;
-
   const params = new URLSearchParams({
     transportMode: "truck",
     origin: `${from.lat},${from.lng}`,
@@ -77,19 +86,57 @@ export const routeMiles = async (from, to, dims) => {
     return: "summary",
     apiKey: process.env.HERE_API_KEY,
   });
-
-  if (dims) {
-    if (dims.widthIn) params.set("vehicle[width]", String(inchesToCm(dims.widthIn)));
-    if (dims.heightIn) params.set("vehicle[height]", String(inchesToCm(dims.heightIn)));
-    if (dims.lengthIn) params.set("vehicle[length]", String(inchesToCm(dims.lengthIn)));
-    if (dims.grossWeightLb)
-      params.set("vehicle[grossWeight]", String(poundsToKg(dims.grossWeightLb)));
-  }
-
+  setVehicleDims(params, dims);
   const res = await fetch(`${ROUTER_URL}?${params}`);
   if (!res.ok) throw new Error(`HERE route failed (${res.status})`);
   const meters = parseRouteMeters(await res.json());
   return meters == null ? null : metersToMiles(meters);
+};
+
+// Pure: HERE route (return=…,tolls) → total toll cost, summing every fare in
+// every section. null when there's no toll data (or a toll-free route).
+export const parseRouteTolls = (json) => {
+  const sections = json?.routes?.[0]?.sections;
+  if (!Array.isArray(sections)) return null;
+  let total = 0;
+  let found = false;
+  for (const s of sections) {
+    if (!Array.isArray(s?.tolls)) continue;
+    for (const t of s.tolls) {
+      if (!Array.isArray(t?.fares)) continue;
+      for (const f of t.fares) {
+        const v = Number(f?.price?.value);
+        if (Number.isFinite(v)) {
+          total += v;
+          found = true;
+        }
+      }
+    }
+  }
+  return found ? Math.round(total * 100) / 100 : null;
+};
+
+// Miles AND estimated toll cost for a leg in one call, with the truck's dims so
+// the toll class is right. { miles, tollUsd }, either possibly null.
+export const routeMilesAndTolls = async (from, to, dims) => {
+  if (!hasKey() || !from || !to) return { miles: null, tollUsd: null };
+  const params = new URLSearchParams({
+    transportMode: "truck",
+    origin: `${from.lat},${from.lng}`,
+    destination: `${to.lat},${to.lng}`,
+    return: "summary,tolls",
+    currency: "USD",
+    apiKey: process.env.HERE_API_KEY,
+  });
+  setVehicleDims(params, dims);
+  const res = await fetch(`${ROUTER_URL}?${params}`);
+  if (!res.ok) throw new Error(`HERE route(tolls) failed (${res.status})`);
+  const json = await res.json();
+  const meters = parseRouteMeters(json);
+  return {
+    miles: meters == null ? null : metersToMiles(meters),
+    tollUsd: parseRouteTolls(json),
+  };
 };
 
 // ---- city autocomplete ----

--- a/backend/src/services/hereProvider.test.js
+++ b/backend/src/services/hereProvider.test.js
@@ -6,6 +6,7 @@ import {
   poundsToKg,
   parseGeocode,
   parseRouteMeters,
+  parseRouteTolls,
   parseCitySuggestions,
 } from "./hereProvider.js";
 
@@ -55,6 +56,28 @@ describe("parseRouteMeters", () => {
   test("null when a section is missing its length (don't trust a partial total)", () => {
     const json = { routes: [{ sections: [{ summary: { length: 1000 } }, { summary: {} }] }] };
     assert.equal(parseRouteMeters(json), null);
+  });
+});
+
+describe("parseRouteTolls", () => {
+  test("sums every fare across every section", () => {
+    const json = {
+      routes: [
+        {
+          sections: [
+            { tolls: [{ fares: [{ price: { value: 12.5 } }, { price: { value: 3.25 } }] }] },
+            { tolls: [{ fares: [{ price: { value: 8 } }] }] },
+          ],
+        },
+      ],
+    };
+    assert.equal(parseRouteTolls(json), 23.75);
+  });
+
+  test("null when there's no toll data (or a toll-free route)", () => {
+    assert.equal(parseRouteTolls({ routes: [{ sections: [{ summary: {} }] }] }), null);
+    assert.equal(parseRouteTolls({ routes: [{ sections: [{ tolls: [] }] }] }), null);
+    assert.equal(parseRouteTolls({}), null);
   });
 });
 

--- a/backend/src/services/routingService.js
+++ b/backend/src/services/routingService.js
@@ -1,7 +1,7 @@
 // Load-scoring mileage + route geometry, provider-agnostic. Talks to hereProvider
 // today; swap that import to change providers. Everything here is an ESTIMATE for
 // scoring/visualizing a load — the odometer stays the single source of truth.
-import { geocode, routeMiles } from "./hereProvider.js";
+import { geocode, routeMiles, routeMilesAndTolls } from "./hereProvider.js";
 
 // One leg's miles: geocode both ends, then route between them with the load's
 // dims. Self-contained try/catch so a failure on one leg never sinks the other
@@ -21,14 +21,36 @@ async function legMiles(from, to, dims) {
   }
 }
 
-// The two legs of a scored load: loaded (pickup → delivery) and, when we know
-// where the truck is, deadhead (truck → pickup). Either can be null.
+// The loaded leg, with estimated tolls (billed as a 100% accessorial, so the
+// Scorer can prompt the ask). Self-contained try/catch like legMiles.
+async function legMilesAndTolls(from, to, dims) {
+  try {
+    if (!from?.city || !from?.state || !to?.city || !to?.state)
+      return { miles: null, tollUsd: null };
+    const [a, b] = await Promise.all([
+      geocode(from.city, from.state),
+      geocode(to.city, to.state),
+    ]);
+    if (!a || !b) return { miles: null, tollUsd: null };
+    const { miles, tollUsd } = await routeMilesAndTolls(a, b, dims);
+    return { miles: miles == null ? null : Math.round(miles * 10) / 10, tollUsd };
+  } catch {
+    return { miles: null, tollUsd: null };
+  }
+}
+
+// The two legs of a scored load: loaded (pickup → delivery, with tolls) and,
+// when we know where the truck is, deadhead (truck → pickup). Any can be null.
 export async function loadMiles({ truckNow, pickup, delivery, dims } = {}) {
-  const [loadedMiles, deadheadMiles] = await Promise.all([
-    legMiles(pickup, delivery, dims),
+  const [loaded, deadheadMiles] = await Promise.all([
+    legMilesAndTolls(pickup, delivery, dims),
     truckNow ? legMiles(truckNow, pickup, dims) : Promise.resolve(null),
   ]);
-  return { loadedMiles, deadheadMiles };
+  return {
+    loadedMiles: loaded.miles,
+    deadheadMiles,
+    tollUsd: loaded.tollUsd,
+  };
 }
 
 // ---- route geometry for the "mission map" ----

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.113.0",
+  "version": "1.114.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/loadScore.test.ts
+++ b/frontend/src/lib/metrics/loadScore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { scoreLoad } from "./loadScore";
+import { scoreLoad, counterRates } from "./loadScore";
 
 // break-even per driven mile = costPerDrivenMile / payTake = 3.08 / 0.78 ≈ $3.95
 const basis = { costPerDrivenMile: 3.08, payTake: 0.78 };
@@ -46,5 +46,22 @@ describe("scoreLoad", () => {
       }).verdict,
     ).toBeNull();
     expect(scoreLoad({ rate: 2000, loadedMiles: 0, deadheadMiles: 0 }, basis).verdict).toBeNull();
+  });
+});
+
+describe("counterRates", () => {
+  it("prices the floor, TAKE IT (+35%), and STEAL (+60%) on the driven miles", () => {
+    const c = counterRates(4, 500)!; // $4/mi break-even, 500 mi
+    expect(c.floor).toBeCloseTo(2000, 5); // 4 × 500
+    expect(c.take).toBeCloseTo(2700, 5); // 4 × 1.35 × 500
+    expect(c.steal).toBeCloseTo(3200, 5); // 4 × 1.60 × 500
+    expect(c.take).toBeGreaterThan(c.floor);
+    expect(c.steal).toBeGreaterThan(c.take);
+  });
+
+  it("is null without a usable break-even or miles", () => {
+    expect(counterRates(null, 500)).toBeNull();
+    expect(counterRates(0, 500)).toBeNull();
+    expect(counterRates(4, 0)).toBeNull();
   });
 });

--- a/frontend/src/lib/metrics/loadScore.ts
+++ b/frontend/src/lib/metrics/loadScore.ts
@@ -81,6 +81,27 @@ export const scoreLoad = (input: ScoreInput, basis: ScoreBasis): LoadScore => {
   };
 };
 
+export interface CounterRates {
+  floor: number; // break-even rate for these miles — a loss below it
+  take: number; // rate that reaches TAKE IT (target tier)
+  steal: number; // rate that reaches STEAL (strong tier)
+}
+
+// What to counter with when a load comes in under target: the break-even floor,
+// the TAKE-IT rate, and the STEAL rate — priced on THIS load's driven miles from
+// the same break-even and tiers the verdict uses. null without a cost basis.
+export const counterRates = (
+  breakevenRpm: number | null,
+  drivenMiles: number,
+): CounterRates | null => {
+  if (breakevenRpm == null || breakevenRpm <= 0 || drivenMiles <= 0) return null;
+  return {
+    floor: breakevenRpm * drivenMiles,
+    take: breakevenRpm * (1 + RATE_TIERS.target) * drivenMiles,
+    steal: breakevenRpm * (1 + RATE_TIERS.strong) * drivenMiles,
+  };
+};
+
 export const VERDICT_META: Record<
   Verdict,
   { label: string; fg: string; bg: string }

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -623,6 +623,15 @@ const GuidePage = () => {
               still truth once you run it. Every mile field stays editable if you'd
               rather type your own.
             </Why>
+            <Why>
+              It also shows this route's{" "}
+              <span className="text-light">estimated tolls</span> — a reminder to
+              bill them as an accessorial (Landstar pays 100%), not eat them. And
+              when a load comes in under target, it lays out{" "}
+              <span className="text-light">what to ask the agent</span>: the floor
+              (break-even), the TAKE-IT rate, and the STEAL rate for that load's
+              miles — so you know the room to bargain.
+            </Why>
           </Metric>
 
           <Metric

--- a/frontend/src/pages/ScoreLoadPage.tsx
+++ b/frontend/src/pages/ScoreLoadPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, type ReactNode } from "react";
 import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
-import { scoreLoad, VERDICT_META } from "@/lib/metrics/loadScore";
+import { scoreLoad, counterRates, VERDICT_META } from "@/lib/metrics/loadScore";
 import { RATE_TIERS } from "@/lib/constants/targets";
 import {
   getLoadMiles,
@@ -178,6 +178,7 @@ const ScoreLoadPage = () => {
   const [routing, setRouting] = useState(false);
   const [routeErr, setRouteErr] = useState(false);
   const [route, setRoute] = useState<RouteGeo | null>(null);
+  const [toll, setToll] = useState<number | null>(null);
 
   // Prefill "Truck now" (the deadhead origin) with the truck's last-known
   // location. Non-fatal — no data just leaves it blank to fill by hand.
@@ -233,10 +234,12 @@ const ScoreLoadPage = () => {
       if (res.loadedMiles == null && res.deadheadMiles == null) {
         setRouteErr(true);
         setRoute(null);
+        setToll(null);
         return;
       }
       if (res.loadedMiles != null) setLoaded(String(res.loadedMiles));
       if (res.deadheadMiles != null) setDeadhead(String(res.deadheadMiles));
+      setToll(res.tollUsd);
       // The mission map for what was just entered (haul + deadhead leg).
       getScoreRoute({
         truckNow: truckNow.city && truckNow.state ? truckNow : null,
@@ -266,6 +269,11 @@ const ScoreLoadPage = () => {
     },
   );
   const meta = score.verdict ? VERDICT_META[score.verdict] : null;
+  // Counter ladder — only when the load comes in under target (PASS/MEH).
+  const belowTarget = score.verdict === "pass" || score.verdict === "meh";
+  const counter =
+    belowTarget ? counterRates(score.breakevenRpm, score.drivenMiles) : null;
+  const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 
   const routeNote = routing
     ? "routing…"
@@ -366,6 +374,17 @@ const ScoreLoadPage = () => {
           </div>
         </div>
 
+        {toll != null && (
+          <div className="flex items-center gap-2 mt-2 mb-1 px-3 py-2 rounded-[9px]" style={{ background: "#141b28" }}>
+            <span className="text-[13px]" style={{ color: "#cdd8e8" }}>
+              Est. tolls <span style={{ color: "#f4f7fb", fontWeight: 600 }}>≈ {money0(toll)}</span>
+            </span>
+            <span className="ml-auto text-[10px]" style={{ color: "#5f6b80" }}>
+              bill as accessorial · Landstar pays 100%
+            </span>
+          </div>
+        )}
+
         {route?.pickup && route?.delivery && (
           <div className="mt-2.5 mb-1 rounded-[9px] overflow-hidden" style={{ border: "1px solid #2a3347" }}>
             <MissionMap
@@ -456,6 +475,31 @@ const ScoreLoadPage = () => {
                 <span style={{ color: "#fbbf24" }}>STEAL</span>
               </div>
             </div>
+
+            {counter && (
+              <div className="mt-4 rounded-[10px] p-3" style={{ border: "1px solid #2a3347" }}>
+                <div className="text-[10px] tracking-wide mb-2" style={{ color: "#8b98a9" }}>
+                  WHAT TO ASK THE AGENT
+                </div>
+                <div className="flex gap-2">
+                  <div className="flex-1 text-center rounded-[8px] py-2" style={{ background: "#141b28" }}>
+                    <div className="text-[9px]" style={{ color: "#f87171" }}>FLOOR</div>
+                    <div className="text-base font-semibold" style={{ color: "#cdd8e8" }}>{money0(counter.floor)}</div>
+                    <div className="text-[8.5px]" style={{ color: "#5f6b80" }}>break-even</div>
+                  </div>
+                  <div className="flex-1 text-center rounded-[8px] py-2" style={{ background: "#12261a", border: "1px solid #1a5c3a" }}>
+                    <div className="text-[9px]" style={{ color: "#4ade80" }}>TAKE IT</div>
+                    <div className="text-base font-semibold" style={{ color: "#4ade80" }}>{money0(counter.take)}</div>
+                    <div className="text-[8.5px]" style={{ color: "#5f8a6e" }}>fair</div>
+                  </div>
+                  <div className="flex-1 text-center rounded-[8px] py-2" style={{ background: "#231d06", border: "1px solid #6b5410" }}>
+                    <div className="text-[9px]" style={{ color: "#fbbf24" }}>STEAL</div>
+                    <div className="text-base font-semibold" style={{ color: "#fbbf24" }}>{money0(counter.steal)}</div>
+                    <div className="text-[8.5px]" style={{ color: "#9a7f2e" }}>open here</div>
+                  </div>
+                </div>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/frontend/src/services/routingService.ts
+++ b/frontend/src/services/routingService.ts
@@ -36,6 +36,7 @@ export interface LoadDims {
 export interface LoadMiles {
   loadedMiles: number | null;
   deadheadMiles: number | null;
+  tollUsd: number | null; // estimated tolls on the loaded leg (bill as accessorial)
 }
 
 // Routed miles for a scored load — loaded (pickup → delivery) and deadhead
@@ -52,9 +53,10 @@ export const getLoadMiles = async (body: {
     return {
       loadedMiles: res.data.loadedMiles ?? null,
       deadheadMiles: res.data.deadheadMiles ?? null,
+      tollUsd: res.data.tollUsd ?? null,
     };
   } catch {
-    return { loadedMiles: null, deadheadMiles: null };
+    return { loadedMiles: null, deadheadMiles: null, tollUsd: null };
   }
 };
 


### PR DESCRIPTION
Two negotiation aids on the Load Scorer, from Jason's asks.

## Tolls
- Estimated tolls for the loaded leg (HERE `return=tolls` with the truck's dims so the toll class is right).
- Shown as a **heads-up to bill them as a 100% accessorial** — *not* deducted from profit. Tolls are recoverable when billed, and this avoids double-counting any tolls already sitting in the P&L break-even.

## Counter-rate ladder
- When a load comes in **under target (PASS/MEH)**, the Scorer shows "what to ask the agent": **FLOOR** (break-even), **TAKE IT** (+35%), **STEAL** (+60%) — priced on the load's driven miles from the same break-even + tiers the verdict uses. Hidden once a load's already good.

## Under the hood
- `parseRouteTolls` + `routeMilesAndTolls` (shared `setVehicleDims`); `loadMiles` returns `tollUsd`.
- `counterRates` (pure) drives the ladder; Guide's Load Scorer entry updated.
- Toll parse degrades to null → the line just hides. No profit-math change (no double-count).

## Verified
- Strict build clean; **382 frontend + 31 backend tests** (both new parsers unit-tested); design matches the approved mock.
- Toll line + ladder are data-gated locally (need real P&L + a live toll route) — first confirmed by scoring a real load post-deploy.

No migration. **v1.114.0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)