### PR TITLE
feat: FRED macro-index overlay on the Market barometer (Phase 2)

### DIFF
--- a/backend/src/routes/freightIndexRoutes.js
+++ b/backend/src/routes/freightIndexRoutes.js
@@ -1,0 +1,20 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import { getFreightIndexMonthly } from "../services/fredIndexService.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+// ---- MACRO FREIGHT-RATE INDEX (FRED PPI proxy, cached) ----
+// A blip at FRED should never break the Market page — degrade to an empty series
+// so the barometer just shows the owner's own rate line.
+router.get("/", async (req, res) => {
+  try {
+    const series = await getFreightIndexMonthly();
+    return res.status(200).json({ series });
+  } catch (err) {
+    return res.status(200).json({ series: [], message: err.message });
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -29,6 +29,7 @@ import trophyRouter from "./routes/trophyRoutes.js";
 import settlementScheduleRouter from "./routes/settlementScheduleRoutes.js";
 import accessorialRateRouter from "./routes/accessorialRateRoutes.js";
 import routingRouter from "./routes/routingRoutes.js";
+import freightIndexRouter from "./routes/freightIndexRoutes.js";
 
 const app = express();
 
@@ -79,6 +80,7 @@ app.use("/avatars", avatarRouter);
 app.use("/settlement-schedule", settlementScheduleRouter);
 app.use("/accessorial-rates", accessorialRateRouter);
 app.use("/routing", routingRouter);
+app.use("/freight-index", freightIndexRouter);
 
 app.get("/", (req, res) => {
   res.send("Home Page");

--- a/backend/src/services/fredIndexService.js
+++ b/backend/src/services/fredIndexService.js
@@ -1,0 +1,51 @@
+// Macro freight-rate barometer from the U.S. FRED (St. Louis Fed), fetched
+// server-side so the API key never reaches the browser. Series PCU484230484230 —
+// PPI by Industry: Specialized Freight (except Used Goods) Trucking, Long-Distance
+// (monthly, index Dec-2003=100). Flatbed/oversize is "specialized freight," so
+// this is the closest public macro read for Jason's niche. Cached in memory; the
+// series only updates monthly, so there's no reason to hit FRED per page load.
+
+const FRED_BASE = "https://api.stlouisfed.org/fred/series/observations";
+const SERIES_ID = "PCU484230484230";
+const CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+let cache = null; // { data, fetchedAt }
+
+// Pure: FRED observations → [{ month:'YYYY-MM', value }] ascending. FRED marks
+// missing months with ".", which coerces to NaN and is skipped. Monthly
+// observations are dated the 1st, so the month is the date's YYYY-MM.
+export const parseFredSeries = (json) => {
+  const rows = json?.observations ?? [];
+  const out = [];
+  for (const r of rows) {
+    const date = r?.date;
+    const value = Number(r?.value);
+    if (!date || !Number.isFinite(value)) continue;
+    out.push({ month: String(date).slice(0, 7), value });
+  }
+  return out.sort((a, b) => (a.month < b.month ? -1 : 1));
+};
+
+// The specialized-freight PPI as a monthly series for the barometer overlay.
+// Returns [] when unconfigured or on a FRED blip, so the page degrades to just
+// the owner's own rate line.
+export const getFreightIndexMonthly = async () => {
+  const now = Date.now();
+  if (cache && now - cache.fetchedAt < CACHE_TTL_MS) return cache.data;
+
+  const key = process.env.FRED_API_KEY;
+  if (!key) return []; // not configured — barometer shows only the owner's line
+
+  const params = new URLSearchParams({
+    series_id: SERIES_ID,
+    api_key: key,
+    file_type: "json",
+    observation_start: "2024-01-01",
+    sort_order: "asc",
+  });
+
+  const res = await fetch(`${FRED_BASE}?${params}`);
+  if (!res.ok) throw new Error(`FRED request failed (${res.status})`);
+  const data = parseFredSeries(await res.json());
+  cache = { data, fetchedAt: now };
+  return data;
+};

--- a/backend/src/services/fredIndexService.test.js
+++ b/backend/src/services/fredIndexService.test.js
@@ -1,0 +1,37 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { parseFredSeries } from "./fredIndexService.js";
+
+describe("parseFredSeries", () => {
+  test("maps FRED observations to {month, value}, ascending", () => {
+    const json = {
+      observations: [
+        { date: "2026-01-01", value: "155.359" },
+        { date: "2025-12-01", value: "154.2" },
+        { date: "2026-02-01", value: "156.0" },
+      ],
+    };
+    assert.deepEqual(parseFredSeries(json), [
+      { month: "2025-12", value: 154.2 },
+      { month: "2026-01", value: 155.359 },
+      { month: "2026-02", value: 156.0 },
+    ]);
+  });
+
+  test("skips FRED's '.' missing markers and bad rows", () => {
+    const json = {
+      observations: [
+        { date: "2026-01-01", value: "." },
+        { date: "2026-02-01", value: "156.0" },
+        { date: null, value: "1" },
+      ],
+    };
+    assert.deepEqual(parseFredSeries(json), [{ month: "2026-02", value: 156.0 }]);
+  });
+
+  test("empty / malformed payload → []", () => {
+    assert.deepEqual(parseFredSeries({}), []);
+    assert.deepEqual(parseFredSeries(null), []);
+    assert.deepEqual(parseFredSeries({ observations: [] }), []);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.117.1",
+  "version": "1.118.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -707,7 +707,12 @@ const GuidePage = () => {
             <Why>
               The <span className="text-light">barometer</span> is your own median
               rate per driven mile by month — your personal read on where the
-              market is. The <span className="text-light">tier gauge</span> then
+              market is — with the national{" "}
+              <span className="text-light">PPI for specialized freight trucking</span>{" "}
+              (from the Fed's FRED data) overlaid on a second axis. Your own rate
+              lags; when that macro line turns down first, it's an early nudge the
+              market's softening before your own loads show it. The{" "}
+              <span className="text-light">tier gauge</span> then
               asks the useful question: where do your tiers land in the last 90
               days? A target sitting at the 40th percentile means the market
               clears it easily (hot — room to raise); one at the 90th means it's

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ScatterChart,
   Scatter,
@@ -13,6 +13,7 @@ import {
 } from "recharts";
 import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
+import { getFreightIndex, type FreightIndexPoint } from "@/services/marketService";
 import { Panel } from "@/components/ui/Panel";
 import type { RateLadder } from "@/lib/metrics/rateTargets";
 import {
@@ -21,6 +22,8 @@ import {
   tierGauge,
   type RatePoint,
 } from "@/lib/metrics/marketAnalytics";
+
+const MACRO = "#7fb2e6"; // FRED PPI overlay line
 
 const COLOR: Record<RatePoint["bucket"], string> = {
   standard: "#4a90d9",
@@ -119,16 +122,25 @@ const RateScatter = ({
   );
 };
 
-// ---- Barometer: monthly median rate over time vs break-even ----
+// ---- Barometer: your monthly median rate vs break-even, with the FRED macro
+// index overlaid on a second axis (units differ — $/mile vs index points — so
+// the read is "do the two trends move together", not absolute levels). ----
+interface BaroPoint {
+  month: string;
+  median: number | null;
+  ppi: number | null;
+}
 const Barometer = ({
-  monthly,
+  data,
   breakEven,
+  hasPpi,
 }: {
-  monthly: { month: string; median: number; n: number }[];
+  data: BaroPoint[];
   breakEven: number | null;
+  hasPpi: boolean;
 }) => (
   <ResponsiveContainer width="100%" height={240}>
-    <LineChart data={monthly} margin={{ top: 10, right: 84, bottom: 0, left: 4 }}>
+    <LineChart data={data} margin={{ top: 10, right: hasPpi ? 6 : 84, bottom: 0, left: 4 }}>
       <CartesianGrid stroke={GRID} strokeDasharray="3 3" vertical={false} />
       <XAxis
         dataKey="month"
@@ -139,6 +151,7 @@ const Barometer = ({
         axisLine={{ stroke: GRID }}
       />
       <YAxis
+        yAxisId="rate"
         domain={[0, "auto"]}
         tickFormatter={(v) => `$${v}`}
         stroke={MUTED}
@@ -146,22 +159,58 @@ const Barometer = ({
         tickLine={false}
         axisLine={false}
       />
+      {hasPpi && (
+        <YAxis
+          yAxisId="ppi"
+          orientation="right"
+          domain={["auto", "auto"]}
+          tickFormatter={(v) => `${Math.round(Number(v))}`}
+          stroke={MACRO}
+          fontSize={11}
+          tickLine={false}
+          axisLine={false}
+          width={40}
+        />
+      )}
       <Tooltip
         contentStyle={{ background: "#1c2333", border: "1px solid #2a3347", borderRadius: 8, fontSize: 12 }}
         labelFormatter={(m) => monthTick(m as string)}
-        formatter={(v) => [money2(Number(v)), "median"]}
+        formatter={(v, name) =>
+          name === "ppi" ? [`${Number(v).toFixed(1)} idx`, "FRED PPI"] : [money2(Number(v)), "your median"]
+        }
       />
       {breakEven != null && (
         <ReferenceLine
+          yAxisId="rate"
           y={breakEven}
           stroke={BE}
           strokeWidth={1.4}
           strokeDasharray="4 3"
           ifOverflow="extendDomain"
-          label={{ value: `break-even ${money2(breakEven)}`, position: "right", fill: BE, fontSize: 10 }}
+          label={{ value: `break-even ${money2(breakEven)}`, position: "insideTopLeft", fill: BE, fontSize: 10 }}
         />
       )}
-      <Line type="monotone" dataKey="median" stroke="#4ade80" strokeWidth={2.5} dot={{ fill: "#4ade80", r: 3 }} />
+      {hasPpi && (
+        <Line
+          yAxisId="ppi"
+          type="monotone"
+          dataKey="ppi"
+          stroke={MACRO}
+          strokeWidth={1.8}
+          strokeDasharray="5 3"
+          dot={false}
+          connectNulls
+        />
+      )}
+      <Line
+        yAxisId="rate"
+        type="monotone"
+        dataKey="median"
+        stroke="#4ade80"
+        strokeWidth={2.5}
+        dot={{ fill: "#4ade80", r: 3 }}
+        connectNulls
+      />
     </LineChart>
   </ResponsiveContainer>
 );
@@ -170,9 +219,28 @@ const MarketPage = () => {
   const { loads } = useLoads(0);
   const targets = useRateTargets(loads);
   const now = useMemo(() => new Date(), []);
+  const [freightIndex, setFreightIndex] = useState<FreightIndexPoint[]>([]);
+
+  useEffect(() => {
+    getFreightIndex().then(setFreightIndex).catch(() => {});
+  }, []);
 
   const points = useMemo(() => ratePoints(loads), [loads]);
   const monthly = useMemo(() => monthlyMedianRate(points), [points]);
+
+  // Merge the owner's monthly median with the FRED macro index on a shared month
+  // axis (union of months). Either line can gap where the other has no value.
+  const baroData = useMemo(() => {
+    const map = new Map<string, BaroPoint>();
+    for (const m of monthly) map.set(m.month, { month: m.month, median: m.median, ppi: null });
+    for (const f of freightIndex) {
+      const e = map.get(f.month) ?? { month: f.month, median: null, ppi: null };
+      e.ppi = f.value;
+      map.set(f.month, e);
+    }
+    return [...map.values()].sort((a, b) => (a.month < b.month ? -1 : 1));
+  }, [monthly, freightIndex]);
+  const hasPpi = freightIndex.length > 0;
   const gauge = useMemo(
     () => tierGauge(points, targets.bookingLadder, targets.specLadder, now),
     [points, targets.bookingLadder, targets.specLadder, now],
@@ -226,7 +294,15 @@ const MarketPage = () => {
                 your median rate per driven mile, by month
               </p>
               {monthly.length > 0 ? (
-                <Barometer monthly={monthly} breakEven={targets.bookingLadder.walkAway} />
+                <>
+                  <Barometer data={baroData} breakEven={targets.bookingLadder.walkAway} hasPpi={hasPpi} />
+                  <div className="flex gap-4 text-[11px] text-muted-text mt-1">
+                    <span><span style={{ color: "#4ade80" }}>▬</span> you (median $/mi)</span>
+                    {hasPpi && (
+                      <span><span style={{ color: MACRO }}>╌</span> PPI specialized freight (FRED)</span>
+                    )}
+                  </div>
+                </>
               ) : (
                 <p className="text-xs text-muted-text py-6 text-center">No data yet.</p>
               )}

--- a/frontend/src/services/marketService.ts
+++ b/frontend/src/services/marketService.ts
@@ -1,0 +1,23 @@
+import api from "./api";
+
+export interface FreightIndexPoint {
+  month: string; // 'YYYY-MM'
+  value: number; // FRED PPI index (Dec-2003 = 100)
+}
+
+// Macro freight-rate barometer (FRED PPI: Specialized Freight Trucking,
+// Long-Distance), proxied + cached by the backend. Degrades to [] so the Market
+// page's barometer just shows the owner's own line when FRED is unconfigured/down.
+export const getFreightIndex = async (): Promise<FreightIndexPoint[]> => {
+  try {
+    const res = await api.get("/freight-index");
+    return (res.data.series ?? []).map(
+      (s: { month: string; value: number }) => ({
+        month: s.month,
+        value: Number(s.value),
+      }),
+    );
+  } catch {
+    return [];
+  }
+};


### PR DESCRIPTION
## What
Phase 2 of the Market page. Overlays the national **PPI for Specialized Freight Trucking, Long-Distance** (FRED series `PCU484230484230`, monthly) on the barometer's second axis — a *leading* macro read that can flag a softening market before the owner's own (lagging) rate line shows it.

- **Backend**: `fredIndexService.js` (FRED proxy, 12h in-memory cache, key stays server-side, degrades to `[]` on any FRED blip) + `GET /freight-index`. Parser unit-tested.
- **Frontend**: `marketService.getFreightIndex`; the barometer becomes **dual-axis** (your median $/mi on the left, PPI index on the right) with a legend. The FRED line renders only when the series is present, so it's a no-op if unconfigured.
- **Guide** updated.

## Verification
Frontend build clean; backend 34 tests (+3 for the FRED parser). Overlay render verified on dev with canned data (dual-axis + legend correct). Series ID confirmed via FRED.

The **live** FRED fetch couldn't be tested locally (`FRED_API_KEY` is Railway-only) — it lights up on prod. Safe failure mode: no key / bad response → no overlay, no crash.

Closes the Market & Rates arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)