### PR TITLE
feat: Market & Rates analytics page (Phase 1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.116.0",
+  "version": "1.117.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import TripsPage from "@/pages/TripsPage";
 import ScoreLoadPage from "@/pages/ScoreLoadPage";
 import GaragePage from "@/pages/GaragePage";
 import ExpensesPage from "@/pages/ExpensesPage";
+import MarketPage from "@/pages/MarketPage";
 import PerDiemPage from "@/pages/PerDiemPage";
 import MaintenancePage from "@/pages/MaintenancePage";
 import AgentsPage from "@/pages/AgentsPage";
@@ -86,6 +87,7 @@ const App = () => {
           {/* Owner-only — a dispatcher is redirected to /dashboard (see roles.ts) */}
           <Route element={<AdminRoute />}>
             <Route path="/expenses" element={<ExpensesPage />} />
+            <Route path="/market" element={<MarketPage />} />
             <Route path="/per-diem" element={<PerDiemPage />} />
             <Route path="/recap" element={<RecapPage />} />
             <Route path="/garage" element={<GaragePage />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -71,6 +71,7 @@ const nav: Entry[] = [
     icon: Wallet,
     children: [
       { to: "/expenses", label: "Expenses", adminOnly: true },
+      { to: "/market", label: "Market", adminOnly: true },
       { to: "/per-diem", label: "Per Diem", adminOnly: true },
       { to: "/recap", label: "Recap", adminOnly: true },
       { to: "/garage", label: "Garage", adminOnly: true },

--- a/frontend/src/lib/metrics/marketAnalytics.test.ts
+++ b/frontend/src/lib/metrics/marketAnalytics.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { RateLadder } from "./rateTargets";
+import {
+  ratePoints,
+  median,
+  monthlyMedianRate,
+  percentileOf,
+  windowRates,
+  tierGauge,
+} from "./marketAnalytics";
+
+// Minimal delivered-load fixture: gross_revenue over an odometer window gives a
+// clean gross-$/driven-mile.
+const load = (over: Partial<Load>): Load =>
+  ({
+    load_id: "l",
+    load_number: "n",
+    load_status: "delivered",
+    delivery_date: "2026-05-10",
+    gross_revenue: "2000",
+    odometer_start: 0,
+    odometer_end: 500,
+    loaded_miles: 500,
+    deadhead_miles: 0,
+    load_type: "standard flatbed",
+    ...over,
+  }) as Load;
+
+describe("ratePoints", () => {
+  it("computes gross/driven-mile, buckets by type, sorts oldest→newest", () => {
+    const pts = ratePoints([
+      load({ delivery_date: "2026-05-10", gross_revenue: "2500", odometer_start: 0, odometer_end: 500, load_type: "oversize" }),
+      load({ delivery_date: "2026-02-01", gross_revenue: "2000", odometer_start: 0, odometer_end: 500, load_type: "standard flatbed" }),
+      load({ delivery_date: "2026-03-01", gross_revenue: "3000", odometer_start: 0, odometer_end: 500, load_type: "hazmat" }),
+    ]);
+    expect(pts.map((p) => p.date)).toEqual(["2026-02-01", "2026-03-01", "2026-05-10"]);
+    expect(pts[0]).toMatchObject({ rate: 4, bucket: "standard" });
+    expect(pts[1]).toMatchObject({ rate: 6, bucket: "hazmat" });
+    expect(pts[2]).toMatchObject({ rate: 5, bucket: "specialized" });
+  });
+
+  it("falls back to loaded+deadhead when there's no odometer window", () => {
+    const [p] = ratePoints([
+      load({ odometer_start: null, odometer_end: null, loaded_miles: 400, deadhead_miles: 100, gross_revenue: "2500" }),
+    ]);
+    expect(p.rate).toBe(5); // 2500 / (400+100)
+  });
+
+  it("drops non-delivered loads and zero-mile loads", () => {
+    expect(
+      ratePoints([
+        load({ load_status: "booked" }),
+        load({ odometer_start: null, odometer_end: null, loaded_miles: 0, deadhead_miles: 0 }),
+      ]),
+    ).toHaveLength(0);
+  });
+});
+
+describe("median", () => {
+  it("odd, even, and empty", () => {
+    expect(median([5, 1, 3])).toBe(3);
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+    expect(median([])).toBeNull();
+  });
+});
+
+describe("monthlyMedianRate", () => {
+  it("groups rates by calendar month, oldest→newest", () => {
+    const pts = ratePoints([
+      load({ delivery_date: "2026-02-05", gross_revenue: "1500", odometer_end: 500 }), // 3.0
+      load({ delivery_date: "2026-02-20", gross_revenue: "2500", odometer_end: 500 }), // 5.0
+      load({ delivery_date: "2026-03-03", gross_revenue: "2000", odometer_end: 500 }), // 4.0
+    ]);
+    const m = monthlyMedianRate(pts);
+    expect(m).toEqual([
+      { month: "2026-02", median: 4, n: 2 },
+      { month: "2026-03", median: 4, n: 1 },
+    ]);
+  });
+});
+
+describe("percentileOf", () => {
+  it("fraction at or below the value", () => {
+    expect(percentileOf([1, 2, 3, 4, 5], 3)).toBeCloseTo(0.6); // 1,2,3
+    expect(percentileOf([1, 2, 3, 4, 5], 5)).toBe(1);
+    expect(percentileOf([], 3)).toBeNull();
+  });
+});
+
+describe("windowRates", () => {
+  it("keeps only the trailing window, clock injected", () => {
+    const now = new Date("2026-07-15T00:00:00Z");
+    const pts = ratePoints([
+      load({ delivery_date: "2026-02-01", gross_revenue: "1000", odometer_end: 500 }), // old, out
+      load({ delivery_date: "2026-06-01", gross_revenue: "2500", odometer_end: 500 }), // in
+      load({ delivery_date: "2026-07-10", gross_revenue: "3000", odometer_end: 500 }), // in
+    ]);
+    expect(windowRates(pts, now, 90).sort()).toEqual([5, 6]);
+  });
+});
+
+describe("tierGauge", () => {
+  const ladder = (target: number, strong: number): RateLadder => ({
+    walkAway: 3,
+    minimum: target,
+    target,
+    strong,
+  });
+  // five recent loads at $3–7/mi
+  const recent = ratePoints(
+    [3, 4, 5, 6, 7].map((r, i) =>
+      load({ delivery_date: `2026-06-0${i + 1}`, gross_revenue: String(r * 500), odometer_end: 500 }),
+    ),
+  );
+  const now = new Date("2026-06-15T00:00:00Z");
+
+  it("places tiers as percentiles and reads a HOT market when target is low", () => {
+    const g = tierGauge(recent, ladder(4, 6), ladder(9, 10), now);
+    const std = g.rows.find((r) => r.label === "Standard target")!;
+    expect(std.pctile).toBeCloseTo(0.4); // 3,4 ≤ 4 → 2/5
+    expect(g.tone).toBe("hot");
+    expect(g.windowN).toBe(5);
+  });
+
+  it("reads a SOFT market when the target sits high in the window", () => {
+    const g = tierGauge(recent, ladder(7, 8), ladder(9, 10), now);
+    const std = g.rows.find((r) => r.label === "Standard target")!;
+    expect(std.pctile).toBe(1); // all ≤ 7
+    expect(g.tone).toBe("soft");
+  });
+
+  it("no tone without a break-even/ladder", () => {
+    const empty: RateLadder = { walkAway: null, minimum: null, target: null, strong: null };
+    const g = tierGauge(recent, empty, empty, now);
+    expect(g.rows).toHaveLength(0);
+    expect(g.tone).toBeNull();
+  });
+});

--- a/frontend/src/lib/metrics/marketAnalytics.ts
+++ b/frontend/src/lib/metrics/marketAnalytics.ts
@@ -1,0 +1,150 @@
+// Market & Rates analytics — pure aggregations over delivered loads so the page
+// can show a rate scatter, a market barometer (rolling median), and a tier gauge
+// (where your current tiers land as percentiles of the recent market). Clock is
+// injected as `now` so everything is testable without touching the real date.
+import type { Load } from "@/types/load";
+import type { RateLadder } from "./rateTargets";
+import { loadGross } from "./rateTargets";
+import { isSpecializedLoadType } from "@/lib/dimensions";
+
+export type RateBucket = "standard" | "hazmat" | "specialized";
+
+export interface RatePoint {
+  date: string; // 'YYYY-MM-DD' delivery date
+  rate: number; // gross $ per DRIVEN mile (loaded + deadhead)
+  bucket: RateBucket;
+  loadNumber: string | null;
+}
+
+// Driven miles = the odometer window when present (truth), else the planning
+// loaded + deadhead. Mirrors the Scorer / rate ladder basis.
+const drivenMiles = (l: Load): number => {
+  const os = Number(l.odometer_start);
+  const oe = Number(l.odometer_end);
+  if (l.odometer_start != null && l.odometer_end != null && oe > os) return oe - os;
+  return Number(l.loaded_miles || 0) + Number(l.deadhead_miles || 0);
+};
+
+const bucketOf = (l: Load): RateBucket =>
+  l.load_type === "hazmat"
+    ? "hazmat"
+    : isSpecializedLoadType(l.load_type)
+      ? "specialized"
+      : "standard";
+
+// Delivered loads with a computable gross rate per driven mile, oldest → newest.
+export const ratePoints = (loads: Load[]): RatePoint[] =>
+  loads
+    .filter((l) => l.load_status === "delivered" && l.delivery_date)
+    .map((l): RatePoint | null => {
+      const d = drivenMiles(l);
+      const rate = d > 0 ? loadGross(l) / d : NaN;
+      if (!Number.isFinite(rate) || rate <= 0) return null;
+      return {
+        date: l.delivery_date!.slice(0, 10),
+        rate,
+        bucket: bucketOf(l),
+        loadNumber: l.load_number ?? null,
+      };
+    })
+    .filter((p): p is RatePoint => p !== null)
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+export const median = (xs: number[]): number | null => {
+  if (xs.length === 0) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+
+// Median rate per calendar month — the barometer line. Oldest → newest.
+export const monthlyMedianRate = (
+  points: RatePoint[],
+): { month: string; median: number; n: number }[] => {
+  const byMonth = new Map<string, number[]>();
+  for (const p of points) {
+    const m = p.date.slice(0, 7);
+    const arr = byMonth.get(m);
+    if (arr) arr.push(p.rate);
+    else byMonth.set(m, [p.rate]);
+  }
+  return [...byMonth.entries()]
+    .map(([month, rates]) => ({ month, median: median(rates)!, n: rates.length }))
+    .sort((a, b) => a.month.localeCompare(b.month));
+};
+
+// Fraction of `xs` at or below `value` (0..1). null when there's no window.
+export const percentileOf = (xs: number[], value: number): number | null => {
+  if (xs.length === 0) return null;
+  return xs.filter((x) => x <= value).length / xs.length;
+};
+
+// Rates from the trailing `days` window ending at `now` (inclusive of today).
+export const windowRates = (
+  points: RatePoint[],
+  now: Date,
+  days = 90,
+): number[] => {
+  const today = now.toISOString().slice(0, 10);
+  const cut = new Date(now.getTime() - days * 86400000)
+    .toISOString()
+    .slice(0, 10);
+  return points.filter((p) => p.date > cut && p.date <= today).map((p) => p.rate);
+};
+
+export interface TierGaugeRow {
+  label: string;
+  value: number; // the tier's gross $/driven-mile
+  pctile: number; // 0..1 within the trailing window
+}
+
+export interface TierGauge {
+  rows: TierGaugeRow[];
+  windowN: number; // loads in the window (sample size)
+  tone: "hot" | "balanced" | "soft" | null;
+  suggestion: string | null;
+}
+
+// Where your current tiers land as percentiles of the recent market, plus a
+// plain-language read. A LOW percentile for your target = the market clears it
+// easily (hot → room to raise); a HIGH percentile = it's hard to hit (soft →
+// trim). Ideal target sits around the middle of what's out there.
+export const tierGauge = (
+  points: RatePoint[],
+  ladder: RateLadder,
+  specLadder: RateLadder,
+  now: Date,
+  days = 90,
+): TierGauge => {
+  const w = windowRates(points, now, days);
+  const row = (label: string, value: number | null): TierGaugeRow | null =>
+    value != null && w.length > 0
+      ? { label, value, pctile: percentileOf(w, value)! }
+      : null;
+  const rows = [
+    row("Standard target", ladder.target),
+    row("Standard strong", ladder.strong),
+    row("Specialized strong", specLadder.strong),
+  ].filter((r): r is TierGaugeRow => r !== null);
+
+  const std = rows.find((r) => r.label === "Standard target");
+  let tone: TierGauge["tone"] = null;
+  let suggestion: string | null = null;
+  if (std && w.length >= 5) {
+    if (std.pctile < 0.45) {
+      tone = "hot";
+      suggestion =
+        "Market's running hot — your Standard target sits below the median of recent loads. Room to raise your tiers.";
+    } else if (std.pctile > 0.7) {
+      tone = "soft";
+      suggestion =
+        "Market's softening — your Standard target is hard to hit right now. Consider trimming your tiers.";
+    } else {
+      tone = "balanced";
+      suggestion = "Your tiers are well-placed against the current market.";
+    }
+  } else if (std) {
+    suggestion = "Not enough recent loads to read the market confidently yet.";
+  }
+  return { rows, windowN: w.length, tone, suggestion };
+};

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -309,6 +309,7 @@ const NAV: { group: string; items: string[] }[] = [
       "The rate ladder",
       "Load Scorer — Take It or Leave It",
       "Weekly & daily targets",
+      "Market & Rates — reading the cycle",
       "Rate per mile (RPM)",
       "Lane rate — typical vs blended",
       "Outstanding loads — how long money sits",
@@ -688,6 +689,30 @@ const GuidePage = () => {
               per-mile targets drop, but you cover more miles, so the weekly
               dollars you need don't move. Only your cost and your margin goal
               change this number.
+            </Why>
+          </Metric>
+
+          <Metric
+            title="Market & Rates — reading the cycle"
+            answers="Every delivered load plotted by what it paid per driven mile, over time — so you can see the freight market turn and tell whether your rate tiers still fit it."
+            sources={[{ label: "Market", to: "/market" }]}
+          >
+            <Why>
+              The <span className="text-light">scatter</span> drops every load on
+              a timeline by its gross rate per driven mile, colored by type, with
+              your break-even and tier lines drawn across it. A soft market shows
+              up as a cluster sinking toward — or under — the break-even line
+              before you'd feel it load by load.
+            </Why>
+            <Why>
+              The <span className="text-light">barometer</span> is your own median
+              rate per driven mile by month — your personal read on where the
+              market is. The <span className="text-light">tier gauge</span> then
+              asks the useful question: where do your tiers land in the last 90
+              days? A target sitting at the 40th percentile means the market
+              clears it easily (hot — room to raise); one at the 90th means it's
+              barely gettable (soft — trim). That turns "when do I adjust my
+              tiers" into a number you read instead of a gut call.
             </Why>
           </Metric>
 

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -1,0 +1,293 @@
+import { useMemo } from "react";
+import { useLoads } from "@/hooks/useLoads";
+import { useRateTargets } from "@/hooks/useRateTargets";
+import { Panel } from "@/components/ui/Panel";
+import type { RateLadder } from "@/lib/metrics/rateTargets";
+import {
+  ratePoints,
+  monthlyMedianRate,
+  tierGauge,
+  type RatePoint,
+} from "@/lib/metrics/marketAnalytics";
+
+const COLOR: Record<RatePoint["bucket"], string> = {
+  standard: "#4a90d9",
+  hazmat: "#e0a020",
+  specialized: "#e05a3a",
+};
+const BE = "#e0533a";
+const money2 = (n: number) => `$${n.toFixed(2)}`;
+const shortMonth = (ym: string) =>
+  new Date(ym + "-01T00:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    timeZone: "UTC",
+  });
+
+// ---- Scatter: every delivered load, rate/driven-mile over time, by type ----
+const RateScatter = ({
+  points,
+  ladder,
+  specLadder,
+}: {
+  points: RatePoint[];
+  ladder: RateLadder;
+  specLadder: RateLadder;
+}) => {
+  const W = 680;
+  const H = 320;
+  const L = 40;
+  const R = 12;
+  const T = 14;
+  const B = 40;
+  const t = (d: string) => new Date(d + "T00:00:00Z").getTime();
+  const tMin = t(points[0].date);
+  const tMax = Math.max(t(points[points.length - 1].date), tMin + 86400000);
+  // Scale to the LOADS, not the tier lines — so tiers that sit far above every
+  // load (a very soft market, or a high break-even) never squash the points.
+  // Overlay lines above the range clamp to the top edge (see `line`).
+  const yMax = Math.ceil(Math.max(...points.map((p) => p.rate), 1) + 0.5);
+  const x = (d: string) => L + ((t(d) - tMin) / (tMax - tMin)) * (W - L - R);
+  const y = (r: number) => T + (1 - r / yMax) * (H - T - B);
+  const yClamp = (r: number) => Math.max(T, Math.min(H - B, y(r)));
+
+  // month gridline dates spanning the range
+  const months: string[] = [];
+  const cur = new Date(tMin);
+  cur.setUTCDate(1);
+  while (cur.getTime() <= tMax) {
+    months.push(cur.toISOString().slice(0, 7));
+    cur.setUTCMonth(cur.getUTCMonth() + 1);
+  }
+
+  const yTicks = Array.from({ length: yMax / 2 + 1 }, (_, i) => i * 2);
+  // `slot` staggers the label when a line is pinned to the top (above every
+  // load) so break-even + both tier lines don't collide in a deep-downturn view.
+  const line = (
+    v: number | null,
+    color: string,
+    dash: string,
+    label: string,
+    slot: number,
+  ) => {
+    if (v == null) return null;
+    const yy = yClamp(v);
+    const above = v > yMax;
+    return (
+      <g key={label}>
+        <line x1={L} y1={yy} x2={W - R} y2={yy} stroke={color} strokeWidth={1.4} strokeDasharray={dash} />
+        <text x={W - R} y={above ? T + 9 + slot * 11 : yy - 3} textAnchor="end" fontSize={9} fill={color}>
+          {label} {money2(v)}
+          {above ? " ↑" : ""}
+        </text>
+      </g>
+    );
+  };
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} width="100%" role="img" aria-label="Scatter of every delivered load's gross rate per driven mile over time, colored by load type, with break-even and tier overlays">
+      {yTicks.map((v) => (
+        <g key={v}>
+          <line x1={L} y1={y(v)} x2={W - R} y2={y(v)} stroke="rgba(255,255,255,0.06)" strokeWidth={0.5} />
+          <text x={L - 6} y={y(v) + 3} textAnchor="end" fontSize={9} fill="#5f6b80">
+            ${v}
+          </text>
+        </g>
+      ))}
+      {months.map((m) => (
+        <text key={m} x={x(m + "-01")} y={H - 24} textAnchor="middle" fontSize={9} fill="#5f6b80">
+          {shortMonth(m)}
+        </text>
+      ))}
+      {line(ladder.walkAway, BE, "0", "break-even", 0)}
+      {line(ladder.target, "#7fb2e6", "4 3", "std target", 1)}
+      {line(specLadder.target, "#e05a3a", "4 3", "spec target", 2)}
+      {points.map((p, i) => (
+        <circle
+          key={i}
+          cx={x(p.date).toFixed(1)}
+          cy={y(p.rate).toFixed(1)}
+          r={5}
+          fill={COLOR[p.bucket]}
+          fillOpacity={0.78}
+          stroke={COLOR[p.bucket]}
+          strokeWidth={1}
+        />
+      ))}
+    </svg>
+  );
+};
+
+// ---- Barometer: monthly median rate over time vs break-even ----
+const Barometer = ({
+  monthly,
+  breakEven,
+}: {
+  monthly: { month: string; median: number; n: number }[];
+  breakEven: number | null;
+}) => {
+  const W = 680;
+  const H = 200;
+  const L = 40;
+  const R = 12;
+  const T = 14;
+  const B = 34;
+  const yMax = Math.ceil(
+    Math.max(...monthly.map((m) => m.median), breakEven ?? 0, 1) + 0.5,
+  );
+  const x = (i: number) =>
+    L + (monthly.length <= 1 ? 0.5 : i / (monthly.length - 1)) * (W - L - R);
+  const y = (r: number) => T + (1 - r / yMax) * (H - T - B);
+  const path = monthly
+    .map((m, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(m.median).toFixed(1)}`)
+    .join(" ");
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} width="100%" role="img" aria-label="Line of your monthly median rate per driven mile against your break-even">
+      {[0, yMax / 2, yMax].map((v) => (
+        <g key={v}>
+          <line x1={L} y1={y(v)} x2={W - R} y2={y(v)} stroke="rgba(255,255,255,0.06)" strokeWidth={0.5} />
+          <text x={L - 6} y={y(v) + 3} textAnchor="end" fontSize={9} fill="#5f6b80">
+            ${v}
+          </text>
+        </g>
+      ))}
+      {breakEven != null && (
+        <g>
+          <line x1={L} y1={y(breakEven)} x2={W - R} y2={y(breakEven)} stroke={BE} strokeWidth={1.4} strokeDasharray="4 3" />
+          <text x={W - R} y={y(breakEven) - 3} textAnchor="end" fontSize={9} fill={BE}>
+            break-even {money2(breakEven)}
+          </text>
+        </g>
+      )}
+      <path d={path} fill="none" stroke="#4ade80" strokeWidth={2.5} />
+      {monthly.map((m, i) => (
+        <g key={m.month}>
+          <circle cx={x(i)} cy={y(m.median)} r={3.5} fill="#4ade80" />
+          <text x={x(i)} y={H - 18} textAnchor="middle" fontSize={9} fill="#5f6b80">
+            {shortMonth(m.month)}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+};
+
+const MarketPage = () => {
+  const { loads } = useLoads(0);
+  const targets = useRateTargets(loads);
+  const now = useMemo(() => new Date(), []);
+
+  const points = useMemo(() => ratePoints(loads), [loads]);
+  const monthly = useMemo(() => monthlyMedianRate(points), [points]);
+  const gauge = useMemo(
+    () => tierGauge(points, targets.bookingLadder, targets.specLadder, now),
+    [points, targets.bookingLadder, targets.specLadder, now],
+  );
+
+  const toneColor =
+    gauge.tone === "hot" ? "#4ade80" : gauge.tone === "soft" ? "#f87171" : "#e0a020";
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      <h1 className="text-3xl font-condensed">Market &amp; Rates</h1>
+      <p className="text-sm text-muted-text mt-1 max-w-[680px]">
+        Every delivered load by what it paid per driven mile — against your
+        break-even and rate tiers. Watch the market turn, and read whether your
+        tiers still fit it.
+      </p>
+
+      {points.length === 0 ? (
+        <Panel className="mt-6 max-w-[720px] p-6">
+          <p className="text-muted-text">
+            No delivered loads with rate + mileage yet. Once you've run some
+            freight, your rate history shows up here.
+          </p>
+        </Panel>
+      ) : (
+        <>
+          <Panel className="mt-6 max-w-[720px] p-5">
+            <div className="flex justify-between items-baseline flex-wrap gap-2">
+              <h2 className="text-lg font-medium text-light">Every load · rate vs the year</h2>
+              <span className="text-xs text-muted-text">gross $/driven mile</span>
+            </div>
+            <div className="flex gap-4 text-[11px] text-muted-text mt-1 mb-1">
+              <span><span className="inline-block w-2.5 h-2.5 rounded-full align-middle mr-1" style={{ background: COLOR.standard }} />standard</span>
+              <span><span className="inline-block w-2.5 h-2.5 rounded-full align-middle mr-1" style={{ background: COLOR.hazmat }} />hazmat</span>
+              <span><span className="inline-block w-2.5 h-2.5 rounded-full align-middle mr-1" style={{ background: COLOR.specialized }} />oversize/heavy</span>
+            </div>
+            {targets.ready ? (
+              <RateScatter points={points} ladder={targets.bookingLadder} specLadder={targets.specLadder} />
+            ) : (
+              <p className="text-xs text-muted-text py-6 text-center">
+                Upload a few months of P&amp;L on the Expenses page to draw your
+                break-even and tier lines.
+              </p>
+            )}
+          </Panel>
+
+          <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-4 mt-4 max-w-[720px]">
+            <Panel className="p-5">
+              <h2 className="text-lg font-medium text-light">Market barometer</h2>
+              <p className="text-xs text-muted-text mt-0.5 mb-2">
+                your median rate per driven mile, by month
+              </p>
+              {monthly.length > 0 ? (
+                <Barometer monthly={monthly} breakEven={targets.bookingLadder.walkAway} />
+              ) : (
+                <p className="text-xs text-muted-text py-6 text-center">No data yet.</p>
+              )}
+            </Panel>
+
+            <Panel className="p-5">
+              <h2 className="text-lg font-medium text-light">Tier gauge</h2>
+              <p className="text-xs text-muted-text mt-0.5 mb-3">
+                where your tiers land · last 90 days
+                {gauge.windowN > 0 ? ` · ${gauge.windowN} loads` : ""}
+              </p>
+              {gauge.rows.length > 0 ? (
+                <>
+                  <div className="space-y-2.5">
+                    {gauge.rows.map((r) => (
+                      <div key={r.label}>
+                        <div className="flex justify-between text-xs">
+                          <span className="text-light">
+                            {r.label}{" "}
+                            <span className="text-muted-text">{money2(r.value)}</span>
+                          </span>
+                          <span className="tabular-nums" style={{ color: toneColor }}>
+                            {Math.round(r.pctile * 100)}
+                            <span className="text-muted-text text-[10px]">th pctile</span>
+                          </span>
+                        </div>
+                        <div className="mt-1 h-1.5 rounded" style={{ background: "#232c3f" }}>
+                          <div
+                            className="h-1.5 rounded"
+                            style={{ width: `${Math.round(r.pctile * 100)}%`, background: toneColor }}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  {gauge.suggestion && (
+                    <div
+                      className="mt-4 rounded-lg p-3 text-[11px] leading-relaxed"
+                      style={{ background: "#0d1119", color: "#c9d3e0" }}
+                    >
+                      {gauge.suggestion}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <p className="text-xs text-muted-text py-6 text-center">
+                  Needs your break-even (Expenses P&amp;L) to place the tiers.
+                </p>
+              )}
+            </Panel>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default MarketPage;


### PR DESCRIPTION
## What
A new owner-only **Market & Rates** page (`/market`, under Money) to read the freight cycle and whether your rate tiers still fit it — all from your own delivered loads. Grew out of the adjustable-rate-tiers arc: the tiers are static, but the achievable market moves, so this shows *when* to re-fit them.

- **Scatter** — every delivered load by gross $/driven-mile over time, colored by type, with break-even + Standard/Specialized target overlays. Scales to the loads; overlay lines above the data clamp to the top edge (staggered) so a soft-market view stays readable.
- **Barometer** — your monthly median rate per driven mile vs break-even.
- **Tier gauge** — where your tiers land as percentiles of the last 90 days + a hot/balanced/soft read with a raise/trim suggestion. Turns "when do I adjust my tiers" into a number.
- Pure `marketAnalytics` module (`ratePoints` / `monthlyMedianRate` / `percentileOf` / `windowRates` / `tierGauge`) + 10 unit tests; route + nav + Guide entry.

## Verification
Strict build clean; 405 tests pass (+10). Verified end-to-end on dev — scatter, barometer, and gauge render and compute correctly, including the above-range clamping.

## Deferred (Phase 2)
A free FRED macro-index overlay on the barometer (a leading market signal) — needs a free FRED API key on Railway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)