### PR TITLE
feat: dispatcher booking-credit on the load form + roll out the new field look (v1.126.0)

### DIFF
--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -8,14 +8,16 @@ import {
 
 const router = express.Router();
 
-// Team management is owner/admin only.
+// Team MANAGEMENT (create/remove dispatchers) is owner/admin only.
 const adminOnly = (req, res, next) =>
   req.user?.role === "admin"
     ? next()
     : res.status(403).json({ error: "Admin only" });
 
-// ---- LIST the account's team ---- (owner + its dispatchers)
-router.get("/", requireAuth, adminOnly, async (req, res) => {
+// ---- LIST the account's team ---- (owner + its dispatchers). Any member may
+// read it — it's scoped to their own account_id — so a dispatcher's forms can
+// offer booking-credit options (e.g. "Booked by"). Mutations stay adminOnly.
+router.get("/", requireAuth, async (req, res) => {
   try {
     const team = await listAccountUsers(req.user.account_id);
     return res.status(200).json({ team });

--- a/backend/src/services/loadServices.js
+++ b/backend/src/services/loadServices.js
@@ -238,9 +238,11 @@ export async function getLoad(user_id, load_id) {
 }
 
 // ---- CREATE LOAD SERVICE ----
-// `self_id` is the logged-in person; a load's booker defaults to them so the
-// dispatcher who enters it gets the credit. The client may override booked_by
-// (e.g. the owner crediting a dispatcher for a load they sourced).
+// A load's booker defaults to the ACCOUNT OWNER (user_id === account_id), not
+// whoever enters it: in this owner-operator shop the owner does the booking and
+// a training dispatcher just logs the loads. The client sends booked_by
+// explicitly (the "Booked by" picker, default = owner) and anyone can reassign
+// it per-load. `self_id` (the logged-in person) is accepted for caller parity.
 export async function createLoad(user_id, data, self_id) {
   // Reject missing user_id
   if (!user_id) throw new ValidationError("Missing user_id");
@@ -304,8 +306,8 @@ export async function createLoad(user_id, data, self_id) {
 
   if (errors.length > 0) throw new ValidationError("Validation failed", errors);
 
-  // Booker: explicit override, else the logged-in creator.
-  const booker = data.booked_by ?? self_id ?? user_id;
+  // Booker: explicit override (the "Booked by" picker), else the account owner.
+  const booker = data.booked_by ?? user_id;
   let fields = ["user_id", "booked_by"];
   let values = [user_id, booker];
   let placeholders = ["$1", "$2"];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.125.0",
+  "version": "1.126.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/LoadForm.tsx
+++ b/frontend/src/components/LoadForm.tsx
@@ -214,8 +214,8 @@ const LoadForm = ({
           truck_id: null,
           driver_id: null,
           trailer_id: null,
-          // Default credit to the creator; the owner can reassign below.
-          booked_by: localStorage.getItem("user_id") ?? null,
+          // Booker defaults to the account owner once the team loads (below).
+          booked_by: null,
         },
   );
 
@@ -224,14 +224,27 @@ const LoadForm = ({
   const [marketList, setMarketList] = useState<Market[]>(markets);
   const [facilityList, setFacilityList] = useState<Facility[]>(facilities);
 
-  // Booking credit: the owner (admin) can attribute a load to a dispatcher. A
-  // dispatcher's loads auto-credit to them (server default), so no picker for her.
+  // Booking credit. Anyone on the account (owner or a dispatcher) can attribute
+  // a load; the picker below defaults to the account owner, since in this shop
+  // the owner does the booking and a training dispatcher just logs the loads.
   const selfId = localStorage.getItem("user_id");
-  const isAdmin = localStorage.getItem("role") === "admin";
   const [team, setTeam] = useState<TeamMember[]>([]);
   useEffect(() => {
-    if (isAdmin) getTeam().then(setTeam).catch(() => {});
-  }, [isAdmin]);
+    getTeam().then(setTeam).catch(() => {});
+  }, []);
+  // New load: once the team loads, default the booker to the account owner
+  // (role "admin"). Edit mode keeps the load's existing booker; a manual pick
+  // wins (we only fill a still-empty booked_by).
+  useEffect(() => {
+    if (initialData) return;
+    // The account owner is the first row — listAccountUsers sorts owner-first.
+    const owner = team[0];
+    if (owner) {
+      setFormData((prev) =>
+        prev.booked_by ? prev : { ...prev, booked_by: owner.user_id },
+      );
+    }
+  }, [team, initialData]);
 
   const [trucks, setTrucks] = useState<Truck[]>([]);
   const [drivers, setDrivers] = useState<Driver[]>([]);
@@ -492,8 +505,8 @@ const LoadForm = ({
                 </SelectContent>
               </Select>
             </div>
-            {/* Booked by — owner only; credits a dispatcher for the booking */}
-            {isAdmin && team.length > 1 && (
+            {/* Booked by — anyone on the account; defaults to the owner */}
+            {team.length > 1 && (
               <div>
                 <Label htmlFor="booked_by">Booked by</Label>
                 <Select

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -5,9 +5,9 @@ import { cn } from "@/lib/utils"
 // The base input styling, exported so other controls (e.g. CityAutocomplete's
 // text field) can match the shared Input exactly.
 export const inputClass = cn(
-  "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-  "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-  "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "file:text-foreground placeholder:text-[#5f6b80] selection:bg-primary selection:text-primary-foreground h-11 w-full min-w-0 rounded-[10px] border border-[#2a3347] bg-[#141b28] px-3 text-[15px] text-light transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+  "focus-visible:border-ring focus-visible:ring-ring/40 focus-visible:ring-[3px]",
+  "aria-invalid:border-destructive aria-invalid:ring-destructive/30",
 )
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -35,7 +35,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex w-full items-center justify-between gap-2 rounded-[10px] border border-[#2a3347] bg-[#141b28] px-3 text-[15px] whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/30 data-[placeholder]:text-muted-foreground data-[size=default]:h-11 data-[size=sm]:h-9 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -366,11 +366,17 @@
   pointer-events: none;
 }
 
-/* No number spinners — the desktop up/down steppers are visual noise. */
+/* No number spinners — the desktop up/down steppers are visual noise. App-wide,
+   on any number input as well as the affix control. */
 .ds-num::-webkit-outer-spin-button,
-.ds-num::-webkit-inner-spin-button {
+.ds-num::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
+}
+input[type="number"] {
+  -moz-appearance: textfield;
 }
 
 /* The native date-picker calendar icon is a near-black glyph, invisible on the


### PR DESCRIPTION
## Dispatcher attribution (the Brandie bug)

A dispatcher couldn't set who booked a load: the "Booked by" picker was owner-only, loads defaulted to whoever *entered* them, and the team-list endpoint was admin-only (so her account couldn't even load the options — she had to log into the owner's account).

- **Backend:** `GET /users` (team **list**) is now readable by any account member, scoped to their own `account_id`. Team **management** (create/remove dispatchers) stays owner-only.
- **Backend:** a load's booker defaults to the account **owner** (`data.booked_by ?? user_id`).
- **LoadForm:** the "Booked by" picker shows for dispatchers too, and defaults to the owner on new loads (owner = the team's first row, which the API sorts owner-first). Anyone can reassign per-load.

Net: a training dispatcher's entries credit the owner by default, overridable when she actually booked it.

## Field-look rollout

Rather than rewrite a big critical form field-by-field, upgrade the shared **`Input`** and **`Select`** primitives to the new field look (taller, boxed, amber focus) — rolling it out to **LoadForm, Trips, Facilities, Rating, and the auth pages** at once — and kill the **number spinner arrows app-wide**.

## Verify
- Build + **419 tests** + `tsc` clean.
- New `Input` look confirmed rendering (login page).
- ⚠️ **Live LoadForm/dispatcher testing was blocked** — the dev Supabase DB is auto-paused. Attribution behavior to be confirmed on prod (open a new load as a dispatcher → "Booked by" appears, defaulting to the owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)