### PR TITLE
feat: adjustable rate tiers (Standard + Specialized) + separate margin goal

### DIFF
--- a/backend/db/migrations/053_rate_tiers.sql
+++ b/backend/db/migrations/053_rate_tiers.sql
@@ -1,0 +1,22 @@
+-- Two rate-tier sets (Standard vs Specialized) + a margin goal on the settlement
+-- schedule.
+--
+-- Rate tiers are markup-over-break-even, per driven mile. The load Scorer grades
+-- oversize / hazmat / heavy-haul freight against the Specialized set and every-
+-- thing else against the Standard set. Seeds are calibrated from Jason's own
+-- delivered history (2026-07): standard freight medians ~break-even, specialized
+-- medians ~+40% over break-even.
+--
+-- The margin goal (profit ÷ revenue) drives the weekly/daily REVENUE targets
+-- (grind streak, recap, pace bar) and is deliberately INDEPENDENT of the rate
+-- tiers. Seed 0.26 reproduces the prior +35%-over-cost weekly target (0.35/1.35).
+--
+-- ALTER only (no new table) → no RLS statement needed.
+ALTER TABLE settlement_schedules
+  ADD COLUMN IF NOT EXISTS rate_tier_std_min     numeric NOT NULL DEFAULT 0.10 CHECK (rate_tier_std_min     >= 0 AND rate_tier_std_min     <= 3),
+  ADD COLUMN IF NOT EXISTS rate_tier_std_target  numeric NOT NULL DEFAULT 0.20 CHECK (rate_tier_std_target  >= 0 AND rate_tier_std_target  <= 3),
+  ADD COLUMN IF NOT EXISTS rate_tier_std_strong  numeric NOT NULL DEFAULT 0.30 CHECK (rate_tier_std_strong  >= 0 AND rate_tier_std_strong  <= 3),
+  ADD COLUMN IF NOT EXISTS rate_tier_spec_min    numeric NOT NULL DEFAULT 0.35 CHECK (rate_tier_spec_min    >= 0 AND rate_tier_spec_min    <= 3),
+  ADD COLUMN IF NOT EXISTS rate_tier_spec_target numeric NOT NULL DEFAULT 0.45 CHECK (rate_tier_spec_target >= 0 AND rate_tier_spec_target <= 3),
+  ADD COLUMN IF NOT EXISTS rate_tier_spec_strong numeric NOT NULL DEFAULT 0.60 CHECK (rate_tier_spec_strong >= 0 AND rate_tier_spec_strong <= 3),
+  ADD COLUMN IF NOT EXISTS margin_goal           numeric NOT NULL DEFAULT 0.26 CHECK (margin_goal >= 0 AND margin_goal < 1);

--- a/backend/src/services/settlementScheduleServices.js
+++ b/backend/src/services/settlementScheduleServices.js
@@ -14,6 +14,13 @@ const DEFAULTS = {
   per_diem_deduct_pct: 0.8,
   hometime_threshold_days: 21,
   operation: "flatbed",
+  rate_tier_std_min: 0.1,
+  rate_tier_std_target: 0.2,
+  rate_tier_std_strong: 0.3,
+  rate_tier_spec_min: 0.35,
+  rate_tier_spec_target: 0.45,
+  rate_tier_spec_strong: 0.6,
+  margin_goal: 0.26,
 };
 
 const OPERATIONS = [
@@ -35,6 +42,20 @@ const PCT_FIELDS = [
   "accessorial_pct",
 ];
 
+// Two rate-tier sets: Standard (all freight) and Specialized (oversize/hazmat/
+// heavy). Each set is a fraction OVER break-even and must ascend internally.
+const STD_TIER_FIELDS = [
+  "rate_tier_std_min",
+  "rate_tier_std_target",
+  "rate_tier_std_strong",
+];
+const SPEC_TIER_FIELDS = [
+  "rate_tier_spec_min",
+  "rate_tier_spec_target",
+  "rate_tier_spec_strong",
+];
+const TIER_FIELDS = [...STD_TIER_FIELDS, ...SPEC_TIER_FIELDS];
+
 const COLUMNS = [
   ...PCT_FIELDS,
   "carrier_name",
@@ -43,6 +64,8 @@ const COLUMNS = [
   "per_diem_deduct_pct",
   "hometime_threshold_days",
   "operation",
+  ...TIER_FIELDS,
+  "margin_goal",
 ];
 
 // ---- GET ---- (always returns a schedule; defaults if none saved yet)
@@ -109,6 +132,21 @@ export async function upsertSettlementSchedule(user_id, data) {
     provided.operation = data.operation;
   }
 
+  for (const f of TIER_FIELDS) {
+    if (data[f] === undefined) continue;
+    const n = Number(data[f]);
+    if (!Number.isFinite(n) || n < 0 || n > 3)
+      throw new ValidationError(`${f} must be a fraction between 0 and 3`);
+    provided[f] = n;
+  }
+
+  if (data.margin_goal !== undefined) {
+    const n = Number(data.margin_goal);
+    if (!Number.isFinite(n) || n < 0 || n >= 1)
+      throw new ValidationError("margin_goal must be a fraction between 0 and 1");
+    provided.margin_goal = n;
+  }
+
   if (Object.keys(provided).length === 0)
     throw new ValidationError("No valid fields to update");
 
@@ -116,36 +154,34 @@ export async function upsertSettlementSchedule(user_id, data) {
   const current = await getSettlementSchedule(user_id);
   const m = { ...current, ...provided };
 
+  // Each tier set must ascend: a "good" load can't be worth less than the minimum.
+  const ascends = (fields) => {
+    const [a, b, c] = fields.map((f) => Number(m[f]));
+    return a <= b && b <= c;
+  };
+  if (!ascends(STD_TIER_FIELDS))
+    throw new ValidationError(
+      "standard rate tiers must ascend: minimum ≤ target ≤ strong",
+    );
+  if (!ascends(SPEC_TIER_FIELDS))
+    throw new ValidationError(
+      "specialized rate tiers must ascend: minimum ≤ target ≤ strong",
+    );
+
+  // Build the upsert from COLUMNS so the field list stays in one place.
+  const cols = ["user_id", ...COLUMNS];
+  const placeholders = cols.map((_, i) => `$${i + 1}`).join(", ");
+  const updates = COLUMNS.map((c) => `${c} = EXCLUDED.${c}`).join(",\n       ");
+  const values = [user_id, ...COLUMNS.map((c) => m[c])];
+
   const result = await db.query(
-    `INSERT INTO settlement_schedules
-       (user_id, linehaul_pct, trailer_pct, fuel_surcharge_pct, accessorial_pct, carrier_name, detention_free_hours, per_diem_rate, per_diem_deduct_pct, hometime_threshold_days, operation)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+    `INSERT INTO settlement_schedules (${cols.join(", ")})
+     VALUES (${placeholders})
      ON CONFLICT (user_id) DO UPDATE SET
-       linehaul_pct            = EXCLUDED.linehaul_pct,
-       trailer_pct             = EXCLUDED.trailer_pct,
-       fuel_surcharge_pct      = EXCLUDED.fuel_surcharge_pct,
-       accessorial_pct         = EXCLUDED.accessorial_pct,
-       carrier_name            = EXCLUDED.carrier_name,
-       detention_free_hours    = EXCLUDED.detention_free_hours,
-       per_diem_rate           = EXCLUDED.per_diem_rate,
-       per_diem_deduct_pct     = EXCLUDED.per_diem_deduct_pct,
-       hometime_threshold_days = EXCLUDED.hometime_threshold_days,
-       operation               = EXCLUDED.operation,
-       updated_at              = NOW()
+       ${updates},
+       updated_at = NOW()
      RETURNING ${COLUMNS.join(", ")}`,
-    [
-      user_id,
-      m.linehaul_pct,
-      m.trailer_pct,
-      m.fuel_surcharge_pct,
-      m.accessorial_pct,
-      m.carrier_name,
-      m.detention_free_hours,
-      m.per_diem_rate,
-      m.per_diem_deduct_pct,
-      m.hometime_threshold_days,
-      m.operation,
-    ],
+    values,
   );
   return result.rows[0];
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.114.0",
+  "version": "1.115.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -8,40 +8,33 @@ const RED = "#e24b4a";
 const AMBER = "#e8940a";
 const GREEN = "#1d9e75";
 const GREEN_TICK = "#35c47a"; // brighter than the fill, so the target tick reads on top of it
-const GOLD = "#f5b03a";
-const GRAY = "#5b6b82";
 const TRACK = "#232c3f";
 
 const money = (n: number | null): string =>
   n == null ? "—" : `$${Math.round(n).toLocaleString("en-US")}`;
 
-// This week's gross vs floor (break-even), target, and strong. The bar spans to
-// STRONG; solid fill is EARNED (delivered), the faded extension is COMMITTED
-// (booked/in-transit) still to haul. Floor + target are ticks. Color grades off
-// earned vs the floor/target thresholds.
+// This week's gross vs floor (break-even) and target (your margin goal). The bar
+// spans past target for headroom; solid fill is EARNED (delivered), the faded
+// extension is COMMITTED (booked/in-transit) still to haul. Color grades off
+// earned vs the floor/target thresholds. The weekly target is a total-REVENUE
+// goal (margin goal) — the per-mile rate tiers don't belong on this bar.
 const PaceBar = ({
   earned,
   committed,
   floor,
-  minimum,
   target,
-  strong,
 }: {
   earned: number;
   committed: number;
   floor: number;
-  minimum: number;
   target: number;
-  strong: number;
 }) => {
-  // Headroom past `strong` so it sits inside the bar as a milestone, not flush
+  // Headroom past target so it sits inside the bar as a milestone, not flush
   // at the right edge.
-  const top = strong > 0 ? strong : target;
-  const max = top > 0 ? top * 1.12 : target;
+  const max = target > 0 ? target * 1.15 : 1;
   const frac = (v: number) => (max > 0 ? Math.max(0, Math.min(1, v / max)) : 0);
   const color = earned >= target ? GREEN : earned >= floor ? AMBER : RED;
-  // Floor/min are quiet reference ticks; target (green) and strong (gold) are the
-  // goals — taller, glowing, and color-coded to the theme.
+  // Floor is a quiet reference tick; target (green) is the goal — taller, glowing.
   const tick = (v: number, c: string, goal: boolean, title: string) => (
     <div
       className="absolute"
@@ -70,9 +63,7 @@ const PaceBar = ({
         style={{ width: `${frac(earned) * 100}%`, background: color }}
       />
       {tick(floor, AMBER, false, "break-even floor")}
-      {tick(minimum, GRAY, false, "minimum")}
       {tick(target, GREEN_TICK, true, "target")}
-      {strong > 0 && tick(strong, GOLD, true, "strong")}
     </div>
   );
 };
@@ -139,8 +130,6 @@ export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
     bookingLadder,
     grossRate,
     gross,
-    weeklyMinimum,
-    weeklyStrong,
     weekBooked,
     weekEarned,
     basis,
@@ -193,23 +182,14 @@ export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
               earned={weekEarned}
               committed={weekBooked}
               floor={gross.weeklyBreakEven ?? 0}
-              minimum={weeklyMinimum ?? 0}
               target={gross.weeklyTarget ?? 0}
-              strong={weeklyStrong ?? 0}
             />
             <div className="flex flex-wrap gap-x-3 gap-y-1 mt-1.5 text-[11px] text-muted-text">
               <LegendItem color={AMBER} label="floor" value={money(gross.weeklyBreakEven)} />
-              <LegendItem color={GRAY} label="min" value={money(weeklyMinimum)} />
               <LegendItem
                 color={GREEN_TICK}
                 label="target"
                 value={money(gross.weeklyTarget)}
-                emphasize
-              />
-              <LegendItem
-                color={GOLD}
-                label="strong"
-                value={money(weeklyStrong)}
                 emphasize
               />
             </div>

--- a/frontend/src/hooks/useAwardPops.ts
+++ b/frontend/src/hooks/useAwardPops.ts
@@ -14,8 +14,11 @@ import { getTrips } from "@/services/tripsService";
 import { getObligations } from "@/services/obligationsService";
 import { getDrivers } from "@/services/driversService";
 import { getTrophies } from "@/services/trophyService";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import type { SettlementSchedule } from "@/types/settlementSchedule";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { computeGrind } from "@/lib/metrics/grind";
+import { marginGoalFrom } from "@/lib/constants/targets";
 import { loadRevenue } from "@/lib/metrics/rateTargets";
 import { assetLoanStatus } from "@/lib/metrics/payoff";
 import { computeAllStatuses } from "@/lib/trophies/status";
@@ -68,6 +71,7 @@ export const useAwardPops = (
     obligations: Obligation[];
     trophies: Trophy[];
     drivers: Driver[];
+    schedule: SettlementSchedule | null;
   } | null>(null);
   const [done, setDone] = useState(false);
 
@@ -80,9 +84,10 @@ export const useAwardPops = (
       getObligations(),
       getTrophies(),
       getDrivers(),
+      getSettlementSchedule().catch(() => null),
     ])
-      .then(([periods, fuel, trucks, trips, obligations, trophies, drivers]) =>
-        setData({ periods, fuel, trucks, trips, obligations, trophies, drivers }),
+      .then(([periods, fuel, trucks, trips, obligations, trophies, drivers, schedule]) =>
+        setData({ periods, fuel, trucks, trips, obligations, trophies, drivers, schedule }),
       )
       .catch(() => {});
   }, []);
@@ -104,7 +109,7 @@ export const useAwardPops = (
     const obligationsAllActive = data.obligations
       .filter((o) => o.active)
       .reduce((s, o) => s + Number(o.amount), 0);
-    const grind = computeGrind(loads, data.periods, obligationsAllActive, now);
+    const grind = computeGrind(loads, data.periods, obligationsAllActive, now, marginGoalFrom(data.schedule));
     const truckLoan = assetLoanStatus(data.obligations, "truck", now);
     const trailerLoan = assetLoanStatus(data.obligations, "trailer", now);
     const paidPcts = [truckLoan?.ownedPct, trailerLoan?.ownedPct].filter(

--- a/frontend/src/hooks/useGrind.ts
+++ b/frontend/src/hooks/useGrind.ts
@@ -4,17 +4,22 @@ import type { ExpensePeriod } from "@/types/expense";
 import type { Obligation } from "@/types/obligation";
 import { getExpensePeriods } from "@/services/expensesService";
 import { getObligations } from "@/services/obligationsService";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import type { SettlementSchedule } from "@/types/settlementSchedule";
 import { computeGrind, type Grind } from "@/lib/metrics/grind";
+import { marginGoalFrom } from "@/lib/constants/targets";
 
 // Fetches the P&L + obligations the rate ladder needs, then grades every pay-week
 // into the grind streak. Null until there's data.
 export const useGrind = (loads: Load[]): Grind | null => {
   const [periods, setPeriods] = useState<ExpensePeriod[] | null>(null);
   const [obligations, setObligations] = useState<Obligation[] | null>(null);
+  const [schedule, setSchedule] = useState<SettlementSchedule | null>(null);
 
   useEffect(() => {
     getExpensePeriods().then(setPeriods).catch(() => {});
     getObligations().then(setObligations).catch(() => {});
+    getSettlementSchedule().then(setSchedule).catch(() => {});
   }, []);
 
   return useMemo(() => {
@@ -22,6 +27,6 @@ export const useGrind = (loads: Load[]): Grind | null => {
     const obligationsMonthly = obligations
       .filter((o) => o.active)
       .reduce((s, o) => s + Number(o.amount), 0);
-    return computeGrind(loads, periods, obligationsMonthly, new Date());
-  }, [periods, obligations, loads]);
+    return computeGrind(loads, periods, obligationsMonthly, new Date(), marginGoalFrom(schedule));
+  }, [periods, obligations, loads, schedule]);
 };

--- a/frontend/src/hooks/useRateTargets.ts
+++ b/frontend/src/hooks/useRateTargets.ts
@@ -16,7 +16,9 @@ import {
   getWindowRpm,
 } from "@/lib/metrics/rateTargets";
 import {
-  RATE_TIERS,
+  tiersFrom,
+  specTiersFrom,
+  marginGoalFrom,
   WORKING_DAYS_PER_MONTH,
   PAY_WEEK_START_DOW,
 } from "@/lib/constants/targets";
@@ -65,33 +67,30 @@ export const useRateTargets = (loads: Load[]) => {
 
     // Ladder: gross rate to book per mile DRIVEN (deadhead folded into total miles)
     // = cost-per-total-mile ÷ keep, scaled by tiers; marker = your gross rate/mile.
+    // TWO ladders — standard is the app-wide baseline; specialized is what the
+    // Scorer holds oversize/hazmat/heavy freight to.
+    const tiers = tiersFrom(schedule);
+    const specTiers = specTiersFrom(schedule);
+    const marginGoal = marginGoalFrom(schedule);
     const bookingBase =
       basis.costPerTotalMile != null && linehaulTake > 0
         ? basis.costPerTotalMile / linehaulTake
         : null;
-    const bookingLadder = getRateLadder(bookingBase, RATE_TIERS);
+    const bookingLadder = getRateLadder(bookingBase, tiers);
+    const specLadder = getRateLadder(bookingBase, specTiers);
 
-    // Weekly/daily GROSS to book = monthly cost grossed up by your keep, spread over
-    // the pay-week / working day, plus the target markup.
+    // Weekly/daily GROSS revenue targets = monthly cost grossed up by your keep,
+    // spread over the pay-week / working day, lifted to your MARGIN goal. The
+    // margin goal is a total-revenue KPI, independent of the per-mile rate tiers.
     const bookingCost =
       basis.trueMonthlyCost != null && linehaulTake > 0
         ? basis.trueMonthlyCost / linehaulTake
         : null;
     const gross = getGrossTargets(
       bookingCost,
-      RATE_TIERS.target,
+      marginGoal,
       WORKING_DAYS_PER_MONTH,
     );
-    // Weekly MINIMUM (+15%) and STRONG (+60%) tiers — the extra ticks on the pace
-    // bar (floor · min · target · strong).
-    const weeklyMinimum =
-      gross.weeklyBreakEven != null
-        ? gross.weeklyBreakEven * (1 + RATE_TIERS.minimum)
-        : null;
-    const weeklyStrong =
-      gross.weeklyBreakEven != null
-        ? gross.weeklyBreakEven * (1 + RATE_TIERS.strong)
-        : null;
 
     // This week's gross booked (committed) + gross delivered (earned).
     const weekBooked = getWeekGrossCommitted(loads, start, end);
@@ -100,17 +99,19 @@ export const useRateTargets = (loads: Load[]) => {
     const rollingRpm = getWindowRpm(loads, now); // net RPM — the Avg RPM KPI
     return {
       basis,
-      gross, // weekly/daily GROSS dollars to book (break-even + target)
-      weeklyMinimum, // weekly +15% tier (gross)
-      weeklyStrong, // weekly +60% stretch tier (gross)
+      gross, // weekly/daily GROSS revenue targets (break-even + margin goal)
+      marginGoal, // target profit margin driving those revenue targets
       weekBooked, // this week's gross committed (booked + in-transit + delivered)
       weekEarned, // this week's gross earned (delivered only)
       rollingRpm,
       linehaulTake,
-      bookingLadder, // gross rate to book per mile driven (walk-away/target/strong)
+      bookingLadder, // STANDARD gross rate to book per mile driven (walk/target/strong)
+      specLadder, // SPECIALIZED ladder — oversize/hazmat/heavy
       grossRate: basis.grossPerTotalMile, // your gross rate/mile — the ladder marker
       weekStart: start,
       weekEnd: end,
+      tiers, // standard markup tiers (Scorer default + downstream)
+      specTiers, // specialized markup tiers (Scorer, for specialized loads)
       ready: basis.breakEvenRpm != null,
     };
   }, [periods, obligationsMonthly, loads, schedule]);

--- a/frontend/src/lib/awards/dispatcherAwards.ts
+++ b/frontend/src/lib/awards/dispatcherAwards.ts
@@ -8,9 +8,15 @@ import { loadGross, type RateLadder } from "@/lib/metrics/rateTargets";
 import { scoreLoad, type ScoreBasis } from "@/lib/metrics/loadScore";
 import { loadDeadheadPct, loadEmptyMiles } from "@/lib/metrics/deadhead";
 import { onTimeStatus, detentionCollected } from "@/lib/detention";
+import { isSpecializedLoadType } from "@/lib/dimensions";
 import { tiered, type Medal } from "./medals";
 import type { Award } from "@/lib/metrics/awards";
-import { DEADHEAD_TARGET } from "@/lib/constants/targets";
+import {
+  DEADHEAD_TARGET,
+  RATE_TIERS,
+  SPEC_TIERS,
+  type RateTiers,
+} from "@/lib/constants/targets";
 
 export interface DispatcherAwardInput {
   loads: Load[];
@@ -19,6 +25,8 @@ export interface DispatcherAwardInput {
   scoreBasis: ScoreBasis;
   freeHours: number;
   streak: number; // best booking streak in weeks (from the grind)
+  tiers?: RateTiers; // standard markup tiers — the "steal" verdict for legal freight
+  specTiers?: RateTiers; // specialized tiers — for oversize/hazmat/heavy loads
 }
 
 // A grind patch for display: a value that climbs toward milestones.
@@ -84,7 +92,14 @@ interface Stats {
 }
 
 const computeStats = (input: DispatcherAwardInput): Stats => {
-  const { loads, userId, ladder, scoreBasis } = input;
+  const {
+    loads,
+    userId,
+    ladder,
+    scoreBasis,
+    tiers = RATE_TIERS,
+    specTiers = SPEC_TIERS,
+  } = input;
   const mine = loads.filter((l) => l.booked_by === userId && l.load_status !== "cancelled");
   const delivered = mine.filter((l) => l.load_status === "delivered");
   const target = ladder.target ?? Infinity;
@@ -100,6 +115,8 @@ const computeStats = (input: DispatcherAwardInput): Stats => {
         deadheadMiles: loadEmptyMiles(l) ?? (Number(l.deadhead_miles) || 0),
       },
       scoreBasis,
+      // Specialized freight is graded on the higher set, mirroring the Scorer.
+      isSpecializedLoadType(l.load_type) ? specTiers : tiers,
     ).verdict === "steal";
 
   // Deepest single-agent relationship.

--- a/frontend/src/lib/constants/targets.test.ts
+++ b/frontend/src/lib/constants/targets.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  tiersFrom,
+  specTiersFrom,
+  marginGoalFrom,
+  STD_TIERS,
+  SPEC_TIERS,
+  MARGIN_GOAL,
+} from "./targets";
+
+describe("tiersFrom / specTiersFrom", () => {
+  it("falls back to the seed defaults when nothing is saved", () => {
+    expect(tiersFrom(null)).toEqual(STD_TIERS);
+    expect(tiersFrom(undefined)).toEqual(STD_TIERS);
+    expect(specTiersFrom(null)).toEqual(SPEC_TIERS);
+  });
+
+  it("reads the standard set from its own columns", () => {
+    const s = {
+      rate_tier_std_min: 0.05,
+      rate_tier_std_target: 0.18,
+      rate_tier_std_strong: 0.4,
+      // specialized columns present but must NOT leak into the standard set
+      rate_tier_spec_min: 0.9,
+      rate_tier_spec_target: 0.95,
+      rate_tier_spec_strong: 0.99,
+    };
+    expect(tiersFrom(s)).toEqual({ minimum: 0.05, target: 0.18, strong: 0.4 });
+    expect(specTiersFrom(s)).toEqual({ minimum: 0.9, target: 0.95, strong: 0.99 });
+  });
+
+  it("fills only the missing tier from the default, keeps the rest", () => {
+    const t = tiersFrom({ rate_tier_std_target: 0.25 });
+    expect(t.target).toBe(0.25);
+    expect(t.minimum).toBe(STD_TIERS.minimum);
+    expect(t.strong).toBe(STD_TIERS.strong);
+  });
+
+  it("ignores non-finite / null values (uses the default)", () => {
+    const t = tiersFrom({
+      rate_tier_std_min: null,
+      rate_tier_std_target: NaN as unknown as number,
+    });
+    expect(t.minimum).toBe(STD_TIERS.minimum);
+    expect(t.target).toBe(STD_TIERS.target);
+  });
+});
+
+describe("marginGoalFrom", () => {
+  it("defaults when unset", () => {
+    expect(marginGoalFrom(null)).toBe(MARGIN_GOAL);
+    expect(marginGoalFrom({})).toBe(MARGIN_GOAL);
+  });
+
+  it("reads a saved margin", () => {
+    expect(marginGoalFrom({ margin_goal: 0.3 })).toBe(0.3);
+  });
+
+  it("clamps to [0, 0.95] so the revenue uplift can't blow up", () => {
+    expect(marginGoalFrom({ margin_goal: -0.5 })).toBe(0);
+    expect(marginGoalFrom({ margin_goal: 1.5 })).toBe(0.95);
+  });
+});

--- a/frontend/src/lib/constants/targets.ts
+++ b/frontend/src/lib/constants/targets.ts
@@ -7,10 +7,64 @@ export const BREAK_EVEN_RPM = 2.96;
 // Deadhead target: fraction of miles that are empty. Lower is better.
 export const DEADHEAD_TARGET = 0.2; // 20%
 
-// Rate tiers = markup OVER the break-even (walk-away) rate — a load at the
-// break-even rate makes $0; each tier adds margin on top. Matches Jason's ops
-// sheet (walk-away × 1.15 / 1.35 / 1.60).
-export const RATE_TIERS = { minimum: 0.15, target: 0.35, strong: 0.6 } as const;
+export interface RateTiers {
+  minimum: number;
+  target: number;
+  strong: number;
+}
+
+// Rate tiers = markup OVER the break-even (walk-away) rate, per driven mile — a
+// load at break-even makes $0; each tier adds margin on top. TWO sets: the load
+// Scorer picks by type — Specialized (oversize / hazmat / heavy haul) vs Standard
+// (everything else). Seeds are calibrated from Jason's own delivered history
+// (2026-07): standard freight medians ~break-even, specialized medians ~+40%.
+export const STD_TIERS: RateTiers = { minimum: 0.1, target: 0.2, strong: 0.3 };
+export const SPEC_TIERS: RateTiers = { minimum: 0.35, target: 0.45, strong: 0.6 };
+
+// Back-compat default = the standard set (the app-wide baseline). Used as the
+// fallback when a metric isn't handed an explicit set.
+export const RATE_TIERS = STD_TIERS;
+
+// Target profit margin (profit ÷ revenue) → the weekly/daily REVENUE targets
+// (grind, recap, pace bar). Deliberately INDEPENDENT of the rate tiers: tiers
+// judge a load's per-mile rate; the margin goal judges total revenue generated.
+// Seed reproduces the prior +35%-over-cost target (0.35 / 1.35 ≈ 0.26).
+export const MARGIN_GOAL = 0.26;
+
+const num = (v: unknown, d: number) =>
+  v != null && Number.isFinite(Number(v)) ? Number(v) : d;
+
+// A user's saved STANDARD markup tiers (settlement schedule) → RateTiers, with
+// the seed defaults filling anything missing. The app-wide baseline set.
+export const tiersFrom = (
+  s?: {
+    rate_tier_std_min?: number | null;
+    rate_tier_std_target?: number | null;
+    rate_tier_std_strong?: number | null;
+  } | null,
+): RateTiers => ({
+  minimum: num(s?.rate_tier_std_min, STD_TIERS.minimum),
+  target: num(s?.rate_tier_std_target, STD_TIERS.target),
+  strong: num(s?.rate_tier_std_strong, STD_TIERS.strong),
+});
+
+// The SPECIALIZED markup tiers — the Scorer uses these for oversize/hazmat/heavy.
+export const specTiersFrom = (
+  s?: {
+    rate_tier_spec_min?: number | null;
+    rate_tier_spec_target?: number | null;
+    rate_tier_spec_strong?: number | null;
+  } | null,
+): RateTiers => ({
+  minimum: num(s?.rate_tier_spec_min, SPEC_TIERS.minimum),
+  target: num(s?.rate_tier_spec_target, SPEC_TIERS.target),
+  strong: num(s?.rate_tier_spec_strong, SPEC_TIERS.strong),
+});
+
+// The target profit margin (0–0.95) → drives weekly/daily revenue targets.
+export const marginGoalFrom = (
+  s?: { margin_goal?: number | null } | null,
+): number => Math.max(0, Math.min(0.95, num(s?.margin_goal, MARGIN_GOAL)));
 
 // Gross-pace targets: working days per month for the daily rate.
 export const WORKING_DAYS_PER_MONTH = 22;

--- a/frontend/src/lib/dimensions.ts
+++ b/frontend/src/lib/dimensions.ts
@@ -52,6 +52,14 @@ export const LEGAL_HEIGHT_IN = 162; // 13'6"
 export const LEGAL_LENGTH_IN = 636; // 53' overall
 export const LEGAL_GROSS_LB = 80000; // gross vehicle weight
 
+// Load types held to the SPECIALIZED (higher) rate-tier set — the premium bands
+// in Jason's delivered history: oversize, hazmat, and heavy haul. Everything else
+// is graded on the standard set. The Scorer derives "specialized" live from the
+// dims + hazmat toggle; anything working off stored history uses this by type.
+export const SPECIALIZED_LOAD_TYPES = ["oversize", "hazmat", "heavy haul"];
+export const isSpecializedLoadType = (t?: string | null): boolean =>
+  t != null && SPECIALIZED_LOAD_TYPES.includes(t);
+
 export interface TravelDims {
   widthIn?: number | null;
   heightIn?: number | null; // total travel height (deck + load)

--- a/frontend/src/lib/metrics/grind.ts
+++ b/frontend/src/lib/metrics/grind.ts
@@ -15,8 +15,8 @@ import {
   type GrossTargets,
 } from "./rateTargets";
 import {
+  MARGIN_GOAL,
   PAY_WEEK_START_DOW,
-  RATE_TIERS,
   WORKING_DAYS_PER_MONTH,
 } from "@/lib/constants/targets";
 
@@ -78,12 +78,13 @@ export const computeGrind = (
   periods: ExpensePeriod[],
   obligationsMonthly: number,
   now: Date,
+  marginGoal: number = MARGIN_GOAL,
   weeksToShow = 14,
 ): Grind => {
   const basis = getCostBasis(periods, obligationsMonthly, loads, now);
   const targets = getGrossTargets(
     basis.trueMonthlyCost,
-    RATE_TIERS.target,
+    marginGoal,
     WORKING_DAYS_PER_MONTH,
   );
   const hasLadder = targets.weeklyTarget != null;

--- a/frontend/src/lib/metrics/loadScore.test.ts
+++ b/frontend/src/lib/metrics/loadScore.test.ts
@@ -3,10 +3,12 @@ import { scoreLoad, counterRates } from "./loadScore";
 
 // break-even per driven mile = costPerDrivenMile / payTake = 3.08 / 0.78 ≈ $3.95
 const basis = { costPerDrivenMile: 3.08, payTake: 0.78 };
+// Explicit tiers so verdict thresholds are pinned regardless of the seed defaults.
+const TIERS = { minimum: 0.15, target: 0.35, strong: 0.6 };
 
 describe("scoreLoad", () => {
   it("bakes deadhead into the all-in rate and lands TAKE IT above target", () => {
-    const s = scoreLoad({ rate: 2900, loadedMiles: 460, deadheadMiles: 80 }, basis);
+    const s = scoreLoad({ rate: 2900, loadedMiles: 460, deadheadMiles: 80 }, basis, TIERS);
     expect(s.drivenMiles).toBe(540);
     expect(s.allInRpm).toBeCloseTo(2900 / 540); // ~5.37, over loaded+deadhead
     expect(s.breakevenRpm).toBeCloseTo(3.95, 1);
@@ -24,7 +26,7 @@ describe("scoreLoad", () => {
   });
 
   it("STEALs a load 60%+ over break-even", () => {
-    const s = scoreLoad({ rate: 4200, loadedMiles: 400, deadheadMiles: 60 }, basis);
+    const s = scoreLoad({ rate: 4200, loadedMiles: 400, deadheadMiles: 60 }, basis, TIERS);
     expect(s.allInRpm).toBeCloseTo(4200 / 460); // ~9.13
     expect(s.pctOverBreakeven).toBeGreaterThan(0.6);
     expect(s.verdict).toBe("steal");
@@ -32,10 +34,20 @@ describe("scoreLoad", () => {
 
   it("MEHs a load just above break-even but under target", () => {
     // aim ~15% over break-even: rate ≈ 3.95*1.15 * driven
-    const s = scoreLoad({ rate: 2560, loadedMiles: 500, deadheadMiles: 60 }, basis);
+    const s = scoreLoad({ rate: 2560, loadedMiles: 500, deadheadMiles: 60 }, basis, TIERS);
     expect(s.verdict).toBe("meh");
     expect(s.pctOverBreakeven).toBeGreaterThan(0);
     expect(s.pctOverBreakeven).toBeLessThan(0.35);
+  });
+
+  it("grades the SAME load differently under standard vs specialized tiers", () => {
+    // ~+40% over break-even: a steal on standard (strong +30%), only meh on
+    // specialized (target +45%). This is the whole point of the two sets.
+    const std = { minimum: 0.1, target: 0.2, strong: 0.3 };
+    const spec = { minimum: 0.35, target: 0.45, strong: 0.6 };
+    const load = { rate: 2760, loadedMiles: 500, deadheadMiles: 0 }; // 5.52/mi ≈ +40%
+    expect(scoreLoad(load, basis, std).verdict).toBe("steal");
+    expect(scoreLoad(load, basis, spec).verdict).toBe("meh");
   });
 
   it("returns a null verdict when there's no cost basis or no miles", () => {
@@ -51,7 +63,7 @@ describe("scoreLoad", () => {
 
 describe("counterRates", () => {
   it("prices the floor, TAKE IT (+35%), and STEAL (+60%) on the driven miles", () => {
-    const c = counterRates(4, 500)!; // $4/mi break-even, 500 mi
+    const c = counterRates(4, 500, TIERS)!; // $4/mi break-even, 500 mi
     expect(c.floor).toBeCloseTo(2000, 5); // 4 × 500
     expect(c.take).toBeCloseTo(2700, 5); // 4 × 1.35 × 500
     expect(c.steal).toBeCloseTo(3200, 5); // 4 × 1.60 × 500

--- a/frontend/src/lib/metrics/loadScore.ts
+++ b/frontend/src/lib/metrics/loadScore.ts
@@ -1,4 +1,4 @@
-import { RATE_TIERS } from "@/lib/constants/targets";
+import { RATE_TIERS, type RateTiers } from "@/lib/constants/targets";
 
 // The "Take It or Leave It" load scorer. Judges ONE offered load by what it
 // actually pays per mile you DRIVE (loaded + deadhead), against your real
@@ -29,7 +29,11 @@ export interface LoadScore {
   verdict: Verdict | null; // null when there's no cost basis yet
 }
 
-export const scoreLoad = (input: ScoreInput, basis: ScoreBasis): LoadScore => {
+export const scoreLoad = (
+  input: ScoreInput,
+  basis: ScoreBasis,
+  tiers: RateTiers = RATE_TIERS,
+): LoadScore => {
   const driven =
     (Number(input.loadedMiles) || 0) + (Number(input.deadheadMiles) || 0);
   const rate = Number(input.rate) || 0;
@@ -65,8 +69,8 @@ export const scoreLoad = (input: ScoreInput, basis: ScoreBasis): LoadScore => {
 
   let verdict: Verdict;
   if (allInRpm < breakevenRpm) verdict = "pass";
-  else if (pctOverBreakeven < RATE_TIERS.target) verdict = "meh";
-  else if (pctOverBreakeven < RATE_TIERS.strong) verdict = "take";
+  else if (pctOverBreakeven < tiers.target) verdict = "meh";
+  else if (pctOverBreakeven < tiers.strong) verdict = "take";
   else verdict = "steal";
 
   return {
@@ -93,12 +97,13 @@ export interface CounterRates {
 export const counterRates = (
   breakevenRpm: number | null,
   drivenMiles: number,
+  tiers: RateTiers = RATE_TIERS,
 ): CounterRates | null => {
   if (breakevenRpm == null || breakevenRpm <= 0 || drivenMiles <= 0) return null;
   return {
     floor: breakevenRpm * drivenMiles,
-    take: breakevenRpm * (1 + RATE_TIERS.target) * drivenMiles,
-    steal: breakevenRpm * (1 + RATE_TIERS.strong) * drivenMiles,
+    take: breakevenRpm * (1 + tiers.target) * drivenMiles,
+    steal: breakevenRpm * (1 + tiers.strong) * drivenMiles,
   };
 };
 

--- a/frontend/src/lib/metrics/rateTargets.test.ts
+++ b/frontend/src/lib/metrics/rateTargets.test.ts
@@ -172,12 +172,20 @@ describe("bookedRate", () => {
 });
 
 describe("getGrossTargets", () => {
-  it("weekly + daily floors and target-markup", () => {
-    const g = getGrossTargets(26000, 0.35, 22);
+  it("weekly + daily floors and margin-goal target", () => {
+    // 2nd arg is the target profit margin (profit ÷ revenue). At 20% margin the
+    // target = break-even ÷ (1 − 0.20) = break-even × 1.25.
+    const g = getGrossTargets(26000, 0.2, 22);
     expect(g.weeklyBreakEven).toBeCloseTo(26000 / (52 / 12), 5); // 6000
-    expect(g.weeklyTarget).toBeCloseTo((26000 / (52 / 12)) * 1.35, 5);
+    expect(g.weeklyTarget).toBeCloseTo((26000 / (52 / 12)) / 0.8, 5);
     expect(g.dailyBreakEven).toBeCloseTo(26000 / 22, 5);
-    expect(g.dailyTarget).toBeCloseTo((26000 / 22) * 1.35, 5);
+    expect(g.dailyTarget).toBeCloseTo((26000 / 22) / 0.8, 5);
+  });
+
+  it("a 0% margin target equals break-even", () => {
+    const g = getGrossTargets(26000, 0, 22);
+    expect(g.weeklyTarget).toBeCloseTo(g.weeklyBreakEven!, 5);
+    expect(g.dailyTarget).toBeCloseTo(g.dailyBreakEven!, 5);
   });
 
   it("null when there's no cost basis", () => {

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -170,17 +170,22 @@ export const bookedRate = (net: number | null, take: number): number | null =>
 const WEEKS_PER_MONTH = 52 / 12;
 
 export interface GrossTargets {
-  weeklyBreakEven: number | null; // gross needed to cover true cost
-  weeklyTarget: number | null; // + target-tier markup
+  weeklyBreakEven: number | null; // revenue needed to cover true cost
+  weeklyTarget: number | null; // revenue that hits the margin goal
   dailyBreakEven: number | null;
   dailyTarget: number | null;
 }
 
+// Weekly/daily REVENUE targets from your true cost and your target profit margin
+// (profit ÷ revenue). Revenue at margin m = cost ÷ (1 − m). The margin goal is a
+// business KPI set in Settings, deliberately separate from the per-mile rate
+// tiers. Clamped elsewhere to < 1; guarded here so a bad value can't divide by 0.
 export const getGrossTargets = (
   trueMonthlyCost: number | null,
-  targetTier: number,
+  marginGoal: number,
   workingDaysPerMonth: number,
 ): GrossTargets => {
+  const uplift = marginGoal < 1 ? 1 / (1 - Math.max(0, marginGoal)) : 1;
   if (trueMonthlyCost == null || trueMonthlyCost <= 0)
     return {
       weeklyBreakEven: null,
@@ -192,9 +197,9 @@ export const getGrossTargets = (
   const daily = trueMonthlyCost / workingDaysPerMonth;
   return {
     weeklyBreakEven: weekly,
-    weeklyTarget: weekly * (1 + targetTier),
+    weeklyTarget: weekly * uplift,
     dailyBreakEven: daily,
-    dailyTarget: daily * (1 + targetTier),
+    dailyTarget: daily * uplift,
   };
 };
 

--- a/frontend/src/lib/metrics/recap.ts
+++ b/frontend/src/lib/metrics/recap.ts
@@ -13,8 +13,8 @@ import {
 import { mpgWindows } from "./fuelEconomy";
 import { classify, bestStreakOf, type WeekStatus } from "./grind";
 import {
+  MARGIN_GOAL,
   PAY_WEEK_START_DOW,
-  RATE_TIERS,
   WORKING_DAYS_PER_MONTH,
 } from "@/lib/constants/targets";
 
@@ -131,6 +131,7 @@ export const computeRecap = (
   range: RecapRange,
   scope: RecapScope,
   now: Date,
+  marginGoal: number = MARGIN_GOAL,
 ): RecapStats => {
   const mine = loads.filter((l) => l.load_status === "delivered" && inRange(l.delivery_date, range));
 
@@ -198,7 +199,7 @@ export const computeRecap = (
   // weekly gross → best week + best target-beating streak in the range
   const targets = getGrossTargets(
     getCostBasis(periods, obligationsMonthly, loads, now).trueMonthlyCost,
-    RATE_TIERS.target,
+    marginGoal,
     WORKING_DAYS_PER_MONTH,
   );
   let bestWeek: number | null = null;

--- a/frontend/src/pages/DispatcherPage.tsx
+++ b/frontend/src/pages/DispatcherPage.tsx
@@ -107,6 +107,8 @@ const DispatcherPage = () => {
     },
     freeHours,
     streak: grind?.bestStreak ?? 0,
+    tiers: targets.tiers,
+    specTiers: targets.specTiers,
   };
   const medals = dispatcherMedals(awardInput);
   const patches = dispatcherPatches(awardInput);

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -26,7 +26,13 @@ import {
   getRateLadder,
   loadRevenue,
 } from "@/lib/metrics/rateTargets";
-import { RATE_TIERS } from "@/lib/constants/targets";
+import {
+  RATE_TIERS,
+  MARGIN_GOAL,
+  tiersFrom,
+  marginGoalFrom,
+  type RateTiers,
+} from "@/lib/constants/targets";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import {
   careerRank,
@@ -73,6 +79,8 @@ const DriverDetailPage = () => {
   const [lastHome, setLastHome] = useState<string | null>(null);
   const [hometimeThreshold, setHometimeThreshold] = useState(21);
   const [operation, setOperation] = useState("flatbed");
+  const [tiers, setTiers] = useState<RateTiers>(RATE_TIERS);
+  const [marginGoal, setMarginGoal] = useState(MARGIN_GOAL);
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -95,6 +103,8 @@ const DriverDetailPage = () => {
       .then((s) => {
         setHometimeThreshold(s.hometime_threshold_days);
         setOperation(s.operation);
+        setTiers(tiersFrom(s));
+        setMarginGoal(marginGoalFrom(s));
       })
       .catch(() => {});
   }, []);
@@ -139,7 +149,7 @@ const DriverDetailPage = () => {
       ...driverLoads.map((l) => Number(l.odometer_end) || 0),
     );
     const basis = getCostBasis(periods, obligationsTotal, driverLoads, now);
-    const ladder = getRateLadder(basis.breakEvenRpm, RATE_TIERS);
+    const ladder = getRateLadder(basis.breakEvenRpm, tiers);
     const season = getSeasonStats(periods, driverLoads, driverTrips, now, 3, obligationsDebt);
     const rpmG = rpmGrade(basis.windowRpm, ladder);
     const marginG = marginGrade(season.netMargin);
@@ -160,7 +170,7 @@ const DriverDetailPage = () => {
       winDays > 0
         ? Math.min(1, underLoadDaySet(driverLoads, winStart, nowKey).size / winDays)
         : null;
-    const grind = computeGrind(driverLoads, periods, obligationsTotal, now);
+    const grind = computeGrind(driverLoads, periods, obligationsTotal, now, marginGoal);
     // Medals (fixed tiers), records (improving bests), patches (hard stackable feats).
     const del = driverLoads.filter((l) => l.load_status === "delivered");
     const paidPcts = [
@@ -192,7 +202,7 @@ const DriverDetailPage = () => {
       oversize: loadTypeMix(driverLoads, "oversize"),
       heavyHaul: loadTypeMix(driverLoads, "heavy haul"),
     };
-  }, [driverLoads, driverTrips, periods, obligations, fuel, trucks, operation]);
+  }, [driverLoads, driverTrips, periods, obligations, fuel, trucks, operation, tiers, marginGoal]);
 
   // Hometime status for the (owner-op) driver — days since their last home mark.
   const hometime = useMemo(

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -14,7 +14,7 @@ import {
   getTrueMonthly,
 } from "@/lib/metrics/expenses";
 import { getCostBasis, getRateLadder } from "@/lib/metrics/rateTargets";
-import { RATE_TIERS } from "@/lib/constants/targets";
+import { tiersFrom } from "@/lib/constants/targets";
 import { RateLadder } from "@/components/dashboard/RateLadder";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
 import type { SettlementSchedule } from "@/types/settlementSchedule";
@@ -191,7 +191,7 @@ const ExpensesPage = () => {
     rateBasis.costPerTotalMile != null && linehaulTake > 0
       ? rateBasis.costPerTotalMile / linehaulTake
       : null;
-  const rateLadder = getRateLadder(bookingBase, RATE_TIERS);
+  const rateLadder = getRateLadder(bookingBase, tiersFrom(schedule));
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -245,7 +245,7 @@ const MiniLadder = () => (
       className="flex h-3 rounded overflow-hidden"
       style={{ background: TRACK }}
     >
-      <div style={{ width: "58%", background: AMBER, opacity: 0.55 }} />
+      <div style={{ width: "67%", background: AMBER, opacity: 0.55 }} />
       <div style={{ flex: 1, background: GREEN, opacity: 0.55 }} />
     </div>
     <div className="relative h-9 mt-1 text-xs text-muted-text">
@@ -254,15 +254,15 @@ const MiniLadder = () => (
         <br />
         <span className="text-light">$4.34</span>
       </span>
-      <span className="absolute left-[58%] -translate-x-1/2 text-center">
+      <span className="absolute left-[67%] -translate-x-1/2 text-center">
         target
         <br />
-        <span className="text-light">$5.86</span>
+        <span className="text-light">$5.21</span>
       </span>
       <span className="absolute right-0 text-right">
         strong
         <br />
-        <span className="text-light">$6.94</span>
+        <span className="text-light">$5.64</span>
       </span>
     </div>
   </div>
@@ -577,13 +577,19 @@ const GuidePage = () => {
           >
             <MiniLadder />
             <Formula>
-              walk-away = break-even · minimum = ×1.15 · target = ×1.35 · strong
-              = ×1.60
+              walk-away = break-even · minimum / target / strong = break-even ×
+              (1 + your tier %)
             </Formula>
             <Why>
-              The tiers mark up your break-even by 15 / 35 / 60%. The marker on
-              the dashboard is your actual gross rate per mile — where you're
-              really pricing.
+              There are <span className="text-light">two tier sets</span>, both
+              editable in Settings.{" "}
+              <span className="text-light">Standard</span> (seeded +10 / 20 / 30%,
+              shown above) is your everyday freight and drives the dashboard
+              ladder. <span className="text-light">Specialized</span> (+35 / 45 /
+              60%) is the higher bar for oversize, hazmat, and heavy-haul loads —
+              they command a real premium, so they're judged against it. The
+              marker on the dashboard is your actual gross rate per mile — where
+              you're really pricing.
             </Why>
           </Metric>
 
@@ -606,11 +612,14 @@ const GuidePage = () => {
               <span className="text-light">driven</span> mile (your cost/mile ÷
               your Landstar take), so it's apples-to-apples with the all-in rate
               — a lower number than the dashboard's per-loaded-mile ladder, by
-              design. The stamp maps to your tiers:{" "}
+              design. The stamp maps to whichever tier set fits the load:{" "}
               <span style={{ color: "#f87171" }}>PASS</span> below break-even,{" "}
-              <span style={{ color: "#e8940a" }}>MEH</span> under +35%,{" "}
-              <span style={{ color: "#4ade80" }}>TAKE IT</span> at +35%,{" "}
-              <span style={{ color: "#fbbf24" }}>STEAL</span> at +60%.
+              <span style={{ color: "#e8940a" }}>MEH</span> under target,{" "}
+              <span style={{ color: "#4ade80" }}>TAKE IT</span> at target,{" "}
+              <span style={{ color: "#fbbf24" }}>STEAL</span> at strong. A legal
+              load hits those at your Standard tiers (+20 / +30%); an
+              oversize, hazmat, or heavy load has to reach the Specialized ones
+              (+45 / +60%). A line under the verdict names which set graded it.
             </Why>
             <Why>
               Miles come from truck routing (HERE), not a straight line — the
@@ -619,9 +628,12 @@ const GuidePage = () => {
               delivery, fuel stop, or trip). Enter the load's dimensions and it
               flags <span className="text-light">legal vs oversize</span> and
               routes an oversize load around the clearances it can't make, so the
-              miles are honest. It's an estimate for the decision; the odometer is
-              still truth once you run it. Every mile field stays editable if you'd
-              rather type your own.
+              miles are honest. Oversize and overweight are read straight from the
+              dimensions; hazmat isn't dimensional, so there's a{" "}
+              <span className="text-light">Hazmat toggle</span> — flip it and the
+              load is graded on the Specialized tiers too. It's an estimate for
+              the decision; the odometer is still truth once you run it. Every
+              mile field stays editable if you'd rather type your own.
             </Why>
             <Why>
               It also shows this route's{" "}
@@ -640,15 +652,25 @@ const GuidePage = () => {
             sources={[{ label: "Dashboard", to: "/dashboard" }]}
           >
             <Formula>
-              weekly = (true cost ÷ your keep) ÷ 4.33 weeks
+              weekly break-even = (true cost ÷ your keep) ÷ 4.33 weeks
               <br />
-              daily = (true cost ÷ your keep) ÷ 22 working days · × tiers for
-              target/strong
+              weekly target = weekly break-even ÷ (1 − your margin goal)
             </Formula>
             <Why>
-              Same idea as the ladder, in dollars instead of per-mile — and all
-              in <span className="text-light">gross booking dollars</span>, the
-              number you track when you take a load.
+              A total-dollars goal, not a per-mile one: cover your true monthly
+              cost, spread over the pay week, then lift it to your{" "}
+              <span className="text-light">margin goal</span> (profit ÷ revenue,
+              set in Settings). It's the line the grind meter and pace bar grade
+              you against, in gross booking dollars.
+            </Why>
+            <Why>
+              Two things it does <span className="text-light">not</span> ride.
+              Your <span className="text-light">rate tiers</span> — those judge a
+              load's per-mile rate, a different question. And your{" "}
+              <span className="text-light">miles</span> — drive more and your
+              per-mile targets drop, but you cover more miles, so the weekly
+              dollars you need don't move. Only your cost and your margin goal
+              change this number.
             </Why>
           </Metric>
 

--- a/frontend/src/pages/RecapPage.tsx
+++ b/frontend/src/pages/RecapPage.tsx
@@ -10,6 +10,8 @@ import { getFuelEntries } from "@/services/fuelService";
 import { getExpensePeriods } from "@/services/expensesService";
 import { getObligations } from "@/services/obligationsService";
 import { getTrucks } from "@/services/trucksService";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import type { SettlementSchedule } from "@/types/settlementSchedule";
 import { useLocation } from "react-router-dom";
 import {
   computeRecap,
@@ -18,6 +20,7 @@ import {
   type RecapScope,
   type RecapRange,
 } from "@/lib/metrics/recap";
+import { marginGoalFrom } from "@/lib/constants/targets";
 import { careerRank } from "@/lib/metrics/playerCard";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { RecapPoster } from "@/components/recap/RecapPoster";
@@ -41,6 +44,7 @@ const RecapPage = () => {
   const [periods, setPeriods] = useState<ExpensePeriod[]>([]);
   const [obligations, setObligations] = useState<Obligation[]>([]);
   const [trucks, setTrucks] = useState<Truck[]>([]);
+  const [schedule, setSchedule] = useState<SettlementSchedule | null>(null);
   const location = useLocation();
   const navScope = (location.state as { scope?: RecapScope } | null)?.scope;
   const [scope, setScope] = useState<RecapScope>(navScope ?? "month");
@@ -55,6 +59,7 @@ const RecapPage = () => {
     getExpensePeriods().then(setPeriods).catch(() => {});
     getObligations().then(setObligations).catch(() => {});
     getTrucks().then(setTrucks).catch(() => {});
+    getSettlementSchedule().then(setSchedule).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -71,9 +76,9 @@ const RecapPage = () => {
     .reduce((s, o) => s + Number(o.amount), 0);
 
   const stats = useMemo(
-    () => computeRecap(loads, fuel, periods, obligationsMonthly, range, scope, now),
+    () => computeRecap(loads, fuel, periods, obligationsMonthly, range, scope, now, marginGoalFrom(schedule)),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [loads, fuel, periods, obligationsMonthly, range.label, scope],
+    [loads, fuel, periods, obligationsMonthly, range.label, scope, schedule],
   );
 
   const truckAvatarUrl = trucks.find((t) => t.avatar_url)?.avatar_url ?? null;

--- a/frontend/src/pages/ScoreLoadPage.tsx
+++ b/frontend/src/pages/ScoreLoadPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, type ReactNode } from "react";
 import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { scoreLoad, counterRates, VERDICT_META } from "@/lib/metrics/loadScore";
-import { RATE_TIERS } from "@/lib/constants/targets";
+import { RATE_TIERS, type RateTiers } from "@/lib/constants/targets";
 import {
   getLoadMiles,
   getScoreRoute,
@@ -18,13 +18,18 @@ const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const rpm = (n: number | null) => (n != null ? `$${n.toFixed(2)}` : "—");
 
 // Where the load sits on the PASS | MEH | TAKE IT | STEAL bar (0–100%).
-const markerPct = (pct: number | null, allIn: number | null, be: number | null): number => {
+const markerPct = (
+  pct: number | null,
+  allIn: number | null,
+  be: number | null,
+  tiers: RateTiers = RATE_TIERS,
+): number => {
   if (pct == null || allIn == null || be == null) return 0;
   if (allIn < be) return Math.max(0, Math.min(25, (allIn / be) * 25)); // PASS band
-  if (pct < RATE_TIERS.target) return 25 + (pct / RATE_TIERS.target) * 25; // MEH
-  if (pct < RATE_TIERS.strong)
-    return 50 + ((pct - RATE_TIERS.target) / (RATE_TIERS.strong - RATE_TIERS.target)) * 25; // TAKE
-  return 75 + Math.min(1, (pct - RATE_TIERS.strong) / 0.4) * 25; // STEAL
+  if (pct < tiers.target) return 25 + (pct / tiers.target) * 25; // MEH
+  if (pct < tiers.strong)
+    return 50 + ((pct - tiers.target) / (tiers.strong - tiers.target)) * 25; // TAKE
+  return 75 + Math.min(1, (pct - tiers.strong) / 0.4) * 25; // STEAL
 };
 
 const box = (accent?: boolean) => ({
@@ -175,6 +180,7 @@ const ScoreLoadPage = () => {
   const [hgt, setHgt] = useState<FtIn>({ ft: "", in: "" });
   const [loaded, setLoaded] = useState("");
   const [deadhead, setDeadhead] = useState("");
+  const [hazmat, setHazmat] = useState(false);
   const [routing, setRouting] = useState(false);
   const [routeErr, setRouteErr] = useState(false);
   const [route, setRoute] = useState<RouteGeo | null>(null);
@@ -209,6 +215,11 @@ const ScoreLoadPage = () => {
     dims.lengthIn != null ||
     dims.grossWeightLb != null;
   const oversize = useMemo(() => classifyOversize(dims), [dims]);
+  // Specialized freight (oversize by dims/weight, OR hazmat) is held to the
+  // higher tier set; everything else uses the standard set. This is the only
+  // thing that decides which tiers grade the load.
+  const specialized = oversize.oversize || hazmat;
+  const activeTiers = specialized ? targets.specTiers : targets.tiers;
 
   const pickupReady = !!(pickup.city && pickup.state);
   const deliveryReady = !!(delivery.city && delivery.state);
@@ -267,12 +278,13 @@ const ScoreLoadPage = () => {
       costPerDrivenMile: targets.basis.costPerTotalMile,
       payTake: targets.basis.payTake,
     },
+    activeTiers,
   );
   const meta = score.verdict ? VERDICT_META[score.verdict] : null;
   // Counter ladder — only when the load comes in under target (PASS/MEH).
   const belowTarget = score.verdict === "pass" || score.verdict === "meh";
   const counter =
-    belowTarget ? counterRates(score.breakevenRpm, score.drivenMiles) : null;
+    belowTarget ? counterRates(score.breakevenRpm, score.drivenMiles, activeTiers) : null;
   const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 
   const routeNote = routing
@@ -334,6 +346,22 @@ const ScoreLoadPage = () => {
           <DimField label="Width" val={wid} onChange={setWid} accent={oversize.reasons.some((r) => r.startsWith("width"))} />
           <DimField label="Height" val={hgt} onChange={setHgt} />
         </div>
+
+        <label
+          className="flex items-center gap-2 px-3 py-2 mb-3 cursor-pointer select-none"
+          style={{ background: "#141b28", border: `1px solid ${hazmat ? "#85500b" : "#24304a"}`, borderRadius: 9 }}
+        >
+          <input
+            type="checkbox"
+            checked={hazmat}
+            onChange={(e) => setHazmat(e.target.checked)}
+            className="accent-[#e8940a]"
+          />
+          <span className="text-[12px]" style={{ color: "#cdd8e8" }}>Hazmat</span>
+          <span className="ml-auto text-[10px]" style={{ color: "#5f6b80" }}>
+            premium freight · specialized tiers
+          </span>
+        </label>
 
         {anyDim &&
           (oversize.oversize ? (
@@ -426,6 +454,15 @@ const ScoreLoadPage = () => {
               </div>
             </div>
 
+            <div className="text-center text-[10px] mb-1" style={{ color: "#7c899b" }}>
+              graded on your{" "}
+              <span style={{ color: specialized ? "#f5b03a" : "#7fb2e6" }}>
+                {specialized ? "Specialized" : "Standard"}
+              </span>{" "}
+              tiers · target +{Math.round(activeTiers.target * 100)}% · steal +
+              {Math.round(activeTiers.strong * 100)}%
+            </div>
+
             <div className="grid grid-cols-3 gap-2 mt-3.5">
               <div className="rounded-[9px] py-2 text-center" style={{ background: "#141b28" }}>
                 <div className="text-[9px] text-muted-text tracking-wide">ALL-IN / MI</div>
@@ -460,7 +497,7 @@ const ScoreLoadPage = () => {
                 <div
                   style={{
                     position: "absolute",
-                    left: `${markerPct(score.pctOverBreakeven, score.allInRpm, score.breakevenRpm)}%`,
+                    left: `${markerPct(score.pctOverBreakeven, score.allInRpm, score.breakevenRpm, activeTiers)}%`,
                     top: -3,
                     width: 2,
                     height: 16,

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,9 +3,77 @@ import {
   getSettlementSchedule,
   updateSettlementSchedule,
 } from "@/services/settlementScheduleService";
+import { useLoads } from "@/hooks/useLoads";
+import { useRateTargets } from "@/hooks/useRateTargets";
 import { AccessorialRatesCard } from "@/components/settings/AccessorialRatesCard";
 import { TeamCard } from "@/components/settings/TeamCard";
 import { Panel } from "@/components/ui/Panel";
+
+type Tier3 = { min: number; target: number; strong: number };
+const pct = (x: number) => Math.round(x * 1000) / 10; // fraction → clean percent
+
+// Rate-tier set editor: three markup inputs + a live preview at the real
+// break-even. The Scorer's verdict uses target + strong; min is the ladder's
+// lower rung.
+const TierCard = ({
+  label,
+  dot,
+  tiers,
+  onChange,
+  be,
+}: {
+  label: string;
+  dot: string;
+  tiers: Tier3;
+  onChange: (t: Tier3) => void;
+  be: number | null;
+}) => {
+  const at = (m: number) => `$${(be! * (1 + m / 100)).toFixed(2)}`;
+  const keys: (keyof Tier3)[] = ["min", "target", "strong"];
+  const labels = { min: "Min", target: "Target", strong: "Strong" };
+  return (
+    <div className="rounded-lg p-3.5" style={{ background: "#0d1119" }}>
+      <div className="flex items-center gap-2 mb-3">
+        <span
+          className="inline-block rounded-full"
+          style={{ width: 9, height: 9, background: dot }}
+        />
+        <span className="text-sm font-medium text-light">{label}</span>
+      </div>
+      <div className="flex gap-2.5">
+        {keys.map((k) => (
+          <label key={k} className="flex-1 min-w-0">
+            <span className="text-[11px] text-muted-text">{labels[k]}</span>
+            <div className="flex items-center gap-1 mt-1">
+              <span className="text-muted-text text-xs">+</span>
+              <input
+                type="number"
+                min={0}
+                max={300}
+                step={1}
+                value={Number.isFinite(tiers[k]) ? tiers[k] : ""}
+                onChange={(e) => onChange({ ...tiers, [k]: Number(e.target.value) })}
+                className="w-full bg-steel rounded px-1.5 py-1 text-light text-right text-sm tabular-nums"
+              />
+              <span className="text-muted-text text-xs">%</span>
+            </div>
+          </label>
+        ))}
+      </div>
+      <div className="text-[11px] text-muted-text mt-2.5">
+        {be != null ? (
+          <>
+            ${be.toFixed(2)} → <span className="text-light">{at(tiers.min)}</span>{" "}
+            · <span style={{ color: "#e8940a" }}>{at(tiers.target)}</span> ·{" "}
+            <span style={{ color: "#4ade80" }}>{at(tiers.strong)}</span>
+          </>
+        ) : (
+          "add a few months of P&L to preview the rates"
+        )}
+      </div>
+    </div>
+  );
+};
 
 const money = (n: number) =>
   `$${n.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
@@ -58,9 +126,19 @@ const SettingsPage = () => {
   const [perDiemPct, setPerDiemPct] = useState(80); // stored as %, saved as fraction
   const [hometimeThresh, setHometimeThresh] = useState(21);
   const [operation, setOperation] = useState("flatbed");
+  const [stdTiers, setStdTiers] = useState<Tier3>({ min: 10, target: 20, strong: 30 });
+  const [specTiers, setSpecTiers] = useState<Tier3>({ min: 35, target: 45, strong: 60 });
+  const [marginGoal, setMarginGoal] = useState(26);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+
+  // Real break-even for the tier previews + weekly-target preview (cost-based,
+  // so it's independent of the tier values being edited).
+  const { loads } = useLoads(0);
+  const targets = useRateTargets(loads);
+  const be = targets.bookingLadder.walkAway;
+  const weeklyBE = targets.gross.weeklyBreakEven;
 
   useEffect(() => {
     getSettlementSchedule()
@@ -77,6 +155,17 @@ const SettingsPage = () => {
         setPerDiemPct(Math.round(s.per_diem_deduct_pct * 100));
         setHometimeThresh(s.hometime_threshold_days);
         setOperation(s.operation);
+        setStdTiers({
+          min: pct(s.rate_tier_std_min),
+          target: pct(s.rate_tier_std_target),
+          strong: pct(s.rate_tier_std_strong),
+        });
+        setSpecTiers({
+          min: pct(s.rate_tier_spec_min),
+          target: pct(s.rate_tier_spec_target),
+          strong: pct(s.rate_tier_spec_strong),
+        });
+        setMarginGoal(pct(s.margin_goal));
       })
       .catch(() => setErr("Couldn't load your settlement schedule."));
   }, []);
@@ -86,8 +175,15 @@ const SettingsPage = () => {
     setPcts((p) => (p ? { ...p, [k]: v } : p));
   };
 
+  const ascends = (t: Tier3) => t.min <= t.target && t.target <= t.strong;
+  const tierErr = !ascends(stdTiers)
+    ? "Standard tiers must climb: min ≤ target ≤ strong."
+    : !ascends(specTiers)
+      ? "Specialized tiers must climb: min ≤ target ≤ strong."
+      : null;
+
   const save = async () => {
-    if (!pcts) return;
+    if (!pcts || tierErr) return;
     setSaving(true);
     setErr(null);
     setMsg(null);
@@ -103,6 +199,13 @@ const SettingsPage = () => {
         per_diem_deduct_pct: perDiemPct / 100,
         hometime_threshold_days: hometimeThresh,
         operation,
+        rate_tier_std_min: stdTiers.min / 100,
+        rate_tier_std_target: stdTiers.target / 100,
+        rate_tier_std_strong: stdTiers.strong / 100,
+        rate_tier_spec_min: specTiers.min / 100,
+        rate_tier_spec_target: specTiers.target / 100,
+        rate_tier_spec_strong: specTiers.strong / 100,
+        margin_goal: marginGoal / 100,
       });
       setMsg("Saved. Your revenue and targets now use this split.");
     } catch (e) {
@@ -121,6 +224,10 @@ const SettingsPage = () => {
       SAMPLE_FSC * (pcts.fsc / 100)
     : gross;
   const effLinehaul = pcts ? pcts.linehaul + pcts.trailer : 100;
+  const weeklyTarget =
+    weeklyBE != null && marginGoal < 100
+      ? weeklyBE / (1 - marginGoal / 100)
+      : null;
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -209,16 +316,96 @@ const SettingsPage = () => {
               <p className="text-status-positive-text text-sm mt-4">{msg}</p>
             )}
             {err && <p className="text-destructive text-sm mt-4">{err}</p>}
+            {tierErr && (
+              <p className="text-destructive text-sm mt-4">
+                {tierErr} (in Rate tiers below)
+              </p>
+            )}
 
             <button
               onClick={save}
-              disabled={saving}
+              disabled={saving || !!tierErr}
               className="mt-4 bg-amber text-steel px-4 py-2 rounded font-semibold disabled:opacity-50"
             >
               {saving ? "Saving…" : "Save schedule"}
             </button>
           </>
         )}
+      </Panel>
+
+      <Panel className="mt-6 max-w-[680px] p-5">
+        <h2 className="text-lg font-medium text-light">Rate tiers</h2>
+        <p className="text-sm text-muted-text mt-1">
+          Your markup over break-even, per driven mile. Two sets — the load Scorer
+          grades <span className="text-light">specialized</span> freight (oversize,
+          hazmat, heavy haul) on the higher set and everything else on{" "}
+          <span className="text-light">standard</span>. Drives the Scorer's verdict,
+          counter-rate ladder, and the rate ladders across the app.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4">
+          <TierCard
+            label="Standard"
+            dot="#4a90d9"
+            tiers={stdTiers}
+            onChange={(t) => {
+              setMsg(null);
+              setStdTiers(t);
+            }}
+            be={be}
+          />
+          <TierCard
+            label="Specialized"
+            dot="#e05a3a"
+            tiers={specTiers}
+            onChange={(t) => {
+              setMsg(null);
+              setSpecTiers(t);
+            }}
+            be={be}
+          />
+        </div>
+        {tierErr ? (
+          <p className="text-destructive text-xs mt-3">{tierErr}</p>
+        ) : (
+          <p className="text-xs text-muted-text mt-3">
+            Each set must climb: min ≤ target ≤ strong. Saved with the schedule
+            above.
+          </p>
+        )}
+      </Panel>
+
+      <Panel className="mt-6 max-w-[680px] p-5">
+        <h2 className="text-lg font-medium text-light">Margin goal</h2>
+        <p className="text-sm text-muted-text mt-1">
+          Your target profit margin (profit ÷ revenue). Sets your weekly and daily
+          revenue targets — the grind streak and recap. Independent of the rate
+          tiers above.
+        </p>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 mt-4">
+          <label className="flex items-center gap-2">
+            <input
+              type="number"
+              min={0}
+              max={95}
+              step={1}
+              value={Number.isFinite(marginGoal) ? marginGoal : ""}
+              onChange={(e) => {
+                setMsg(null);
+                setMarginGoal(Number(e.target.value));
+              }}
+              className="w-20 bg-steel rounded px-2 py-1.5 text-light text-right tabular-nums"
+            />
+            <span className="text-muted-text">%</span>
+          </label>
+          <span className="text-xs text-muted-text">
+            {weeklyTarget != null
+              ? `weekly revenue target ≈ ${money(weeklyTarget)}`
+              : "add a few months of P&L to preview your weekly target"}
+          </span>
+        </div>
+        <span className="text-xs text-muted-text mt-3 block">
+          Saved with the schedule above.
+        </span>
       </Panel>
 
       <Panel className="mt-6 max-w-[680px] p-5">

--- a/frontend/src/services/settlementScheduleService.ts
+++ b/frontend/src/services/settlementScheduleService.ts
@@ -17,6 +17,19 @@ const coerce = (s: Record<string, unknown>): SettlementSchedule => ({
       ? Number(s.hometime_threshold_days)
       : 21,
   operation: (s.operation as string) ?? "flatbed",
+  rate_tier_std_min:
+    s.rate_tier_std_min != null ? Number(s.rate_tier_std_min) : 0.1,
+  rate_tier_std_target:
+    s.rate_tier_std_target != null ? Number(s.rate_tier_std_target) : 0.2,
+  rate_tier_std_strong:
+    s.rate_tier_std_strong != null ? Number(s.rate_tier_std_strong) : 0.3,
+  rate_tier_spec_min:
+    s.rate_tier_spec_min != null ? Number(s.rate_tier_spec_min) : 0.35,
+  rate_tier_spec_target:
+    s.rate_tier_spec_target != null ? Number(s.rate_tier_spec_target) : 0.45,
+  rate_tier_spec_strong:
+    s.rate_tier_spec_strong != null ? Number(s.rate_tier_spec_strong) : 0.6,
+  margin_goal: s.margin_goal != null ? Number(s.margin_goal) : 0.26,
 });
 
 export const getSettlementSchedule = async (): Promise<SettlementSchedule> => {
@@ -25,7 +38,7 @@ export const getSettlementSchedule = async (): Promise<SettlementSchedule> => {
 };
 
 export const updateSettlementSchedule = async (
-  data: SettlementSchedule,
+  data: Partial<SettlementSchedule>,
 ): Promise<SettlementSchedule> => {
   const res = await api.put("/settlement-schedule", data);
   return coerce(res.data.schedule);

--- a/frontend/src/types/settlementSchedule.ts
+++ b/frontend/src/types/settlementSchedule.ts
@@ -12,4 +12,16 @@ export interface SettlementSchedule {
   per_diem_deduct_pct: number; // deductible share (0.80 for DOT drivers)
   hometime_threshold_days: number; // flag the driver page past this many days out
   operation: string; // equipment/discipline — tailors which achievements apply
+  // Rate markup tiers — the fraction over break-even for a minimum / good
+  // (TAKE IT) / great (STEAL) load, per driven mile. TWO sets: the Scorer grades
+  // oversize/hazmat/heavy freight on Specialized, everything else on Standard.
+  rate_tier_std_min: number;
+  rate_tier_std_target: number;
+  rate_tier_std_strong: number;
+  rate_tier_spec_min: number;
+  rate_tier_spec_target: number;
+  rate_tier_spec_strong: number;
+  // Target profit margin (profit ÷ revenue) → weekly/daily REVENUE targets.
+  // Independent of the rate tiers above.
+  margin_goal: number;
 }


### PR DESCRIPTION
## What

Splits the single rate-tier set into **two editable sets** and decouples the weekly/daily revenue targets from them, with a new margin goal.

- **Rate tiers** — Standard (+10/20/30) and Specialized (+35/45/60), seeded from Jason's delivered-load distribution (standard freight medians ~break-even; oversize + hazmat + heavy-haul median ~+40%). The load Scorer grades specialized freight on the higher set and everything else on Standard, with a new **Hazmat toggle** (oversize/heavy still auto-detected from dims). The dispatcher "steal" award picks the set per load.
- **Margin goal** — target profit margin (profit ÷ revenue, seed 26%) now drives the weekly/daily **revenue** targets (grind streak, recap, pace bar), independent of the rate tiers. `getGrossTargets` is margin-based; numbers are unchanged at the seed.
- **Settings** — two tier cards + a margin-goal card with live previews at the real break-even and an ascending guard that disables save.
- **Pace bar** — simplified to floor → target (the revenue bar no longer rides the per-mile tiers).
- **Guide** — rate ladder, Scorer verdict mapping, and the weekly-target section (cost-vs-miles) updated.

## DB
Migration `053_rate_tiers.sql` adds six tier columns + `margin_goal` (range CHECKs). **Already applied to dev and prod** (additive, backward-compatible).

## Verification
- Strict build clean (tsc + vite); 391 frontend + 31 backend tests green (incl. new two-set verdict test, tier/margin parsers, margin-based `getGrossTargets`).
- Backend service round-trip verified against dev (upsert persists + reads back; ascending guard rejects out-of-order).
- Visual on dev: Settings both sets + live previews + guard; Scorer flips the same +42% load STEAL (Standard) → MEH (Specialized) on the Hazmat toggle.

Phase 1 of 2 — Phase 2 adds the specialized readout to the app-wide rate cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)