### PR TITLE
feat: Lanes — rate-shaded map + click-a-state agent drill-down

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.119.0",
+  "version": "1.120.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/lanes/LanesMap.tsx
+++ b/frontend/src/components/lanes/LanesMap.tsx
@@ -10,7 +10,13 @@ import type { StateMapDatum } from "@/lib/metrics/lanes";
 interface Props {
   data: Record<string, StateMapDatum>;
   windowDays: number;
+  selected: string | null;
+  onSelect: (state: string) => void;
 }
+
+type Mode = "rate" | "volume";
+// Below this, a state shades dim in rate mode — one lucky run shouldn't light it up.
+const MIN_STATE_LOADS = 2;
 
 // Parsed once at module load — the topology never changes.
 const usStates = feature(
@@ -21,9 +27,12 @@ const usStates = feature(
 const projection = geoAlbersUsa().scale(1100).translate([450, 280]);
 const pathGen = geoPath(projection);
 
-// Dark-theme amber ramp: dim → bright as origin load count rises.
-const RAMP = ["#6b4e12", "#9a6c0e", "#c8890a", "#e8940a", "#f5b03a"];
+// Volume ramp (amber) → brighter as origin load count rises. Rate ramp (teal→green)
+// → brighter as your median $/mi rises. Distinct hues so the toggle reads clearly.
+const VOL_RAMP = ["#6b4e12", "#9a6c0e", "#c8890a", "#e8940a", "#f5b03a"];
+const RATE_RAMP = ["#134e3a", "#1a6b4e", "#26855f", "#35b07a", "#4ade80"];
 const NO_DATA = "#2a3347";
+const DIM = "#243b33"; // thin state in rate mode (low confidence)
 
 // lucide "flame" path, filled solid for a comic pin on your best-paying states.
 const FLAME_PATH =
@@ -37,12 +46,23 @@ interface HoverState {
   datum: StateMapDatum;
 }
 
-export const LanesMap = ({ data, windowDays }: Props) => {
+export const LanesMap = ({ data, windowDays, selected, onSelect }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [hover, setHover] = useState<HoverState | null>(null);
+  const [mode, setMode] = useState<Mode>("rate");
 
   const maxLoads = useMemo(
     () => Math.max(1, ...Object.values(data).map((d) => d.loadCount)),
+    [data],
+  );
+  const maxRate = useMemo(
+    () =>
+      Math.max(
+        0.01,
+        ...Object.values(data)
+          .filter((d) => d.loadCount >= MIN_STATE_LOADS && d.medianRpm != null)
+          .map((d) => d.medianRpm as number),
+      ),
     [data],
   );
 
@@ -65,32 +85,61 @@ export const LanesMap = ({ data, windowDays }: Props) => {
   const colorFor = (name: string): string => {
     const datum = data[name];
     if (!datum) return NO_DATA;
+    if (mode === "volume") {
+      const idx = Math.min(
+        VOL_RAMP.length - 1,
+        Math.floor((datum.loadCount / maxLoads) * VOL_RAMP.length),
+      );
+      return VOL_RAMP[idx];
+    }
+    if (datum.medianRpm == null) return NO_DATA;
+    if (datum.loadCount < MIN_STATE_LOADS) return DIM;
     const idx = Math.min(
-      RAMP.length - 1,
-      Math.floor((datum.loadCount / maxLoads) * RAMP.length),
+      RATE_RAMP.length - 1,
+      Math.floor((datum.medianRpm / maxRate) * RATE_RAMP.length),
     );
-    return RAMP[idx];
+    return RATE_RAMP[idx];
   };
+
+  const toggle = (m: Mode, label: string) => (
+    <button
+      onClick={() => setMode(m)}
+      className="text-[11px] rounded-full px-2.5 py-0.5"
+      style={
+        mode === m
+          ? { background: m === "rate" ? "#2e9e6b" : "#e8940a", color: "#0d1119", fontWeight: 600 }
+          : { border: "1px solid #2a3347", color: "#8b93a3" }
+      }
+    >
+      {label}
+    </button>
+  );
 
   return (
     <Panel ref={containerRef} className="p-4 relative">
-      <p className="text-xs text-muted-text mb-2 flex items-center gap-1 flex-wrap">
-        Footprint · shaded by loads ·
-        <Flame size={12} style={{ color: "#e8621e" }} /> best-paying states ·
-        hover for RPM ({windowDays}d)
-      </p>
+      <div className="text-xs text-muted-text mb-2 flex items-center gap-2 flex-wrap">
+        <span>Shade by</span>
+        {toggle("rate", "your $/mi")}
+        {toggle("volume", "volume")}
+        <span className="flex items-center gap-1">
+          · <Flame size={12} style={{ color: "#e8621e" }} /> best-paying
+        </span>
+        <span>· click a state to drill in</span>
+      </div>
       <svg viewBox="0 0 900 560" className="w-full">
         {usStates.features.map((f, i) => {
           const name = f.properties.name;
           const datum = data[name];
+          const isSel = selected === name;
           return (
             <path
               key={i}
               d={pathGen(f) ?? undefined}
               fill={colorFor(name)}
-              stroke="rgba(255,255,255,0.15)"
-              strokeWidth={0.6}
+              stroke={isSel ? "#f4f7fb" : "rgba(255,255,255,0.15)"}
+              strokeWidth={isSel ? 2 : 0.6}
               style={{ cursor: datum ? "pointer" : "default" }}
+              onClick={() => datum && onSelect(name)}
               onMouseMove={(e) => {
                 const rect = containerRef.current?.getBoundingClientRect();
                 if (datum && rect) {

--- a/frontend/src/components/lanes/StateDetailPanel.tsx
+++ b/frontend/src/components/lanes/StateDetailPanel.tsx
@@ -1,0 +1,109 @@
+import { Link } from "react-router-dom";
+import { X } from "lucide-react";
+import { Panel } from "@/components/ui/Panel";
+import type { StateDetail } from "@/lib/metrics/lanes";
+
+const rpm = (n: number | null) => (n == null ? "—" : `$${n.toFixed(2)}`);
+const pct = (n: number | null) => (n == null ? "—" : `${Math.round(n * 100)}%`);
+const otColor = (n: number | null) =>
+  n == null ? "#8b93a3" : n >= 0.9 ? "#4ade80" : n >= 0.7 ? "#e0a020" : "#f87171";
+const rowBorder = { borderTop: "0.5px solid rgba(255,255,255,0.06)" };
+
+// Drill-down for a clicked origin state: the agents you've booked out of it
+// (each linking to its detail page) and your top lanes from it.
+export const StateDetailPanel = ({
+  detail,
+  windowDays,
+  onClear,
+}: {
+  detail: StateDetail;
+  windowDays: number;
+  onClear: () => void;
+}) => (
+  <Panel className="mt-6 p-5">
+    <div className="flex items-baseline justify-between border-b border-plate pb-2.5 mb-4">
+      <div>
+        <span className="text-xl font-condensed text-light">{detail.state}</span>
+        <span className="text-xs text-muted-text ml-3">
+          last {windowDays} days · {detail.loadCount} load
+          {detail.loadCount === 1 ? "" : "s"}
+          {detail.medianRpm != null && (
+            <>
+              {" · "}
+              <span className="text-light">{rpm(detail.medianRpm)}/mi median</span>
+            </>
+          )}
+        </span>
+      </div>
+      <button
+        onClick={onClear}
+        className="text-xs text-muted-text hover:text-light flex items-center gap-1"
+      >
+        clear <X size={13} />
+      </button>
+    </div>
+
+    {detail.agents.length === 0 ? (
+      <p className="text-sm text-muted-text">
+        No delivered loads out of {detail.state} in this window.
+      </p>
+    ) : (
+      <>
+        <div className="text-xs text-muted-text mb-2">
+          Agents you've booked out of {detail.state}
+        </div>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-[10px] text-muted-text text-left">
+              <th className="font-normal py-1">AGENT</th>
+              <th className="font-normal text-right">$/MI</th>
+              <th className="font-normal text-right">LOADS</th>
+              <th className="font-normal text-right">ON-TIME</th>
+            </tr>
+          </thead>
+          <tbody>
+            {detail.agents.map((a) => (
+              <tr key={a.agentId} style={rowBorder}>
+                <td className="py-2">
+                  <Link
+                    to={`/agents/${a.agentId}`}
+                    className="text-status-info-text hover:underline"
+                  >
+                    {a.agent}
+                  </Link>
+                </td>
+                <td className="text-right tabular-nums">{rpm(a.medianRpm)}</td>
+                <td className="text-right text-muted-text">{a.loadCount}</td>
+                <td
+                  className="text-right tabular-nums"
+                  style={{ color: otColor(a.onTimePct) }}
+                >
+                  {pct(a.onTimePct)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {detail.lanes.length > 0 && (
+          <>
+            <div className="text-xs text-muted-text mt-5 mb-2">
+              Top lanes out of {detail.state}
+            </div>
+            <div className="text-sm space-y-1">
+              {detail.lanes.slice(0, 6).map((l) => (
+                <div key={l.lane} className="flex justify-between gap-3">
+                  <span className="truncate">{l.lane}</span>
+                  <span className="text-muted-text whitespace-nowrap">
+                    {rpm(l.medianRpm)}/mi · {l.loadCount} load
+                    {l.loadCount === 1 ? "" : "s"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </>
+    )}
+  </Panel>
+);

--- a/frontend/src/lib/metrics/lanes.test.ts
+++ b/frontend/src/lib/metrics/lanes.test.ts
@@ -7,6 +7,7 @@ import {
   getLanesSummary,
   getRecentLoads,
   getStateMapData,
+  getStateDetail,
 } from "./lanes";
 
 const makeLoad = (over: Partial<Load>): Load => ({
@@ -235,5 +236,38 @@ describe("recency windowing", () => {
     expect(data["Georgia"].avgRpm).toBeCloseTo(3.0, 5); // only the recent load
     expect(data["Texas"].loadCount).toBe(1); // shaded (ran there this year)
     expect(data["Texas"].avgRpm).toBeNull(); // but nothing in the 90-day window
+  });
+});
+
+describe("getStateDetail", () => {
+  const NOW = new Date("2026-06-10T00:00:00Z").getTime();
+  const loads = [
+    makeLoad({ origin_state: "GA", origin_market: "Atlanta", delivery_market: "Dallas", agent_id: "a1", agent: "Mike", linehaul: "2000", loaded_miles: 1000, delivery_date: "2026-06-01" }),
+    makeLoad({ origin_state: "GA", origin_market: "Atlanta", delivery_market: "Dallas", agent_id: "a1", agent: "Mike", linehaul: "2400", loaded_miles: 1000, delivery_date: "2026-06-03" }),
+    makeLoad({ origin_state: "GA", origin_market: "Savannah", delivery_market: "Miami", agent_id: "a2", agent: "Dana", linehaul: "1800", loaded_miles: 1000, delivery_date: "2026-06-04" }),
+    makeLoad({ origin_state: "TX", agent_id: "a3", agent: "Rick", linehaul: "3000", loaded_miles: 1000, delivery_date: "2026-06-05" }),
+    makeLoad({ origin_state: "GA", load_status: "booked", agent_id: "a1", agent: "Mike", delivery_date: "2026-06-06" }),
+  ];
+
+  it("groups your agents out of the state, most-used first; excludes other states + non-delivered", () => {
+    const d = getStateDetail(loads, "Georgia", 3, 90, NOW);
+    expect(d.state).toBe("Georgia");
+    expect(d.loadCount).toBe(3);
+    expect(d.agents.map((a) => a.agent)).toEqual(["Mike", "Dana"]);
+    expect(d.agents[0]).toMatchObject({ agentId: "a1", loadCount: 2 });
+    expect(d.agents[0].medianRpm).toBeCloseTo(2.2); // median of 2.0, 2.4
+    expect(d.agents.find((a) => a.agent === "Rick")).toBeUndefined();
+  });
+
+  it("lists your lanes out of the state, most-run first", () => {
+    const d = getStateDetail(loads, "Georgia", 3, 90, NOW);
+    expect(d.lanes[0]).toMatchObject({ lane: "Atlanta → Dallas", loadCount: 2 });
+    expect(d.lanes.map((l) => l.lane)).toContain("Savannah → Miami");
+  });
+
+  it("empty for a state you haven't run", () => {
+    const d = getStateDetail(loads, "Wyoming", 3, 90, NOW);
+    expect(d.loadCount).toBe(0);
+    expect(d.agents).toHaveLength(0);
   });
 });

--- a/frontend/src/lib/metrics/lanes.ts
+++ b/frontend/src/lib/metrics/lanes.ts
@@ -1,6 +1,7 @@
 import type { Load } from "@/types/load";
 import { getRegion, getStateName } from "@/lib/constants/states";
 import { median } from "./stats";
+import { agentStops, scoreStops } from "./stopScore";
 
 // Minimum loads before a lane/market can win an RPM-based KPI — keeps a single
 // lucky run from crowning a corridor. Volume KPIs ignore this.
@@ -38,6 +39,7 @@ export interface StateLoadStat {
   state: string; // full name, e.g. "Georgia"
   loadCount: number;
   avgRpm: number | null;
+  medianRpm: number | null;
   markets: string[];
 }
 
@@ -187,6 +189,7 @@ export const getStateLoadMap = (
       state: name,
       loadCount: stateLoads.length,
       avgRpm: avgRpm(stateLoads),
+      medianRpm: medianRpm(stateLoads),
       markets: [...new Set(stateLoads.map((l) => l.origin_market))],
     };
   }
@@ -196,8 +199,9 @@ export const getStateLoadMap = (
 
 export interface StateMapDatum {
   state: string;
-  loadCount: number; // footprint window (drives the shading)
+  loadCount: number; // footprint window (drives the volume shading)
   avgRpm: number | null; // rpm window (null when nothing recent)
+  medianRpm: number | null; // footprint median $/mi (drives the rate shading)
   markets: string[];
 }
 
@@ -222,9 +226,86 @@ export const getStateMapData = (
       loadCount: fp.loadCount,
       markets: fp.markets,
       avgRpm: windowed[name]?.avgRpm ?? null,
+      medianRpm: fp.medianRpm,
     };
   }
   return out;
+};
+
+// ---- STATE DRILL-DOWN ----
+export interface AgentStat {
+  agentId: string;
+  agent: string;
+  loadCount: number;
+  medianRpm: number | null;
+  onTimePct: number | null; // 0..1 of graded stops on time; null when none graded
+}
+
+export interface StateDetail {
+  state: string;
+  loadCount: number;
+  avgRpm: number | null;
+  medianRpm: number | null;
+  agents: AgentStat[]; // who you've booked out of here, most-used first
+  lanes: LaneStat[]; // your lanes out of here, most-run first
+}
+
+// Everything you'd want when you click a state: the agents you've booked freight
+// out of it (rate / volume / on-time) and your top lanes from it — all from your
+// delivered loads inside the window. `freeHours` drives on-time (from settlement).
+export const getStateDetail = (
+  loads: Load[],
+  stateName: string,
+  freeHours: number,
+  days: number,
+  now: number = Date.now(),
+): StateDetail => {
+  const recent = getRecentLoads(deliveredOnly(loads), days, now);
+  const stateLoads = recent.filter(
+    (l) => getStateName(l.origin_state) === stateName,
+  );
+
+  const agents: AgentStat[] = [];
+  for (const [agentId, agentLoads] of groupBy(stateLoads, (l) => l.agent_id)) {
+    agents.push({
+      agentId,
+      agent: agentLoads[0].agent,
+      loadCount: agentLoads.length,
+      medianRpm: medianRpm(agentLoads),
+      onTimePct: scoreStops(agentStops(agentLoads, freeHours)).onTimePct,
+    });
+  }
+  agents.sort(
+    (a, b) => b.loadCount - a.loadCount || (b.medianRpm ?? 0) - (a.medianRpm ?? 0),
+  );
+
+  const lanes: LaneStat[] = [];
+  for (const [, laneLoads] of groupBy(
+    stateLoads,
+    (l) => `${l.origin_market} → ${l.delivery_market}`,
+  )) {
+    const first = laneLoads[0];
+    lanes.push({
+      lane: `${first.origin_market} → ${first.delivery_market}`,
+      origin: first.origin_market,
+      destination: first.delivery_market,
+      loadCount: laneLoads.length,
+      avgRpm: avgRpm(laneLoads),
+      medianRpm: medianRpm(laneLoads),
+    });
+  }
+  lanes.sort(
+    (a, b) => b.loadCount - a.loadCount || (b.medianRpm ?? 0) - (a.medianRpm ?? 0),
+  );
+
+  return {
+    state: stateName,
+    loadCount: stateLoads.length,
+    avgRpm: avgRpm(stateLoads),
+    medianRpm: medianRpm(stateLoads),
+    agents,
+    lanes,
+  };
 };
 
 // ---- TOP-LANE KPIs ----

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -766,6 +766,15 @@ const GuidePage = () => {
               high-accessorial run. The median asks "what does a normal load
               here pay," which is the honest basis for deciding where to book.
             </Why>
+            <Why>
+              The <span className="text-light">map</span> shades states by your
+              own median $/mi (toggle to volume for footprint) — thin states dim
+              so one fluke doesn't light one up. <span className="text-light">Click
+              a state</span> to see the agents you've booked out of it (rate,
+              volume, on-time, each linking to their page) and your top lanes from
+              it. It's all your own history — who to call for freight out of a
+              region, and how they've paid.
+            </Why>
           </Metric>
 
           <Metric

--- a/frontend/src/pages/LanesPage.tsx
+++ b/frontend/src/pages/LanesPage.tsx
@@ -1,14 +1,18 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLoads } from "@/hooks/useLoads";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import type { SettlementSchedule } from "@/types/settlementSchedule";
 import {
   getRecentLoads,
   getRegionRollup,
   getLanesSummary,
   getStateMapData,
+  getStateDetail,
 } from "@/lib/metrics/lanes";
 import { LanesKpis } from "@/components/lanes/LanesKpis";
 import { LanesMap } from "@/components/lanes/LanesMap";
 import { LanesTable } from "@/components/lanes/LanesTable";
+import { StateDetailPanel } from "@/components/lanes/StateDetailPanel";
 import { Panel } from "@/components/ui/Panel";
 
 const WINDOWS = [30, 60, 90];
@@ -16,7 +20,13 @@ const WINDOWS = [30, 60, 90];
 const LanesPage = () => {
   const [refreshKey] = useState(0);
   const [windowDays, setWindowDays] = useState(90);
+  const [selectedState, setSelectedState] = useState<string | null>(null);
+  const [schedule, setSchedule] = useState<SettlementSchedule | null>(null);
   const { loads, isLoading, error } = useLoads(refreshKey);
+
+  useEffect(() => {
+    getSettlementSchedule().then(setSchedule).catch(() => {});
+  }, []);
 
   if (isLoading)
     return (
@@ -37,6 +47,10 @@ const LanesPage = () => {
   const rollup = getRegionRollup(windowLoads);
   const summary = getLanesSummary(windowLoads);
   const mapData = getStateMapData(loads, windowDays);
+  const freeHours = schedule?.detention_free_hours ?? 3;
+  const stateDetail = selectedState
+    ? getStateDetail(loads, selectedState, freeHours, windowDays)
+    : null;
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
@@ -62,15 +76,29 @@ const LanesPage = () => {
       <LanesKpis summary={summary} />
 
       <div className="mt-6">
-        <LanesMap data={mapData} windowDays={windowDays} />
+        <LanesMap
+          data={mapData}
+          windowDays={windowDays}
+          selected={selectedState}
+          onSelect={setSelectedState}
+        />
       </div>
 
-      <Panel className="mt-6 p-4">
-        <p className="text-xs text-muted-text mb-2">
-          By region · last {windowDays} days · expand a market for its lanes
-        </p>
-        <LanesTable rollup={rollup} />
-      </Panel>
+      {stateDetail ? (
+        <StateDetailPanel
+          detail={stateDetail}
+          windowDays={windowDays}
+          onClear={() => setSelectedState(null)}
+        />
+      ) : (
+        <Panel className="mt-6 p-4">
+          <p className="text-xs text-muted-text mb-2">
+            By region · last {windowDays} days · expand a market for its lanes ·
+            or click a state on the map
+          </p>
+          <LanesTable rollup={rollup} />
+        </Panel>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Turns the Lanes map into a decision tool, **all from your own loads — no new API** (matching the "don't over-depend on outside sources" call).

- **Map**: toggle "shade by **your \$/mi**" (default) or **volume**. Rate mode shades states by your median \$/mi per origin on a teal→green ramp; thin states (< 2 loads) shade dim so a fluke doesn't light one up. Best-paying flame + hover kept.
- **Click a state** → drill-down panel: the **agents you've booked out of it** (median \$/mi · loads · on-time, each linking to its agent page) and your **top lanes** from it. Clear returns to the region breakdown.
- `lanes.ts`: `getStateDetail` (agents + lanes per origin state; on-time via the existing stop-scoring with `freeHours` from settlement), plus `medianRpm` on the state map data. Unit-tested.

On-time uses your appointment data; agents with none show "—".

## Why no API
The "current market rates by territory" you floated needs regional flatbed rate data, which doesn't exist free (FRED is national; DAT/Truckstop is paid) — so instead the map shows **your own** realized rates by territory, which is the more relevant signal for your decisions and keeps the app self-contained.

## Verification
Build clean; 417 tests (+3 for `getStateDetail`). Verified on dev: rate-shaded map + toggle, click-to-select highlight, and the Texas drill-down (16 loads, agents sorted by volume with links, top lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)