### PR TITLE
feat: show the Specialized rate ladder on the app-wide cards (Phase 2)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.115.1",
+  "version": "1.116.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/RateLadder.tsx
+++ b/frontend/src/components/dashboard/RateLadder.tsx
@@ -3,11 +3,14 @@ import type { RateLadder as Ladder } from "@/lib/metrics/rateTargets";
 interface Props {
   ladder: Ladder;
   rpm: number | null; // your current rate — the marker
+  spec?: Ladder; // optional Specialized ladder — shown as a compact second row
 }
 
 const RED = "#e24b4a";
 const AMBER = "#e8940a";
 const GREEN = "#1d9e75";
+const GREEN_BRIGHT = "#4ade80"; // reads as text on dark, unlike the fill green
+const CORAL = "#e05a3a"; // Specialized — matches the Scorer/Settings dot
 const TRACK = "#232c3f";
 
 const rate = (n: number | null): string => (n == null ? "—" : `$${n.toFixed(2)}`);
@@ -15,9 +18,12 @@ const rate = (n: number | null): string => (n == null ? "—" : `$${n.toFixed(2)
 // Horizontal ladder from walk-away → strong, split at the target tier. A marker
 // shows where the current rate lands: red at/below walk-away (losing money),
 // amber below target, green at/above target.
-export const RateLadder = ({ ladder, rpm }: Props) => {
+export const RateLadder = ({ ladder, rpm, spec }: Props) => {
   const { walkAway, target, strong } = ladder;
   if (walkAway == null || target == null || strong == null) return null;
+  // Specialized shares the same walk-away (break-even) — only its target/strong
+  // markups differ, so the compact row shows just those two.
+  const showSpec = spec != null && spec.target != null && spec.strong != null;
 
   const span = strong - walkAway;
   const targetPos = span > 0 ? ((target - walkAway) / span) * 100 : 58;
@@ -73,6 +79,26 @@ export const RateLadder = ({ ladder, rpm }: Props) => {
           <span className="text-light">{rate(strong)}</span>
         </span>
       </div>
+
+      {showSpec && (
+        <div
+          className="flex items-center gap-2 flex-wrap mt-2 pt-2 text-xs"
+          style={{ borderTop: "0.5px solid rgba(255,255,255,0.07)" }}
+        >
+          <span className="inline-flex items-center gap-1.5">
+            <span
+              className="inline-block rounded-full shrink-0"
+              style={{ width: 8, height: 8, background: CORAL }}
+            />
+            <span className="text-light">Specialized</span>
+          </span>
+          <span className="text-[11px] text-muted-text">oversize · hazmat · heavy</span>
+          <span className="ml-auto text-muted-text">
+            target <span style={{ color: AMBER }}>{rate(spec!.target)}</span> · strong{" "}
+            <span style={{ color: GREEN_BRIGHT }}>{rate(spec!.strong)}</span>
+          </span>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -128,6 +128,7 @@ const TargetBurst = () => (
 export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
   const {
     bookingLadder,
+    specLadder,
     grossRate,
     gross,
     weekBooked,
@@ -164,7 +165,7 @@ export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
             <p className="text-xs text-muted-text mb-3">
               Rate to book · gross $/mile driven · marker = your rate
             </p>
-            <RateLadder ladder={bookingLadder} rpm={grossRate} />
+            <RateLadder ladder={bookingLadder} rpm={grossRate} spec={specLadder} />
             <p className="text-[11px] text-muted-text mt-2">
               walk-away = your cost/mile ÷ your{" "}
               {Math.round(linehaulTake * 100)}% keep. Book above it — with your

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -18,7 +18,7 @@ import {
   getRateLadder,
   monthlyObligationCost,
 } from "@/lib/metrics/rateTargets";
-import { tiersFrom } from "@/lib/constants/targets";
+import { tiersFrom, specTiersFrom } from "@/lib/constants/targets";
 import { RateLadder } from "@/components/dashboard/RateLadder";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
 import type { SettlementSchedule } from "@/types/settlementSchedule";
@@ -203,6 +203,7 @@ const ExpensesPage = () => {
       ? rateBasis.costPerTotalMile / linehaulTake
       : null;
   const rateLadder = getRateLadder(bookingBase, tiersFrom(schedule));
+  const specRateLadder = getRateLadder(bookingBase, specTiersFrom(schedule));
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -325,7 +326,7 @@ const ExpensesPage = () => {
                   <span className="text-muted-text">to book</span>
                 </span>
               </div>
-              <RateLadder ladder={rateLadder} rpm={rateBasis.grossPerTotalMile} />
+              <RateLadder ladder={rateLadder} rpm={rateBasis.grossPerTotalMile} spec={specRateLadder} />
               <p className="text-[11px] text-muted-text mt-2">
                 walk-away = your cost/mile ÷ your{" "}
                 {Math.round(linehaulTake * 100)}% keep. Book above it with your

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -265,6 +265,23 @@ const MiniLadder = () => (
         <span className="text-light">$5.64</span>
       </span>
     </div>
+    <div
+      className="flex items-center gap-2 flex-wrap mt-2 pt-2 text-xs"
+      style={{ borderTop: "0.5px solid rgba(255,255,255,0.07)" }}
+    >
+      <span className="inline-flex items-center gap-1.5">
+        <span
+          className="inline-block rounded-full shrink-0"
+          style={{ width: 8, height: 8, background: "#e05a3a" }}
+        />
+        <span className="text-light">Specialized</span>
+      </span>
+      <span className="text-[11px] text-muted-text">oversize · hazmat · heavy</span>
+      <span className="ml-auto text-muted-text">
+        target <span style={{ color: AMBER }}>$6.29</span> · strong{" "}
+        <span style={{ color: "#4ade80" }}>$6.94</span>
+      </span>
+    </div>
   </div>
 );
 
@@ -582,14 +599,14 @@ const GuidePage = () => {
             </Formula>
             <Why>
               There are <span className="text-light">two tier sets</span>, both
-              editable in Settings.{" "}
-              <span className="text-light">Standard</span> (seeded +10 / 20 / 30%,
-              shown above) is your everyday freight and drives the dashboard
-              ladder. <span className="text-light">Specialized</span> (+35 / 45 /
+              editable in Settings and both shown on the ladder above.{" "}
+              <span className="text-light">Standard</span> (seeded +10 / 20 / 30%)
+              is your everyday freight and carries the full bar plus your rate
+              marker. <span className="text-light">Specialized</span> (+35 / 45 /
               60%) is the higher bar for oversize, hazmat, and heavy-haul loads —
-              they command a real premium, so they're judged against it. The
-              marker on the dashboard is your actual gross rate per mile — where
-              you're really pricing.
+              they command a real premium — shown as the compact row beneath (same
+              walk-away, higher target and strong). The marker is your actual gross
+              rate per mile, against the Standard bar.
             </Why>
           </Metric>
 


### PR DESCRIPTION
## What
Phase 2 of the two-set rate tiers. The dashboard and Expenses rate cards showed only the **Standard** ladder; this adds a compact **Specialized** readout beneath it so oversize/hazmat/heavy pricing is visible app-wide, not just in the Scorer.

- `RateLadder` gains an optional `spec` prop → renders a compact coral-dotted row: `Specialized · oversize · hazmat · heavy · target $X · strong $Y` (same walk-away, so only target + strong shown).
- Wired via `targets.specLadder` (dashboard `RateTargetsCard`) and a specialized `getRateLadder` on `ExpensesPage`.
- Driver page only *grades* against the ladder (no visible bar), so it's untouched.
- Guide: `MiniLadder` + rate-ladder copy updated to show both sets.

## Verification
Strict build clean; 395 tests pass. Verified on dev: both the dashboard and Expenses cards render the Standard bar + "you ▼" marker with the Specialized row beneath (target $25.44 · strong $28.07 at the dev $17.54 break-even).

Completes the adjustable-rate-tiers epic (v1.115.0 tiers + margin, v1.115.1 draw fix, v1.116.0 app-wide readout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)