### PR TITLE
fix: read P&L month from the title on single-period exports (v1.124.2)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.124.1",
+  "version": "1.124.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/pnl/parsePnl.test.ts
+++ b/frontend/src/lib/pnl/parsePnl.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parsePnlRows, classifyExpenses, cleanNum } from "./parsePnl";
+import { labelToMonth } from "./parseFile";
 
 // A faithful miniature of the real QuickBooks P&L structure: a parent with a
 // direct amount + children + total, a nested group, standalones, a COGS group,
@@ -135,5 +136,59 @@ describe("parsePnlRows — single-month file (the normal case)", () => {
     );
     expect(byName["Insurance"]).toBe("fixed"); // keyword
     expect(byName["Wages"]).toBe("variable"); // unknown mover → variable
+  });
+});
+
+// The format QuickBooks actually exports for a SINGLE period (no comparison
+// column): the month lives in the title's first cell ("July 2026"), the data
+// column header is just "Total", and a timestamp footer trails the report.
+// Regression for "Couldn't read the month from this file" — period_month was
+// coming back null because the month wasn't in a blank-first-cell header row.
+const SINGLE_PERIOD_TITLE_MONTH: string[][] = [
+  ["Delgado Trucking Services", ""],
+  ["Profit and Loss", ""],
+  ["July 2026", ""],
+  [""],
+  ["", "Total"],
+  ["Income", ""],
+  ["Landstar Commissions", "-1,000.00"],
+  ["Truck Revenue", ""],
+  ["Line Haul", "6,000.00"],
+  ["Total for Truck Revenue", "$6,000.00"],
+  ["Total for Income", "$5,000.00"],
+  ["Cost of Goods Sold", ""],
+  ["Cost of goods sold", ""],
+  ["Fuel", "400.00"],
+  ["Total for Cost of goods sold", "$400.00"],
+  ["Total for Cost of Goods Sold", "$400.00"],
+  ["Gross Profit", "$4,600.00"],
+  ["Expenses", ""],
+  ["Insurance", ""],
+  ["CPP", "125.00"],
+  ["Total for Insurance", "$125.00"],
+  ["Wages", "700.00"],
+  ["Total for Expenses", "$825.00"],
+  ["Net Operating Income", "$3,775.00"],
+  ["Net Income", "$3,775.00"],
+  [""],
+  ["Accrual Basis Sunday, August 02, 2026 06:22 PM GMT-04:00", ""],
+];
+
+describe("parsePnlRows — single-period export (month in the title, no comparison column)", () => {
+  const parsed = parsePnlRows(SINGLE_PERIOD_TITLE_MONTH);
+
+  it("recovers the month from the title, not the timestamp footer", () => {
+    expect(parsed.currentLabel).toBe("July 2026");
+    expect(labelToMonth(parsed.currentLabel)).toBe("2026-07-01"); // the check the upload makes
+    expect(parsed.priorLabel).toBeNull();
+  });
+
+  it("still parses totals and expense lines from the single Total column", () => {
+    expect(parsed.incomeTotal).toBe(5000);
+    expect(parsed.cogsTotal).toBe(400);
+    expect(parsed.expenseTotal).toBe(825);
+    const expenses = parsed.lines.filter((l) => l.section === "expenses");
+    expect(expenses.map((l) => l.name)).toEqual(["Insurance", "Wages"]);
+    expect(expenses.every((l) => l.prior === null)).toBe(true);
   });
 });

--- a/frontend/src/lib/pnl/parsePnl.ts
+++ b/frontend/src/lib/pnl/parsePnl.ts
@@ -26,6 +26,14 @@ export interface ParsedPnl {
 
 const SECTIONS = ["Income", "Cost of Goods Sold", "Expenses", "Other Income"];
 
+// Month name (abbrev or full) + 4-digit year, e.g. "Jul 2026" / "July 2026".
+// Used to recover the period from the title block of single-period exports —
+// QuickBooks omits the ",Jul 2026,Jun 2026 (PP)" column header and instead puts
+// "July 2026" in the title's first cell. Won't match "August 02, 2026" (the
+// export-timestamp footer): a day number sits between the month and the year.
+const MONTH_YEAR_RE =
+  /\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+\d{4}\b/i;
+
 // "$2,547.70" → 2547.7 · "-10,936.24" → -10936.24 · "" → null
 export const cleanNum = (raw: string | undefined): number | null => {
   if (raw == null) return null;
@@ -115,6 +123,26 @@ export const parsePnlRows = (rows: string[][]): ParsedPnl => {
     // Standalone leaf: only a top-level (depth 0) row with an amount counts.
     if (inCost && depth === 0 && cur != null) {
       lines.push({ name, current: cur, prior: pri, section: sectionKey });
+    }
+  }
+
+  // Single-period exports (no comparison column) omit the "…,Jul 2026,…" header
+  // and instead label the period only in the title block ("July 2026", first
+  // cell). If the header scan above found nothing, recover it from the rows
+  // above the first section — scoped there so the export-timestamp footer can
+  // never win.
+  if (!currentLabel) {
+    const firstSection = rows.findIndex((r) =>
+      SECTIONS.includes((r[0] ?? "").trim()),
+    );
+    const end = firstSection < 0 ? rows.length : firstSection;
+    for (let i = 0; i < end && !currentLabel; i++) {
+      for (const cell of rows[i]) {
+        if (MONTH_YEAR_RE.test((cell ?? "").trim())) {
+          currentLabel = (cell ?? "").trim();
+          break;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Bug

Uploading a QuickBooks P&L exported for a **single period** (no prior-month comparison column) failed on the Expenses page with **"Couldn't read the month from this file."**

## Cause

That export layout puts the month in the **title block's first cell** (`July 2026`) and labels the data column just `Total` — there is no `,Jul 2026,Jun 2026 (PP)` header row. The parser only searched for the month in a blank-first-cell header row, so `period_month` came back `null` and the upload bailed before the confirm step.

## Fix

When the header row is absent, recover the month from the title block — scoped to the rows **above the first section** so the export's timestamp footer (`…August 02, 2026…`) can never be mistaken for the period. Both export layouts (comparison-column and single-period) now parse.

## Verify

- Ran the **real** `july.csv` through the actual parser → `period_month = 2026-07-01` (the exact check the upload makes). Temp test, deleted — no financial figures committed.
- New regression test mirrors the single-period export shape (title-cell month, single `Total` column, timestamp footer) with made-up amounts.
- Full suite **419/419** green; strict build green.

Two files: the parser + its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)