### PR TITLE
feat: loading skeletons + on-theme empty states across core pages (v1.121.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.120.0",
+  "version": "1.121.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/ui/PageSkeletons.tsx
+++ b/frontend/src/components/ui/PageSkeletons.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "./skeleton";
+
+// Shape-matched loading placeholders that mirror the app's page shapes — a
+// skeleton that looks like the page beats a bare "Loading…" line. Compose these
+// inside each page's own shell so the background/padding still match.
+
+// A row of stat/KPI cards.
+export const StatCardsSkeleton = ({ count = 3 }: { count?: number }) => (
+  <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+    {Array.from({ length: count }, (_, i) => (
+      <Skeleton key={i} className="h-24" style={{ borderRadius: 13 }} />
+    ))}
+  </div>
+);
+
+// A stack of list/table rows.
+export const RowsSkeleton = ({ rows = 6 }: { rows?: number }) => (
+  <div className="space-y-2">
+    {Array.from({ length: rows }, (_, i) => (
+      <Skeleton key={i} className="h-14" style={{ borderRadius: 10 }} />
+    ))}
+  </div>
+);
+
+// A single large panel/chart block.
+export const BlockSkeleton = ({ className = "h-72" }: { className?: string }) => (
+  <Skeleton className={className} style={{ borderRadius: 16 }} />
+);

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -38,6 +38,8 @@ import {
 } from "@/lib/metrics/agent";
 import { loadRevenue } from "@/lib/metrics/loads";
 import { Panel } from "@/components/ui/Panel";
+import { Skeleton } from "@/components/ui/skeleton";
+import { StatCardsSkeleton, BlockSkeleton } from "@/components/ui/PageSkeletons";
 
 const money0 = (n: number) =>
   n.toLocaleString("en-US", {
@@ -108,7 +110,10 @@ const AgentDetailPage = () => {
   if (isLoading)
     return (
       <div className="p-6 bg-iron text-light min-h-screen font-body">
-        <p className="text-muted-text">Loading agent...</p>
+        <Skeleton className="h-8 w-48 mb-2" />
+        <Skeleton className="h-4 w-32 mb-6" />
+        <StatCardsSkeleton count={4} />
+        <BlockSkeleton className="h-56 mt-6" />
       </div>
     );
   if (error)

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -5,6 +5,8 @@ import { useLoads } from "@/hooks/useLoads";
 import { Kpi } from "@/components/Kpi";
 import { AgentCard } from "@/components/agents/AgentCard";
 import { useCarrierName } from "@/hooks/useCarrierName";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   computeHonors,
   perAgentStats,
@@ -79,7 +81,13 @@ const AgentsPage = () => {
   if (isLoading || loadsLoading)
     return (
       <div className="p-6 bg-iron text-light min-h-screen font-body">
-        <p className="text-muted-text">Loading agents...</p>
+        <Skeleton className="h-8 w-32 mb-6" />
+        <Skeleton className="h-10 w-full max-w-md mb-6" style={{ borderRadius: 10 }} />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {Array.from({ length: 6 }, (_, i) => (
+            <Skeleton key={i} className="h-32" style={{ borderRadius: 13 }} />
+          ))}
+        </div>
       </div>
     );
 
@@ -161,11 +169,14 @@ const AgentsPage = () => {
       </div>
 
       {shown.length === 0 ? (
-        <p className="text-muted-text text-sm">
-          {(agents ?? []).length === 0
-            ? "No agents yet."
-            : "No agents match your search."}
-        </p>
+        (agents ?? []).length === 0 ? (
+          <EmptyState
+            title="No agents yet"
+            hint="Add an agent to track who books your freight and how they pay."
+          />
+        ) : (
+          <p className="text-muted-text text-sm">No agents match your search.</p>
+        )
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           {shown.map((agent) => (

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -27,6 +27,8 @@ import { ExpenseLedger } from "@/components/expenses/ExpenseLedger";
 import { ExpenseYtdChart } from "@/components/expenses/ExpenseYtdChart";
 import { ObligationsCard } from "@/components/expenses/ObligationsCard";
 import { Panel } from "@/components/ui/Panel";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { StatCardsSkeleton, BlockSkeleton } from "@/components/ui/PageSkeletons";
 
 const money = (n: number): string =>
   `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
@@ -233,11 +235,15 @@ const ExpensesPage = () => {
       )}
 
       {loading ? (
-        <p className="text-muted-text">Loading...</p>
+        <div>
+          <StatCardsSkeleton count={3} />
+          <BlockSkeleton className="h-64 mt-6" />
+        </div>
       ) : periods.length === 0 ? (
-        <p className="text-muted-text">
-          No P&amp;L uploaded yet. Upload one to get started.
-        </p>
+        <EmptyState
+          title="No P&L uploaded yet"
+          hint="Upload a profit & loss statement to see your true cost per mile."
+        />
       ) : selected && metrics && trueMonthly ? (
         <>
           {periods.length > 1 && (

--- a/frontend/src/pages/LanesPage.tsx
+++ b/frontend/src/pages/LanesPage.tsx
@@ -14,6 +14,8 @@ import { LanesMap } from "@/components/lanes/LanesMap";
 import { LanesTable } from "@/components/lanes/LanesTable";
 import { StateDetailPanel } from "@/components/lanes/StateDetailPanel";
 import { Panel } from "@/components/ui/Panel";
+import { Skeleton } from "@/components/ui/skeleton";
+import { StatCardsSkeleton, BlockSkeleton } from "@/components/ui/PageSkeletons";
 
 const WINDOWS = [30, 60, 90];
 
@@ -30,8 +32,11 @@ const LanesPage = () => {
 
   if (isLoading)
     return (
-      <div className="p-6 bg-iron text-light font-body">
-        <p className="text-muted-text">Loading lanes...</p>
+      <div className="p-6 bg-iron text-light font-body min-h-screen">
+        <Skeleton className="h-8 w-28 mb-6" />
+        <StatCardsSkeleton count={3} />
+        <BlockSkeleton className="h-80 mt-6" />
+        <BlockSkeleton className="h-56 mt-6" />
       </div>
     );
 

--- a/frontend/src/pages/LoadsPage.tsx
+++ b/frontend/src/pages/LoadsPage.tsx
@@ -15,6 +15,9 @@ import { createLoad } from "@/services/createLoadService";
 import { loadsKpis, loadRevenue } from "@/lib/metrics/loads";
 import { fmtRpm, rpmTextClass } from "@/components/lanes/rpmStyle";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton } from "@/components/ui/skeleton";
+import { StatCardsSkeleton, BlockSkeleton } from "@/components/ui/PageSkeletons";
 import {
   loadFlag,
   detentionOwed,
@@ -209,7 +212,9 @@ const LoadsPage = () => {
   if (isLoading)
     return (
       <div className="p-6 bg-iron text-light min-h-screen">
-        <p className="text-muted-text">Loading loads...</p>
+        <Skeleton className="h-8 w-28 mb-6" />
+        <StatCardsSkeleton count={4} />
+        <BlockSkeleton className="h-64 mt-6" />
       </div>
     );
 
@@ -366,13 +371,18 @@ const LoadsPage = () => {
 
       <Panel className="p-4 mt-4 overflow-x-auto">
         {rest.length === 0 ? (
-          <p className="text-muted-text text-sm">
-            {(loads ?? []).length === 0
-              ? "No loads yet."
-              : inTransit.length > 0
+          (loads ?? []).length === 0 ? (
+            <EmptyState
+              title="No loads yet"
+              hint="Log your first load to start tracking revenue, agents, and lanes."
+            />
+          ) : (
+            <p className="text-muted-text text-sm py-2">
+              {inTransit.length > 0
                 ? "No other loads match these filters."
                 : "No loads match these filters."}
-          </p>
+            </p>
+          )
         ) : (
           <table className="w-full text-sm min-w-[760px] [&_th]:pr-5 [&_td]:pr-5 [&_th:last-child]:pr-0 [&_td:last-child]:pr-0">
             <thead>

--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -18,6 +18,7 @@ import {
 import { maxFuelOdometer } from "@/lib/metrics/fuelEconomy";
 import { ScheduleTab } from "@/components/maintenance/ScheduleTab";
 import { ServicesTab } from "@/components/maintenance/ServicesTab";
+import { RowsSkeleton } from "@/components/ui/PageSkeletons";
 
 const MaintenancePage = () => {
   const { loads } = useLoads(0);
@@ -114,7 +115,7 @@ const MaintenancePage = () => {
       </div>
 
       {loading ? (
-        <p className="text-muted-text">Loading...</p>
+        <RowsSkeleton rows={6} />
       ) : tab === "schedule" ? (
         <ScheduleTab
           items={items}

--- a/frontend/src/pages/TripsPage.tsx
+++ b/frontend/src/pages/TripsPage.tsx
@@ -3,6 +3,9 @@ import { useTrips } from "@/hooks/useTrips";
 import TripForm from "@/components/TripForm";
 import { formatDate } from "@/lib/format";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton } from "@/components/ui/skeleton";
+import { RowsSkeleton } from "@/components/ui/PageSkeletons";
 import type { Trip } from "@/types/trip";
 
 // "Irving, TX" from a city/state pair; falls back to whichever is present.
@@ -36,8 +39,9 @@ const TripsPage = () => {
 
   if (isLoading)
     return (
-      <div className="p-6 bg-iron text-light font-body">
-        <p className="text-muted-text">Loading trips...</p>
+      <div className="p-6 bg-iron text-light font-body min-h-screen">
+        <Skeleton className="h-8 w-24 mb-6" />
+        <RowsSkeleton rows={8} />
       </div>
     );
 
@@ -65,32 +69,39 @@ const TripsPage = () => {
       )}
 
       <div className="bg-iron mt-4 p-6">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Trip #</TableHead>
-              <TableHead>Date</TableHead>
-              <TableHead>Purpose</TableHead>
-              <TableHead>Route</TableHead>
-              <TableHead>OD Start</TableHead>
-              <TableHead>OD End</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {trips.map((trip) => (
-              <TableRow key={trip.trip_id}>
-                <TableCell className="text-foreground">
-                  {trip.trip_number}
-                </TableCell>
-                <TableCell>{formatDate(trip.trip_date)}</TableCell>
-                <TableCell>{trip.trip_purpose}</TableCell>
-                <TableCell>{tripRoute(trip)}</TableCell>
-                <TableCell>{trip.odometer_start}</TableCell>
-                <TableCell>{trip.odometer_end}</TableCell>
+        {trips.length === 0 ? (
+          <EmptyState
+            title="No trips logged yet"
+            hint="Log a trip to track odometer miles, routes, and deadhead."
+          />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Trip #</TableHead>
+                <TableHead>Date</TableHead>
+                <TableHead>Purpose</TableHead>
+                <TableHead>Route</TableHead>
+                <TableHead>OD Start</TableHead>
+                <TableHead>OD End</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHeader>
+            <TableBody>
+              {trips.map((trip) => (
+                <TableRow key={trip.trip_id}>
+                  <TableCell className="text-foreground">
+                    {trip.trip_number}
+                  </TableCell>
+                  <TableCell>{formatDate(trip.trip_date)}</TableCell>
+                  <TableCell>{trip.trip_purpose}</TableCell>
+                  <TableCell>{tripRoute(trip)}</TableCell>
+                  <TableCell>{trip.odometer_start}</TableCell>
+                  <TableCell>{trip.odometer_end}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Polish sweep #1 — loading + empty-state finish pass.

**Loading skeletons.** The 7 pages that showed a bare `Loading…` line now render shape-matched skeletons that mirror the real page (title bar + KPI-card row + content block, or a row/list variant), via a new shared `PageSkeletons.tsx` (`StatCardsSkeleton` / `RowsSkeleton` / `BlockSkeleton`): Loads, Lanes, Agents, Trips, Maintenance, Expenses, Agent detail.

**Empty states.** Now use the on-theme `EmptyState` primitive (flatbed-on-a-road illustration + a helpful next step) on Loads, Agents, Expenses, and Trips. **Trips previously had no empty state at all** — it rendered a headers-only table.

## Design calls
- The illustrated empty state is reserved for *genuine first-run* empties. Transient "no match for these filters" cases (Loads/Agents search) stay as one-line text.
- Agent-detail's two small in-card empties left as text (two truck illustrations on one page reads noisy).

## Verify
- `npm run build` clean; 417/417 frontend tests pass.
- Skeleton + empty-state renders confirmed live in the dev preview.

No Guide update needed — skeletons/empty copy are self-explanatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)