### PR TITLE
feat: vendor directory with ratings, category champions, shop spend (v1.128.0)

### DIFF
--- a/backend/db/migrations/054_vendors.sql
+++ b/backend/db/migrations/054_vendors.sql
@@ -1,0 +1,52 @@
+-- Vendors: the people/companies you PAY for services (shops, escort/pilot cars,
+-- permit services, tires, towing, ...). The cost-side mirror of agents — a company
+-- you have an opinion about — so it carries the same subjective 1–5 rating and an
+-- audited rating history (why the grade changed). Categories are a curated list
+-- validated in the app (see lib/constants/vendorCategories); stored as text here so
+-- adding one is a code change, not a migration. No load/expense links yet — the
+-- shop-spend readout is derived by name-match against maintenance_services.
+
+CREATE TABLE IF NOT EXISTS vendors (
+    vendor_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    name VARCHAR(120) NOT NULL,
+    category VARCHAR(40) NOT NULL,
+    rating SMALLINT NULL CHECK(rating > 0 AND rating < 6),
+    contact_name VARCHAR(80) NULL,
+    phone VARCHAR(50) NULL,
+    email VARCHAR(120) NULL,
+    website VARCHAR(255) NULL,
+    city VARCHAR(80) NULL,
+    state VARCHAR(2) NULL,
+    service_area VARCHAR(120) NULL,   -- free text, e.g. "TX·OK·NM" (escorts span states)
+    status VARCHAR(20) NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'inactive')),
+    notes TEXT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT vendor_name_per_user UNIQUE(name, user_id)
+);
+
+-- Audit trail for rating changes — same shape as agent_rating_history: every grade
+-- change records the old/new value, a required reason, and the initials of who did
+-- it. CASCADE so deleting a vendor cleans up its history.
+CREATE TABLE IF NOT EXISTS vendor_rating_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    vendor_id UUID NOT NULL REFERENCES vendors(vendor_id) ON DELETE CASCADE,
+    old_rating SMALLINT CHECK(old_rating > 0 AND old_rating < 6),
+    new_rating SMALLINT NOT NULL CHECK(new_rating > 0 AND new_rating < 6),
+    reason TEXT NOT NULL,
+    changed_by VARCHAR(5) NOT NULL,
+    changed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vendors_user ON vendors(user_id);
+CREATE INDEX IF NOT EXISTS idx_vendors_user_category ON vendors(user_id, category);
+CREATE INDEX IF NOT EXISTS idx_vendor_rating_history_vendor ON vendor_rating_history(vendor_id);
+
+-- RLS on (no policies) — the backend connects as the postgres owner and bypasses
+-- RLS; this only walls the tables off from Supabase's PostgREST. Per CLAUDE.md §5,
+-- every migration creating a public table must enable RLS explicitly (prod has no
+-- superuser event trigger to do it automatically).
+ALTER TABLE vendors               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vendor_rating_history ENABLE ROW LEVEL SECURITY;

--- a/backend/src/routes/vendorRoutes.js
+++ b/backend/src/routes/vendorRoutes.js
@@ -1,0 +1,154 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import {
+  getVendors,
+  getVendor,
+  createVendor,
+  patchVendor,
+  deleteVendor,
+} from "../services/vendorServices.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+// ---- GET ALL VENDORS ----
+router.get("/", async (req, res) => {
+  try {
+    const user_id = req.user.user_id;
+
+    const vendors = await getVendors(user_id);
+
+    return res.status(200).json({
+      message: "Vendors retrieved successfully",
+      count: vendors.length,
+      vendors,
+    });
+  } catch (err) {
+    if (err.type === "validation") {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+// ---- GET VENDOR BY ID ----
+router.get("/:vendor_id", async (req, res) => {
+  try {
+    const user_id = req.user.user_id;
+    const vendor_id = req.params.vendor_id;
+
+    const { vendor, ratingHistory } = await getVendor(user_id, vendor_id);
+
+    return res.status(200).json({
+      message: "Vendor retrieved successfully",
+      vendor,
+      ratingHistory,
+    });
+  } catch (err) {
+    if (err.type === "validation") {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+
+    if (err.type === "not_found") {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+// ---- CREATE VENDOR ----
+router.post("/", async (req, res) => {
+  try {
+    const user_id = req.user.user_id;
+    const data = req.body;
+
+    const vendor = await createVendor(user_id, data);
+
+    return res.status(201).json({
+      message: "Vendor created successfully",
+      vendor,
+    });
+  } catch (err) {
+    if (err.type === "validation") {
+      return res.status(err.statusCode).json({
+        error: err.message,
+        details: err.details,
+      });
+    }
+
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+// ---- PATCH VENDOR ----
+router.patch("/:vendor_id", async (req, res) => {
+  try {
+    const user_id = req.user.user_id;
+    const vendor_id = req.params.vendor_id;
+    const data = req.body;
+
+    const vendor = await patchVendor(user_id, vendor_id, data);
+
+    return res.status(200).json({
+      message: "Vendor updated successfully",
+      vendor,
+    });
+  } catch (err) {
+    if (err.type === "not_found") {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+
+    if (err.type === "validation") {
+      return res.status(err.statusCode).json({
+        error: err.message,
+        details: err.details,
+      });
+    }
+
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+// ---- DELETE VENDOR ----
+router.delete("/:vendor_id", async (req, res) => {
+  try {
+    const user_id = req.user.user_id;
+    const vendor_id = req.params.vendor_id;
+
+    const vendor = await deleteVendor(user_id, vendor_id);
+
+    return res.status(200).json({
+      message: "Vendor deleted successfully",
+      vendor,
+    });
+  } catch (err) {
+    if (err.type === "validation") {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+
+    if (err.type === "not_found") {
+      return res.status(err.statusCode).json({ error: err.message });
+    }
+
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -30,6 +30,7 @@ import settlementScheduleRouter from "./routes/settlementScheduleRoutes.js";
 import accessorialRateRouter from "./routes/accessorialRateRoutes.js";
 import routingRouter from "./routes/routingRoutes.js";
 import freightIndexRouter from "./routes/freightIndexRoutes.js";
+import vendorRouter from "./routes/vendorRoutes.js";
 
 const app = express();
 
@@ -81,6 +82,7 @@ app.use("/settlement-schedule", settlementScheduleRouter);
 app.use("/accessorial-rates", accessorialRateRouter);
 app.use("/routing", routingRouter);
 app.use("/freight-index", freightIndexRouter);
+app.use("/vendors", vendorRouter);
 
 app.get("/", (req, res) => {
   res.send("Home Page");

--- a/backend/src/services/vendorServices.js
+++ b/backend/src/services/vendorServices.js
@@ -1,0 +1,247 @@
+import { db } from "../../db/pool.js";
+import {
+  validateVendorCreate,
+  validateVendorPatch,
+} from "../utils/validation/vendorValidation.js";
+import { ValidationError, NotFoundError } from "../utils/error.js";
+
+// The writable columns (user_id is always set from the token, never the body).
+const VENDOR_FIELDS = [
+  "name",
+  "category",
+  "rating",
+  "contact_name",
+  "phone",
+  "email",
+  "website",
+  "city",
+  "state",
+  "service_area",
+  "status",
+  "notes",
+];
+
+// Shop vendors get a spend readout derived from the maintenance log, matched by
+// name (the maintenance vendor field is free text — no FK yet). Gated to category
+// 'Shop' so a coincidental name match can't attribute shop spend to an escort.
+// SUM(cost) is numeric → serialized as a string; service_count is a real integer.
+const SPEND_JOIN = `
+  LEFT JOIN LATERAL (
+    SELECT
+      SUM(m.cost)            AS total_spend,
+      COUNT(*)::int          AS service_count,
+      MAX(m.service_date)    AS last_service
+    FROM maintenance_services m
+    WHERE m.user_id = v.user_id
+      AND v.category = 'Shop'
+      AND LOWER(TRIM(m.vendor)) = LOWER(TRIM(v.name))
+  ) spend ON TRUE
+`;
+
+const VENDOR_COLUMNS = `
+  v.vendor_id,
+  v.name,
+  v.category,
+  v.rating,
+  v.contact_name,
+  v.phone,
+  v.email,
+  v.website,
+  v.city,
+  v.state,
+  v.service_area,
+  v.status,
+  v.notes,
+  v.created_at,
+  v.updated_at,
+  spend.total_spend,
+  spend.service_count,
+  spend.last_service
+`;
+
+// ---- GET VENDORS SERVICE ----
+export async function getVendors(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+
+  const query = `
+    SELECT ${VENDOR_COLUMNS}
+    FROM vendors v
+    ${SPEND_JOIN}
+    WHERE v.user_id = $1
+    ORDER BY v.name;
+  `;
+
+  const result = await db.query(query, [user_id]);
+  return result.rows;
+}
+
+// ---- GET VENDOR SERVICE ----
+export async function getVendor(user_id, vendor_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!vendor_id) throw new ValidationError("Missing vendor_id");
+
+  const vendorQuery = `
+    SELECT ${VENDOR_COLUMNS}
+    FROM vendors v
+    ${SPEND_JOIN}
+    WHERE v.user_id = $1
+    AND v.vendor_id = $2;
+  `;
+
+  const vendorResult = await db.query(vendorQuery, [user_id, vendor_id]);
+  if (vendorResult.rowCount === 0) throw new NotFoundError("Vendor not found");
+
+  const ratingHistoryResult = await db.query(
+    `SELECT * FROM vendor_rating_history WHERE vendor_id = $1 ORDER BY changed_at DESC;`,
+    [vendor_id],
+  );
+
+  return {
+    vendor: vendorResult.rows[0],
+    ratingHistory: ratingHistoryResult.rows,
+  };
+}
+
+// ---- CREATE VENDOR SERVICE ----
+export async function createVendor(user_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+
+  for (const field in data) {
+    if (!VENDOR_FIELDS.includes(field)) {
+      throw new ValidationError(`${field} not allowed`);
+    }
+  }
+
+  const errors = validateVendorCreate(data);
+  if (errors.length > 0) throw new ValidationError("Validation failed", errors);
+
+  const fields = ["user_id"];
+  const values = [user_id];
+  const placeholders = ["$1"];
+  let index = 2;
+
+  for (const field in data) {
+    if (data[field] !== undefined) {
+      fields.push(field);
+      values.push(data[field]);
+      placeholders.push(`$${index}`);
+      index++;
+    }
+  }
+
+  const query = `
+    INSERT INTO vendors(${fields.join(", ")})
+    VALUES (${placeholders.join(", ")})
+    RETURNING *;
+  `;
+
+  const result = await db.query(query, values);
+  return result.rows[0];
+}
+
+// ---- PATCH VENDOR SERVICE ----
+export async function patchVendor(user_id, vendor_id, data) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!vendor_id) throw new ValidationError("Missing vendor_id");
+
+  // Pull audit fields off — they aren't vendor columns.
+  const { reason, changed_by, ...vendorData } = data;
+
+  for (const field in vendorData) {
+    if (!VENDOR_FIELDS.includes(field))
+      throw new ValidationError(`${field} not allowed`);
+  }
+
+  const errors = validateVendorPatch(vendorData);
+  if (errors.length > 0) throw new ValidationError("Validation failed", errors);
+
+  const updates = [];
+  const values = [];
+  let index = 1;
+
+  for (const field of VENDOR_FIELDS) {
+    if (vendorData[field] !== undefined) {
+      updates.push(`${field} = $${index}`);
+      values.push(vendorData[field]);
+      index++;
+    }
+  }
+
+  if (updates.length === 0) {
+    throw new ValidationError("No valid fields provided for update");
+  }
+
+  updates.push(`updated_at = NOW()`);
+
+  const ratingIsChanging = vendorData.rating !== undefined;
+
+  const client = await db.pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    // Read the old rating FIRST, on the same client, so the history is accurate.
+    let oldRating = null;
+    if (ratingIsChanging) {
+      const current = await client.query(
+        `SELECT rating FROM vendors WHERE user_id=$1 AND vendor_id=$2`,
+        [user_id, vendor_id],
+      );
+      if (current.rowCount === 0) throw new NotFoundError("Vendor not found");
+      oldRating = current.rows[0].rating;
+    }
+
+    const query = `
+      UPDATE vendors
+      SET ${updates.join(", ")}
+      WHERE user_id = $${index}
+        AND vendor_id = $${index + 1}
+      RETURNING *;
+    `;
+    const updateValues = [...values, user_id, vendor_id];
+    const result = await client.query(query, updateValues);
+    if (result.rowCount === 0) throw new NotFoundError("Vendor not found");
+
+    // Only record history if the rating ACTUALLY changed.
+    if (ratingIsChanging && vendorData.rating !== oldRating) {
+      if (!reason || !changed_by) {
+        throw new ValidationError(
+          "Rating changes require a reason and initials",
+        );
+      }
+      const historyResult = await client.query(
+        `INSERT INTO vendor_rating_history(vendor_id, old_rating, new_rating, reason, changed_by)
+         VALUES($1, $2, $3, $4, $5)
+         RETURNING *;`,
+        [vendor_id, oldRating, vendorData.rating, reason, changed_by],
+      );
+      if (historyResult.rowCount === 0)
+        throw new Error("Unable to record rating change");
+    }
+
+    await client.query("COMMIT");
+    return result.rows[0];
+  } catch (e) {
+    await client.query("ROLLBACK");
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
+// ---- DELETE VENDOR SERVICE ----
+export async function deleteVendor(user_id, vendor_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!vendor_id) throw new ValidationError("Missing vendor_id");
+
+  const query = `
+    DELETE FROM vendors
+    WHERE user_id = $1
+    AND vendor_id = $2
+    RETURNING *;
+  `;
+
+  const result = await db.query(query, [user_id, vendor_id]);
+  if (result.rowCount === 0) throw new NotFoundError("Vendor not found");
+
+  return result.rows[0];
+}

--- a/backend/src/utils/validation/vendorValidation.js
+++ b/backend/src/utils/validation/vendorValidation.js
@@ -1,0 +1,115 @@
+import { isValidType } from "../helper.js";
+
+// The curated category vocabulary. Stored as plain text on the row; validated here
+// so a typo can't fragment "Escort" vs "Escorts". Keep in lockstep with the
+// frontend list in lib/constants/vendorCategories.ts. 'Shop' is load-bearing — it
+// gates the maintenance spend readout — so don't rename it without updating the
+// service query.
+export const VENDOR_CATEGORIES = [
+  "Shop",
+  "Escort / Pilot Car",
+  "Permits",
+  "Tires",
+  "Parts",
+  "Towing",
+  "Washout",
+  "Securement",
+  "Scale",
+  "Other",
+];
+
+const VENDOR_STATUSES = ["active", "inactive"];
+
+const nonBlankString = (label) => (value, errors) => {
+  if (!value) return;
+  if (!isValidType("string", value)) {
+    errors.push(`${label} must be a string`);
+    return;
+  }
+  if (value.trim().length === 0) errors.push(`${label} cannot be blank`);
+};
+
+const rules = {
+  name: (value, errors) => {
+    if (!isValidType("string", value)) {
+      errors.push("name must be a string");
+      return;
+    }
+    if (value.trim().length === 0) errors.push("name cannot be blank");
+  },
+  category: (value, errors) => {
+    if (!isValidType("string", value)) {
+      errors.push("category must be a string");
+      return;
+    }
+    if (!VENDOR_CATEGORIES.includes(value.trim())) {
+      errors.push("not a valid category");
+    }
+  },
+  rating: (value, errors) => {
+    if (!value) return;
+    if (!isValidType("integer", value)) {
+      errors.push("rating must be an integer");
+      return;
+    }
+    if (value < 1 || value > 5) errors.push("rating must be between 1 and 5");
+  },
+  contact_name: nonBlankString("contact_name"),
+  phone: nonBlankString("phone"),
+  email: (value, errors) => {
+    if (!value) return;
+    if (!isValidType("string", value)) {
+      errors.push("email must be a string");
+      return;
+    }
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      errors.push("email cannot be blank");
+      return;
+    }
+    if (!trimmed.includes("@") || !trimmed.includes(".")) {
+      errors.push("not a valid email");
+    }
+  },
+  website: nonBlankString("website"),
+  city: nonBlankString("city"),
+  state: (value, errors) => {
+    if (!value) return;
+    if (!isValidType("string", value)) {
+      errors.push("state must be a string");
+      return;
+    }
+    if (value.trim().length !== 2) errors.push("state must be 2 letters");
+  },
+  service_area: nonBlankString("service_area"),
+  status: (value, errors) => {
+    if (!value) return;
+    if (!VENDOR_STATUSES.includes(value)) errors.push("not a valid status");
+  },
+  notes: nonBlankString("notes"),
+};
+
+// ---- CREATE VENDOR VALIDATION ----
+export const validateVendorCreate = (data) => {
+  const errors = [];
+
+  if (!data.name) errors.push("Missing name");
+  if (!data.category) errors.push("Missing category");
+
+  for (const field in data) {
+    if (rules[field]) rules[field](data[field], errors);
+  }
+
+  return errors;
+};
+
+// ---- PATCH VENDOR VALIDATION ----
+export const validateVendorPatch = (data) => {
+  const errors = [];
+
+  for (const field in data) {
+    if (rules[field]) rules[field](data[field], errors);
+  }
+
+  return errors;
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.127.1",
+  "version": "1.128.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,8 @@ import PerDiemPage from "@/pages/PerDiemPage";
 import MaintenancePage from "@/pages/MaintenancePage";
 import AgentsPage from "@/pages/AgentsPage";
 import AgentDetailPage from "./pages/AgentDetailPage";
+import VendorsPage from "@/pages/VendorsPage";
+import VendorDetailPage from "@/pages/VendorDetailPage";
 import FuelEntriesPage from "@/pages/FuelEntriesPage";
 import TrucksPage from "@/pages/TrucksPage";
 import TruckDetailPage from "@/pages/TruckDetailPage";
@@ -73,6 +75,8 @@ const App = () => {
           <Route path="/compliance" element={<CompliancePage />} />
           <Route path="/agents" element={<AgentsPage />} />
           <Route path="/agents/:agent_id" element={<AgentDetailPage />} />
+          <Route path="/vendors" element={<VendorsPage />} />
+          <Route path="/vendors/:vendor_id" element={<VendorDetailPage />} />
           <Route path="/trucks" element={<TrucksPage />} />
           <Route path="/trucks/:id" element={<TruckDetailPage />} />
           <Route path="/drivers" element={<DriversPage />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -55,6 +55,7 @@ const nav: Entry[] = [
       { to: "/trips", label: "Trips" },
       { to: "/lanes", label: "Lanes" },
       { to: "/agents", label: "Agents" },
+      { to: "/vendors", label: "Vendors" },
       { to: "/facilities", label: "Facilities" },
     ],
   },

--- a/frontend/src/components/vendors/VendorForm.tsx
+++ b/frontend/src/components/vendors/VendorForm.tsx
@@ -1,0 +1,290 @@
+import { useState } from "react";
+import type { Vendor } from "@/types/vendor";
+import type { CreateVendorInput } from "@/types/createVendorInput";
+import type { VendorPatchPayload } from "@/types/vendorPatchPayload";
+import { createVendor } from "@/services/createVendorService";
+import { patchVendor } from "@/services/patchVendorService";
+import { VENDOR_CATEGORIES } from "@/lib/constants/vendorCategories";
+import { VENDOR_RATING_OPTIONS } from "@/lib/metrics/vendorRatingLabels";
+import { Field, SelectControl } from "@/components/ui/FormControls";
+import CityAutocomplete from "@/components/CityAutocomplete";
+
+interface VendorFormProps {
+  vendor?: Vendor; // present → edit mode
+  onSuccess: (v: Vendor) => void;
+  onClose: () => void;
+}
+
+// Create or edit a vendor's core fields. Rating is offered ONLY on create (an
+// initial grade needs no audit); once a vendor exists, rating changes go through
+// VendorRatingForm so the reason + history are enforced.
+const VendorForm = ({ vendor, onSuccess, onClose }: VendorFormProps) => {
+  const isEdit = !!vendor;
+
+  const [name, setName] = useState(vendor?.name ?? "");
+  const [category, setCategory] = useState(vendor?.category ?? "");
+  const [rating, setRating] = useState<number | null>(vendor?.rating ?? null);
+  const [contactName, setContactName] = useState(vendor?.contact_name ?? "");
+  const [phone, setPhone] = useState(vendor?.phone ?? "");
+  const [email, setEmail] = useState(vendor?.email ?? "");
+  const [website, setWebsite] = useState(vendor?.website ?? "");
+  const [city, setCity] = useState(vendor?.city ?? "");
+  const [stateVal, setStateVal] = useState(vendor?.state ?? "");
+  const [serviceArea, setServiceArea] = useState(vendor?.service_area ?? "");
+  const [status, setStatus] = useState(vendor?.status ?? "active");
+  const [notes, setNotes] = useState(vendor?.notes ?? "");
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const validate = () => {
+    const e: Record<string, string> = {};
+    if (!name.trim()) e.name = "Required";
+    if (!category) e.category = "Pick a category";
+    if (email.trim() && (!email.includes("@") || !email.includes(".")))
+      e.email = "Not a valid email";
+    if (stateVal.trim() && stateVal.trim().length !== 2)
+      e.state = "Use the 2-letter state";
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    setFormError(null);
+    if (!validate()) return;
+
+    const clean = (s: string) => (s.trim() ? s.trim() : null);
+
+    try {
+      setSaving(true);
+      let saved: Vendor;
+      if (isEdit) {
+        const payload: VendorPatchPayload = {
+          name: name.trim(),
+          category,
+          contact_name: clean(contactName),
+          phone: clean(phone),
+          email: clean(email),
+          website: clean(website),
+          city: clean(city),
+          state: clean(stateVal)?.toUpperCase() ?? null,
+          service_area: clean(serviceArea),
+          status,
+          notes: clean(notes),
+        };
+        saved = await patchVendor(vendor!.vendor_id, payload);
+      } else {
+        const payload: CreateVendorInput = {
+          name: name.trim(),
+          category,
+          rating: rating ?? null,
+          contact_name: clean(contactName),
+          phone: clean(phone),
+          email: clean(email),
+          website: clean(website),
+          city: clean(city),
+          state: clean(stateVal)?.toUpperCase() ?? null,
+          service_area: clean(serviceArea),
+          notes: clean(notes),
+        };
+        saved = await createVendor(payload);
+      }
+      onSuccess(saved);
+      onClose();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Failed to save vendor");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="font-body">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-semibold text-light">
+          {isEdit ? "Edit vendor" : "New vendor"}
+        </h2>
+        <button
+          onClick={onClose}
+          className="text-muted-text hover:text-light"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="Name" htmlFor="v-name" error={errors.name} className="sm:col-span-2">
+          <input
+            id="v-name"
+            className="ds-input"
+            placeholder="Lone Star Pilot Cars"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </Field>
+
+        <Field label="Category" htmlFor="v-cat" error={errors.category}>
+          <SelectControl
+            id="v-cat"
+            invalid={!!errors.category}
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            <option value="" disabled>
+              Select a category
+            </option>
+            {VENDOR_CATEGORIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </SelectControl>
+        </Field>
+
+        {isEdit ? (
+          <Field label="Status" htmlFor="v-status">
+            <SelectControl
+              id="v-status"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            >
+              <option value="active">Active</option>
+              <option value="inactive">Inactive</option>
+            </SelectControl>
+          </Field>
+        ) : (
+          <Field label="Rating" htmlFor="v-rating" hint="· optional">
+            <SelectControl
+              id="v-rating"
+              value={rating === null ? "" : String(rating)}
+              onChange={(e) =>
+                setRating(e.target.value ? Number(e.target.value) : null)
+              }
+            >
+              <option value="">Unrated</option>
+              {VENDOR_RATING_OPTIONS.map((o) => (
+                <option key={o.value} value={String(o.value)}>
+                  {o.label}
+                </option>
+              ))}
+            </SelectControl>
+          </Field>
+        )}
+
+        <Field label="Contact" htmlFor="v-contact">
+          <input
+            id="v-contact"
+            className="ds-input"
+            placeholder="Maria Lopez"
+            value={contactName}
+            onChange={(e) => setContactName(e.target.value)}
+          />
+        </Field>
+
+        <Field label="Phone" htmlFor="v-phone">
+          <input
+            id="v-phone"
+            className="ds-input"
+            placeholder="(956) 555-0142"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+          />
+        </Field>
+
+        <Field label="Email" htmlFor="v-email" error={errors.email}>
+          <input
+            id="v-email"
+            className="ds-input"
+            placeholder="dispatch@vendor.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </Field>
+
+        <Field label="Website" htmlFor="v-web">
+          <input
+            id="v-web"
+            className="ds-input"
+            placeholder="lonestarpilot.com"
+            value={website}
+            onChange={(e) => setWebsite(e.target.value)}
+          />
+        </Field>
+
+        <Field label="City" htmlFor="v-city" hint="· fills state">
+          <CityAutocomplete
+            id="v-city"
+            value={city}
+            onType={setCity}
+            onSelect={(c, s) => {
+              setCity(c);
+              setStateVal(s);
+            }}
+            inputClassName="ds-input"
+            placeholder="Laredo"
+          />
+        </Field>
+
+        <Field label="State" htmlFor="v-state" error={errors.state}>
+          <input
+            id="v-state"
+            className="ds-input"
+            placeholder="TX"
+            maxLength={2}
+            value={stateVal}
+            onChange={(e) => setStateVal(e.target.value.toUpperCase())}
+          />
+        </Field>
+
+        <Field
+          label="Service area"
+          htmlFor="v-area"
+          hint="· where they cover"
+          className="sm:col-span-2"
+        >
+          <input
+            id="v-area"
+            className="ds-input"
+            placeholder="TX · OK · NM"
+            value={serviceArea}
+            onChange={(e) => setServiceArea(e.target.value)}
+          />
+        </Field>
+
+        <Field label="Notes" htmlFor="v-notes" className="sm:col-span-2">
+          <textarea
+            id="v-notes"
+            className="ds-input"
+            style={{ minHeight: 72, paddingTop: 8 }}
+            placeholder="Great on the I-10 permit runs; slow to invoice."
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
+        </Field>
+      </div>
+
+      {formError && <p className="text-destructive text-sm mt-3">{formError}</p>}
+
+      <div className="flex gap-2 justify-end mt-5">
+        <button
+          onClick={onClose}
+          disabled={saving}
+          className="px-3 py-2 rounded text-sm border border-[#3b4660] text-light disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleSubmit}
+          disabled={saving}
+          className="bg-amber text-steel px-4 py-2 rounded text-sm font-semibold disabled:opacity-50"
+        >
+          {saving ? "Saving…" : isEdit ? "Save changes" : "Add vendor"}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default VendorForm;

--- a/frontend/src/components/vendors/VendorRatingForm.tsx
+++ b/frontend/src/components/vendors/VendorRatingForm.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import type { Vendor } from "@/types/vendor";
+import type { VendorPatchPayload } from "@/types/vendorPatchPayload";
+import { patchVendor } from "@/services/patchVendorService";
+import { VENDOR_RATING_OPTIONS } from "@/lib/metrics/vendorRatingLabels";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface VendorRatingFormProps {
+  vendor: Vendor;
+  onSuccess: () => void;
+  onClose: () => void;
+}
+
+// Edit a vendor's rating. A change requires a reason + initials (mirrors the agent
+// flow) so the vendor_rating_history keeps the "why" behind every grade.
+const VendorRatingForm = ({
+  vendor,
+  onSuccess,
+  onClose,
+}: VendorRatingFormProps) => {
+  const [rating, setRating] = useState<number | null>(vendor.rating ?? null);
+  const [reason, setReason] = useState("");
+  const [changedBy, setChangedBy] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const ratingChanged = rating !== (vendor.rating ?? null);
+
+  const handleSubmit = async () => {
+    setError(null);
+
+    if (ratingChanged && (!reason.trim() || !changedBy.trim())) {
+      setError("Rating changes require a reason and initials");
+      return;
+    }
+
+    if (!ratingChanged) {
+      onClose();
+      return;
+    }
+
+    const payload: VendorPatchPayload = {
+      rating,
+      reason: reason.trim(),
+      changed_by: changedBy.trim(),
+    };
+
+    try {
+      setIsSaving(true);
+      await patchVendor(vendor.vendor_id, payload);
+      onSuccess();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update rating");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="font-body">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-semibold text-foreground">
+          Edit rating —{" "}
+          <span className="font-normal text-muted-foreground">
+            {vendor.name}
+          </span>
+        </h2>
+        <button
+          onClick={onClose}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="grid gap-4">
+        <div>
+          <Label htmlFor="rating">Rating</Label>
+          <Select
+            value={rating !== null ? String(rating) : undefined}
+            onValueChange={(value) => setRating(Number(value))}
+          >
+            <SelectTrigger id="rating">
+              <SelectValue placeholder="Select a rating" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {VENDOR_RATING_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={String(option.value)}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label htmlFor="reason">
+            Reason {ratingChanged && <span className="text-primary">*</span>}
+          </Label>
+          <Textarea
+            id="reason"
+            placeholder="Why is the rating changing?"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="changed_by">
+            Your initials{" "}
+            {ratingChanged && <span className="text-primary">*</span>}
+          </Label>
+          <Input
+            id="changed_by"
+            maxLength={5}
+            placeholder="e.g. JD"
+            value={changedBy}
+            onChange={(e) => setChangedBy(e.target.value)}
+          />
+        </div>
+
+        {error && <p className="text-destructive text-sm">{error}</p>}
+
+        <div className="flex gap-2 justify-end mt-2">
+          <Button variant="outline" onClick={onClose} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSaving}>
+            {isSaving ? "Saving..." : "Save rating"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VendorRatingForm;

--- a/frontend/src/components/vendors/VendorRatingMedallion.tsx
+++ b/frontend/src/components/vendors/VendorRatingMedallion.tsx
@@ -1,0 +1,34 @@
+import { Crown, ThumbsUp, Minus, AlertTriangle, Ban } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+// The 1–5 vendor rating as a bold comic medallion — one clear verdict. Cost-side
+// twin of the agent RatingMedallion, worded for a vendor you pay.
+const TIERS: Record<number, { label: string; cls: string; Icon: LucideIcon }> = {
+  5: { label: "Go-to", cls: "bg-amber text-steel", Icon: Crown },
+  4: { label: "Solid", cls: "bg-[#2fae6b] text-[#06231a]", Icon: ThumbsUp },
+  3: { label: "Fine", cls: "bg-[#45526e] text-light", Icon: Minus },
+  2: { label: "Last resort", cls: "bg-[#d9761c] text-steel", Icon: AlertTriangle },
+  1: { label: "Avoid", cls: "bg-[#d23b3b] text-white", Icon: Ban },
+};
+
+export const VendorRatingMedallion = ({
+  rating,
+  size = "sm",
+}: {
+  rating?: number | null;
+  size?: "sm" | "lg";
+}) => {
+  const pad = size === "lg" ? "text-sm px-3 py-1.5" : "text-xs px-2.5 py-1";
+  const base = `inline-flex items-center gap-1.5 rounded font-condensed uppercase tracking-wide ${pad}`;
+
+  if (!rating)
+    return <span className={`${base} bg-steel text-muted-text`}>Unrated</span>;
+
+  const t = TIERS[rating];
+  const Icon = t.Icon;
+  return (
+    <span className={`${base} ${t.cls}`}>
+      <Icon size={size === "lg" ? 16 : 13} /> {t.label}
+    </span>
+  );
+};

--- a/frontend/src/components/vendors/VendorRatingStamp.tsx
+++ b/frontend/src/components/vendors/VendorRatingStamp.tsx
@@ -1,0 +1,25 @@
+// The "hero" rating display for the vendor detail page — a comic rubber stamp,
+// tier-colored and cocked at an angle. Cost-side twin of the agent RatingStamp.
+const STAMP: Record<number, { label: string; color: string }> = {
+  5: { label: "Go-to", color: "#e8940a" },
+  4: { label: "Solid", color: "#3fbf78" },
+  3: { label: "Fine", color: "#9daabb" },
+  2: { label: "Last resort", color: "#e0822e" },
+  1: { label: "Avoid", color: "#e24b4a" },
+};
+
+export const VendorRatingStamp = ({ rating }: { rating?: number | null }) => {
+  const s = rating ? STAMP[rating] : { label: "Unrated", color: "#9daabb" };
+  return (
+    <div
+      className="inline-block px-4 py-1 rotate-[-6deg] font-comic uppercase text-2xl rounded"
+      style={{
+        border: `3px double ${s.color}`,
+        color: s.color,
+        letterSpacing: "2px",
+      }}
+    >
+      {s.label}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useVendor.ts
+++ b/frontend/src/hooks/useVendor.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+import type { Vendor } from "@/types/vendor";
+import type { VendorRatingHistory } from "@/types/vendorRatingHistory";
+import { getVendor } from "@/services/vendorService";
+import { useParams } from "react-router";
+
+export const useVendor = (refreshKey: number = 0) => {
+  const [vendor, setVendor] = useState<Vendor>();
+  const [ratingHistory, setRatingHistory] = useState<VendorRatingHistory[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { vendor_id } = useParams();
+
+  useEffect(() => {
+    if (!vendor_id) {
+      setError("No vendor specified");
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchVendor = async () => {
+      try {
+        const data = await getVendor(vendor_id);
+        setVendor(data.vendor);
+        setRatingHistory(data.ratingHistory);
+      } catch {
+        setError("Failed to load vendor");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchVendor();
+  }, [refreshKey, vendor_id]);
+
+  return {
+    vendor,
+    ratingHistory,
+    isLoading,
+    error,
+  };
+};

--- a/frontend/src/hooks/useVendors.ts
+++ b/frontend/src/hooks/useVendors.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+import type { Vendor } from "@/types/vendor";
+import { getVendors } from "@/services/vendorsService";
+
+export const useVendors = (refreshKey: number = 0) => {
+  const [vendors, setVendors] = useState<Vendor[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchVendors = async () => {
+      try {
+        const data = await getVendors();
+        setVendors(data);
+      } catch {
+        setError("Failed to load vendors");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchVendors();
+  }, [refreshKey]);
+
+  return {
+    vendors,
+    isLoading,
+    error,
+  };
+};

--- a/frontend/src/lib/constants/vendorCategories.ts
+++ b/frontend/src/lib/constants/vendorCategories.ts
@@ -1,0 +1,31 @@
+// The curated vendor category vocabulary. Keep in lockstep with the backend list
+// in utils/validation/vendorValidation.js (VENDOR_CATEGORIES). 'Shop' is special —
+// it's the category that gets the maintenance spend readout.
+export const VENDOR_CATEGORIES = [
+  "Shop",
+  "Escort / Pilot Car",
+  "Permits",
+  "Tires",
+  "Parts",
+  "Towing",
+  "Washout",
+  "Securement",
+  "Scale",
+  "Other",
+] as const;
+
+export type VendorCategory = (typeof VENDOR_CATEGORIES)[number];
+
+// A lucide-react icon name per category, for the list group headers and chips.
+export const CATEGORY_ICON: Record<string, string> = {
+  Shop: "Wrench",
+  "Escort / Pilot Car": "ShieldCheck",
+  Permits: "FileText",
+  Tires: "CircleDot",
+  Parts: "Cog",
+  Towing: "Truck",
+  Washout: "Droplets",
+  Securement: "Link",
+  Scale: "Scale",
+  Other: "Package",
+};

--- a/frontend/src/lib/metrics/vendorLeaderboard.test.ts
+++ b/frontend/src/lib/metrics/vendorLeaderboard.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { groupVendorsByCategory, goToCount } from "./vendorLeaderboard";
+import type { Vendor } from "@/types/vendor";
+
+const v = (over: Partial<Vendor>): Vendor => ({
+  vendor_id: over.name ?? Math.random().toString(),
+  name: over.name ?? "x",
+  category: over.category ?? "Shop",
+  rating: over.rating ?? null,
+  status: "active",
+  created_at: "2026-01-01",
+  updated_at: "2026-01-01",
+  ...over,
+});
+
+describe("groupVendorsByCategory", () => {
+  it("returns nothing for an empty roster", () => {
+    expect(groupVendorsByCategory([])).toEqual([]);
+  });
+
+  it("groups by category and sorts categories by name", () => {
+    const groups = groupVendorsByCategory([
+      v({ name: "A", category: "Shop" }),
+      v({ name: "B", category: "Escort / Pilot Car" }),
+    ]);
+    expect(groups.map((g) => g.category)).toEqual(["Escort / Pilot Car", "Shop"]);
+  });
+
+  it("ranks by rating desc, unrated last, ties broken by name", () => {
+    const groups = groupVendorsByCategory([
+      v({ name: "Zeta", category: "Shop", rating: 5 }),
+      v({ name: "Alpha", category: "Shop", rating: 5 }),
+      v({ name: "Mid", category: "Shop", rating: 3 }),
+      v({ name: "Unrated", category: "Shop", rating: null }),
+    ]);
+    expect(groups[0].vendors.map((x) => x.name)).toEqual([
+      "Alpha",
+      "Zeta",
+      "Mid",
+      "Unrated",
+    ]);
+  });
+
+  it("crowns the top-rated vendor as champion (ties broken by name)", () => {
+    const groups = groupVendorsByCategory([
+      v({ name: "Zeta", category: "Shop", rating: 5 }),
+      v({ name: "Alpha", category: "Shop", rating: 5 }),
+    ]);
+    expect(groups[0].champion?.name).toBe("Alpha");
+  });
+
+  it("crowns the best even when it's a modest rating", () => {
+    const groups = groupVendorsByCategory([
+      v({ name: "Only", category: "Towing", rating: 2 }),
+    ]);
+    expect(groups[0].champion?.name).toBe("Only");
+  });
+
+  it("has no champion when nobody in the category is rated", () => {
+    const groups = groupVendorsByCategory([
+      v({ name: "A", category: "Parts", rating: null }),
+      v({ name: "B", category: "Parts", rating: null }),
+    ]);
+    expect(groups[0].champion).toBeNull();
+  });
+});
+
+describe("goToCount", () => {
+  it("counts only 5-rated vendors", () => {
+    expect(
+      goToCount([
+        v({ rating: 5 }),
+        v({ rating: 5 }),
+        v({ rating: 4 }),
+        v({ rating: null }),
+      ]),
+    ).toBe(2);
+  });
+});

--- a/frontend/src/lib/metrics/vendorLeaderboard.ts
+++ b/frontend/src/lib/metrics/vendorLeaderboard.ts
@@ -1,0 +1,44 @@
+import type { Vendor } from "@/types/vendor";
+
+export interface VendorGroup {
+  category: string;
+  vendors: Vendor[]; // ranked: rating desc, unrated last, then name asc
+  champion: Vendor | null; // top-rated in the category; null if nobody is rated
+}
+
+// Rank two vendors: higher rating first, unrated (null) sinks to the bottom, ties
+// broken by name so the order — and the champion — is deterministic.
+const rankVendors = (a: Vendor, b: Vendor): number => {
+  const ra = a.rating ?? -1;
+  const rb = b.rating ?? -1;
+  if (rb !== ra) return rb - ra;
+  return a.name.localeCompare(b.name);
+};
+
+// Group vendors by category, rank within each, and crown the champion — the single
+// top-rated vendor in the category (the answer to "who's my best escort?"). A
+// category where nobody is rated has no champion. Categories come back sorted by
+// name for a stable list.
+export const groupVendorsByCategory = (vendors: Vendor[]): VendorGroup[] => {
+  const byCategory = new Map<string, Vendor[]>();
+  for (const v of vendors) {
+    const list = byCategory.get(v.category) ?? [];
+    list.push(v);
+    byCategory.set(v.category, list);
+  }
+
+  const groups: VendorGroup[] = [];
+  for (const [category, list] of byCategory) {
+    const ranked = [...list].sort(rankVendors);
+    const top = ranked[0];
+    const champion = top && top.rating != null ? top : null;
+    groups.push({ category, vendors: ranked, champion });
+  }
+
+  groups.sort((a, b) => a.category.localeCompare(b.category));
+  return groups;
+};
+
+// How many vendors you've marked a go-to (rated 5) — a roster KPI.
+export const goToCount = (vendors: Vendor[]): number =>
+  vendors.filter((v) => v.rating === 5).length;

--- a/frontend/src/lib/metrics/vendorRatingLabels.ts
+++ b/frontend/src/lib/metrics/vendorRatingLabels.ts
@@ -1,0 +1,17 @@
+// Vendor rating labels — the cost-side twin of the agent scale (ratingLabels.ts),
+// worded for a vendor you pay: 5 you seek out, 1 you steer around.
+export const VENDOR_RATING_OPTIONS = [
+  { value: 5, label: "5 - Go-to" },
+  { value: 4, label: "4 - Solid" },
+  { value: 3, label: "3 - Fine" },
+  { value: 2, label: "2 - Last resort" },
+  { value: 1, label: "1 - Avoid" },
+];
+
+export const getVendorRatingLabel = (
+  rating: number | null | undefined,
+): string => {
+  if (!rating) return "Unrated";
+  const option = VENDOR_RATING_OPTIONS.find((o) => o.value === rating);
+  return option ? option.label : "Unrated";
+};

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { Trophy, ArrowRight } from "lucide-react";
 import { RatingMedallion } from "@/components/agents/RatingMedallion";
+import { VendorRatingMedallion } from "@/components/vendors/VendorRatingMedallion";
 import {
   PrestigeBurst,
   PRESTIGE_META,
@@ -367,6 +368,10 @@ const NAV: { group: string; items: string[] }[] = [
       "Trophies",
       "Career rank",
     ],
+  },
+  {
+    group: "Vendors",
+    items: ["Vendor ratings", "Best per category", "Shop spend"],
   },
   {
     group: "Team &amp; roles",
@@ -1548,6 +1553,88 @@ const GuidePage = () => {
               The full record — every board, gold, and silver by quarter — lives
               on each agent's own page.
             </p>
+          </Section>
+
+          <div
+            className="my-6 border-t"
+            style={{ borderColor: "#22304a" }}
+            aria-hidden="true"
+          />
+          <GroupHeading>Vendors</GroupHeading>
+
+          <Section
+            title="Vendor ratings"
+            sources={[{ label: "Vendors", to: "/vendors" }]}
+          >
+            <p className="text-sm text-muted-text mb-4">
+              Vendors are the flip side of agents — the shops, escorts, permit
+              services, and tire shops you <span className="text-light">pay</span>
+              . You grade each one by hand, 1–5, worst to best. The grade rides
+              along as a medallion everywhere. Change it and dash asks why,
+              keeping a history on the vendor's page — same as agents.
+            </p>
+            <div className="flex flex-col gap-3">
+              {(
+                [
+                  [5, "Your first call. Trusted with a tight window or a heavy load."],
+                  [4, "Solid. No complaints — you'd use them again."],
+                  [3, "Fine. Gets the job done."],
+                  [2, "Last resort. Only when nobody better is free."],
+                  [1, "Avoid. Burned you — steer around them."],
+                ] as [number, string][]
+              ).map(([r, desc]) => (
+                <div key={r} className="flex items-center gap-4">
+                  <div className="w-32 shrink-0">
+                    <VendorRatingMedallion rating={r} />
+                  </div>
+                  <p className="text-sm text-muted-text">{desc}</p>
+                </div>
+              ))}
+            </div>
+          </Section>
+
+          <Section
+            title="Best per category"
+            sources={[{ label: "Vendors", to: "/vendors" }]}
+          >
+            <p className="text-sm text-muted-text">
+              Every vendor sits in one category — Shop, Escort / Pilot Car,
+              Permits, and so on. Within each, dash ranks them by the grade you
+              gave and pins a crown on the top one. That crown is the quick
+              answer to “who's my best escort?” — no digging.
+            </p>
+            <Formula>
+              champion = highest-rated vendor in the category (ties broken by
+              name)
+            </Formula>
+            <Why>
+              It's ranked on <span className="text-light">your</span> grades,
+              nothing automatic — an honest “best of what I've got,” even when a
+              category is thin. Use the chips up top to filter to a single
+              category's board.
+            </Why>
+          </Section>
+
+          <Section
+            title="Shop spend"
+            sources={[
+              { label: "Vendors", to: "/vendors" },
+              { label: "Maintenance", to: "/maintenance" },
+            ]}
+          >
+            <p className="text-sm text-muted-text">
+              For <span className="text-light">shops</span>, dash pulls what
+              you've already spent with them straight from your maintenance log —
+              the total and how many services — and shows it on the list and
+              their page.
+            </p>
+            <Why>
+              It's matched by <span className="text-light">name</span>: a shop's
+              spend links when the vendor name on a maintenance service matches
+              the vendor's name here. Escorts, permits, and the rest just carry
+              the rating for now — the spend score grows from the shops, where
+              the data already lives.
+            </Why>
           </Section>
 
           <div

--- a/frontend/src/pages/VendorDetailPage.tsx
+++ b/frontend/src/pages/VendorDetailPage.tsx
@@ -1,0 +1,275 @@
+import { useState, useMemo } from "react";
+import { Link, useNavigate } from "react-router";
+import {
+  Mail,
+  Phone,
+  Globe,
+  MapPin,
+  Star,
+  Wrench,
+  Crown,
+  Trash2,
+} from "lucide-react";
+
+import { useVendor } from "@/hooks/useVendor";
+import { useVendors } from "@/hooks/useVendors";
+import { deleteVendor } from "@/services/deleteVendorService";
+import { groupVendorsByCategory } from "@/lib/metrics/vendorLeaderboard";
+
+import VendorRatingForm from "@/components/vendors/VendorRatingForm";
+import VendorForm from "@/components/vendors/VendorForm";
+import { VendorRatingStamp } from "@/components/vendors/VendorRatingStamp";
+import { Kpi } from "@/components/Kpi";
+import { Panel } from "@/components/ui/Panel";
+import { Skeleton } from "@/components/ui/skeleton";
+import { StatCardsSkeleton, BlockSkeleton } from "@/components/ui/PageSkeletons";
+import { money, formatDate } from "@/lib/format";
+
+const VendorDetailPage = () => {
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [showRating, setShowRating] = useState(false);
+  const [showEdit, setShowEdit] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const navigate = useNavigate();
+
+  const { vendor, ratingHistory, isLoading, error } = useVendor(refreshKey);
+  const { vendors: allVendors } = useVendors(refreshKey);
+
+  // Is this vendor the top-rated in its category? (drives the champion ribbon)
+  const isChampion = useMemo(() => {
+    if (!vendor) return false;
+    const group = groupVendorsByCategory(allVendors).find(
+      (g) => g.category === vendor.category,
+    );
+    return group?.champion?.vendor_id === vendor.vendor_id;
+  }, [vendor, allVendors]);
+
+  if (isLoading)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <Skeleton className="h-8 w-48 mb-2" />
+        <Skeleton className="h-4 w-32 mb-6" />
+        <StatCardsSkeleton count={3} />
+        <BlockSkeleton className="h-56 mt-6" />
+      </div>
+    );
+  if (error)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <p className="text-destructive">{error}</p>
+      </div>
+    );
+  if (!vendor) return null;
+
+  const isShop = vendor.category === "Shop";
+  const hasSpend = isShop && !!vendor.service_count && vendor.service_count > 0;
+  const place = [vendor.city, vendor.state].filter(Boolean).join(", ");
+
+  const handleSuccess = () => {
+    setRefreshKey((p) => p + 1);
+    setShowRating(false);
+    setShowEdit(false);
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm(`Delete ${vendor.name}? This can't be undone.`)) return;
+    try {
+      setDeleting(true);
+      await deleteVendor(vendor.vendor_id);
+      navigate("/vendors");
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Failed to delete vendor");
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      {showRating && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setShowRating(false)}
+          />
+          <div className="relative w-full max-w-[450px] mx-4 max-h-[90vh] bg-iron text-light overflow-y-auto shadow-xl rounded-lg p-4 sm:p-6 border border-plate">
+            <VendorRatingForm
+              vendor={vendor}
+              onSuccess={handleSuccess}
+              onClose={() => setShowRating(false)}
+            />
+          </div>
+        </div>
+      )}
+
+      {showEdit && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setShowEdit(false)}
+          />
+          <div className="relative w-full max-w-[640px] mx-4 max-h-[90vh] bg-iron text-light overflow-y-auto shadow-xl rounded-lg p-4 sm:p-6 border border-plate">
+            <VendorForm
+              vendor={vendor}
+              onSuccess={handleSuccess}
+              onClose={() => setShowEdit(false)}
+            />
+          </div>
+        </div>
+      )}
+
+      <Link to="/vendors" className="text-xs text-muted-text hover:text-light">
+        ← Vendors
+      </Link>
+
+      <div className="flex flex-col gap-4 mt-3 mb-6 sm:flex-row sm:justify-between sm:items-start">
+        <div className="min-w-0">
+          <h1 className="text-3xl font-condensed leading-none">{vendor.name}</h1>
+          <div className="flex items-center gap-2 mt-2 flex-wrap">
+            <span className="text-xs font-semibold uppercase tracking-wide bg-plate text-amber-light px-2 py-0.5 rounded">
+              {vendor.category}
+            </span>
+            {isChampion && (
+              <span className="inline-flex items-center gap-1 text-xs font-semibold text-steel bg-amber px-2 py-0.5 rounded">
+                <Crown size={12} /> #1 {vendor.category}
+              </span>
+            )}
+            {vendor.status === "inactive" && (
+              <span className="text-xs text-muted-text border border-[#3b4660] px-2 py-0.5 rounded">
+                Inactive
+              </span>
+            )}
+          </div>
+          {(place || vendor.service_area) && (
+            <p className="text-sm text-muted-text mt-2">
+              <MapPin size={13} className="inline -mt-0.5 mr-1" />
+              {place}
+              {vendor.service_area ? ` · serves ${vendor.service_area}` : ""}
+            </p>
+          )}
+        </div>
+        <div className="shrink-0 sm:text-right">
+          <VendorRatingStamp rating={vendor.rating} />
+          <div className="mt-3 flex gap-2 sm:justify-end">
+            <button
+              onClick={() => setShowRating(true)}
+              className="bg-steel text-light px-3 py-1.5 rounded text-sm border border-[#3b4660]"
+            >
+              Edit rating
+            </button>
+            <button
+              onClick={() => setShowEdit(true)}
+              className="bg-steel text-light px-3 py-1.5 rounded text-sm border border-[#3b4660]"
+            >
+              Edit
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {hasSpend && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-4">
+          <Kpi
+            label="Spent here"
+            value={
+              vendor.total_spend != null
+                ? money(Number(vendor.total_spend))
+                : "—"
+            }
+            sub="from maintenance"
+          />
+          <Kpi label="Services" value={String(vendor.service_count)} />
+          <Kpi
+            label="Last service"
+            value={formatDate(vendor.last_service) ?? "—"}
+          />
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Panel className="p-4 md:col-span-2">
+          <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
+            Rating history
+          </p>
+          {ratingHistory.length === 0 ? (
+            <p className="text-sm text-muted-text italic px-1 py-2">
+              No rating changes yet
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {ratingHistory.map((h) => (
+                <div
+                  key={h.id}
+                  className="border-l-2 border-l-amber bg-steel/40 px-3 py-2 rounded-sm"
+                >
+                  <p className="text-sm">
+                    <Star size={13} className="inline text-amber -mt-0.5" />{" "}
+                    Rating changed{" "}
+                    <span className="text-muted-text">
+                      {h.old_rating ?? "—"}
+                    </span>{" "}
+                    → <span className="text-amber font-semibold">{h.new_rating}</span>
+                  </p>
+                  {h.reason && (
+                    <p className="text-sm text-muted-text">{h.reason}</p>
+                  )}
+                  <p className="text-xs text-muted-text mt-1">
+                    {formatDate(h.changed_at) ?? ""} · {h.changed_by}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {vendor.notes && (
+            <>
+              <p className="text-xs text-muted-text uppercase tracking-wider mb-2 mt-5">
+                Notes
+              </p>
+              <p className="text-sm whitespace-pre-wrap">{vendor.notes}</p>
+            </>
+          )}
+        </Panel>
+
+        <Panel className="p-4">
+          <p className="text-xs text-muted-text uppercase tracking-wider mb-3">
+            Contact
+          </p>
+          {vendor.contact_name && (
+            <p className="text-sm mb-2">{vendor.contact_name}</p>
+          )}
+          <p className="text-sm mb-2 break-words">
+            <Phone size={14} className="inline text-muted-text mr-1.5 -mt-0.5" />
+            {vendor.phone || "No phone"}
+          </p>
+          <p className="text-sm mb-2 break-words">
+            <Mail size={14} className="inline text-muted-text mr-1.5 -mt-0.5" />
+            {vendor.email || "No email"}
+          </p>
+          {vendor.website && (
+            <p className="text-sm mb-2 break-words">
+              <Globe size={14} className="inline text-muted-text mr-1.5 -mt-0.5" />
+              {vendor.website}
+            </p>
+          )}
+          {isShop && !hasSpend && (
+            <p className="text-xs text-muted-text mt-3 pt-3 border-t border-plate">
+              <Wrench size={12} className="inline -mt-0.5 mr-1" />
+              No matched maintenance yet. Spend links when a service's vendor name
+              matches this one.
+            </p>
+          )}
+
+          <button
+            onClick={handleDelete}
+            disabled={deleting}
+            className="mt-4 text-xs text-[#e0857a] hover:text-[#f0857a] inline-flex items-center gap-1 disabled:opacity-50"
+          >
+            <Trash2 size={13} /> {deleting ? "Deleting…" : "Delete vendor"}
+          </button>
+        </Panel>
+      </div>
+    </div>
+  );
+};
+
+export default VendorDetailPage;

--- a/frontend/src/pages/VendorsPage.tsx
+++ b/frontend/src/pages/VendorsPage.tsx
@@ -1,0 +1,229 @@
+import { useState, useMemo } from "react";
+import { Link } from "react-router";
+import { Plus, Crown, MapPin, Trophy } from "lucide-react";
+import { useVendors } from "@/hooks/useVendors";
+import {
+  groupVendorsByCategory,
+  goToCount,
+} from "@/lib/metrics/vendorLeaderboard";
+import { Kpi } from "@/components/Kpi";
+import { Panel } from "@/components/ui/Panel";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton } from "@/components/ui/skeleton";
+import { VendorRatingMedallion } from "@/components/vendors/VendorRatingMedallion";
+import VendorForm from "@/components/vendors/VendorForm";
+import type { Vendor } from "@/types/vendor";
+import { money } from "@/lib/format";
+
+// Shop-only spend line, derived from the maintenance log. Only shown for shops
+// that actually matched services; guards the null-cost case ("3 services", no $).
+const spendLabel = (v: Vendor): string | null => {
+  if (v.category !== "Shop" || !(v.service_count && v.service_count > 0))
+    return null;
+  const n = v.service_count;
+  const svc = `${n} service${n === 1 ? "" : "s"}`;
+  return v.total_spend != null ? `${money(Number(v.total_spend))} · ${svc}` : svc;
+};
+
+const VendorsPage = () => {
+  const [refreshKey, setRefreshKey] = useState(0);
+  const { vendors, isLoading, error } = useVendors(refreshKey);
+  const [search, setSearch] = useState("");
+  const [activeCat, setActiveCat] = useState<string>("All");
+  const [showNew, setShowNew] = useState(false);
+
+  const categories = useMemo(
+    () => [...new Set(vendors.map((v) => v.category))].sort(),
+    [vendors],
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return vendors.filter((v) => {
+      if (activeCat !== "All" && v.category !== activeCat) return false;
+      if (!q) return true;
+      return `${v.name} ${v.city ?? ""} ${v.state ?? ""} ${v.contact_name ?? ""}`
+        .toLowerCase()
+        .includes(q);
+    });
+  }, [vendors, search, activeCat]);
+
+  const groups = useMemo(() => groupVendorsByCategory(filtered), [filtered]);
+
+  if (isLoading)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <Skeleton className="h-8 w-32 mb-6" />
+        <div className="grid grid-cols-3 gap-4 mb-4">
+          {Array.from({ length: 3 }, (_, i) => (
+            <Skeleton key={i} className="h-20" style={{ borderRadius: 13 }} />
+          ))}
+        </div>
+        <Skeleton className="h-10 w-full mb-4" style={{ borderRadius: 10 }} />
+        <Skeleton className="h-64 w-full" style={{ borderRadius: 13 }} />
+      </div>
+    );
+
+  if (error)
+    return (
+      <div className="p-6 bg-iron text-light min-h-screen font-body">
+        <p className="text-destructive">{error}</p>
+      </div>
+    );
+
+  return (
+    <div className="p-6 bg-iron text-light font-body min-h-screen">
+      {showNew && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setShowNew(false)}
+          />
+          <div className="relative w-full max-w-[640px] mx-4 max-h-[90vh] bg-iron text-light overflow-y-auto shadow-xl rounded-lg p-4 sm:p-6 border border-plate">
+            <VendorForm
+              onSuccess={() => setRefreshKey((p) => p + 1)}
+              onClose={() => setShowNew(false)}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-between items-baseline mb-6">
+        <h1 className="text-3xl font-condensed text-light">Vendors</h1>
+        <Link
+          to="/guide"
+          className="text-xs text-muted-text hover:text-amber-light"
+        >
+          How this works →
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <Kpi label="Vendors" value={String(vendors.length)} />
+        <Kpi label="Categories" value={String(categories.length)} />
+        <Kpi
+          label="Your go-to's"
+          value={String(goToCount(vendors))}
+          valueClass="text-amber"
+          sub="rated 5"
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 mt-4 mb-3">
+        <input
+          className="bg-plate rounded px-3 py-2 text-sm flex-1 min-w-[180px] text-light placeholder:text-muted-text"
+          placeholder="Search name, city, contact"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <button
+          onClick={() => setShowNew(true)}
+          className="bg-amber text-steel px-3 py-2 rounded text-sm font-semibold inline-flex items-center gap-1"
+        >
+          <Plus size={15} /> New vendor
+        </button>
+      </div>
+
+      {categories.length > 0 && (
+        <div className="flex gap-1.5 flex-wrap mb-5">
+          {["All", ...categories].map((cat) => (
+            <button
+              key={cat}
+              onClick={() => setActiveCat(cat)}
+              className={`px-3 py-1 rounded-full text-sm border ${
+                activeCat === cat
+                  ? "bg-amber text-steel border-amber font-semibold"
+                  : "border-[#2c3854] text-muted-text hover:text-light"
+              }`}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {vendors.length === 0 ? (
+        <EmptyState
+          title="No vendors yet"
+          hint="Add a shop, escort, or permit service to start ranking who you trust."
+        />
+      ) : filtered.length === 0 ? (
+        <p className="text-muted-text text-sm">No vendors match your search.</p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {groups.map((g) => (
+            <Panel key={g.category} className="p-0 overflow-hidden">
+              <div className="flex items-center gap-2 px-4 py-3 border-b border-[#232d43]">
+                <span className="font-condensed uppercase tracking-wide">
+                  {g.category}
+                </span>
+                <span className="text-muted-text text-xs">
+                  · {g.vendors.length}
+                </span>
+                {g.champion && (
+                  <span className="ml-auto inline-flex items-center gap-1 text-xs font-semibold text-amber">
+                    <Trophy size={13} /> {g.champion.name}
+                  </span>
+                )}
+              </div>
+              <div>
+                {g.vendors.map((v, i) => {
+                  const isChamp = g.champion?.vendor_id === v.vendor_id;
+                  const spend = spendLabel(v);
+                  const place = [v.city, v.state].filter(Boolean).join(", ");
+                  return (
+                    <Link
+                      key={v.vendor_id}
+                      to={`/vendors/${v.vendor_id}`}
+                      className="flex items-center gap-3 px-4 py-2.5 border-t border-[#1e2740] first:border-t-0 hover:bg-steel/30"
+                    >
+                      <span className="w-6 text-center shrink-0">
+                        {isChamp ? (
+                          <Crown size={16} className="text-amber inline" />
+                        ) : (
+                          <span className="text-muted-text text-sm">
+                            {i + 1}
+                          </span>
+                        )}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div
+                          className={`truncate ${isChamp ? "font-semibold" : ""}`}
+                        >
+                          {v.name}
+                        </div>
+                        {(place || spend) && (
+                          <div className="text-xs text-muted-text truncate">
+                            {place && (
+                              <>
+                                <MapPin size={11} className="inline -mt-0.5" />{" "}
+                                {place}
+                              </>
+                            )}
+                            {spend && (
+                              <>
+                                {place ? " · " : ""}
+                                <span className="text-[#c9d3e2]">{spend}</span>
+                              </>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                      <VendorRatingMedallion rating={v.rating} />
+                    </Link>
+                  );
+                })}
+              </div>
+            </Panel>
+          ))}
+        </div>
+      )}
+
+      <p className="text-xs text-muted-text mt-6">
+        {filtered.length} vendor{filtered.length === 1 ? "" : "s"}
+      </p>
+    </div>
+  );
+};
+
+export default VendorsPage;

--- a/frontend/src/services/createVendorService.ts
+++ b/frontend/src/services/createVendorService.ts
@@ -1,0 +1,18 @@
+import api from "./api";
+import { AxiosError } from "axios";
+import type { Vendor } from "@/types/vendor";
+import type { CreateVendorInput } from "@/types/createVendorInput";
+
+export const createVendor = async (
+  data: CreateVendorInput,
+): Promise<Vendor> => {
+  try {
+    const response = await api.post("/vendors", data);
+    return response.data.vendor;
+  } catch (error) {
+    if (error instanceof AxiosError && error.response?.data?.error) {
+      throw new Error(error.response.data.error);
+    }
+    throw new Error("Unable to create new vendor");
+  }
+};

--- a/frontend/src/services/deleteVendorService.ts
+++ b/frontend/src/services/deleteVendorService.ts
@@ -1,0 +1,15 @@
+import api from "./api";
+import { AxiosError } from "axios";
+import type { Vendor } from "@/types/vendor";
+
+export const deleteVendor = async (vendor_id: string): Promise<Vendor> => {
+  try {
+    const response = await api.delete(`/vendors/${vendor_id}`);
+    return response.data.vendor;
+  } catch (error) {
+    if (error instanceof AxiosError && error.response?.data?.error) {
+      throw new Error(error.response.data.error);
+    }
+    throw new Error("Unable to delete vendor");
+  }
+};

--- a/frontend/src/services/patchVendorService.ts
+++ b/frontend/src/services/patchVendorService.ts
@@ -1,0 +1,19 @@
+import api from "./api";
+import { AxiosError } from "axios";
+import type { Vendor } from "@/types/vendor";
+import type { VendorPatchPayload } from "@/types/vendorPatchPayload";
+
+export const patchVendor = async (
+  vendor_id: string,
+  data: VendorPatchPayload,
+): Promise<Vendor> => {
+  try {
+    const response = await api.patch(`/vendors/${vendor_id}`, data);
+    return response.data.vendor;
+  } catch (error) {
+    if (error instanceof AxiosError && error.response?.data?.error) {
+      throw new Error(error.response.data.error);
+    }
+    throw new Error("Unable to patch vendor");
+  }
+};

--- a/frontend/src/services/vendorService.ts
+++ b/frontend/src/services/vendorService.ts
@@ -1,0 +1,22 @@
+import api from "./api";
+import type { Vendor } from "@/types/vendor";
+import type { VendorRatingHistory } from "@/types/vendorRatingHistory";
+
+interface GetVendorResponse {
+  vendor: Vendor;
+  ratingHistory: VendorRatingHistory[];
+}
+
+export const getVendor = async (
+  vendor_id: string,
+): Promise<GetVendorResponse> => {
+  try {
+    const response = await api.get(`/vendors/${vendor_id}`);
+    return {
+      vendor: response.data.vendor,
+      ratingHistory: response.data.ratingHistory,
+    };
+  } catch {
+    throw new Error("Unable to fetch vendor");
+  }
+};

--- a/frontend/src/services/vendorsService.ts
+++ b/frontend/src/services/vendorsService.ts
@@ -1,0 +1,11 @@
+import api from "./api";
+import type { Vendor } from "@/types/vendor";
+
+export const getVendors = async (): Promise<Vendor[]> => {
+  try {
+    const response = await api.get("/vendors");
+    return response.data.vendors;
+  } catch {
+    throw new Error("Unable to fetch vendors");
+  }
+};

--- a/frontend/src/types/createVendorInput.ts
+++ b/frontend/src/types/createVendorInput.ts
@@ -1,0 +1,17 @@
+// Create payload. The backend skips `undefined` fields and the DB fills defaults
+// (status → 'active'), so optional (`?:`) is the right shape — send only what the
+// user filled.
+export interface CreateVendorInput {
+  name: string;
+  category: string;
+  rating?: number | null;
+  contact_name?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  website?: string | null;
+  city?: string | null;
+  state?: string | null;
+  service_area?: string | null;
+  status?: string;
+  notes?: string | null;
+}

--- a/frontend/src/types/vendor.ts
+++ b/frontend/src/types/vendor.ts
@@ -1,0 +1,23 @@
+export interface Vendor {
+  vendor_id: string;
+  name: string;
+  category: string;
+  rating?: number | null;
+  contact_name?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  website?: string | null;
+  city?: string | null;
+  state?: string | null;
+  service_area?: string | null;
+  status: string; // 'active' | 'inactive'
+  notes?: string | null;
+  created_at: string;
+  updated_at: string;
+
+  // Derived, shop-only spend from the maintenance log (matched by name). numeric
+  // comes back as a STRING; null for non-shops or shops with no matched services.
+  total_spend?: string | null;
+  service_count?: number | null;
+  last_service?: string | null;
+}

--- a/frontend/src/types/vendorPatchPayload.ts
+++ b/frontend/src/types/vendorPatchPayload.ts
@@ -1,0 +1,16 @@
+export interface VendorPatchPayload {
+  name?: string;
+  category?: string;
+  rating?: number | null;
+  contact_name?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  website?: string | null;
+  city?: string | null;
+  state?: string | null;
+  service_area?: string | null;
+  status?: string;
+  notes?: string | null;
+  reason?: string; // only when rating changes
+  changed_by?: string; // only when rating changes
+}

--- a/frontend/src/types/vendorRatingHistory.ts
+++ b/frontend/src/types/vendorRatingHistory.ts
@@ -1,0 +1,9 @@
+export interface VendorRatingHistory {
+  id: string;
+  vendor_id: string;
+  old_rating?: number | null;
+  new_rating: number;
+  reason: string;
+  changed_by: string;
+  changed_at: string;
+}


### PR DESCRIPTION
A first-class **Vendors** entity — the cost-side mirror of agents (who you *pay*, not who pays you): shops, escort/pilot cars, permit services, tires, towing, and so on.

## What's included
- **List** (`/vendors`, under Freight, dispatcher-visible): grouped by category, ranked within each by the rating you set, top vendor crowned **champion**. Category filter chips, KPIs, search.
- **Detail**: rubber-stamp rating hero, `#1 {category}` ribbon, contact block, audited rating-history timeline, delete.
- **Rating** (1–5, Go-to → Avoid) mirrors the agent flow — a change requires a reason + initials, recorded in `vendor_rating_history` inside a transaction.
- **Curated categories**, validated on both ends and kept in sync.
- **Shop spend**: shops show total/count from the maintenance log, matched by name (`LEFT JOIN LATERAL`, gated to `'Shop'`). Escorts/permits carry just the rating for now — the deferred growth path (a real vendor↔maintenance/load link comes later).

## Backend
Migration `054_vendors.sql` (vendors + vendor_rating_history, **RLS enabled** per convention), `vendorServices`/`Routes`/`Validation`, registered in `server.js`.

## Verification
- Backend SQL exercised against the **real dev DB**: CRUD, the shop-spend join, the rating→history transaction (rollback when the reason's missing), cascade-on-delete.
- Live UI walkthrough (created vendors, confirmed grouping/champions/spend, drove a rating change 5→4 through the modal — stamp flipped, history logged), then cleaned the test data out of dev.
- Strict production build clean · **426 frontend + 34 backend tests** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)