### PR TITLE
fix: exclude owner draws from break-even and pace targets

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.115.0",
+  "version": "1.115.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/hooks/useAwardPops.ts
+++ b/frontend/src/hooks/useAwardPops.ts
@@ -103,13 +103,12 @@ export const useAwardPops = (
       maxFuelOdometer(data.fuel) ?? 0,
       ...loads.map((l) => Number(l.odometer_end) || 0),
     );
+    // Break-even excludes owner draws, so the grind's pace targets use the
+    // debt-only obligation sum (not "all active").
     const obligationsDebtMonthly = data.obligations
       .filter((o) => o.active && !o.is_draw)
       .reduce((s, o) => s + Number(o.amount), 0);
-    const obligationsAllActive = data.obligations
-      .filter((o) => o.active)
-      .reduce((s, o) => s + Number(o.amount), 0);
-    const grind = computeGrind(loads, data.periods, obligationsAllActive, now, marginGoalFrom(data.schedule));
+    const grind = computeGrind(loads, data.periods, obligationsDebtMonthly, now, marginGoalFrom(data.schedule));
     const truckLoan = assetLoanStatus(data.obligations, "truck", now);
     const trailerLoan = assetLoanStatus(data.obligations, "trailer", now);
     const paidPcts = [truckLoan?.ownedPct, trailerLoan?.ownedPct].filter(

--- a/frontend/src/hooks/useGrind.ts
+++ b/frontend/src/hooks/useGrind.ts
@@ -7,6 +7,7 @@ import { getObligations } from "@/services/obligationsService";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
 import type { SettlementSchedule } from "@/types/settlementSchedule";
 import { computeGrind, type Grind } from "@/lib/metrics/grind";
+import { monthlyObligationCost } from "@/lib/metrics/rateTargets";
 import { marginGoalFrom } from "@/lib/constants/targets";
 
 // Fetches the P&L + obligations the rate ladder needs, then grades every pay-week
@@ -24,9 +25,7 @@ export const useGrind = (loads: Load[]): Grind | null => {
 
   return useMemo(() => {
     if (!periods || !obligations || loads.length === 0) return null;
-    const obligationsMonthly = obligations
-      .filter((o) => o.active)
-      .reduce((s, o) => s + Number(o.amount), 0);
+    const obligationsMonthly = monthlyObligationCost(obligations);
     return computeGrind(loads, periods, obligationsMonthly, new Date(), marginGoalFrom(schedule));
   }, [periods, obligations, loads, schedule]);
 };

--- a/frontend/src/hooks/useRateTargets.ts
+++ b/frontend/src/hooks/useRateTargets.ts
@@ -14,6 +14,7 @@ import {
   getWeekGrossCommitted,
   getWeekGrossEarned,
   getWindowRpm,
+  monthlyObligationCost,
 } from "@/lib/metrics/rateTargets";
 import {
   tiersFrom,
@@ -49,7 +50,7 @@ export const useRateTargets = (loads: Load[]) => {
   }, []);
 
   const obligationsMonthly = useMemo(
-    () => obligations.filter((o) => o.active).reduce((s, o) => s + o.amount, 0),
+    () => monthlyObligationCost(obligations),
     [obligations],
   );
 

--- a/frontend/src/lib/metrics/rateTargets.test.ts
+++ b/frontend/src/lib/metrics/rateTargets.test.ts
@@ -14,7 +14,9 @@ import {
   getWeekEarnedGross,
   getWeekRpm,
   getWindowRpm,
+  monthlyObligationCost,
 } from "./rateTargets";
+import type { Obligation } from "@/types/obligation";
 
 const load = (over: Partial<Load>): Load =>
   ({
@@ -295,5 +297,54 @@ describe("getWindowRpm", () => {
 
   it("null when there are no loaded miles in the window", () => {
     expect(getWindowRpm([], now)).toBeNull();
+  });
+});
+
+describe("monthlyObligationCost", () => {
+  const ob = (over: Partial<Obligation>): Obligation =>
+    ({
+      obligation_id: "o",
+      label: "x",
+      amount: 0,
+      active: true,
+      is_draw: false,
+      original_balance: null,
+      current_balance: null,
+      balance_as_of: null,
+      payoff_date: null,
+      asset_type: null,
+      asset_id: null,
+      ...over,
+    }) as Obligation;
+
+  it("sums active debt obligations", () => {
+    expect(
+      monthlyObligationCost([
+        ob({ amount: 1575 }),
+        ob({ amount: 475.19 }),
+        ob({ amount: 358 }),
+      ]),
+    ).toBeCloseTo(2408.19, 2);
+  });
+
+  it("excludes owner draws — a distribution is not a cost", () => {
+    const cost = monthlyObligationCost([
+      ob({ amount: 1575 }),
+      ob({ amount: 1000, is_draw: true }), // active draw must NOT count
+    ]);
+    expect(cost).toBe(1575);
+  });
+
+  it("excludes inactive obligations", () => {
+    expect(
+      monthlyObligationCost([
+        ob({ amount: 1575 }),
+        ob({ amount: 900, active: false }),
+      ]),
+    ).toBe(1575);
+  });
+
+  it("is 0 for an empty list", () => {
+    expect(monthlyObligationCost([])).toBe(0);
   });
 });

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -1,8 +1,20 @@
 import type { Load } from "@/types/load";
 import type { ExpensePeriod } from "@/types/expense";
+import type { Obligation } from "@/types/obligation";
 
 // Rate & pace targets, all derived live from the P&L + loads. Pure functions
 // take `now` explicitly so they're testable without touching the clock.
+
+// Monthly obligation cash that belongs in break-even / pace targets: active
+// obligations only, EXCLUDING owner draws. A draw (is_draw) is a distribution of
+// profit, not a cost of operating — folding it into break-even would treat paying
+// yourself out as an expense and inflate the rate you "need". Mirrors how True Net
+// already excludes draws. (The Expenses page keeps a separate cash-out view that
+// intentionally includes draws.)
+export const monthlyObligationCost = (obligations: Obligation[]): number =>
+  obligations
+    .filter((o) => o.active && !o.is_draw)
+    .reduce((s, o) => s + Number(o.amount), 0);
 
 // The full customer rate (gross) = linehaul + fuel surcharge + accessorials. Used
 // for pricing guidance, where the rate you actually book is what matters.

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -134,11 +134,8 @@ const DriverDetailPage = () => {
   const card = useMemo(() => {
     if (driverLoads.length === 0) return null;
     const now = new Date();
-    // All active obligations (incl. the owner draw) drive break-even/rate; only
-    // the debt ones (draws excluded) subtract from True Net.
-    const obligationsTotal = obligations
-      .filter((o) => o.active)
-      .reduce((s, o) => s + Number(o.amount), 0);
+    // Active DEBT obligations (owner draws excluded) drive break-even/rate and
+    // subtract from True Net — a draw is a profit distribution, not a cost.
     const obligationsDebt = obligations
       .filter((o) => o.active && !o.is_draw)
       .reduce((s, o) => s + Number(o.amount), 0);
@@ -148,7 +145,7 @@ const DriverDetailPage = () => {
       maxFuelOdometer(fuel) ?? 0,
       ...driverLoads.map((l) => Number(l.odometer_end) || 0),
     );
-    const basis = getCostBasis(periods, obligationsTotal, driverLoads, now);
+    const basis = getCostBasis(periods, obligationsDebt, driverLoads, now);
     const ladder = getRateLadder(basis.breakEvenRpm, tiers);
     const season = getSeasonStats(periods, driverLoads, driverTrips, now, 3, obligationsDebt);
     const rpmG = rpmGrade(basis.windowRpm, ladder);
@@ -170,7 +167,7 @@ const DriverDetailPage = () => {
       winDays > 0
         ? Math.min(1, underLoadDaySet(driverLoads, winStart, nowKey).size / winDays)
         : null;
-    const grind = computeGrind(driverLoads, periods, obligationsTotal, now, marginGoal);
+    const grind = computeGrind(driverLoads, periods, obligationsDebt, now, marginGoal);
     // Medals (fixed tiers), records (improving bests), patches (hard stackable feats).
     const del = driverLoads.filter((l) => l.load_status === "delivered");
     const paidPcts = [

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -13,7 +13,11 @@ import {
   getCashMetrics,
   getTrueMonthly,
 } from "@/lib/metrics/expenses";
-import { getCostBasis, getRateLadder } from "@/lib/metrics/rateTargets";
+import {
+  getCostBasis,
+  getRateLadder,
+  monthlyObligationCost,
+} from "@/lib/metrics/rateTargets";
 import { tiersFrom } from "@/lib/constants/targets";
 import { RateLadder } from "@/components/dashboard/RateLadder";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
@@ -165,6 +169,13 @@ const ExpensesPage = () => {
     () => obligations.filter((o) => o.active).reduce((s, o) => s + o.amount, 0),
     [obligations],
   );
+  // Break-even / rate-ladder basis excludes owner draws (a draw is a profit
+  // distribution, not an operating cost); the cash-out "true cost" above keeps
+  // them. Equal until a draw is active.
+  const obligationsCost = useMemo(
+    () => monthlyObligationCost(obligations),
+    [obligations],
+  );
   const trueMonthly =
     metrics && selected
       ? getTrueMonthly(metrics.monthlyCost, obligationsTotal, selected.income_total)
@@ -179,8 +190,8 @@ const ExpensesPage = () => {
   // Rate targets anchored to today (last 3 complete months, NOT the selected
   // month) — forward pricing guidance, same basis as the dashboard card.
   const rateBasis = useMemo(
-    () => getCostBasis(periods, obligationsTotal, loads, new Date()),
-    [periods, obligationsTotal, loads],
+    () => getCostBasis(periods, obligationsCost, loads, new Date()),
+    [periods, obligationsCost, loads],
   );
   const linehaulTake = schedule
     ? Number(schedule.linehaul_pct) + Number(schedule.trailer_pct)

--- a/frontend/src/pages/RecapPage.tsx
+++ b/frontend/src/pages/RecapPage.tsx
@@ -21,6 +21,7 @@ import {
   type RecapRange,
 } from "@/lib/metrics/recap";
 import { marginGoalFrom } from "@/lib/constants/targets";
+import { monthlyObligationCost } from "@/lib/metrics/rateTargets";
 import { careerRank } from "@/lib/metrics/playerCard";
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { RecapPoster } from "@/components/recap/RecapPoster";
@@ -71,9 +72,7 @@ const RecapPage = () => {
 
   const now = new Date();
   const range = resolvePeriod(scope, ago, now);
-  const obligationsMonthly = obligations
-    .filter((o) => o.active)
-    .reduce((s, o) => s + Number(o.amount), 0);
+  const obligationsMonthly = monthlyObligationCost(obligations);
 
   const stats = useMemo(
     () => computeRecap(loads, fuel, periods, obligationsMonthly, range, scope, now, marginGoalFrom(schedule)),


### PR DESCRIPTION
## What
`getCostBasis`-fed obligation sums counted **all** active obligations, including owner draws (`is_draw`). A draw is a profit distribution, not an operating cost — including it inflates break-even and the rate you "need," and it was inconsistent with True Net (which already excludes draws).

- New shared helper `monthlyObligationCost(obligations)` = active **and not** a draw.
- Routed through it: break-even (`useRateTargets`), grind (`useGrind`, `useAwardPops`), recap (`RecapPage`), and the driver page (`DriverDetailPage`). `ExpensesPage`'s rate ladder too.
- **Left as-is:** the Expenses page's labeled cash-out "true cost" (loan principal + draws) — a deliberate separate lens.

## Impact
**Zero change to current numbers** — the only draw (Distribution $1,000) is inactive, so the sum is identical ($2,408.19/mo). The fix prevents a silent +$1,000/mo break-even inflation the moment a draw is activated.

## Verification
Strict build clean; 395 tests pass (+4 for `monthlyObligationCost`: sums active debt, excludes draws, excludes inactive, empty = 0). No-op on current data, so nothing observable in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)