### PR TITLE
feat: count-up + lit rim-light on the Dashboard hero KPIs (v1.124.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.123.0",
+  "version": "1.124.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/KpiCard.tsx
+++ b/frontend/src/components/KpiCard.tsx
@@ -1,5 +1,6 @@
 import { Panel } from "@/components/ui/Panel";
 import { Sparkline } from "@/components/ui/Sparkline";
+import { RollingValue } from "@/components/comic/RollingNumber";
 
 type Status = "good" | "bad" | "neutral";
 
@@ -44,7 +45,16 @@ export const KpiCard = ({
         <Sparkline data={trend} color={sparkColor[status]} />
       )}
     </div>
-    <p className={`text-2xl font-condensed ${statusColor[status]}`}>{value}</p>
+    <p
+      className={`w-fit text-2xl font-condensed ${statusColor[status]}`}
+      style={{
+        padding: "3px 10px 3px 3px",
+        background:
+          "radial-gradient(ellipse at 18% 55%, rgba(245,176,58,0.2), transparent 68%)",
+      }}
+    >
+      <RollingValue text={value} />
+    </p>
 
     {delta && (
       <p

--- a/frontend/src/components/comic/RollingNumber.tsx
+++ b/frontend/src/components/comic/RollingNumber.tsx
@@ -1,13 +1,23 @@
 import { useEffect, useState, type CSSProperties } from "react";
 
+// Users who ask for less motion get the value straight away — no odometer roll.
+const prefersReducedMotion = () =>
+  typeof window !== "undefined" &&
+  !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
 // One digit as a 0–9 vertical strip, clipped to a single row. On mount (and on
 // value change) it rolls up to its target, like a mechanical odometer wheel.
 const Digit = ({ target, delay }: { target: number; delay: number }) => {
-  const [n, setN] = useState(0);
+  const reduced = prefersReducedMotion();
+  const [n, setN] = useState(() => (reduced ? target : 0));
   useEffect(() => {
+    if (reduced) {
+      setN(target);
+      return;
+    }
     const t = setTimeout(() => setN(target), delay);
     return () => clearTimeout(t);
-  }, [target, delay]);
+  }, [target, delay, reduced]);
   return (
     <span
       style={{
@@ -22,7 +32,9 @@ const Digit = ({ target, delay }: { target: number; delay: number }) => {
           display: "flex",
           flexDirection: "column",
           transform: `translateY(-${n}em)`,
-          transition: "transform 0.9s cubic-bezier(0.2, 0.8, 0.2, 1)",
+          transition: reduced
+            ? "none"
+            : "transform 0.9s cubic-bezier(0.2, 0.8, 0.2, 1)",
         }}
       >
         {Array.from({ length: 10 }, (_, k) => (
@@ -35,8 +47,34 @@ const Digit = ({ target, delay }: { target: number; delay: number }) => {
   );
 };
 
-// A number whose digits roll up into place. Commas/other chars render static.
-// Reusable for the truck odometer and big KPI numbers.
+// A pre-formatted string (e.g. "$23,944.00", "39.8%") whose DIGITS roll up into
+// place; every other char ($ , . %) renders static. The KPI cards use this —
+// the value is already formatted, so nothing gets rounded away.
+export const RollingValue = ({
+  text,
+  className,
+  style,
+}: {
+  text: string;
+  className?: string;
+  style?: CSSProperties;
+}) => (
+  <span
+    className={className}
+    style={{ display: "inline-flex", fontVariantNumeric: "tabular-nums", ...style }}
+  >
+    {text.split("").map((c, i) =>
+      /\d/.test(c) ? (
+        <Digit key={i} target={Number(c)} delay={80 + i * 45} />
+      ) : (
+        <span key={i}>{c}</span>
+      ),
+    )}
+  </span>
+);
+
+// A number whose digits roll up into place — rounds to an integer, commas added.
+// Reusable for the truck odometer.
 export const RollingNumber = ({
   value,
   className,
@@ -45,20 +83,10 @@ export const RollingNumber = ({
   value: number;
   className?: string;
   style?: CSSProperties;
-}) => {
-  const chars = Math.round(value).toLocaleString("en-US").split("");
-  return (
-    <span
-      className={className}
-      style={{ display: "inline-flex", fontVariantNumeric: "tabular-nums", ...style }}
-    >
-      {chars.map((c, i) =>
-        /\d/.test(c) ? (
-          <Digit key={i} target={Number(c)} delay={80 + i * 45} />
-        ) : (
-          <span key={i}>{c}</span>
-        ),
-      )}
-    </span>
-  );
-};
+}) => (
+  <RollingValue
+    text={Math.round(value).toLocaleString("en-US")}
+    className={className}
+    style={style}
+  />
+);


### PR DESCRIPTION
## What

Polish track #3 — number delight, with the lit hero-KPI treatment.

- **`RollingValue`** (new, in `RollingNumber.tsx`) — a string-aware digit roller that rolls each digit of an already-formatted value (`$23,944.00`, `39.8%`) and passes `$ , . %` through, so decimals and percent survive (the old integer-only `RollingNumber` would round `$2.50` → `$3`). It reuses the odometer `Digit`; `RollingNumber` now wraps it, so the truck-odometer output is byte-identical.
- **`KpiCard`** — the Dashboard (and dispatcher) hero KPI strip now counts up on load, with a warm amber rim-light behind each hero number ("lit").
- **`prefers-reduced-motion`** — respected everywhere: the value snaps in with no roll.

## Verify
- `npm run build` clean; 417/417 frontend tests pass.
- Verified live: settled values correct with decimals preserved (`$2.50`, `100.0%`) + the lit glow; caught a mid-roll frame with every wheel at `0` climbing to target.

No Guide update needed — pure motion/aesthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)