### PR TITLE
refactor: consolidate money/rate formatting to shared helpers (v1.124.1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.124.0",
+  "version": "1.124.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/OutstandingLoadsList.tsx
+++ b/frontend/src/components/OutstandingLoadsList.tsx
@@ -5,17 +5,11 @@ import {
 } from "@/lib/metrics/dashboard";
 import { Panel } from "@/components/ui/Panel";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { money } from "@/lib/format";
 
 interface Props {
   loads: OutstandingLoad[];
 }
-
-const formatCurrency = (n: number): string =>
-  n.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  });
 
 // Color the aging: older = more urgent
 const ageColor = (days: number): string => {
@@ -33,7 +27,7 @@ export const OutstandingLoadsList = ({ loads }: Props) => {
       <div className="flex items-baseline justify-between mb-4">
         <h3 className="text-sm font-medium text-light">Outstanding loads</h3>
         <span className="text-sm text-status-aware-text font-medium">
-          {formatCurrency(total)} owed
+          {money(total)} owed
           {medianDaysOutstanding !== null && (
             <span className="text-muted-text font-normal">
               {" "}
@@ -68,7 +62,7 @@ export const OutstandingLoadsList = ({ loads }: Props) => {
                 </p>
               </div>
               <span className="text-sm text-status-aware-text font-medium">
-                {formatCurrency(load.revenue)}
+                {money(load.revenue)}
               </span>
             </Link>
           ))}

--- a/frontend/src/components/RevenueChart.tsx
+++ b/frontend/src/components/RevenueChart.tsx
@@ -10,6 +10,7 @@ import {
   Cell,
 } from "recharts";
 import { Panel } from "@/components/ui/Panel";
+import { money } from "@/lib/format";
 
 interface MonthlyRevenue {
   month: string; // "2026-06"
@@ -27,13 +28,6 @@ const formatMonthLabel = (month: string): string => {
   const date = new Date(Date.UTC(Number(year), Number(m) - 1, 1));
   return date.toLocaleDateString("en-US", { month: "short", timeZone: "UTC" });
 };
-
-const formatCurrency = (n: number): string =>
-  n.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  });
 
 const AMBER = "#e8940a";
 const AMBER_BRIGHT = "#f5b03a";
@@ -75,7 +69,7 @@ export const RevenueChart = ({ data, target }: Props) => {
               fontSize: 12,
             }}
             labelFormatter={(label) => formatMonthLabel(label as string)}
-            formatter={(value) => [formatCurrency(Number(value)), "Revenue"]}
+            formatter={(value) => [money(Number(value)), "Revenue"]}
           />
           {target && (
             <ReferenceLine
@@ -83,7 +77,7 @@ export const RevenueChart = ({ data, target }: Props) => {
               stroke={MUTED}
               strokeDasharray="4 4"
               label={{
-                value: `Target ${formatCurrency(target)}`,
+                value: `Target ${money(target)}`,
                 fill: MUTED,
                 fontSize: 10,
                 position: "right",

--- a/frontend/src/components/RpmChart.tsx
+++ b/frontend/src/components/RpmChart.tsx
@@ -9,6 +9,7 @@ import {
   ReferenceLine,
 } from "recharts";
 import { Panel } from "@/components/ui/Panel";
+import { rpm } from "@/lib/format";
 
 interface MonthlyRpm {
   month: string; // "2026-06"
@@ -26,8 +27,6 @@ const formatMonthLabel = (month: string): string => {
   const date = new Date(Date.UTC(Number(year), Number(m) - 1, 1));
   return date.toLocaleDateString("en-US", { month: "short", timeZone: "UTC" });
 };
-
-const formatRpm = (n: number): string => `$${n.toFixed(2)}`;
 
 const GREEN = "#1d9e75";
 const RED = "#e24b4a";
@@ -73,7 +72,7 @@ export const RpmChart = ({ data, breakEven }: Props) => {
             }}
             labelFormatter={(label) => formatMonthLabel(label as string)}
             formatter={(value) => [
-              value === null ? "No data" : formatRpm(Number(value)),
+              value === null ? "No data" : rpm(Number(value)),
               "RPM",
             ]}
           />

--- a/frontend/src/components/agents/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard.tsx
@@ -8,6 +8,7 @@ import type {
 import { agentPrestige } from "@/lib/metrics/agentLeaderboard";
 import { RatingMedallion } from "./RatingMedallion";
 import { PrestigeBadge, PRESTIGE_META } from "./PrestigeBadge";
+import { money } from "@/lib/format";
 
 // Short live blurb — only shown on the card when the agent is currently on the
 // board this quarter, so it stays a highlight rather than clutter.
@@ -17,13 +18,6 @@ const liveBlurb = (live: LiveStanding): string | null => {
   if (live.result === "board") return `#${live.boardRank} this quarter`;
   return null;
 };
-
-const money0 = (n: number) =>
-  n.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  });
 
 const fmtDate = (d: string | null) =>
   d
@@ -96,7 +90,7 @@ export const AgentCard = ({
       )}
 
       <div className="mt-2.5 pt-2 border-t border-[#3b4660] text-xs text-muted-text">
-        {stats?.loadCount ?? 0} loads · {money0(stats?.revenue ?? 0)} ·{" "}
+        {stats?.loadCount ?? 0} loads · {money(stats?.revenue ?? 0)} ·{" "}
         {fmtDate(stats?.lastWorked ?? null)}
       </div>
     </Link>

--- a/frontend/src/components/dashboard/RateLadder.tsx
+++ b/frontend/src/components/dashboard/RateLadder.tsx
@@ -1,4 +1,6 @@
 import type { RateLadder as Ladder } from "@/lib/metrics/rateTargets";
+// The rpm formatter, aliased — `rpm` is already a prop name in this component.
+import { rpm as rate } from "@/lib/format";
 
 interface Props {
   ladder: Ladder;
@@ -13,7 +15,6 @@ const GREEN_BRIGHT = "#4ade80"; // reads as text on dark, unlike the fill green
 const CORAL = "#e05a3a"; // Specialized — matches the Scorer/Settings dot
 const TRACK = "#232c3f";
 
-const rate = (n: number | null): string => (n == null ? "—" : `$${n.toFixed(2)}`);
 
 // Horizontal ladder from walk-away → strong, split at the target tier. A marker
 // shows where the current rate lands: red at/below walk-away (losing money),

--- a/frontend/src/components/dashboard/RateTargetsCard.tsx
+++ b/frontend/src/components/dashboard/RateTargetsCard.tsx
@@ -1,6 +1,7 @@
 import type { useRateTargets } from "@/hooks/useRateTargets";
 import { RateLadder } from "./RateLadder";
 import { Panel } from "@/components/ui/Panel";
+import { money } from "@/lib/format";
 
 type Targets = ReturnType<typeof useRateTargets>;
 
@@ -9,9 +10,6 @@ const AMBER = "#e8940a";
 const GREEN = "#1d9e75";
 const GREEN_TICK = "#35c47a"; // brighter than the fill, so the target tick reads on top of it
 const TRACK = "#232c3f";
-
-const money = (n: number | null): string =>
-  n == null ? "—" : `$${Math.round(n).toLocaleString("en-US")}`;
 
 // This week's gross vs floor (break-even) and target (your margin goal). The bar
 // spans past target for headroom; solid fill is EARNED (delivered), the faded

--- a/frontend/src/components/expenses/ExpenseLedger.tsx
+++ b/frontend/src/components/expenses/ExpenseLedger.tsx
@@ -6,6 +6,7 @@ import {
   deleteExpenseLine,
   addExpenseLine,
 } from "@/services/expensesService";
+import { money, rpm } from "@/lib/format";
 
 interface Props {
   period: ExpensePeriod;
@@ -14,9 +15,6 @@ interface Props {
   onChange: () => void;
 }
 
-const money = (n: number): string =>
-  `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
-const perMile = (n: number | null): string => (n == null ? "—" : `$${n.toFixed(2)}`);
 const pct = (n: number | null): string => (n == null ? "—" : `${(n * 100).toFixed(0)}%`);
 
 export const ExpenseLedger = ({ period, totalMiles, income, onChange }: Props) => {
@@ -71,7 +69,7 @@ export const ExpenseLedger = ({ period, totalMiles, income, onChange }: Props) =
             )}
           </td>
           <td className="p-2 text-right text-muted-text">
-            {perMile(totalMiles > 0 ? l.amount / totalMiles : null)}
+            {rpm(totalMiles > 0 ? l.amount / totalMiles : null)}
           </td>
           <td className="p-2 text-right text-muted-text">
             {pct(income && income > 0 ? l.amount / income : null)}

--- a/frontend/src/components/expenses/ExpenseUpload.tsx
+++ b/frontend/src/components/expenses/ExpenseUpload.tsx
@@ -11,14 +11,12 @@ import {
 } from "@/services/expensesService";
 import type { ExpenseType } from "@/types/expense";
 import { Panel } from "@/components/ui/Panel";
+import { money } from "@/lib/format";
 
 interface Props {
   onSaved: () => void;
   onCancel: () => void;
 }
-
-const money = (n: number | null): string =>
-  n == null ? "—" : `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
 
 export const ExpenseUpload = ({ onSaved, onCancel }: Props) => {
   const [proposed, setProposed] = useState<ProposedPeriod | null>(null);

--- a/frontend/src/components/expenses/ExpenseYtdChart.tsx
+++ b/frontend/src/components/expenses/ExpenseYtdChart.tsx
@@ -10,6 +10,7 @@ import {
 } from "recharts";
 import type { ExpensePeriod } from "@/types/expense";
 import { Panel } from "@/components/ui/Panel";
+import { money } from "@/lib/format";
 
 interface Datum {
   month: string;
@@ -17,9 +18,6 @@ interface Datum {
   cost: number;
   profit: number;
 }
-
-const money = (n: number): string =>
-  `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
 
 // Two clean lines (income + cost); the gap is the margin, spelled out on hover.
 const ChartTooltip = ({

--- a/frontend/src/components/expenses/ObligationsCard.tsx
+++ b/frontend/src/components/expenses/ObligationsCard.tsx
@@ -7,14 +7,12 @@ import {
   deleteObligation,
 } from "@/services/obligationsService";
 import { Panel } from "@/components/ui/Panel";
+import { money } from "@/lib/format";
 
 interface Props {
   items: Obligation[];
   onChange: () => void; // refetch at the page level after a mutation
 }
-
-const money = (n: number): string =>
-  `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
 
 // Manages the obligations list. Their dollar/break-even impact now shows in the
 // page's headline KPIs (obligations are folded into true cost); this card is

--- a/frontend/src/components/fleet/PayoffTracker.tsx
+++ b/frontend/src/components/fleet/PayoffTracker.tsx
@@ -1,8 +1,8 @@
 import { Truck, Container, Flag } from "lucide-react";
 import type { Obligation } from "@/types/obligation";
 import { computePayoff } from "@/lib/metrics/payoff";
+import { money } from "@/lib/format";
 
-const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 const monthYear = (iso: string) => {
   const d = new Date(iso.slice(0, 10) + "T00:00:00Z");

--- a/frontend/src/components/fuel/DieselCompareCard.tsx
+++ b/frontend/src/components/fuel/DieselCompareCard.tsx
@@ -1,8 +1,7 @@
 import type { NationalDiesel } from "@/types/fuelEntry";
 import { Stamp } from "@/components/Stamp";
 import { Panel } from "@/components/ui/Panel";
-
-const money3 = (n: number) => `$${n.toFixed(3)}`;
+import { dieselPrice } from "@/lib/format";
 
 const fmtWeek = (d: string) =>
   new Date(d + "T00:00:00Z").toLocaleDateString("en-US", {
@@ -46,13 +45,13 @@ export const DieselCompareCard = ({
         <div>
           <p className="text-xs text-muted-text">National avg</p>
           <p className="text-2xl font-condensed mt-1 text-light">
-            {money3(national.value)}
+            {dieselPrice(national.value)}
           </p>
         </div>
         <div>
           <p className="text-xs text-muted-text">Your avg / gal</p>
           <p className="text-2xl font-condensed mt-1 text-light">
-            {yourCostPerGallon == null ? "—" : money3(yourCostPerGallon)}
+            {yourCostPerGallon == null ? "—" : dieselPrice(yourCostPerGallon)}
           </p>
         </div>
         <div>

--- a/frontend/src/components/fuel/DieselPriceChart.tsx
+++ b/frontend/src/components/fuel/DieselPriceChart.tsx
@@ -10,8 +10,8 @@ import {
 } from "recharts";
 import type { DieselMonth } from "@/lib/metrics/fuelEconomy";
 import { Panel } from "@/components/ui/Panel";
+import { dieselPrice } from "@/lib/format";
 
-const money3 = (n: number) => `$${n.toFixed(3)}`;
 const label = (key: string) => (key === "you" ? "Your avg" : "National (EIA)");
 
 // You vs. national retail diesel, monthly. Your line is gallon-weighted from the
@@ -57,7 +57,7 @@ export const DieselPriceChart = ({ data }: { data: DieselMonth[] }) => (
               fontSize: 12,
             }}
             formatter={(v, name) => [
-              v == null ? "—" : money3(Number(v)),
+              v == null ? "—" : dieselPrice(Number(v)),
               label(String(name)),
             ]}
           />

--- a/frontend/src/components/fuel/FuelVsRevenueCard.tsx
+++ b/frontend/src/components/fuel/FuelVsRevenueCard.tsx
@@ -1,8 +1,8 @@
 import type { FuelVsRevenue, FuelMonth } from "@/lib/metrics/fuelRevenue";
 import { Panel } from "@/components/ui/Panel";
 import { Stamp } from "@/components/Stamp";
+import { money } from "@/lib/format";
 
-const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const pct0 = (n: number) => `${Math.round(n * 100)}%`;
 
 const monthLabel = (ym: string, opts: Intl.DateTimeFormatOptions) =>
@@ -103,8 +103,8 @@ export const FuelVsRevenueCard = ({ data }: { data: FuelVsRevenue }) => {
             {m.fuelPctNet == null ? "—" : pct0(m.fuelPctNet)}
           </p>
           <p className="text-[11px] text-muted-text mt-0.5">
-            {money0(m.fuelSpend)}
-            {m.net > 0 ? ` of ${money0(m.net)} net` : ""}
+            {money(m.fuelSpend)}
+            {m.net > 0 ? ` of ${money(m.net)} net` : ""}
           </p>
         </div>
 
@@ -131,8 +131,8 @@ export const FuelVsRevenueCard = ({ data }: { data: FuelVsRevenue }) => {
             className="text-[11px] mt-0.5"
             style={{ color: covered ? "#9daabb" : "#f2a6a3" }}
           >
-            {money0(m.fsc)} FSC vs {money0(m.fuelSpend)} fuel
-            {gap != null && gap < 0 ? ` · ${money0(gap)} from linehaul` : ""}
+            {money(m.fsc)} FSC vs {money(m.fuelSpend)} fuel
+            {gap != null && gap < 0 ? ` · ${money(gap)} from linehaul` : ""}
           </p>
         </div>
       </div>

--- a/frontend/src/components/lanes/StateDetailPanel.tsx
+++ b/frontend/src/components/lanes/StateDetailPanel.tsx
@@ -2,8 +2,8 @@ import { Link } from "react-router-dom";
 import { X } from "lucide-react";
 import { Panel } from "@/components/ui/Panel";
 import type { StateDetail } from "@/lib/metrics/lanes";
+import { rpm } from "@/lib/format";
 
-const rpm = (n: number | null) => (n == null ? "—" : `$${n.toFixed(2)}`);
 const pct = (n: number | null) => (n == null ? "—" : `${Math.round(n * 100)}%`);
 const otColor = (n: number | null) =>
   n == null ? "#8b93a3" : n >= 0.9 ? "#4ade80" : n >= 0.7 ? "#e0a020" : "#f87171";

--- a/frontend/src/components/lanes/rpmStyle.ts
+++ b/frontend/src/components/lanes/rpmStyle.ts
@@ -1,11 +1,11 @@
 import { BREAK_EVEN_RPM } from "@/lib/constants/targets";
+import { rpm } from "@/lib/format";
 
 // A lane is "strong" comfortably above break-even, "thin" between break-even
 // and strong, "below" under break-even. Mirrors the mockup's three tiers.
 const STRONG_RPM = 3.2;
 
-export const fmtRpm = (n: number | null): string =>
-  n === null ? "—" : `$${n.toFixed(2)}`;
+export const fmtRpm = rpm;
 
 export const rpmTextClass = (n: number | null): string => {
   if (n === null) return "text-muted-text";

--- a/frontend/src/components/maintenance/ServicesTab.tsx
+++ b/frontend/src/components/maintenance/ServicesTab.tsx
@@ -9,17 +9,13 @@ import {
 import { ServiceForm } from "./ServiceForm";
 import { Stamp } from "@/components/Stamp";
 import { Panel } from "@/components/ui/Panel";
+import { moneyCents } from "@/lib/format";
 
 interface Props {
   services: MaintenanceService[];
   items: MaintenanceItem[];
   onChange: () => void;
 }
-
-const money = (n: number | null): string =>
-  n == null
-    ? "—"
-    : `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
 const num = (n: number | null) => (n == null ? "—" : n.toLocaleString("en-US"));
 
@@ -210,7 +206,7 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
           ))}
           <span className="text-xs text-muted-text ml-auto">
             {filtered.length} service{filtered.length !== 1 ? "s" : ""} ·{" "}
-            {money(rangeTotal)}
+            {moneyCents(rangeTotal)}
           </span>
         </div>
         {mode === "custom" && (
@@ -264,9 +260,9 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
                 <tr key={vendor} className="border-t border-steel">
                   <td className="py-1.5">{vendor}</td>
                   <td className="py-1.5 text-right text-muted-text">{v.count}</td>
-                  <td className="py-1.5 text-right">{money(v.total)}</td>
+                  <td className="py-1.5 text-right">{moneyCents(v.total)}</td>
                   <td className="py-1.5 text-right text-muted-text">
-                    {v.priced ? money(v.total / v.priced) : "—"}
+                    {v.priced ? moneyCents(v.total / v.priced) : "—"}
                   </td>
                 </tr>
               ))}
@@ -326,7 +322,7 @@ export const ServicesTab = ({ services, items, onChange }: Props) => {
                       </span>
                     )}
                   </td>
-                  <td className="py-2 text-right whitespace-nowrap">{money(s.cost)}</td>
+                  <td className="py-2 text-right whitespace-nowrap">{moneyCents(s.cost)}</td>
                   <td className="py-2 text-right">
                     <Trash2
                       size={15}

--- a/frontend/src/components/playercard/DispatcherCard.tsx
+++ b/frontend/src/components/playercard/DispatcherCard.tsx
@@ -5,6 +5,7 @@ import { RANK_TIERS } from "@/lib/metrics/dispatcherCard";
 import type { Grade } from "@/lib/metrics/playerCard";
 import type { Medal } from "@/lib/awards/medals";
 import { MedalBadge } from "@/components/awards/MedalBadge";
+import { rpm } from "@/lib/format";
 
 interface Props {
   name: string;
@@ -20,7 +21,6 @@ const gross = (n: number): string => {
   const k = n / 1000;
   return `$${k < 100 ? k.toFixed(1) : Math.round(k)}k`;
 };
-const rpm = (n: number | null): string => (n == null ? "—" : `$${n.toFixed(2)}`);
 const hrs = (min: number): string => `${(min / 60).toFixed(1)}h`;
 const pct = (r: number | null): string => (r == null ? "—" : `${Math.round(r * 100)}%`);
 

--- a/frontend/src/components/playercard/PlayerCard.tsx
+++ b/frontend/src/components/playercard/PlayerCard.tsx
@@ -9,8 +9,8 @@ import { fmtMiles } from "@/lib/metrics/mileClub";
 import { RANK_TIERS } from "@/lib/constants/playerCard";
 import { DEADHEAD_TARGET } from "@/lib/constants/targets";
 import { MedalBadge } from "@/components/awards/MedalBadge";
+import { money } from "@/lib/format";
 
-const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const pct1 = (n: number) => `${(n * 100).toFixed(1)}%`;
 const pct0 = (n: number) => `${Math.round(n * 100)}%`;
 
@@ -358,9 +358,9 @@ export const PlayerCard = ({
         <span className="text-[11px] text-muted-text">· {season.label} · your last 3 complete months</span>
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-        <Stat label="Net revenue" value={money0(season.netRevenue)} sub="net of carrier cut" />
-        <Stat label="Operating profit" value={money0(season.netProfit)} color={profitColor(season.netProfit)} sub="before obligations" />
-        <Stat label="True net" value={money0(season.trueNet)} color={profitColor(season.trueNet)} sub="what you keep, before draw" />
+        <Stat label="Net revenue" value={money(season.netRevenue)} sub="net of carrier cut" />
+        <Stat label="Operating profit" value={money(season.netProfit)} color={profitColor(season.netProfit)} sub="before obligations" />
+        <Stat label="True net" value={money(season.trueNet)} color={profitColor(season.trueNet)} sub="what you keep, before draw" />
         <Stat label="Loads" value={String(season.loads)} />
         <Stat label="Miles" value={Math.round(season.totalMiles).toLocaleString("en-US")} />
         <Stat label="Deadhead" value={season.deadheadPct != null ? pct1(season.deadheadPct) : "—"} color={deadheadColor(season.deadheadPct)} />

--- a/frontend/src/components/recap/RecapPoster.tsx
+++ b/frontend/src/components/recap/RecapPoster.tsx
@@ -1,10 +1,10 @@
 import { Truck, MapPin, Star, Crown, Leaf } from "lucide-react";
 import type { RecapStats } from "@/lib/metrics/recap";
 import { RECAP_TIERS } from "@/lib/constants/recapTiers";
+import { money } from "@/lib/format";
 
 const kMoney = (n: number) =>
   n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${Math.round(n)}`;
-const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const num = (n: number) => Math.round(n).toLocaleString("en-US");
 
 const Pips = ({ n, color }: { n: number; color: string }) => (
@@ -165,7 +165,7 @@ export const RecapPoster = ({
 
         {rich && stats.netProfit != null && (
           <div className="flex gap-2 mb-2">
-            <Tile value={money0(stats.netProfit)} label="NET PROFIT" color="#4ade80" />
+            <Tile value={money(stats.netProfit)} label="NET PROFIT" color="#4ade80" />
             {stats.bestMonth && <Tile value={stats.bestMonth.label.split(" ")[0]} label="BEST MONTH" color="#4ade80" />}
             {stats.hardestMonth && <Tile value={stats.hardestMonth.label.split(" ")[0]} label="HARDEST" color="#f87171" />}
           </div>

--- a/frontend/src/lib/awards/patches.ts
+++ b/frontend/src/lib/awards/patches.ts
@@ -8,6 +8,7 @@ import type { FuelEntry } from "@/types/fuelEntry";
 import { loadGross, loadRevenue } from "@/lib/metrics/rateTargets";
 import { formatInches } from "@/lib/dimensions";
 import { computeStack, type BarOpts } from "./adaptiveBar";
+import { money } from "@/lib/format";
 
 export interface Patch {
   key: string;
@@ -80,8 +81,6 @@ const ADAPTIVE: {
   { key: "big-ticket", name: "Big Ticket", icon: "cash", unit: "money", opts: { n: 5, floor: 7000 }, value: (l) => loadGross(l) },
   { key: "long-hauler", name: "Long Hauler", icon: "road", unit: "miles", opts: { n: 5, floor: 1200 }, value: (l) => Number(l.loaded_miles) || 0 },
 ];
-
-const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 
 export const computePatches = (
   loads: Load[],

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -10,3 +10,25 @@ export const formatDate = (v: string | null | undefined): string | null => {
     timeZone: "UTC",
   });
 };
+
+// ---- Money ----
+// The app's default: whole-dollar money for aggregates, totals, and per-load
+// amounts shown in lists. null/undefined → "—".
+export const money = (n: number | null | undefined): string =>
+  n == null ? "—" : `$${Math.round(n).toLocaleString("en-US")}`;
+
+// Full currency WITH cents — reserved for an individual load's detail line items
+// and receipt-level amounts (fuel). null/undefined → "—".
+export const moneyCents = (n: number | null | undefined): string =>
+  n == null
+    ? "—"
+    : n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+
+// A per-mile rate ($/mi) — always two decimals. null/undefined → "—".
+export const rpm = (n: number | null | undefined): string =>
+  n == null ? "—" : `$${n.toFixed(2)}`;
+
+// A diesel pump price ($/gal) — three decimals, the fuel-industry convention
+// (e.g. "$3.859"). null/undefined → "—".
+export const dieselPrice = (n: number | null | undefined): string =>
+  n == null ? "—" : `$${n.toFixed(3)}`;

--- a/frontend/src/lib/metrics/awards.ts
+++ b/frontend/src/lib/metrics/awards.ts
@@ -21,6 +21,7 @@ import { computeMedals } from "@/lib/awards/medals";
 import type { TrophyDef } from "@/lib/trophies/catalog";
 import type { TrophyStatus } from "@/lib/trophies/status";
 import type { Trophy } from "@/types/trophy";
+import { money } from "@/lib/format";
 
 // Grandest → smallest. trophy = career Hall monument; medal = a tier-up; recap = a
 // period close; patch = a stacked hard feat; record = a new personal best.
@@ -37,7 +38,6 @@ export interface Award {
   medalTier?: number; // medal tier — drives the medallion metal (1/2/3)
 }
 
-const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const kMoney = (n: number) => (n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${Math.round(n)}`);
 
 export interface AwardInputs {

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -40,13 +40,7 @@ import { loadRevenue } from "@/lib/metrics/loads";
 import { Panel } from "@/components/ui/Panel";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatCardsSkeleton, BlockSkeleton } from "@/components/ui/PageSkeletons";
-
-const money0 = (n: number) =>
-  n.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  });
+import { money } from "@/lib/format";
 
 const fmtDate = (d?: string | null) =>
   d
@@ -224,7 +218,7 @@ const AgentDetailPage = () => {
         <Kpi label="Loads" value={String(getLoadCount(loads))} />
         <Kpi
           label="Gross revenue"
-          value={grossRev == null ? "—" : money0(grossRev)}
+          value={grossRev == null ? "—" : money(grossRev)}
         />
         <Kpi
           label="Avg rate/mile"
@@ -317,7 +311,7 @@ const AgentDetailPage = () => {
                       {fmtDate(load.pickup_date)}
                     </td>
                     <td className="py-2 pr-4 text-right whitespace-nowrap">
-                      {money0(loadRevenue(load))}
+                      {money(loadRevenue(load))}
                     </td>
                     <td className="py-2">
                       <StatusBadge value={load.payment_status} />

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -13,13 +13,7 @@ import {
   rosterKpis,
   currentQuarterStandings,
 } from "@/lib/metrics/agentLeaderboard";
-
-const money0 = (n: number) =>
-  n.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  });
+import { money } from "@/lib/format";
 
 type SortKey = "rating" | "revenue" | "recent";
 const SORTS: [SortKey, string][] = [
@@ -131,7 +125,7 @@ const AgentsPage = () => {
             <Kpi
               label="Top earner"
               value={`${top.first_name.charAt(0)}. ${top.last_name}`}
-              sub={`${money0(kpis.topEarner!.revenue)} · 90 days`}
+              sub={`${money(kpis.topEarner!.revenue)} · 90 days`}
             />
           </Link>
         ) : (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -42,16 +42,9 @@ import { WhatsNext } from "@/components/dashboard/WhatsNext";
 import { RecentLoads } from "@/components/dashboard/RecentLoads";
 import { isDispatcher } from "@/lib/roles";
 import DispatchDashboard from "./DispatchDashboard";
+import { money, rpm } from "@/lib/format";
 
 // helpers
-const formatCurrency = (n: number | null): string =>
-  n === null
-    ? "—"
-    : n.toLocaleString("en-US", { style: "currency", currency: "USD" });
-
-const formatRpm = (n: number | null): string =>
-  n === null ? "—" : `$${n.toFixed(2)}`;
-
 const formatPercent = (ratio: number | null): string =>
   ratio === null ? "—" : `${(ratio * 100).toFixed(1)}%`;
 
@@ -171,17 +164,17 @@ const OwnerDashboard = () => {
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
         <KpiCard
           label="Net revenue · MTD"
-          value={formatCurrency(revenueMTD)}
+          value={money(revenueMTD)}
           delta={mtdDelta}
         />
         <KpiCard
           label="Net revenue · YTD"
-          value={formatCurrency(revenueYTD)}
+          value={money(revenueYTD)}
           trend={revenueTrend}
         />
         <KpiCard
           label="Net RPM · 3mo"
-          value={formatRpm(avgRpm)}
+          value={rpm(avgRpm)}
           status={rpmStatus}
           trend={rpmTrend}
           subtext={

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -19,7 +19,7 @@ import { useTrips } from "@/hooks/useTrips";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { DRIVER_FIELDS, toFormValues } from "@/lib/fleetFields";
-import { formatDate } from "@/lib/format";
+import { formatDate, money } from "@/lib/format";
 import { Panel } from "@/components/ui/Panel";
 import {
   getCostBasis,
@@ -51,8 +51,6 @@ import { assetLoanStatus } from "@/lib/metrics/payoff";
 import { PlayerCard } from "@/components/playercard/PlayerCard";
 import { RecordBook, driverRecordChips } from "@/components/awards/RecordBook";
 import { PatchBoard } from "@/components/awards/PatchBoard";
-
-const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 
 const Spec = ({
   label,

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -29,9 +29,7 @@ import { ObligationsCard } from "@/components/expenses/ObligationsCard";
 import { Panel } from "@/components/ui/Panel";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { StatCardsSkeleton, BlockSkeleton } from "@/components/ui/PageSkeletons";
-
-const money = (n: number): string =>
-  `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+import { money } from "@/lib/format";
 
 // That month's miles from loads (drives cost-per-mile + break-even).
 const monthMiles = (loads: Load[], periodMonth: string) => {

--- a/frontend/src/pages/FuelEntriesPage.tsx
+++ b/frontend/src/pages/FuelEntriesPage.tsx
@@ -26,10 +26,8 @@ import { MpgChart } from "@/components/fuel/MpgChart";
 import { DieselPriceChart } from "@/components/fuel/DieselPriceChart";
 import { DieselCompareCard } from "@/components/fuel/DieselCompareCard";
 import { FuelVsRevenueCard } from "@/components/fuel/FuelVsRevenueCard";
+import { money, moneyCents } from "@/lib/format";
 
-const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
-const money2 = (n: number) =>
-  n.toLocaleString("en-US", { style: "currency", currency: "USD" });
 const fmtDate = (d: string) =>
   new Date(d.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", {
     month: "short",
@@ -239,14 +237,14 @@ const FuelEntriesPage = () => {
         <Kpi
           label="Avg weekly · 90d"
           value={
-            stats.avgWeeklyCost90 == null ? "—" : money0(stats.avgWeeklyCost90)
+            stats.avgWeeklyCost90 == null ? "—" : money(stats.avgWeeklyCost90)
           }
         />
         <Kpi
           label="Total gallons"
           value={Math.round(stats.totalGallons).toLocaleString("en-US")}
         />
-        <Kpi label="Total spend" value={money0(stats.totalSpend)} />
+        <Kpi label="Total spend" value={money(stats.totalSpend)} />
       </div>
 
       <DieselCompareCard
@@ -468,7 +466,7 @@ const FuelEntriesPage = () => {
                       ${e.price_per_gallon.toFixed(3)}
                     </td>
                     <td className="py-2 pr-4 text-right whitespace-nowrap">
-                      {money2(entryCost(e))}
+                      {moneyCents(entryCost(e))}
                     </td>
                     <td className="py-2 pr-4 text-right whitespace-nowrap">
                       {full && mpg != null ? mpg.toFixed(2) : "—"}

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -65,15 +65,7 @@ import { fuelStats } from "@/lib/metrics/fuelEconomy";
 import { getFuelEntries } from "@/services/fuelService";
 import type { FuelEntry } from "@/types/fuelEntry";
 import { fmtRpm, rpmTextClass } from "@/components/lanes/rpmStyle";
-
-const money0 = (n: number) =>
-  n.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  });
-const money2 = (n: number) =>
-  n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+import { money, moneyCents } from "@/lib/format";
 
 const fmtDate = (d?: string | null) =>
   d
@@ -492,7 +484,7 @@ export const LoadDetailPage = () => {
           <Ban size={20} style={{ color: "#f2a6a3" }} />
           <div className="flex-1 min-w-[180px]">
             <p className="font-condensed text-lg" style={{ color: "#f2a6a3" }}>
-              TONU fee owed · {money0(revenue)}
+              TONU fee owed · {money(revenue)}
             </p>
             <p className="text-[11px] text-muted-text">
               Truck ordered, not used. Collect the fee, then mark it.
@@ -586,7 +578,7 @@ export const LoadDetailPage = () => {
       )}
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <Kpi label="Total revenue" value={money0(revenue)} />
+        <Kpi label="Total revenue" value={money(revenue)} />
         <Kpi
           label="Rate / mile"
           value={fmtRpm(rpm)}
@@ -705,25 +697,25 @@ export const LoadDetailPage = () => {
 
         <Panel className="p-4">
           <p className={cardLbl}>Revenue</p>
-          <Row label="Linehaul" value={money2(Number(load.linehaul))} />
+          <Row label="Linehaul" value={moneyCents(Number(load.linehaul))} />
           <Row
             label="Fuel surcharge"
-            value={money2(Number(load.fuel_surcharge))}
+            value={moneyCents(Number(load.fuel_surcharge))}
           />
           <Row
             label="Accessorials"
-            value={money2(Number(load.total_accessorials))}
+            value={moneyCents(Number(load.total_accessorials))}
           />
           <div className="flex justify-between border-t border-steel mt-1.5 pt-1.5 text-sm">
             <span>Total rate</span>
-            <span className="font-condensed text-base">{money2(revenue)}</span>
+            <span className="font-condensed text-base">{moneyCents(revenue)}</span>
           </div>
           {Math.abs(net - revenue) > 0.005 && (
             <>
               <div className="flex justify-between mt-1 text-sm">
                 <span className="text-status-positive-text">Your net</span>
                 <span className="font-condensed text-base text-status-positive-text">
-                  {money2(net)}
+                  {moneyCents(net)}
                 </span>
               </div>
               <p className="text-[11px] text-muted-text mt-1">
@@ -880,7 +872,7 @@ export const LoadDetailPage = () => {
           </div>
           {fuel ? (
             <>
-              <Row label="Fuel cost" value={money2(fuel.cost)} />
+              <Row label="Fuel cost" value={moneyCents(fuel.cost)} />
               <Row
                 label="Miles"
                 value={`${fuel.miles.toLocaleString("en-US")} mi`}
@@ -963,7 +955,7 @@ export const LoadDetailPage = () => {
         <div className="flex justify-between items-center mb-2">
           <p className={`${cardLbl} mb-0`}>Accessorials</p>
           <span className="text-xs text-muted-text">
-            Total {money2(accTotal)}
+            Total {moneyCents(accTotal)}
           </span>
         </div>
 
@@ -1005,7 +997,7 @@ export const LoadDetailPage = () => {
                           }
                         />
                       ) : (
-                        money2(Number(a.amount))
+                        moneyCents(Number(a.amount))
                       )}
                     </td>
                     <td className="py-2">

--- a/frontend/src/pages/LoadsPage.tsx
+++ b/frontend/src/pages/LoadsPage.tsx
@@ -25,13 +25,7 @@ import {
   detentionCollected,
   type LoadFlag,
 } from "@/lib/detention";
-
-const money = (n: number) =>
-  n.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  });
+import { money } from "@/lib/format";
 
 // Date-only, UTC-safe (Postgres dates would otherwise shift a day in local tz).
 const fmtDate = (d: string) =>

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -23,6 +23,7 @@ import {
   type RatePoint,
 } from "@/lib/metrics/marketAnalytics";
 import { marketTrend, youVsMarket } from "@/lib/metrics/marketSignal";
+import { rpm } from "@/lib/format";
 
 const MACRO = "#7fb2e6"; // FRED PPI overlay line
 
@@ -34,7 +35,6 @@ const COLOR: Record<RatePoint["bucket"], string> = {
 const BE = "#e0533a";
 const GRID = "#2a3347";
 const MUTED = "#9daabb";
-const money2 = (n: number) => `$${n.toFixed(2)}`;
 const monthTick = (ym: string) =>
   new Date(ym + "-01T00:00:00Z").toLocaleDateString("en-US", {
     month: "short",
@@ -77,7 +77,7 @@ const RateScatter = ({
         strokeWidth={label === "break-even" ? 1.6 : 1.2}
         strokeDasharray={label === "break-even" ? undefined : "5 3"}
         ifOverflow="extendDomain"
-        label={{ value: `${label} ${money2(v)}`, position: "right", fill: color, fontSize: 10 }}
+        label={{ value: `${label} ${rpm(v)}`, position: "right", fill: color, fontSize: 10 }}
       />
     );
 
@@ -109,7 +109,7 @@ const RateScatter = ({
         <Tooltip
           cursor={{ stroke: GRID }}
           contentStyle={{ background: "#1c2333", border: "1px solid #2a3347", borderRadius: 8, fontSize: 12 }}
-          formatter={(value, name) => [money2(Number(value)), name === "y" ? "rate/mi" : String(name)]}
+          formatter={(value, name) => [rpm(Number(value)), name === "y" ? "rate/mi" : String(name)]}
           labelFormatter={(v) => new Date(v as number).toLocaleDateString("en-US", { timeZone: "UTC" })}
         />
         {refLine(ladder.walkAway, BE, "break-even")}
@@ -177,7 +177,7 @@ const Barometer = ({
         contentStyle={{ background: "#1c2333", border: "1px solid #2a3347", borderRadius: 8, fontSize: 12 }}
         labelFormatter={(m) => monthTick(m as string)}
         formatter={(v, name) =>
-          name === "ppi" ? [`${Number(v).toFixed(1)} idx`, "FRED PPI"] : [money2(Number(v)), "your median"]
+          name === "ppi" ? [`${Number(v).toFixed(1)} idx`, "FRED PPI"] : [rpm(Number(v)), "your median"]
         }
       />
       {breakEven != null && (
@@ -188,7 +188,7 @@ const Barometer = ({
           strokeWidth={1.4}
           strokeDasharray="4 3"
           ifOverflow="extendDomain"
-          label={{ value: `break-even ${money2(breakEven)}`, position: "insideTopLeft", fill: BE, fontSize: 10 }}
+          label={{ value: `break-even ${rpm(breakEven)}`, position: "insideTopLeft", fill: BE, fontSize: 10 }}
         />
       )}
       {hasPpi && (
@@ -382,7 +382,7 @@ const MarketPage = () => {
                         <div className="flex justify-between text-xs">
                           <span className="text-light">
                             {r.label}{" "}
-                            <span className="text-muted-text">{money2(r.value)}</span>
+                            <span className="text-muted-text">{rpm(r.value)}</span>
                           </span>
                           <span className="tabular-nums" style={{ color: toneColor }}>
                             {Math.round(r.pctile * 100)}

--- a/frontend/src/pages/PerDiemPage.tsx
+++ b/frontend/src/pages/PerDiemPage.tsx
@@ -16,11 +16,10 @@ import {
 } from "@/lib/perDiem";
 import type { PerDiemStatus } from "@/types/perDiem";
 import { Panel } from "@/components/ui/Panel";
+import { money, moneyCents } from "@/lib/format";
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 const pad = (n: number) => String(n).padStart(2, "0");
-const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
-const money2 = (n: number) => `$${n.toFixed(2)}`;
 
 const AMBER = "#e8940a";
 const HALF_BG = `linear-gradient(135deg, ${AMBER} 0 50%, #2a3347 50% 100%)`;
@@ -161,7 +160,7 @@ const PerDiemPage = () => {
             style={{ background: "#0d1119", border: "1px solid #22304a" }}
           >
             ({summary.fullDays} × {money(rate)} + {summary.halfDays} ×{" "}
-            {money2(rate * 0.75)}) × {Math.round(deductPct * 100)}%
+            {moneyCents(rate * 0.75)}) × {Math.round(deductPct * 100)}%
           </div>
 
           <p className="text-[11px] text-muted-text mt-2">

--- a/frontend/src/pages/ScoreLoadPage.tsx
+++ b/frontend/src/pages/ScoreLoadPage.tsx
@@ -13,9 +13,7 @@ import { getLastKnownLocation } from "@/services/tripsService";
 import { toInches, classifyOversize } from "@/lib/dimensions";
 import MissionMap from "@/components/MissionMap";
 import CityAutocomplete from "@/components/CityAutocomplete";
-
-const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
-const rpm = (n: number | null) => (n != null ? `$${n.toFixed(2)}` : "—");
+import { money, rpm } from "@/lib/format";
 
 // Where the load sits on the PASS | MEH | TAKE IT | STEAL bar (0–100%).
 const markerPct = (
@@ -285,8 +283,6 @@ const ScoreLoadPage = () => {
   const belowTarget = score.verdict === "pass" || score.verdict === "meh";
   const counter =
     belowTarget ? counterRates(score.breakevenRpm, score.drivenMiles, activeTiers) : null;
-  const money0 = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
-
   const routeNote = routing
     ? "routing…"
     : routeErr
@@ -405,7 +401,7 @@ const ScoreLoadPage = () => {
         {toll != null && (
           <div className="flex items-center gap-2 mt-2 mb-1 px-3 py-2 rounded-[9px]" style={{ background: "#141b28" }}>
             <span className="text-[13px]" style={{ color: "#cdd8e8" }}>
-              Est. tolls <span style={{ color: "#f4f7fb", fontWeight: 600 }}>≈ {money0(toll)}</span>
+              Est. tolls <span style={{ color: "#f4f7fb", fontWeight: 600 }}>≈ {money(toll)}</span>
             </span>
             <span className="ml-auto text-[10px]" style={{ color: "#5f6b80" }}>
               bill as accessorial · Landstar pays 100%
@@ -521,17 +517,17 @@ const ScoreLoadPage = () => {
                 <div className="flex gap-2">
                   <div className="flex-1 text-center rounded-[8px] py-2" style={{ background: "#141b28" }}>
                     <div className="text-[9px]" style={{ color: "#f87171" }}>FLOOR</div>
-                    <div className="text-base font-semibold" style={{ color: "#cdd8e8" }}>{money0(counter.floor)}</div>
+                    <div className="text-base font-semibold" style={{ color: "#cdd8e8" }}>{money(counter.floor)}</div>
                     <div className="text-[8.5px]" style={{ color: "#5f6b80" }}>break-even</div>
                   </div>
                   <div className="flex-1 text-center rounded-[8px] py-2" style={{ background: "#12261a", border: "1px solid #1a5c3a" }}>
                     <div className="text-[9px]" style={{ color: "#4ade80" }}>TAKE IT</div>
-                    <div className="text-base font-semibold" style={{ color: "#4ade80" }}>{money0(counter.take)}</div>
+                    <div className="text-base font-semibold" style={{ color: "#4ade80" }}>{money(counter.take)}</div>
                     <div className="text-[8.5px]" style={{ color: "#5f8a6e" }}>fair</div>
                   </div>
                   <div className="flex-1 text-center rounded-[8px] py-2" style={{ background: "#231d06", border: "1px solid #6b5410" }}>
                     <div className="text-[9px]" style={{ color: "#fbbf24" }}>STEAL</div>
-                    <div className="text-base font-semibold" style={{ color: "#fbbf24" }}>{money0(counter.steal)}</div>
+                    <div className="text-base font-semibold" style={{ color: "#fbbf24" }}>{money(counter.steal)}</div>
                     <div className="text-[8.5px]" style={{ color: "#9a7f2e" }}>open here</div>
                   </div>
                 </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { useRateTargets } from "@/hooks/useRateTargets";
 import { AccessorialRatesCard } from "@/components/settings/AccessorialRatesCard";
 import { TeamCard } from "@/components/settings/TeamCard";
 import { Panel } from "@/components/ui/Panel";
+import { money } from "@/lib/format";
 
 type Tier3 = { min: number; target: number; strong: number };
 const pct = (x: number) => Math.round(x * 1000) / 10; // fraction → clean percent
@@ -74,9 +75,6 @@ const TierCard = ({
     </div>
   );
 };
-
-const money = (n: number) =>
-  `$${n.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
 
 // A sample load for the live preview, so the effect of the percentages is visible.
 const SAMPLE_LINEHAUL = 2000;

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -33,10 +33,9 @@ import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
 import { TRAILER_FIELDS, toFormValues } from "@/lib/fleetFields";
-import { formatDate } from "@/lib/format";
+import { formatDate, money } from "@/lib/format";
 import { Panel } from "@/components/ui/Panel";
 
-const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const num = (n: number) => Math.round(n).toLocaleString("en-US");
 
 // One tile in the trailer-metrics strip.

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -41,10 +41,9 @@ import { EntityAvatar } from "@/components/fleet/EntityAvatar";
 import { EntityForm } from "@/components/fleet/EntityForm";
 import { MileClub } from "@/components/fleet/MileClub";
 import { TRUCK_FIELDS, toFormValues } from "@/lib/fleetFields";
-import { formatDate } from "@/lib/format";
+import { formatDate, money } from "@/lib/format";
 import { Panel } from "@/components/ui/Panel";
 
-const money = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
 const num = (n: number) => Math.round(n).toLocaleString("en-US");
 
 // One tile in the truck-metrics strip.


### PR DESCRIPTION
## What

Polish track #4 (consistency sweep) — the money-formatting half. Replaces ~35 duplicate local money/rate formatters across **37 files** with **four shared helpers** in `lib/format.ts`:

| helper | output | use |
|---|---|---|
| `money(n)` | `$23,944` | aggregates / totals / list amounts (default) |
| `moneyCents(n)` | `$23,944.00` | receipt & line-item detail |
| `rpm(n)` | `$2.50` | per-mile rates |
| `dieselPrice(n)` | `$3.859` | pump price / gallon |

All null-safe → `—`. Grep confirms **zero** local money/rate formatters remain.

## Visible changes (only two — both verified live)
1. **Dashboard revenue KPIs drop cents** — `$23,944.00 → $23,944`, `$124,470.31 → $124,470`. RPM keeps 2 decimals (`$2.50`). This is the cents-rule: whole dollars for aggregates.
2. **Maintenance service costs keep cents** — `$924.23`, avg `$462.12` (receipt-level detail).

Everything else is **byte-identical output** — pure dedup, no visible change.

## Verify
- Strict build green; 417/417 tests pass.
- `grep` clean (no local `money*`/`formatCurrency`/`formatRpm`/`perMile`/`rate` formatters left).
- Both visible changes screenshotted on the dev preview.

## Out of scope (future pass)
Distinct format families intentionally not folded in: compact `$Xk`/`$XM` award/trophy formatters, percent helpers, and inline `$${x.toFixed(2)}` rate expressions (already consistent; invasive to convert). Also spotted: `MetricStrip`/`MetricCard` is dead/unused code.

No Guide update needed — internal refactor + display-consistency fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)