### PR TITLE
fix: make UI sound cues actually audible (v1.127.1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.127.0",
+  "version": "1.127.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/comic/RubberStamp.tsx
+++ b/frontend/src/components/comic/RubberStamp.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from "react";
+import { playSfx } from "@/lib/sfx";
+
 // A distressed, rotated ink stamp that slams down on a load's "won" state —
 // DELIVERED / PAID / CANCELLED / TONU. Pure CSS, no dependency.
 const STAMP_META: Record<string, string> = {
@@ -27,7 +30,12 @@ export const RubberStamp = ({
   value: string | null;
   size?: number;
 }) => {
-  if (!value || !(value in STAMP_META)) return null;
+  const shown = !!value && value in STAMP_META;
+  // The stamp thud when it slams down.
+  useEffect(() => {
+    if (shown) playSfx("stamp");
+  }, [shown]);
+  if (!shown || !value) return null;
   const color = STAMP_META[value];
   return (
     <span

--- a/frontend/src/lib/sfx.ts
+++ b/frontend/src/lib/sfx.ts
@@ -26,20 +26,12 @@ const audio = (): { c: AudioContext; out: GainNode } | null => {
   if (!ctx) {
     ctx = new AC();
     master = ctx.createGain();
-    master.gain.value = 0.5; // keep the whole thing quiet
+    master.gain.value = 1; // matches the approved sound-board volume (per-cue gains already run quiet)
     master.connect(ctx.destination);
   }
   if (ctx.state === "suspended") void ctx.resume();
   return master ? { c: ctx, out: master } : null;
 };
-
-// Unlock on the first interaction so cues that fire without a direct gesture
-// (count-ups, award pops) work for the rest of the session.
-if (typeof window !== "undefined") {
-  const unlock = () => audio();
-  window.addEventListener("pointerdown", unlock, { once: true });
-  window.addEventListener("keydown", unlock, { once: true });
-}
 
 interface ToneOpts {
   freq: number;
@@ -147,15 +139,44 @@ const CUES: Record<Cue, (c: AudioContext, out: GainNode) => void> = {
 };
 
 const lastPlayed: Record<string, number> = {};
+const play = (cue: Cue, a: { c: AudioContext; out: GainNode }) => {
+  const now = Date.now();
+  if (now - (lastPlayed[cue] ?? 0) < 300) return; // collapse rapid repeats
+  lastPlayed[cue] = now;
+  CUES[cue](a.c, a.out);
+};
 
-// Play a cue if sound is enabled and the context is unlocked. Collapses rapid
-// repeats (e.g. five KPI count-ups firing together = one tick).
+// A cue that fires before the context is unlocked (a count-up on a fresh page
+// load, before any click) can't play — browsers block audio until a gesture.
+// Remember the last such cue and play it the moment the user first interacts, so
+// a reload still lands the sound on the first click instead of dropping it.
+let pending: Cue | null = null;
+const unlock = () => {
+  const a = audio();
+  if (!a) return;
+  void a.c.resume().then(() => {
+    const cue = pending;
+    pending = null;
+    const a2 = audio();
+    if (cue && sfxEnabled() && a2 && a2.c.state === "running") play(cue, a2);
+  });
+};
+if (typeof window !== "undefined") {
+  const opts = { once: true } as const;
+  window.addEventListener("pointerdown", unlock, opts);
+  window.addEventListener("touchstart", unlock, opts); // older mobile Safari
+  window.addEventListener("keydown", unlock, opts);
+}
+
+// Play a cue if sound is enabled. If the context isn't unlocked yet, defer it to
+// the first gesture rather than dropping it.
 export const playSfx = (cue: Cue): void => {
   if (!sfxEnabled()) return;
   const a = audio();
-  if (!a || a.c.state !== "running") return; // suspended (no gesture yet) → skip
-  const now = Date.now();
-  if (now - (lastPlayed[cue] ?? 0) < 300) return;
-  lastPlayed[cue] = now;
-  CUES[cue](a.c, a.out);
+  if (!a) return;
+  if (a.c.state !== "running") {
+    pending = cue;
+    return;
+  }
+  play(cue, a);
 };


### PR DESCRIPTION
The sound cues shipped in v1.127.0 weren't audible. Three separate causes:

1. **Volume halved.** Master gain was `0.5`; the approved sound-board had no master scaling, so every cue played at half the signed-off volume. Restored to `1.0` (per-cue gains were already tuned quiet).
2. **Stamp never wired.** The DELIVERED/PAID `RubberStamp` on the load-detail page rendered silently. Now plays the stamp thud when it slams down, via an unconditional effect on the shown state.
3. **Cold-reload autoplay.** The dashboard count-up fires before any gesture, so browsers drop it. Now the last pre-unlock cue is remembered and flushed on the first `pointerdown`/`touchstart`/`keydown` — so the first tap after a reload lands the sound. `touchstart` added for older mobile Safari.

## Caveat
The first count-up *before* any interaction on a cold reload still can't sound — a hard browser rule. The fix makes the first tap land it, and every cue after that in the session plays live.

## Verification
- Strict production build clean; 419 tests pass; no console errors.
- Offline-rendered the stamp cue: peak 0.47 (real, non-silent audio) at the restored gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)