### PR TITLE
feat: roll comic-noir texture to Dashboard, Expenses, Lanes (v1.123.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.122.0",
+  "version": "1.123.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/OutstandingLoadsList.tsx
+++ b/frontend/src/components/OutstandingLoadsList.tsx
@@ -29,7 +29,7 @@ export const OutstandingLoadsList = ({ loads }: Props) => {
     getOutstandingSummary(loads);
 
   return (
-    <Panel variant="panel" className="p-4">
+    <Panel variant="panel" noir className="p-4">
       <div className="flex items-baseline justify-between mb-4">
         <h3 className="text-sm font-medium text-light">Outstanding loads</h3>
         <span className="text-sm text-status-aware-text font-medium">

--- a/frontend/src/components/RevenueChart.tsx
+++ b/frontend/src/components/RevenueChart.tsx
@@ -42,7 +42,7 @@ const GRID = "#2a3347";
 
 export const RevenueChart = ({ data, target }: Props) => {
   return (
-    <Panel className="p-4">
+    <Panel noir className="p-4">
       <h3 className="text-sm font-medium mb-1 text-light">Revenue over time</h3>
       <p className="text-xs text-muted-text mb-4">
         Monthly gross{target ? " · dashed line = target" : ""}

--- a/frontend/src/components/RpmChart.tsx
+++ b/frontend/src/components/RpmChart.tsx
@@ -36,7 +36,7 @@ const GRID = "#2a3347";
 
 export const RpmChart = ({ data, breakEven }: Props) => {
   return (
-    <Panel className="p-4">
+    <Panel noir className="p-4">
       <h3 className="text-sm font-medium mb-1 text-light">RPM vs break-even</h3>
       <p className="text-xs text-muted-text mb-4">
         Blended monthly rate · red line = ${breakEven.toFixed(2)} break-even

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -144,7 +144,7 @@ export const RateTargetsCard = ({ targets }: { targets: Targets }) => {
     weekEarned >= gross.weeklyTarget;
 
   return (
-    <Panel className="p-4">
+    <Panel noir className="p-4">
       <div className="flex justify-between items-baseline mb-3">
         <p className="text-sm font-medium text-light">Rate &amp; pace targets</p>
         <p className="text-xs text-muted-text">

--- a/frontend/src/components/expenses/ExpenseYtdChart.tsx
+++ b/frontend/src/components/expenses/ExpenseYtdChart.tsx
@@ -77,7 +77,7 @@ export const ExpenseYtdChart = ({
   if (data.length === 0) return null;
 
   return (
-    <Panel className="p-4" style={{ height: 280 }}>
+    <Panel noir className="p-4" style={{ height: 280 }}>
       <p className="text-xs text-muted-text mb-2">
         Revenue vs {obligationsTotal > 0 ? "true cost" : "cost"} · year to date
       </p>

--- a/frontend/src/components/expenses/ObligationsCard.tsx
+++ b/frontend/src/components/expenses/ObligationsCard.tsx
@@ -53,7 +53,7 @@ export const ObligationsCard = ({ items, onChange }: Props) => {
     .reduce((s, o) => s + o.amount, 0);
 
   return (
-    <Panel className="p-4 mb-6">
+    <Panel noir className="p-4 mb-6">
       <div className="flex justify-between items-start mb-1">
         <p className="text-xs text-muted-text">
           Monthly obligations · cash out that's not on your P&amp;L

--- a/frontend/src/components/lanes/LanesMap.tsx
+++ b/frontend/src/components/lanes/LanesMap.tsx
@@ -116,7 +116,7 @@ export const LanesMap = ({ data, windowDays, selected, onSelect }: Props) => {
   );
 
   return (
-    <Panel ref={containerRef} className="p-4 relative">
+    <Panel ref={containerRef} noir className="p-4 relative">
       <div className="text-xs text-muted-text mb-2 flex items-center gap-2 flex-wrap">
         <span>Shade by</span>
         {toggle("rate", "your $/mi")}

--- a/frontend/src/components/lanes/StateDetailPanel.tsx
+++ b/frontend/src/components/lanes/StateDetailPanel.tsx
@@ -20,7 +20,7 @@ export const StateDetailPanel = ({
   windowDays: number;
   onClear: () => void;
 }) => (
-  <Panel className="mt-6 p-5">
+  <Panel noir className="mt-6 p-5">
     <div className="flex items-baseline justify-between border-b border-plate pb-2.5 mb-4">
       <div>
         <span className="text-xl font-condensed text-light">{detail.state}</span>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -230,7 +230,7 @@ const OwnerDashboard = () => {
         <div className="lg:col-span-2">
           <RpmChart data={monthlyRpm} breakEven={liveBreakEven} />
         </div>
-        <Panel className="p-4">
+        <Panel noir className="p-4">
           <p className="text-xs text-muted-text mb-2">What's next · booked</p>
           <WhatsNext loads={upcoming} />
         </Panel>
@@ -238,7 +238,7 @@ const OwnerDashboard = () => {
 
       {/* Recent loads + outstanding */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
-        <Panel className="p-4">
+        <Panel noir className="p-4">
           <p className="text-xs text-muted-text mb-2">Recent loads</p>
           <RecentLoads loads={recentLoads} />
         </Panel>

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -299,7 +299,7 @@ const ExpensesPage = () => {
           </p>
 
           {rateLadder.walkAway != null && (
-            <Panel className="p-4 mb-6">
+            <Panel noir className="p-4 mb-6">
               <p className="text-xs text-muted-text mb-3">
                 Rate to book · gross $/mile driven · last {rateBasis.months}{" "}
                 complete month{rateBasis.months > 1 ? "s" : ""}
@@ -345,7 +345,7 @@ const ExpensesPage = () => {
             <ExpenseYtdChart periods={periods} obligationsTotal={obligationsTotal} />
           )}
 
-          <Panel className="p-4 mb-6 mt-6">
+          <Panel noir className="p-4 mb-6 mt-6">
             <p className="text-xs text-muted-text mb-2">
               Fixed vs variable · P&amp;L operating · {money(metrics.monthlyCost)}
             </p>
@@ -382,7 +382,7 @@ const ExpensesPage = () => {
 
           <ObligationsCard items={obligations} onChange={reloadObligations} />
 
-          <Panel className="p-4 mb-6">
+          <Panel noir className="p-4 mb-6">
             <p className="text-xs text-muted-text mb-2">
               All expenses · reclassify, edit value, add or delete
             </p>

--- a/frontend/src/pages/LanesPage.tsx
+++ b/frontend/src/pages/LanesPage.tsx
@@ -96,7 +96,7 @@ const LanesPage = () => {
           onClear={() => setSelectedState(null)}
         />
       ) : (
-        <Panel className="mt-6 p-4">
+        <Panel noir className="mt-6 p-4">
           <p className="text-xs text-muted-text mb-2">
             By region · last {windowDays} days · expand a market for its lanes ·
             or click a state on the map


### PR DESCRIPTION
## What

Completes polish track #2 — the comic-noir texture pass. Applies the `noir` Panel treatment (ink frame + Ben-Day halftone corner, shipped in v1.122.0 on Market) to the substantial analytical panels across the remaining pages.

- **Dashboard** — revenue chart, RPM chart, rate & pace targets, what's-next, recent-loads, outstanding-loads. Sits as one set with the existing amber-comic grind / top-agents cards.
- **Expenses** — rate-to-book, fixed-vs-variable, all-expenses ledger, obligations, YTD chart.
- **Lanes** — rate-shaded map, region table, state drill-down.

Small KPI stat tiles stay clean — the big-panels-only rule from the Market pilot, applied uniformly. (Briefly tried decorating the Dashboard KPI tiles; reverted for consistency + because the rim-light didn't generalize to Lanes' lane-name KPIs.)

## Notes
- Purely additive: 11 files, each just adds the `noir` prop. No CSS change (noir styles already shipped), no logic touched.
- `npm run build` clean; 417/417 frontend tests pass.
- Verified live on all three pages (dev stack): halftone corners + ink frames on the big panels, KPI tiles clean.

No Guide update needed — purely aesthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)