### PR TITLE
feat: comic-noir sound cues on the earned moments (v1.127.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.126.0",
+  "version": "1.127.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -10,6 +10,8 @@ import {
   ShieldCheck,
   Trophy,
   BookOpen,
+  Volume2,
+  VolumeX,
   type LucideIcon,
 } from "lucide-react";
 import {
@@ -28,6 +30,7 @@ import {
 } from "@/components/ui/sidebar";
 import { Link, useLocation } from "react-router-dom";
 import { isDispatcher } from "@/lib/roles";
+import { sfxEnabled, setSfxEnabled, playSfx } from "@/lib/sfx";
 
 // `adminOnly` items are owner-only; a dispatcher's nav filters them out (and the
 // route guard bounces her if she types the URL). Keep these flags in lockstep
@@ -99,6 +102,7 @@ const navFor = (dispatcher: boolean): Entry[] => {
 const AppSidebar = () => {
   const { pathname } = useLocation();
   const dispatcher = isDispatcher();
+  const [sfxOn, setSfxOn] = useState(sfxEnabled());
   const navItems = navFor(dispatcher);
   const active = (to: string) =>
     pathname === to || pathname.startsWith(to + "/");
@@ -215,6 +219,23 @@ const AppSidebar = () => {
             </Link>
           </div>
         )}
+        <div className="px-4 pt-2">
+          <button
+            type="button"
+            onClick={() => {
+              const next = !sfxOn;
+              setSfxOn(next);
+              setSfxEnabled(next);
+              if (next) playSfx("pow"); // hear it come on
+            }}
+            className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-light"
+            aria-label={sfxOn ? "Turn sound effects off" : "Turn sound effects on"}
+            title={sfxOn ? "Sound on" : "Sound off"}
+          >
+            {sfxOn ? <Volume2 size={16} /> : <VolumeX size={16} />}
+            <span>Sound {sfxOn ? "on" : "off"}</span>
+          </button>
+        </div>
         <div className="px-4 pb-4 pt-1 text-sm text-muted-foreground">
           v{__APP_VERSION__}
         </div>

--- a/frontend/src/components/comic/AwardPopHost.tsx
+++ b/frontend/src/components/comic/AwardPopHost.tsx
@@ -5,6 +5,7 @@ import { BurstAward } from "./BurstAward";
 import { RecapCeremony } from "./RecapCeremony";
 import { TrophyCeremony } from "./TrophyCeremony";
 import { MedalAward } from "./MedalAward";
+import { playSfx } from "@/lib/sfx";
 
 // Orchestrates the celebration. Takeovers own the screen one at a time, ranked
 // trophy > recap > medal; corner slide-ins (a stacked patch, a beaten record) fade
@@ -33,9 +34,17 @@ export const AwardPopHost = ({
     ? []
     : visible.filter((p) => p.tier === "patch" || p.tier === "record").slice(0, 4);
 
+  // Sound: a takeover gets the fanfare (trophy/recap) or the sting (medal); the
+  // corner slide-ins (patches, beaten records) get the POW.
+  useEffect(() => {
+    if (!takeover) return;
+    playSfx(takeover.tier === "medal" ? "pow" : "rankup");
+  }, [takeover?.id, takeover?.tier]);
+
   const slideKey = slideIns.map((b) => b.id).join(",");
   useEffect(() => {
     if (!slideKey) return;
+    playSfx("pow");
     const ids = slideKey.split(",");
     // Records/patches hold ~3.5s so they can be read, then slide back out.
     const timers = ids.map((id, idx) => setTimeout(() => dismiss(id), 3500 + idx * 600));

--- a/frontend/src/components/comic/RollingNumber.tsx
+++ b/frontend/src/components/comic/RollingNumber.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type CSSProperties } from "react";
+import { playSfx } from "@/lib/sfx";
 
 // Users who ask for less motion get the value straight away — no odometer roll.
 const prefersReducedMotion = () =>
@@ -58,20 +59,27 @@ export const RollingValue = ({
   text: string;
   className?: string;
   style?: CSSProperties;
-}) => (
-  <span
-    className={className}
-    style={{ display: "inline-flex", fontVariantNumeric: "tabular-nums", ...style }}
-  >
-    {text.split("").map((c, i) =>
-      /\d/.test(c) ? (
-        <Digit key={i} target={Number(c)} delay={80 + i * 45} />
-      ) : (
-        <span key={i}>{c}</span>
-      ),
-    )}
-  </span>
-);
+}) => {
+  // A soft odometer tick as the digits roll — the debounce collapses sibling
+  // values (the five KPIs firing together) into a single tick.
+  useEffect(() => {
+    playSfx("odometer");
+  }, [text]);
+  return (
+    <span
+      className={className}
+      style={{ display: "inline-flex", fontVariantNumeric: "tabular-nums", ...style }}
+    >
+      {text.split("").map((c, i) =>
+        /\d/.test(c) ? (
+          <Digit key={i} target={Number(c)} delay={80 + i * 45} />
+        ) : (
+          <span key={i}>{c}</span>
+        ),
+      )}
+    </span>
+  );
+};
 
 // A number whose digits roll up into place — rounds to an integer, commas added.
 // Reusable for the truck odometer.

--- a/frontend/src/lib/sfx.ts
+++ b/frontend/src/lib/sfx.ts
@@ -1,0 +1,161 @@
+// Comic-noir UI sound cues, synthesized live with the Web Audio API — no audio
+// files to host. Gated by a client preference (default ON, per Jason) and
+// unlocked on the first user gesture so later, non-gesture cues (a KPI count-up
+// on page load, an award pop) can still play once the page has been touched.
+//
+// Design rule: cues fire ONLY on earned/celebratory moments, never routine
+// actions. Everything is short and quiet, and collapses rapid repeats.
+
+const PREF_KEY = "dash.sfx"; // "off" disables; unset/anything else = on (default on)
+
+export const sfxEnabled = (): boolean => localStorage.getItem(PREF_KEY) !== "off";
+export const setSfxEnabled = (on: boolean): void =>
+  localStorage.setItem(PREF_KEY, on ? "on" : "off");
+
+export type Cue = "stamp" | "kaching" | "pow" | "odometer" | "rankup";
+
+type WinAudio = typeof window & { webkitAudioContext?: typeof AudioContext };
+
+let ctx: AudioContext | null = null;
+let master: GainNode | null = null;
+
+const audio = (): { c: AudioContext; out: GainNode } | null => {
+  if (typeof window === "undefined") return null;
+  const AC = window.AudioContext || (window as WinAudio).webkitAudioContext;
+  if (!AC) return null;
+  if (!ctx) {
+    ctx = new AC();
+    master = ctx.createGain();
+    master.gain.value = 0.5; // keep the whole thing quiet
+    master.connect(ctx.destination);
+  }
+  if (ctx.state === "suspended") void ctx.resume();
+  return master ? { c: ctx, out: master } : null;
+};
+
+// Unlock on the first interaction so cues that fire without a direct gesture
+// (count-ups, award pops) work for the rest of the session.
+if (typeof window !== "undefined") {
+  const unlock = () => audio();
+  window.addEventListener("pointerdown", unlock, { once: true });
+  window.addEventListener("keydown", unlock, { once: true });
+}
+
+interface ToneOpts {
+  freq: number;
+  type?: OscillatorType;
+  dur?: number;
+  gain?: number;
+  glideTo?: number;
+  delay?: number;
+}
+const tone = (c: AudioContext, out: GainNode, o: ToneOpts) => {
+  const { freq, type = "sine", dur = 0.15, gain = 0.3, glideTo, delay = 0 } = o;
+  const t0 = c.currentTime + delay;
+  const osc = c.createOscillator();
+  osc.type = type;
+  osc.frequency.setValueAtTime(freq, t0);
+  if (glideTo) osc.frequency.exponentialRampToValueAtTime(glideTo, t0 + dur);
+  const g = c.createGain();
+  g.gain.setValueAtTime(0.0001, t0);
+  g.gain.exponentialRampToValueAtTime(gain, t0 + 0.006);
+  g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+  osc.connect(g).connect(out);
+  osc.start(t0);
+  osc.stop(t0 + dur + 0.03);
+};
+
+interface NoiseOpts {
+  dur?: number;
+  gain?: number;
+  type?: BiquadFilterType;
+  freq?: number;
+  q?: number;
+  delay?: number;
+}
+const noise = (c: AudioContext, out: GainNode, o: NoiseOpts) => {
+  const { dur = 0.12, gain = 0.3, type = "lowpass", freq = 800, q = 1, delay = 0 } = o;
+  const t0 = c.currentTime + delay;
+  const n = Math.floor(c.sampleRate * dur);
+  const buf = c.createBuffer(1, n, c.sampleRate);
+  const d = buf.getChannelData(0);
+  for (let i = 0; i < n; i++) d[i] = Math.random() * 2 - 1;
+  const src = c.createBufferSource();
+  src.buffer = buf;
+  const filt = c.createBiquadFilter();
+  filt.type = type;
+  filt.frequency.value = freq;
+  filt.Q.value = q;
+  const g = c.createGain();
+  g.gain.setValueAtTime(gain, t0);
+  g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+  src.connect(filt).connect(g).connect(out);
+  src.start(t0);
+  src.stop(t0 + dur + 0.03);
+};
+
+// A struck bell via inharmonic partials — reads as a metallic register ding.
+const bell = (
+  c: AudioContext,
+  out: GainNode,
+  { base, dur, gain, delay = 0 }: { base: number; dur: number; gain: number; delay?: number },
+) => {
+  const t0 = c.currentTime + delay;
+  const ratios = [1, 2.76, 5.4, 8.93];
+  const amps = [1, 0.55, 0.36, 0.22];
+  ratios.forEach((r, i) => {
+    const osc = c.createOscillator();
+    osc.type = "sine";
+    osc.frequency.value = base * r;
+    const g = c.createGain();
+    g.gain.setValueAtTime(0.0001, t0);
+    g.gain.exponentialRampToValueAtTime(gain * amps[i], t0 + 0.004);
+    g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur * (1 - i * 0.14));
+    osc.connect(g).connect(out);
+    osc.start(t0);
+    osc.stop(t0 + dur + 0.05);
+  });
+};
+
+const CUES: Record<Cue, (c: AudioContext, out: GainNode) => void> = {
+  stamp(c, out) {
+    noise(c, out, { dur: 0.09, gain: 0.5, type: "lowpass", freq: 480 });
+    tone(c, out, { freq: 160, glideTo: 52, type: "sine", dur: 0.15, gain: 0.5 });
+  },
+  kaching(c, out) {
+    bell(c, out, { base: 1050, dur: 0.5, gain: 0.22 });
+    bell(c, out, { base: 1420, dur: 0.55, gain: 0.2, delay: 0.11 });
+  },
+  pow(c, out) {
+    noise(c, out, { dur: 0.08, gain: 0.42, type: "bandpass", freq: 950, q: 0.7 });
+    [392, 523, 784].forEach((f, i) =>
+      tone(c, out, { freq: f, type: "triangle", dur: 0.17, gain: 0.18, delay: i * 0.055 }),
+    );
+  },
+  odometer(c, out) {
+    [0, 0.04, 0.085, 0.14, 0.205].forEach((t, i) =>
+      noise(c, out, { dur: 0.02, gain: 0.15, type: "lowpass", freq: 1150 - i * 90, q: 1, delay: t }),
+    );
+    tone(c, out, { freq: 190, glideTo: 120, type: "sine", dur: 0.08, gain: 0.13, delay: 0.235 });
+  },
+  rankup(c, out) {
+    [523, 659, 784, 1047].forEach((f, i) =>
+      tone(c, out, { freq: f, type: "triangle", dur: 0.22, gain: 0.2, delay: i * 0.1 }),
+    );
+    tone(c, out, { freq: 1047, type: "sine", dur: 0.45, gain: 0.1, delay: 0.4 });
+  },
+};
+
+const lastPlayed: Record<string, number> = {};
+
+// Play a cue if sound is enabled and the context is unlocked. Collapses rapid
+// repeats (e.g. five KPI count-ups firing together = one tick).
+export const playSfx = (cue: Cue): void => {
+  if (!sfxEnabled()) return;
+  const a = audio();
+  if (!a || a.c.state !== "running") return; // suspended (no gesture yet) → skip
+  const now = Date.now();
+  if (now - (lastPlayed[cue] ?? 0) < 300) return;
+  lastPlayed[cue] = now;
+  CUES[cue](a.c, a.out);
+};

--- a/frontend/src/pages/ScoreLoadPage.tsx
+++ b/frontend/src/pages/ScoreLoadPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, type ReactNode } from "react";
 import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { scoreLoad, counterRates, VERDICT_META } from "@/lib/metrics/loadScore";
+import { playSfx } from "@/lib/sfx";
 import { RATE_TIERS, type RateTiers } from "@/lib/constants/targets";
 import {
   getLoadMiles,
@@ -279,6 +280,10 @@ const ScoreLoadPage = () => {
     activeTiers,
   );
   const meta = score.verdict ? VERDICT_META[score.verdict] : null;
+  // A ka-ching when a load scores a "steal".
+  useEffect(() => {
+    if (score.verdict === "steal") playSfx("kaching");
+  }, [score.verdict]);
   // Counter ladder — only when the load comes in under target (PASS/MEH).
   const belowTarget = score.verdict === "pass" || score.verdict === "meh";
   const counter =

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { AccessorialRatesCard } from "@/components/settings/AccessorialRatesCard";
 import { TeamCard } from "@/components/settings/TeamCard";
+import { sfxEnabled, setSfxEnabled, playSfx } from "@/lib/sfx";
 import { Panel } from "@/components/ui/Panel";
 import { money } from "@/lib/format";
 
@@ -130,6 +131,7 @@ const SettingsPage = () => {
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [sfx, setSfx] = useState(sfxEnabled());
 
   // Real break-even for the tier previews + weekly-target preview (cost-based,
   // so it's independent of the tier values being edited).
@@ -232,6 +234,38 @@ const SettingsPage = () => {
       <h1 className="text-3xl font-condensed">Settings</h1>
 
       {localStorage.getItem("role") === "admin" && <TeamCard />}
+
+      <Panel className="mt-6 max-w-[680px] p-5">
+        <h2 className="text-lg font-medium text-light">Sound effects</h2>
+        <p className="text-sm text-muted-text mt-1">
+          Short comic-book cues on the earned moments — an award pop, a load that
+          scores a steal, the KPI count-up. Turning this off silences them
+          everywhere on this device.
+        </p>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={sfx}
+          onClick={() => {
+            const next = !sfx;
+            setSfx(next);
+            setSfxEnabled(next);
+            if (next) playSfx("pow"); // let them hear it come on
+          }}
+          className="mt-4 inline-flex items-center gap-3"
+        >
+          <span
+            className="relative inline-block h-6 w-11 rounded-full transition-colors"
+            style={{ background: sfx ? "#e8940a" : "#3a4459" }}
+          >
+            <span
+              className="absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform"
+              style={{ left: 2, transform: sfx ? "translateX(20px)" : "translateX(0)" }}
+            />
+          </span>
+          <span className="text-sm text-light">{sfx ? "On" : "Off"}</span>
+        </button>
+      </Panel>
 
       <Panel className="mt-6 max-w-[680px] p-5">
         <h2 className="text-lg font-medium text-light">Settlement schedule</h2>


### PR DESCRIPTION
## What

Adds sound to the app — five comic-noir UI cues, **default on**, on the earned moments only.

`lib/sfx.ts` synthesizes each cue **live with the Web Audio API** (no audio files to host). Gated by a client pref (default on), unlocked on first interaction so non-gesture cues still play, kept quiet, and rapid repeats collapse (`playSfx` debounce).

**Wired:**
- **Odometer tick** → the KPI count-up (`RollingValue`) — debounce collapses the five KPIs into one tick.
- **POW / rank-up** → award pops (`AwardPopHost`): slide-in patches/records = POW, trophy/recap takeovers = fanfare, medals = sting.
- **Ka-ching** → a load scoring a "steal" in the Scorer.
- The **stamp** cue exists but is intentionally *unwired* — `RubberStamp` renders on the load-detail *view*, not a booking action; ready for a real hook later.

**Mute for everyone:** default-on + Settings is owner-only, so the toggle lives in the **sidebar footer** (all roles, so a dispatcher can mute it) plus a described toggle on the **Settings** page.

## Verify
- Build + **419 tests** clean.
- Sidebar toggle renders for all roles and flips on/off (screenshotted).
- Cues are byte-for-byte the approved sound board; every hook is guarded so it can't throw.
- ⚠️ Couldn't verify audio *firing* in-app (no audio via screenshots; dev DB paused) — audible live on load, default on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)