### PR TITLE
feat: friendlier form fields + fuel-form redesign (pilot) (v1.125.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.124.2",
+  "version": "1.125.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/ui/FormControls.tsx
+++ b/frontend/src/components/ui/FormControls.tsx
@@ -1,0 +1,86 @@
+import type {
+  InputHTMLAttributes,
+  ReactNode,
+  SelectHTMLAttributes,
+} from "react";
+
+// The shared form field pieces. The look lives in `.ds-*` classes (index.css)
+// so every form across the app reads the same. Compose: a `Field` (label +
+// inline error) wrapping an `AffixInput`, a `SelectControl`, or any `.ds-input`.
+
+interface FieldProps {
+  label: string;
+  hint?: string; // a light note beside the label, e.g. "· fills from city"
+  error?: string | null;
+  htmlFor?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+export const Field = ({
+  label,
+  hint,
+  error,
+  htmlFor,
+  className,
+  children,
+}: FieldProps) => (
+  <div className={`flex flex-col gap-1.5 ${className ?? ""}`}>
+    <label
+      htmlFor={htmlFor}
+      className="text-[11px] font-semibold uppercase tracking-wide text-[#9fb0c9]"
+    >
+      {label}
+      {hint && (
+        <span className="ml-1 font-medium normal-case tracking-normal text-muted-text">
+          {hint}
+        </span>
+      )}
+    </label>
+    {children}
+    {error && <span className="text-[11.5px] text-[#f0857a]">{error}</span>}
+  </div>
+);
+
+interface AffixInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  prefix?: string; // unit shown before the value, e.g. "$"
+  suffix?: string; // unit shown after the value, e.g. "gal" / "mi"
+  invalid?: boolean;
+}
+
+// A boxed input with an optional unit affix. Numeric by default: right-aligned,
+// tabular figures, and no spinner arrows.
+export const AffixInput = ({
+  prefix,
+  suffix,
+  invalid,
+  className,
+  ...props
+}: AffixInputProps) => (
+  <div className={`ds-ctrl ${invalid ? "ds-ctrl--err" : ""}`}>
+    {prefix && <span className="ds-affix ds-affix--pre">{prefix}</span>}
+    <input className={`ds-num ${className ?? ""}`} {...props} />
+    {suffix && <span className="ds-affix ds-affix--suf">{suffix}</span>}
+  </div>
+);
+
+interface SelectControlProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  invalid?: boolean;
+  children: ReactNode;
+}
+
+// A native <select> styled to match the field system (custom chevron; the
+// native mobile picker is preserved).
+export const SelectControl = ({
+  invalid,
+  className,
+  children,
+  ...props
+}: SelectControlProps) => (
+  <div className={`ds-ctrl ${invalid ? "ds-ctrl--err" : ""}`}>
+    <select className={className} {...props}>
+      {children}
+    </select>
+    <span className="ds-chev">▾</span>
+  </div>
+);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -286,3 +286,101 @@
   animation: ds-shimmer 1.4s ease-in-out infinite;
   border-radius: 6px;
 }
+
+/* ---- Form fields — the shared control style (label + boxed control + unit
+   affix). Defined once here so every form across the app reads the same. ---- */
+.ds-input,
+.ds-ctrl {
+  height: 44px;
+  background: #141b28;
+  border: 1px solid #2a3347;
+  border-radius: 10px;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.ds-input {
+  width: 100%;
+  color: #f4f7fb;
+  font-size: 15px;
+  padding: 0 12px;
+  outline: none;
+  font-family: inherit;
+}
+.ds-input::placeholder,
+.ds-ctrl > input::placeholder {
+  color: #5f6b80;
+}
+.ds-input:focus,
+.ds-ctrl:focus-within {
+  border-color: var(--color-amber);
+  box-shadow: 0 0 0 3px rgba(232, 148, 10, 0.18);
+}
+.ds-input--err,
+.ds-ctrl--err {
+  border-color: #e0533a;
+  box-shadow: 0 0 0 3px rgba(224, 83, 58, 0.16);
+}
+.ds-ctrl {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+}
+.ds-ctrl > input,
+.ds-ctrl > select {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #f4f7fb;
+  font-size: 15px;
+  font-family: inherit;
+  padding: 0 12px;
+}
+.ds-ctrl > input.ds-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+.ds-ctrl > select {
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+}
+.ds-affix {
+  padding: 0 13px;
+  color: #7f8ca6;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.ds-affix--pre {
+  border-right: 1px solid #22304a;
+}
+.ds-affix--suf {
+  border-left: 1px solid #22304a;
+}
+.ds-chev {
+  padding: 0 12px;
+  color: #7f8ca6;
+  pointer-events: none;
+}
+
+/* No number spinners — the desktop up/down steppers are visual noise. */
+.ds-num::-webkit-outer-spin-button,
+.ds-num::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* The native date-picker calendar icon is a near-black glyph, invisible on the
+   dark field — you have to KNOW it's there. Light it up and make it clearly
+   clickable, on every date input across the app. */
+input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(0.8);
+  opacity: 0.85;
+  cursor: pointer;
+}
+input[type="date"]::-webkit-calendar-picker-indicator:hover {
+  opacity: 1;
+}

--- a/frontend/src/pages/FuelEntriesPage.tsx
+++ b/frontend/src/pages/FuelEntriesPage.tsx
@@ -27,6 +27,8 @@ import { DieselPriceChart } from "@/components/fuel/DieselPriceChart";
 import { DieselCompareCard } from "@/components/fuel/DieselCompareCard";
 import { FuelVsRevenueCard } from "@/components/fuel/FuelVsRevenueCard";
 import { money, moneyCents } from "@/lib/format";
+import CityAutocomplete from "@/components/CityAutocomplete";
+import { Field, AffixInput, SelectControl } from "@/components/ui/FormControls";
 
 const fmtDate = (d: string) =>
   new Date(d.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", {
@@ -36,8 +38,9 @@ const fmtDate = (d: string) =>
     timeZone: "UTC",
   });
 
-const inputCls = "bg-steel rounded px-2 py-1.5 text-sm w-full text-light";
-const lbl = "text-xs text-muted-text mb-1 block";
+// Strip commas / $ / spaces so "1,378" or "$555.90" parse cleanly (mobile
+// keyboards and habit add them; parseFloat/parseInt otherwise truncate).
+const numOf = (s: string) => s.replace(/[$,\s]/g, "");
 
 // Remember the last vendor + state so the next fill-up defaults to them.
 const LS_VENDOR = "dash.fuel.lastVendor";
@@ -55,6 +58,7 @@ const FuelEntriesPage = () => {
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errs, setErrs] = useState<Record<string, string>>({});
 
   const [truckId, setTruckId] = useState("");
   const [date, setDate] = useState("");
@@ -127,23 +131,43 @@ const FuelEntriesPage = () => {
 
   // Price/gallon is derived from the total paid ÷ gallons — the numbers on the
   // receipt — rounded to the 3-decimal cents diesel is quoted in.
-  const g = parseFloat(gallons);
-  const t = parseFloat(total);
+  const g = parseFloat(numOf(gallons));
+  const t = parseFloat(numOf(total));
   const computedPpg =
     g > 0 && t > 0 && isFinite(g) && isFinite(t) ? t / g : null;
+  const ppgOver = computedPpg != null && computedPpg > 10;
+
+  // Clear a field's error the moment the user edits it.
+  const clr = (k: string) =>
+    setErrs((p) => (p[k] ? { ...p, [k]: "" } : p));
+
+  // Field-level validation mirroring the server rules, so a bad value is caught
+  // inline (named on the field) before it ever hits the network.
+  const validate = (): Record<string, string> => {
+    const e: Record<string, string> = {};
+    if (!date) e.date = "Pick a date.";
+    const od = parseInt(numOf(odometer), 10);
+    if (!odometer.trim()) e.odometer = "Required.";
+    else if (!Number.isInteger(od) || od < 1 || od > 5_000_000)
+      e.odometer = "Enter a whole number up to 5,000,000.";
+    if (!gallons.trim()) e.gallons = "Required.";
+    else if (!(g >= 1 && g <= 400))
+      e.gallons = "Must be between 1 and 400 gal.";
+    if (!total.trim()) e.total = "Required.";
+    else if (ppgOver)
+      e.total = `That's $${computedPpg!.toFixed(2)}/gal — over the $10 limit. Check gallons.`;
+    else if (computedPpg == null) e.total = "Enter gallons and total.";
+    if (!stateCode.trim()) e.state = "Pick a state.";
+    return e;
+  };
 
   const save = async () => {
     setError(null);
+    const e = validate();
+    setErrs(e);
+    if (Object.keys(e).length > 0) return;
     if (!truckId) {
       setError("Add a truck first (Fleet → Trucks).");
-      return;
-    }
-    if (!date || !odometer || !gallons || !total || !stateCode.trim()) {
-      setError("Date, odometer, gallons, total, and state are required.");
-      return;
-    }
-    if (computedPpg == null) {
-      setError("Enter gallons and total so price/gallon can be calculated.");
       return;
     }
     setBusy(true);
@@ -151,9 +175,9 @@ const FuelEntriesPage = () => {
       await createFuelEntry({
         truck_id: truckId,
         fuel_date: date,
-        gallons: parseFloat(gallons),
-        price_per_gallon: Number(computedPpg.toFixed(3)),
-        odometer_reading: parseInt(odometer, 10),
+        gallons: parseFloat(numOf(gallons)),
+        price_per_gallon: Number(computedPpg!.toFixed(3)),
+        odometer_reading: parseInt(numOf(odometer), 10),
         company_name: company.trim() || null,
         fuel_city: city.trim() || null,
         fuel_state: stateCode.trim().toUpperCase(),
@@ -166,12 +190,20 @@ const FuelEntriesPage = () => {
       setGallons("");
       setTotal("");
       setCity("");
+      setErrs({});
       setShowForm(false);
       await load();
-    } catch (e) {
+    } catch (err) {
+      // Surface the server's specific reason (validation details) rather than a
+      // generic "could not save" — a rejected fill-up should say what to fix.
+      const data = (
+        err as { response?: { data?: { error?: string; details?: string[] } } }
+      )?.response?.data;
+      const reason = data?.details?.[0] || data?.error;
       setError(
-        (e as { response?: { data?: { error?: string } } })?.response?.data
-          ?.error || "Could not save the fill-up",
+        reason && reason !== "Validation failed"
+          ? reason
+          : "Couldn't save the fill-up — check your connection and try again.",
       );
     } finally {
       setBusy(false);
@@ -255,57 +287,84 @@ const FuelEntriesPage = () => {
       <FuelVsRevenueCard data={fuelRev} />
 
       {showForm && (
-        <Panel className="p-4 mt-4">
-          <p className="text-sm font-medium mb-3">Add fill-up</p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3">
-            <div>
-              <label className={lbl}>Date</label>
+        <Panel className="p-5 mt-4">
+          <p className="text-base font-condensed text-light">Log a fill-up</p>
+          <p className="text-xs text-muted-text mb-4">
+            Vendor &amp; state remember your last stop.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Field label="Date" error={errs.date}>
               <input
                 type="date"
-                className={inputCls}
+                className={`ds-input ${errs.date ? "ds-input--err" : ""}`}
                 value={date}
-                onChange={(e) => setDate(e.target.value)}
+                onChange={(e) => {
+                  setDate(e.target.value);
+                  clr("date");
+                }}
               />
-            </div>
-            <div>
-              <label className={lbl}>Odometer</label>
-              <input
-                className={inputCls}
-                value={odometer}
+            </Field>
+            <Field label="Odometer" error={errs.odometer}>
+              <AffixInput
+                suffix="mi"
                 inputMode="numeric"
-                placeholder="582450"
-                onChange={(e) => setOdometer(e.target.value)}
+                placeholder="582,450"
+                value={odometer}
+                invalid={!!errs.odometer}
+                onChange={(e) => {
+                  setOdometer(e.target.value);
+                  clr("odometer");
+                }}
               />
-            </div>
-            <div>
-              <label className={lbl}>Gallons</label>
-              <input
-                className={inputCls}
-                value={gallons}
+            </Field>
+            <Field label="Gallons" error={errs.gallons}>
+              <AffixInput
+                suffix="gal"
                 inputMode="decimal"
                 placeholder="137.8"
-                onChange={(e) => setGallons(e.target.value)}
+                value={gallons}
+                invalid={!!errs.gallons}
+                onChange={(e) => {
+                  setGallons(e.target.value);
+                  clr("gallons");
+                }}
               />
-            </div>
-            <div>
-              <label className={lbl}>Total $</label>
-              <input
-                className={inputCls}
-                value={total}
+            </Field>
+            <Field label="Total paid" error={errs.total}>
+              <AffixInput
+                prefix="$"
                 inputMode="decimal"
                 placeholder="555.90"
-                onChange={(e) => setTotal(e.target.value)}
+                value={total}
+                invalid={!!errs.total}
+                onChange={(e) => {
+                  setTotal(e.target.value);
+                  clr("total");
+                }}
               />
-              <p className="text-[11px] mt-1 text-amber-light">
-                {computedPpg == null
-                  ? "= —/gal"
-                  : `= $${computedPpg.toFixed(3)}/gal`}
-              </p>
+            </Field>
+            <div
+              className="sm:col-span-2 flex items-center gap-2 rounded-lg px-3 py-2 text-sm"
+              style={{
+                background: ppgOver ? "#331414" : "#12331f",
+                border: `1px solid ${ppgOver ? "#5b2020" : "#1f5636"}`,
+              }}
+            >
+              <span className="text-muted-text text-xs">Price / gallon</span>
+              <span
+                className="font-semibold tabular-nums"
+                style={{ color: ppgOver ? "#f0857a" : "#4ade80" }}
+              >
+                {computedPpg == null ? "—" : `$${computedPpg.toFixed(3)} / gal`}
+              </span>
+              {ppgOver && (
+                <span className="text-[11px] text-[#f0857a]">
+                  over the $10 limit — check gallons
+                </span>
+              )}
             </div>
-            <div>
-              <label className={lbl}>Vendor</label>
-              <select
-                className={inputCls}
+            <Field label="Vendor">
+              <SelectControl
                 value={vendorIsOther ? OTHER_VENDOR : company}
                 onChange={(e) => {
                   if (e.target.value === OTHER_VENDOR) {
@@ -324,44 +383,19 @@ const FuelEntriesPage = () => {
                   </option>
                 ))}
                 <option value={OTHER_VENDOR}>Other…</option>
-              </select>
+              </SelectControl>
               {vendorIsOther && (
                 <input
-                  className={`${inputCls} mt-1`}
+                  className="ds-input mt-1.5"
                   value={company}
                   placeholder="Vendor name"
                   onChange={(e) => setCompany(e.target.value)}
                 />
               )}
-            </div>
-            <div>
-              <label className={lbl}>City</label>
-              <input
-                className={inputCls}
-                value={city}
-                onChange={(e) => setCity(e.target.value)}
-              />
-            </div>
-            <div>
-              <label className={lbl}>State</label>
-              <select
-                className={inputCls}
-                value={stateCode}
-                onChange={(e) => setStateCode(e.target.value)}
-              >
-                <option value="">Select…</option>
-                {US_STATES.map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
-            </div>
+            </Field>
             {trucks.length > 1 && (
-              <div>
-                <label className={lbl}>Truck</label>
-                <select
-                  className={inputCls}
+              <Field label="Truck">
+                <SelectControl
                   value={truckId}
                   onChange={(e) => setTruckId(e.target.value)}
                 >
@@ -371,27 +405,58 @@ const FuelEntriesPage = () => {
                       Unit {t.unit_number}
                     </option>
                   ))}
-                </select>
-              </div>
+                </SelectControl>
+              </Field>
             )}
+            <Field label="City">
+              <CityAutocomplete
+                value={city}
+                onType={setCity}
+                onSelect={(c, s) => {
+                  setCity(c);
+                  setStateCode(s);
+                  clr("state");
+                }}
+                placeholder="City"
+                inputClassName="ds-input"
+              />
+            </Field>
+            <Field label="State" hint="· fills from city" error={errs.state}>
+              <SelectControl
+                value={stateCode}
+                invalid={!!errs.state}
+                onChange={(e) => {
+                  setStateCode(e.target.value);
+                  clr("state");
+                }}
+              >
+                <option value="">Select…</option>
+                {US_STATES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </SelectControl>
+            </Field>
           </div>
-          <p className="text-[11px] text-muted-text mt-2">
+          <p className="text-[11px] text-muted-text mt-3">
             120+ gallons counts as a full tank; anything less is a partial.
           </p>
           {error && <p className="text-destructive text-sm mt-2">{error}</p>}
-          <div className="flex gap-2 mt-3">
+          <div className="flex gap-2 mt-5">
             <button
-              className="bg-amber text-steel px-3 py-1.5 rounded text-sm font-semibold disabled:opacity-50"
+              className="bg-amber text-steel px-4 py-2.5 rounded-lg text-sm font-semibold disabled:opacity-50"
               onClick={save}
               disabled={busy}
             >
-              {busy ? "Saving…" : "Save fill-up"}
+              {busy ? "Saving…" : "Log fill-up"}
             </button>
             <button
-              className="bg-steel text-light px-3 py-1.5 rounded text-sm"
+              className="text-muted-text px-4 py-2.5 rounded-lg text-sm border border-steel"
               onClick={() => {
                 setShowForm(false);
                 setError(null);
+                setErrs({});
               }}
             >
               Cancel


### PR DESCRIPTION
## What

A shared **form-field system**, piloted on the fuel form. Approved via mockup first.

**New reusable pieces** (`components/ui/FormControls.tsx` + `.ds-input`/`.ds-ctrl` in index.css): `Field` (label + inline error), `AffixInput` (unit affix, right-aligned, no spinners), `SelectControl` (styled native select). Defined once → rolls out to every form.

**App-wide date fix:** the native calendar-picker icon was a near-black glyph, invisible on the dark theme — you had to *know* it was there. One CSS rule lights it up on **every** date input across the app.

**Fuel form rebuilt (the pilot):**
- Units in the field (`$ / gal / mi`), no spinner arrows, roomier 2-column layout.
- **Comma-safe parsing** — `582,450` no longer silently truncates to `582` (latent bug fixed).
- **City autocomplete** — picking "City, ST" auto-fills the state dropdown.
- **Live price/gallon readout** — turns red with "over the $10 limit — check gallons" when a dropped digit pushes it over.
- **Inline validation** — each field names its own problem; a rejected save surfaces the server's specific reason, not a generic "could not save."

## Verify
- Strict build green; 419/419 tests pass.
- Verified live on the dev preview: visible date icon, autocomplete → state fill (real HERE suggestions), live readout, and per-field validation messages (all screenshotted).
- Caveat: the happy-path POST wasn't exercised on dev (that account has no truck); the save call is unchanged apart from comma-safe parsing.

## Next
Roll the field system to Loads / Trips / Facilities / Settings / P&L upload (small follow-up PRs), then the tabs redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)