### PR TITLE
feat: comic-noir texture pass — Market page pilot (v1.122.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.121.0",
+  "version": "1.122.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/ui/Panel.tsx
+++ b/frontend/src/components/ui/Panel.tsx
@@ -11,18 +11,22 @@ const VARIANT: Record<PanelVariant, string> = {
 interface Props extends HTMLAttributes<HTMLDivElement> {
   variant?: PanelVariant;
   interactive?: boolean; // hover-lift + press feedback
+  noir?: boolean; // comic-noir texture: printed-ink frame + Ben-Day dot corner
 }
 
 // The layered surface primitive. One place for the app's card depth, so every
 // panel reads as part of one system. Forwards a ref so ref'd containers (e.g.
 // hover-tooltip measurement) can adopt it too.
 export const Panel = forwardRef<HTMLDivElement, Props>(
-  ({ variant = "default", interactive = false, className = "", children, ...rest }, ref) => (
+  (
+    { variant = "default", interactive = false, noir = false, className = "", children, ...rest },
+    ref,
+  ) => (
     <div
       ref={ref}
       className={`ds-panel ${VARIANT[variant]} ${
         interactive ? "ds-panel--interactive" : ""
-      } ${className}`}
+      } ${noir ? "ds-panel--noir" : ""} ${className}`}
       {...rest}
     >
       {children}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -230,6 +230,36 @@
   opacity: 0.13; pointer-events: none;
   border-top-right-radius: inherit;
 }
+/* Noir treatment — opt-in via <Panel noir>. Extends the hero halftone motif to
+   any analytical surface: a printed-ink frame (near-black border + inner top
+   light) and a Ben-Day dot corner. Film-noir grit without touching the data. */
+.ds-panel--noir {
+  border: 1.5px solid #0a0e16;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 12px 28px rgba(0, 0, 0, 0.55);
+}
+.ds-panel--noir::after {
+  content: "";
+  position: absolute; top: 0; right: 0;
+  width: 104px; height: 104px;
+  background-image: radial-gradient(#e8940a 1.3px, transparent 1.4px);
+  background-size: 7px 7px;
+  opacity: 0.14; pointer-events: none;
+  -webkit-mask-image: radial-gradient(circle at 100% 0, #000, transparent 70%);
+  mask-image: radial-gradient(circle at 100% 0, #000, transparent 70%);
+  border-top-right-radius: inherit;
+}
+/* Comic sound-effect lettering — a slanted, ink-shadowed verdict word (Bangers).
+   Pair with a tone color inline. */
+.ds-sfx {
+  display: inline-block;
+  font-family: "Bangers", var(--font-condensed), system-ui, sans-serif;
+  font-weight: 400;
+  letter-spacing: 0.045em;
+  line-height: 1;
+  transform: skewX(-8deg);
+  text-shadow: 2px 2px 0 #0a0e16;
+  -webkit-text-stroke: 0.4px #0a0e16;
+}
 .ds-panel--interactive { transition: transform 0.15s ease, box-shadow 0.15s ease; }
 .ds-panel--interactive:hover {
   transform: translateY(-2px);

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -288,7 +288,7 @@ const MarketPage = () => {
         </Panel>
       ) : (
         <>
-          <Panel className="mt-6 p-5">
+          <Panel noir className="mt-6 p-5">
             <div className="flex justify-between items-baseline flex-wrap gap-2">
               <h2 className="text-lg font-medium text-light">Every load · rate vs the year</h2>
               <span className="text-xs text-muted-text">gross $/driven mile</span>
@@ -309,7 +309,7 @@ const MarketPage = () => {
           </Panel>
 
           <div className="grid grid-cols-1 lg:grid-cols-[1.6fr_1fr] gap-4 mt-4">
-            <Panel className="p-5">
+            <Panel noir className="p-5">
               <h2 className="text-lg font-medium text-light">Market barometer</h2>
               <p className="text-xs text-muted-text mt-0.5 mb-2">
                 your median rate per driven mile, by month
@@ -325,7 +325,24 @@ const MarketPage = () => {
                   </div>
                   {yvm && (
                     <div className="mt-3 pt-3 border-t" style={{ borderColor: "rgba(255,255,255,0.07)" }}>
-                      <div className="text-xs text-muted-text mb-2">You vs. the market · last 6 months</div>
+                      <div className="flex items-center justify-between gap-2 mb-2">
+                        <span className="text-xs text-muted-text">You vs. the market · last 6 months</span>
+                        <span
+                          className="ds-sfx text-xl"
+                          style={{
+                            color: yvmColor,
+                            padding: "1px 6px",
+                            background:
+                              "radial-gradient(ellipse at center, rgba(245,176,58,0.16), transparent 72%)",
+                          }}
+                        >
+                          {yvm.verdict === "beating"
+                            ? "BEATING"
+                            : yvm.verdict === "lagging"
+                              ? "LAGGING"
+                              : "IN LINE"}
+                        </span>
+                      </div>
                       <div className="flex items-center gap-2 mb-1.5">
                         <span className="text-[11px] text-muted-text w-14">you</span>
                         <div className="flex-1 h-2 rounded" style={{ background: "#232c3f" }}>
@@ -351,7 +368,7 @@ const MarketPage = () => {
               )}
             </Panel>
 
-            <Panel className="p-5">
+            <Panel noir className="p-5">
               <h2 className="text-lg font-medium text-light">Tier gauge</h2>
               <p className="text-xs text-muted-text mt-0.5 mb-3">
                 where your tiers land · last 90 days


### PR DESCRIPTION
## What

Polish track #2 — comic-noir texture pass. **Market page pilot** (Level 2 "Noir" of the approved texture dial).

**Reusable pieces:**
- `Panel` gains an opt-in **`noir`** prop → `.ds-panel--noir`: a printed-ink frame (near-black border + inner top-light) and an amber Ben-Day dot corner. Extends the halftone motif already on the hero/trophy panels to the analytical surfaces.
- New **`.ds-sfx`** class → slanted, ink-shadowed comic sound-effect lettering (Bangers).

**Applied to the Market page:** `noir` on all three chart panels (scatter, barometer, tier gauge); the you-vs-market verdict now renders as an SFX badge (**BEATING / LAGGING / IN LINE**) in the verdict's tone color with a soft amber rim-light. Texture sits behind the data — numbers stay fully legible.

## Verify
- `npm run build` clean; 417/417 frontend tests pass.
- Verified live on the Market page (dev stack): halftone corners + ink frames on all panels, SFX badge in Bangers, barometer dual-axis intact.

No Guide update needed — purely aesthetic.

## Next
Rollout to Lanes / Expenses / Dashboard hero is just adding `noir` (+ an SFX verdict where it fits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)