### PR TITLE
feat: market-aware insights — you-vs-market, macro-aware tier gauge, dashboard chip

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.118.0",
+  "version": "1.119.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/MarketChip.tsx
+++ b/frontend/src/components/dashboard/MarketChip.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { getFreightIndex } from "@/services/marketService";
+import { marketTrend } from "@/lib/metrics/marketSignal";
+
+// A glanceable freight-market indicator for the dashboard header, from the FRED
+// specialized-freight trend. Renders nothing when FRED isn't configured or there
+// isn't enough history — so it never shows a hollow/misleading state.
+const CFG = {
+  firming: { label: "firming", color: "#4ade80", bg: "#0f2018", border: "#1a5c3a", Icon: TrendingUp },
+  softening: { label: "softening", color: "#f87171", bg: "#241012", border: "#5a2424", Icon: TrendingDown },
+  flat: { label: "steady", color: "#9daabb", bg: "#161d2b", border: "#2a3347", Icon: Minus },
+} as const;
+
+export const MarketChip = () => {
+  const [trend, setTrend] = useState<ReturnType<typeof marketTrend>>(null);
+
+  useEffect(() => {
+    getFreightIndex()
+      .then((s) => setTrend(marketTrend(s)))
+      .catch(() => {});
+  }, []);
+
+  if (!trend) return null;
+  const { label, color, bg, border, Icon } = CFG[trend.direction];
+
+  return (
+    <Link
+      to="/market"
+      title="Freight market trend (national) — open Market & Rates"
+      className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium whitespace-nowrap"
+      style={{ background: bg, border: `1px solid ${border}`, color }}
+    >
+      <Icon size={14} />
+      Freight market {label}
+    </Link>
+  );
+};

--- a/frontend/src/lib/metrics/marketAnalytics.test.ts
+++ b/frontend/src/lib/metrics/marketAnalytics.test.ts
@@ -136,4 +136,13 @@ describe("tierGauge", () => {
     expect(g.rows).toHaveLength(0);
     expect(g.tone).toBeNull();
   });
+
+  it("macro trend tempers the suggestion (hot loads, market turning down → hold)", () => {
+    const hot = tierGauge(recent, ladder(4, 6), ladder(9, 10), now, 90, "softening");
+    expect(hot.tone).toBe("hot");
+    expect(hot.suggestion).toMatch(/hold, don't chase the peak/i);
+
+    const confident = tierGauge(recent, ladder(4, 6), ladder(9, 10), now, 90, "firming");
+    expect(confident.suggestion).toMatch(/confident raise/i);
+  });
 });

--- a/frontend/src/lib/metrics/marketAnalytics.ts
+++ b/frontend/src/lib/metrics/marketAnalytics.ts
@@ -6,6 +6,7 @@ import type { Load } from "@/types/load";
 import type { RateLadder } from "./rateTargets";
 import { loadGross } from "./rateTargets";
 import { isSpecializedLoadType } from "@/lib/dimensions";
+import type { MarketDirection } from "./marketSignal";
 
 export type RateBucket = "standard" | "hazmat" | "specialized";
 
@@ -115,6 +116,7 @@ export const tierGauge = (
   specLadder: RateLadder,
   now: Date,
   days = 90,
+  direction?: MarketDirection,
 ): TierGauge => {
   const w = windowRates(points, now, days);
   const row = (label: string, value: number | null): TierGaugeRow | null =>
@@ -145,6 +147,26 @@ export const tierGauge = (
     }
   } else if (std) {
     suggestion = "Not enough recent loads to read the market confidently yet.";
+  }
+
+  // Temper with the macro trend: your own loads lag, so let the FRED direction
+  // confirm or caution a raise/trim before you act on it.
+  if (direction && tone) {
+    if (tone === "hot") {
+      if (direction === "softening")
+        suggestion =
+          "Your loads say hot, but the freight market's turning down — hold, don't chase the peak.";
+      else if (direction === "firming")
+        suggestion =
+          "Market's running hot and the macro's firming too — a confident raise.";
+    } else if (tone === "soft") {
+      if (direction === "firming")
+        suggestion =
+          "Your loads are soft, but the macro's firming — hold before you trim; it may be recovering.";
+      else if (direction === "softening")
+        suggestion =
+          "Market's soft and the macro's falling too — the softness looks real. Consider trimming.";
+    }
   }
   return { rows, windowN: w.length, tone, suggestion };
 };

--- a/frontend/src/lib/metrics/marketSignal.test.ts
+++ b/frontend/src/lib/metrics/marketSignal.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { marketTrend, youVsMarket } from "./marketSignal";
+
+const idx = (vals: number[], startYear = 2026): { month: string; value: number }[] =>
+  vals.map((value, i) => ({
+    month: `${startYear}-${String(i + 1).padStart(2, "0")}`,
+    value,
+  }));
+
+describe("marketTrend", () => {
+  it("reads a rising series as firming", () => {
+    const t = marketTrend(idx([150, 151, 153, 156]), 3)!; // +4% over 3mo
+    expect(t.direction).toBe("firming");
+    expect(t.pctChange).toBeCloseTo((156 - 150) / 150, 5);
+  });
+
+  it("reads a falling series as softening", () => {
+    expect(marketTrend(idx([160, 158, 156, 152]), 3)!.direction).toBe("softening");
+  });
+
+  it("reads a tiny wobble as flat", () => {
+    expect(marketTrend(idx([155, 155.1, 154.9, 155.2]), 3)!.direction).toBe("flat");
+  });
+
+  it("null when there aren't enough points", () => {
+    expect(marketTrend(idx([150, 151]), 3)).toBeNull();
+    expect(marketTrend([], 3)).toBeNull();
+  });
+});
+
+describe("youVsMarket", () => {
+  const mkt = idx([150, 151, 152, 153, 154, 155, 156]); // ~+4% Jan→Jul
+
+  it("beating: your rate climbs faster than the market", () => {
+    const mine = [
+      { month: "2026-01", median: 3.0 },
+      { month: "2026-07", median: 4.5 }, // +50%
+    ];
+    const r = youVsMarket(mine, mkt, 6)!;
+    expect(r.yourPct).toBeCloseTo(0.5, 5);
+    expect(r.marketPct).toBeGreaterThan(0);
+    expect(r.verdict).toBe("beating");
+  });
+
+  it("lagging: market rises, your rate flat", () => {
+    const mine = [
+      { month: "2026-01", median: 4.0 },
+      { month: "2026-07", median: 4.0 }, // 0%
+    ];
+    expect(youVsMarket(mine, mkt, 6)!.verdict).toBe("lagging");
+  });
+
+  it("inline when both move about the same", () => {
+    const mine = [
+      { month: "2026-01", median: 4.0 },
+      { month: "2026-07", median: 4.16 }, // +4%, ~ market
+    ];
+    expect(youVsMarket(mine, mkt, 6)!.verdict).toBe("inline");
+  });
+
+  it("null without enough of your own points", () => {
+    expect(youVsMarket([{ month: "2026-07", median: 4 }], mkt, 6)).toBeNull();
+    expect(youVsMarket([], mkt, 6)).toBeNull();
+  });
+});

--- a/frontend/src/lib/metrics/marketSignal.ts
+++ b/frontend/src/lib/metrics/marketSignal.ts
@@ -1,0 +1,82 @@
+// Market-signal reads off the national FRED freight index (+ the owner's own
+// median rate). Pure + clock-free — everything keys off the series' own months,
+// so it's testable without touching the date. Powers the dashboard market chip,
+// the "you vs the market" readout, and the macro-aware tier-gauge suggestion.
+
+export type MarketDirection = "firming" | "flat" | "softening";
+
+// A move smaller than this over the window reads as "flat" (kills index wobble).
+const DIR_THRESHOLD = 0.004; // 0.4%
+// Divergence needed to call you "beating"/"lagging" the market.
+const GAP_THRESHOLD = 0.03; // 3 pts
+
+// 'YYYY-MM' shifted by whole months.
+const shiftMonth = (ym: string, delta: number): string => {
+  const [y, m] = ym.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1 + delta, 1)).toISOString().slice(0, 7);
+};
+
+// % change between the earliest and latest points inside [start, end] (inclusive).
+// null when there aren't two usable points or the base is non-positive.
+const pctInWindow = (
+  series: { month: string; value: number }[],
+  start: string,
+  end: string,
+): number | null => {
+  const w = series
+    .filter((p) => p.month >= start && p.month <= end && Number.isFinite(p.value))
+    .sort((a, b) => (a.month < b.month ? -1 : 1));
+  if (w.length < 2) return null;
+  const first = w[0].value;
+  const last = w[w.length - 1].value;
+  return first > 0 ? (last - first) / first : null;
+};
+
+// The freight market's direction from the FRED index over the trailing `months`.
+export const marketTrend = (
+  series: { month: string; value: number }[],
+  months = 3,
+): { direction: MarketDirection; pctChange: number } | null => {
+  const s = [...series].sort((a, b) => (a.month < b.month ? -1 : 1));
+  if (s.length < months + 1) return null;
+  const last = s[s.length - 1].value;
+  const prev = s[s.length - 1 - months].value;
+  if (!(prev > 0)) return null;
+  const pctChange = (last - prev) / prev;
+  const direction: MarketDirection =
+    pctChange > DIR_THRESHOLD ? "firming" : pctChange < -DIR_THRESHOLD ? "softening" : "flat";
+  return { direction, pctChange };
+};
+
+export interface YouVsMarket {
+  yourPct: number; // your median rate's % change over the window
+  marketPct: number; // the FRED index's % change over the same window
+  gap: number; // yourPct − marketPct
+  verdict: "beating" | "lagging" | "inline";
+}
+
+// Your rate trend vs the market's over the trailing `months`, anchored on your
+// latest data month. A rough read (your monthly medians are thin) — the gap
+// threshold keeps small differences reading "inline". null when either side
+// lacks two points in the window.
+export const youVsMarket = (
+  mine: { month: string; median: number }[],
+  market: { month: string; value: number }[],
+  months = 6,
+): YouVsMarket | null => {
+  if (mine.length < 2 || market.length === 0) return null;
+  const sorted = [...mine].sort((a, b) => (a.month < b.month ? -1 : 1));
+  const end = sorted[sorted.length - 1].month;
+  const start = shiftMonth(end, -months);
+  const yourPct = pctInWindow(
+    sorted.map((m) => ({ month: m.month, value: m.median })),
+    start,
+    end,
+  );
+  const marketPct = pctInWindow(market, start, end);
+  if (yourPct == null || marketPct == null) return null;
+  const gap = yourPct - marketPct;
+  const verdict =
+    gap > GAP_THRESHOLD ? "beating" : gap < -GAP_THRESHOLD ? "lagging" : "inline";
+  return { yourPct, marketPct, gap, verdict };
+};

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -31,6 +31,7 @@ import { AwardPopHost } from "@/components/comic/AwardPopHost";
 import { DEMO_AWARDS } from "@/lib/metrics/awards";
 import { latestRecapWithData } from "@/lib/metrics/recap";
 import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
+import { MarketChip } from "@/components/dashboard/MarketChip";
 import { GrindMeter } from "@/components/dashboard/GrindMeter";
 import { RevenueChart } from "@/components/RevenueChart";
 import { RpmChart } from "@/components/RpmChart";
@@ -153,12 +154,15 @@ const OwnerDashboard = () => {
 
       <div className="flex items-center justify-between mb-6 gap-3">
         <h1 className="text-3xl font-condensed">Dashboard</h1>
-        <Link
-          to="/recap"
-          className="text-sm text-status-info-text hover:underline whitespace-nowrap"
-        >
-          Your {latestRecap ? `${latestRecap.label} ` : ""}recap →
-        </Link>
+        <div className="flex items-center gap-3">
+          <MarketChip />
+          <Link
+            to="/recap"
+            className="text-sm text-status-info-text hover:underline whitespace-nowrap"
+          >
+            Your {latestRecap ? `${latestRecap.label} ` : ""}recap →
+          </Link>
+        </div>
       </div>
 
       <AlertBanners alerts={alerts} />

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -717,7 +717,19 @@ const GuidePage = () => {
               days? A target sitting at the 40th percentile means the market
               clears it easily (hot — room to raise); one at the 90th means it's
               barely gettable (soft — trim). That turns "when do I adjust my
-              tiers" into a number you read instead of a gut call.
+              tiers" into a number you read instead of a gut call — and it now
+              factors the macro trend, so it won't tell you to raise into a market
+              that's already turning down.
+            </Why>
+            <Why>
+              <span className="text-light">You vs. the market</span> (under the
+              barometer) compares your rate's move to the freight index's over the
+              last six months. If the market's up and you're flat, that's money on
+              the table you can chase — lanes, agents, negotiation. If you're both
+              down, it's the cycle, not you. And a small{" "}
+              <span className="text-light">freight-market chip</span> rides on the
+              dashboard header so you catch the trend at a glance. All of it is a
+              national read — your own lane heat still comes from your own loads.
             </Why>
           </Metric>
 

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -22,6 +22,7 @@ import {
   tierGauge,
   type RatePoint,
 } from "@/lib/metrics/marketAnalytics";
+import { marketTrend, youVsMarket } from "@/lib/metrics/marketSignal";
 
 const MACRO = "#7fb2e6"; // FRED PPI overlay line
 
@@ -227,6 +228,8 @@ const MarketPage = () => {
 
   const points = useMemo(() => ratePoints(loads), [loads]);
   const monthly = useMemo(() => monthlyMedianRate(points), [points]);
+  const trend = useMemo(() => marketTrend(freightIndex), [freightIndex]);
+  const yvm = useMemo(() => youVsMarket(monthly, freightIndex), [monthly, freightIndex]);
 
   // Merge the owner's monthly median with the FRED macro index on a shared month
   // axis (union of months). Either line can gap where the other has no value.
@@ -242,12 +245,30 @@ const MarketPage = () => {
   }, [monthly, freightIndex]);
   const hasPpi = freightIndex.length > 0;
   const gauge = useMemo(
-    () => tierGauge(points, targets.bookingLadder, targets.specLadder, now),
-    [points, targets.bookingLadder, targets.specLadder, now],
+    () => tierGauge(points, targets.bookingLadder, targets.specLadder, now, 90, trend?.direction),
+    [points, targets.bookingLadder, targets.specLadder, now, trend],
   );
 
   const toneColor =
     gauge.tone === "hot" ? "#4ade80" : gauge.tone === "soft" ? "#f87171" : "#e0a020";
+
+  // #2 You-vs-market readout helpers.
+  const pctLabel = (x: number) => `${x >= 0 ? "+" : ""}${Math.round(x * 100)}%`;
+  const yvmScale = yvm
+    ? Math.max(Math.abs(yvm.yourPct), Math.abs(yvm.marketPct), 0.02)
+    : 1;
+  const yvmBar = (x: number) => Math.min(100, (Math.abs(x) / yvmScale) * 100);
+  const gapPts = yvm ? Math.round(Math.abs(yvm.gap) * 100) : 0;
+  const yvmText =
+    yvm?.verdict === "beating"
+      ? `You're beating the market by ${gapPts} pts — your rates are outrunning the freight index.`
+      : yvm?.verdict === "lagging"
+        ? `You're lagging the market by ${gapPts} pts — it's rising faster than your rates. Room to push on rate or lanes.`
+        : yvm
+          ? "You're moving with the market — this looks like the cycle, not your booking."
+          : null;
+  const yvmColor =
+    yvm?.verdict === "beating" ? "#4ade80" : yvm?.verdict === "lagging" ? "#f0b86a" : "#c9d3e0";
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -302,6 +323,28 @@ const MarketPage = () => {
                       <span><span style={{ color: MACRO }}>╌</span> PPI specialized freight (FRED)</span>
                     )}
                   </div>
+                  {yvm && (
+                    <div className="mt-3 pt-3 border-t" style={{ borderColor: "rgba(255,255,255,0.07)" }}>
+                      <div className="text-xs text-muted-text mb-2">You vs. the market · last 6 months</div>
+                      <div className="flex items-center gap-2 mb-1.5">
+                        <span className="text-[11px] text-muted-text w-14">you</span>
+                        <div className="flex-1 h-2 rounded" style={{ background: "#232c3f" }}>
+                          <div className="h-2 rounded" style={{ width: `${yvmBar(yvm.yourPct)}%`, background: "#4ade80" }} />
+                        </div>
+                        <span className="text-xs w-12 text-right tabular-nums" style={{ color: yvm.yourPct >= 0 ? "#4ade80" : "#f87171" }}>{pctLabel(yvm.yourPct)}</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-[11px] text-muted-text w-14">market</span>
+                        <div className="flex-1 h-2 rounded" style={{ background: "#232c3f" }}>
+                          <div className="h-2 rounded" style={{ width: `${yvmBar(yvm.marketPct)}%`, background: MACRO }} />
+                        </div>
+                        <span className="text-xs w-12 text-right tabular-nums" style={{ color: MACRO }}>{pctLabel(yvm.marketPct)}</span>
+                      </div>
+                      <div className="mt-2.5 rounded-lg p-2.5 text-[11px] leading-relaxed" style={{ background: "#0d1119", color: yvmColor }}>
+                        {yvmText}
+                      </div>
+                    </div>
+                  )}
                 </>
               ) : (
                 <p className="text-xs text-muted-text py-6 text-center">No data yet.</p>


### PR DESCRIPTION
Three overall-market features off the national FRED trend, sharing a pure `marketSignal` module (`marketTrend` + `youVsMarket`, unit-tested).

- **Dashboard chip** — a glanceable "Freight market ▲ firming / ▼ softening / steady" pill in the header (FRED 3-month trend), links to the Market page. Hidden when FRED isn't configured.
- **You vs. the market** — a readout under the barometer comparing your rate's 6-month move to the freight index's, with a beating / lagging / inline verdict. Separates fixable underperformance (lanes/agents/rate) from the cycle.
- **Tier gauge, macro-aware** — the raise/trim suggestion now factors the FRED trend, so it won't tell you to raise into a market that's already turning down.

The Scorer per-load geographic steer (#1 in the batch) was **deliberately shelved** — FRED is national-only and there's no honest free source of regional flatbed rates, so we don't fake geographic precision. The three here are legitimately national-scope.

## Verification
Build clean; 414 tests (+9: marketSignal + tier-gauge tempering). All three verified rendering on dev with canned FRED data: chip pill, you-vs-market bars + verdict, and the tempered gauge suggestion ("soft loads + firming macro → hold before you trim"). No backend change (the `/freight-index` endpoint shipped in v1.118.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)