### PR TITLE
feat: latest-tank fuel scorecard with record + streak (v1.130.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.129.0",
+  "version": "1.130.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/fuel/LatestTankCard.tsx
+++ b/frontend/src/components/fuel/LatestTankCard.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { TrendingUp, TrendingDown, Trophy, Flame } from "lucide-react";
+import type { TankRecap } from "@/lib/metrics/fuelEconomy";
+import { Panel } from "@/components/ui/Panel";
+import { money, dieselPrice, formatDate } from "@/lib/format";
+import { playSfx } from "@/lib/sfx";
+
+const GOOD = "#4ade80";
+const BAD = "#f87171";
+
+const signed = (n: number, d = 2) =>
+  `${n >= 0 ? "+" : "−"}${Math.abs(n).toFixed(d)}`;
+
+const Cell = ({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub: ReactNode;
+}) => (
+  <div className="bg-plate rounded-lg p-3">
+    <p className="text-[11px] uppercase tracking-wide text-muted-text">{label}</p>
+    <p className="text-xl font-semibold mt-0.5">{value}</p>
+    <p className="text-xs mt-0.5">{sub}</p>
+  </div>
+);
+
+// The "how did my last tank do?" scorecard — the most recent completed tank,
+// scored against his own history. See latestTankRecap for the math.
+export const LatestTankCard = ({
+  recap,
+  place,
+}: {
+  recap: TankRecap | null;
+  place?: string | null;
+}) => {
+  // Fire the record cue ONLY when a new record-setting tank first appears (a
+  // fresh fill-up) — never on a passive re-render or a reload of the same tank.
+  const lastTank = useRef<number | null>(null);
+  const primed = useRef(false);
+  useEffect(() => {
+    if (!recap) return;
+    const key = recap.tank.toOdometer;
+    if (!primed.current) {
+      primed.current = true;
+      lastTank.current = key;
+      return;
+    }
+    if (key !== lastTank.current) {
+      lastTank.current = key;
+      if (recap.isRecord) playSfx("pow");
+    }
+  }, [recap]);
+
+  if (!recap) return null;
+  const { tank, isRecord, mpgVsAvg, mpgVsLast, cpmVsAvg, ppgVsNational } = recap;
+
+  return (
+    <Panel
+      className="p-5 mb-4"
+      style={isRecord ? { borderColor: "#5a4410" } : undefined}
+    >
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <span className="text-[11px] tracking-[1.5px] text-muted-text uppercase">
+          Latest tank
+        </span>
+        <span className="text-xs text-muted-text">
+          · {formatDate(tank.date) ?? ""}
+          {place ? ` · ${place}` : ""}
+        </span>
+        {isRecord && (
+          <span
+            className="ml-auto inline-flex items-center gap-1 font-comic uppercase text-sm"
+            style={{
+              border: "3px solid #f5a623",
+              color: "#f5a623",
+              borderRadius: 8,
+              padding: "2px 10px",
+              letterSpacing: 2,
+              transform: "rotate(-6deg)",
+              animation: "stampSlam 0.4s cubic-bezier(0.2, 1.5, 0.4, 1) both",
+            }}
+          >
+            <Trophy size={14} /> New best
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-end gap-2 flex-wrap">
+        <span
+          className="text-[42px] font-condensed leading-none"
+          style={isRecord ? { color: "#f5a623" } : undefined}
+        >
+          {tank.mpg.toFixed(2)}
+        </span>
+        <span className="text-[15px] text-muted-text mb-1.5">MPG</span>
+        <span className="ml-1.5 text-sm mb-1">
+          {mpgVsAvg != null ? (
+            <span style={{ color: mpgVsAvg >= 0 ? GOOD : BAD }}>
+              {mpgVsAvg >= 0 ? (
+                <TrendingUp size={14} className="inline -mt-0.5" />
+              ) : (
+                <TrendingDown size={14} className="inline -mt-0.5" />
+              )}{" "}
+              {signed(mpgVsAvg)} vs your average
+            </span>
+          ) : (
+            <span className="text-muted-text">your first full tank</span>
+          )}
+          {mpgVsLast != null && (
+            <span className="text-muted-text"> · {signed(mpgVsLast)} vs last</span>
+          )}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-4">
+        <Cell
+          label="Fuel cost / mile"
+          value={`$${recap.costPerMile.toFixed(2)}`}
+          sub={
+            cpmVsAvg != null ? (
+              <span style={{ color: cpmVsAvg <= 0 ? GOOD : BAD }}>
+                {cpmVsAvg <= 0 ? (
+                  <TrendingDown size={13} className="inline -mt-0.5" />
+                ) : (
+                  <TrendingUp size={13} className="inline -mt-0.5" />
+                )}{" "}
+                ${Math.abs(cpmVsAvg).toFixed(2)} {cpmVsAvg <= 0 ? "under" : "over"}{" "}
+                avg
+              </span>
+            ) : (
+              <span className="text-muted-text">no average yet</span>
+            )
+          }
+        />
+        <Cell
+          label="Price / gallon"
+          value={dieselPrice(recap.pricePerGallon)}
+          sub={
+            ppgVsNational != null ? (
+              <span style={{ color: ppgVsNational <= 0 ? GOOD : BAD }}>
+                ${Math.abs(ppgVsNational).toFixed(2)}{" "}
+                {ppgVsNational <= 0 ? "under" : "over"} national
+              </span>
+            ) : (
+              <span className="text-muted-text">national n/a</span>
+            )
+          }
+        />
+        <Cell
+          label="This tank"
+          value={`${Math.round(tank.miles).toLocaleString("en-US")} mi`}
+          sub={
+            <span className="text-muted-text">
+              {tank.gallons.toFixed(0)} gal · {money(tank.cost)} spent
+            </span>
+          }
+        />
+      </div>
+
+      {recap.streak >= 2 && (
+        <div
+          className="mt-3 flex items-center gap-1.5 text-sm"
+          style={{ color: "#f5c37a" }}
+        >
+          <Flame size={15} /> {recap.streak} tanks running at or above your
+          average
+        </div>
+      )}
+    </Panel>
+  );
+};

--- a/frontend/src/lib/metrics/fuelEconomy.test.ts
+++ b/frontend/src/lib/metrics/fuelEconomy.test.ts
@@ -8,6 +8,7 @@ import {
   monthlyFuelPrice,
   dieselChartData,
   maxFuelOdometer,
+  latestTankRecap,
 } from "./fuelEconomy";
 
 const e = (
@@ -117,5 +118,57 @@ describe("maxFuelOdometer", () => {
   });
   it("returns null with no fill-ups", () => {
     expect(maxFuelOdometer([])).toBeNull();
+  });
+});
+
+describe("latestTankRecap", () => {
+  const now = new Date("2026-08-01T00:00:00Z");
+  // Fulls only (120 gal each, ≥ the threshold) so each closes a window with
+  // mpg = miles / 120. Pass the per-tank MPGs you want; the opener is implicit.
+  const tanks = (mpgs: number[], price = 5) => {
+    const gal = 120;
+    let odo = 100000;
+    const es = [e(odo, gal, price, "2026-06-01")]; // opening full
+    mpgs.forEach((m, i) => {
+      odo += m * gal;
+      es.push(e(odo, gal, price, `2026-06-${String(2 + i).padStart(2, "0")}`));
+    });
+    return es;
+  };
+
+  it("returns null before any full tank has closed", () => {
+    const stats = fuelStats([e(100000, 130, 5, "2026-06-01")], now); // opens, never closes
+    expect(latestTankRecap(stats, [])).toBeNull();
+  });
+
+  it("scores the latest tank vs average and vs last tank", () => {
+    const r = latestTankRecap(fuelStats(tanks([5, 7, 7, 7]), now), [])!; // avg 6.5
+    expect(r.tank.mpg).toBeCloseTo(7, 5);
+    expect(r.mpgVsAvg).toBeCloseTo(0.5, 5);
+    expect(r.mpgVsLast).toBeCloseTo(0, 5);
+    expect(r.streak).toBe(3); // 7,7,7 ≥ avg; the 5 breaks it
+  });
+
+  it("flags a record only when it strictly beats every prior tank", () => {
+    const r = latestTankRecap(fuelStats(tanks([5.5, 5.5, 6.5]), now), [])!;
+    expect(r.isRecord).toBe(true);
+    expect(r.mpgVsLast).toBeCloseTo(1.0, 5);
+  });
+
+  it("does not flag a record on a tie, nor on the first completed tank", () => {
+    expect(latestTankRecap(fuelStats(tanks([7, 7]), now), [])!.isRecord).toBe(false);
+    const first = latestTankRecap(fuelStats(tanks([6]), now), [])!;
+    expect(first.isRecord).toBe(false);
+    expect(first.mpgVsLast).toBeNull();
+  });
+
+  it("compares tank $/gal to the national price for its month, null when absent", () => {
+    const stats = fuelStats(tanks([6], 5.0), now); // tank ppg = 5.00, month 2026-06
+    expect(
+      latestTankRecap(stats, [{ month: "2026-06", value: 5.2 }])!.ppgVsNational,
+    ).toBeCloseTo(-0.2, 5);
+    expect(
+      latestTankRecap(stats, [{ month: "2020-01", value: 3 }])!.ppgVsNational,
+    ).toBeNull();
   });
 });

--- a/frontend/src/lib/metrics/fuelEconomy.ts
+++ b/frontend/src/lib/metrics/fuelEconomy.ts
@@ -133,6 +133,73 @@ export const fuelStats = (entries: FuelLike[], now: Date): FuelStats => {
   };
 };
 
+// A recap of the most recently COMPLETED tank (the latest full-to-full window),
+// scored against his own history — the "how did my last fill-up do?" card. All
+// deltas are signed so the UI colors them: MPG up is good, cost/mile and price
+// under national are good. Returns null until at least one full tank has closed.
+export interface TankRecap {
+  tank: MpgWindow; // the latest completed tank
+  costPerMile: number; // this tank's fuel $/mile
+  pricePerGallon: number; // this tank's blended $/gal
+  mpgVsAvg: number | null; // tank MPG − overall avg MPG (+ = better)
+  mpgVsLast: number | null; // tank MPG − previous tank's MPG (+ = better)
+  cpmVsAvg: number | null; // tank $/mile − avg $/mile (− = better/cheaper)
+  ppgVsNational: number | null; // tank $/gal − national that month (− = under market)
+  isRecord: boolean; // strictly beat every prior tank's MPG (needs a prior)
+  streak: number; // consecutive most-recent tanks at/above avg MPG
+}
+
+export const latestTankRecap = (
+  stats: FuelStats,
+  national: { month: string; value: number }[],
+): TankRecap | null => {
+  const w = stats.windows;
+  if (w.length === 0) return null;
+
+  const tank = w[w.length - 1];
+  const prior = w.length >= 2 ? w[w.length - 2] : null;
+  const costPerMile = tank.cost / tank.miles;
+  const pricePerGallon = tank.cost / tank.gallons;
+
+  const mpgVsAvg = stats.avgMpg != null ? tank.mpg - stats.avgMpg : null;
+  const mpgVsLast = prior ? tank.mpg - prior.mpg : null;
+  const cpmVsAvg =
+    stats.costPerMile != null ? costPerMile - stats.costPerMile : null;
+
+  // National price for the tank's month (best-effort — null when EIA has none).
+  const month = String(tank.date).slice(0, 7);
+  const nat = national.find((n) => n.month === month);
+  const ppgVsNational = nat ? pricePerGallon - nat.value : null;
+
+  // A record only counts if it strictly beats every earlier tank — so the very
+  // first tank is never a "record", and a tie doesn't re-trigger it.
+  const priorBest = prior
+    ? Math.max(...w.slice(0, -1).map((x) => x.mpg))
+    : null;
+  const isRecord = priorBest != null && tank.mpg > priorBest;
+
+  // How many of the most-recent tanks, unbroken, ran at or above the average.
+  let streak = 0;
+  if (stats.avgMpg != null) {
+    for (let i = w.length - 1; i >= 0; i--) {
+      if (w[i].mpg >= stats.avgMpg) streak++;
+      else break;
+    }
+  }
+
+  return {
+    tank,
+    costPerMile,
+    pricePerGallon,
+    mpgVsAvg,
+    mpgVsLast,
+    cpmVsAvg,
+    ppgVsNational,
+    isRecord,
+    streak,
+  };
+};
+
 // Gallon-weighted average price/gallon per calendar month, ascending — his own
 // line on the you-vs-national diesel chart.
 export interface MonthPrice {

--- a/frontend/src/pages/FuelEntriesPage.tsx
+++ b/frontend/src/pages/FuelEntriesPage.tsx
@@ -14,6 +14,7 @@ import { getTrucks } from "@/services/trucksService";
 import {
   fuelStats,
   dieselChartData,
+  latestTankRecap,
   isFull,
   entryCost,
 } from "@/lib/metrics/fuelEconomy";
@@ -26,6 +27,7 @@ import { MpgChart } from "@/components/fuel/MpgChart";
 import { DieselPriceChart } from "@/components/fuel/DieselPriceChart";
 import { DieselCompareCard } from "@/components/fuel/DieselCompareCard";
 import { FuelVsRevenueCard } from "@/components/fuel/FuelVsRevenueCard";
+import { LatestTankCard } from "@/components/fuel/LatestTankCard";
 import { money, moneyCents } from "@/lib/format";
 import CityAutocomplete from "@/components/CityAutocomplete";
 import { Field, AffixInput, SelectControl } from "@/components/ui/FormControls";
@@ -109,6 +111,24 @@ const FuelEntriesPage = () => {
 
   const now = new Date();
   const stats = useMemo(() => fuelStats(entries, now), [entries]);
+  // The latest completed tank, scored against his history (the "last tank" card).
+  const recap = useMemo(
+    () => latestTankRecap(stats, nationalSeries),
+    [stats, nationalSeries],
+  );
+  // Where that tank closed — the city/state on its closing fill-up.
+  const recapPlace = useMemo(() => {
+    if (!recap) return null;
+    const closing = entries.find(
+      (e) => e.odometer_reading === recap.tank.toOdometer,
+    );
+    if (!closing) return null;
+    // "--" is the import placeholder for an unknown state — treat it as blank.
+    const parts = [closing.fuel_city, closing.fuel_state].filter(
+      (p) => p && p !== "--",
+    );
+    return parts.join(", ") || null;
+  }, [recap, entries]);
   const fuelRev = useMemo(
     () => fuelVsRevenue(entries, loads),
     [entries, loads],
@@ -246,6 +266,8 @@ const FuelEntriesPage = () => {
           </button>
         )}
       </div>
+
+      <LatestTankCard recap={recap} place={recapPlace} />
 
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
         <Kpi

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -317,6 +317,7 @@ const NAV: { group: string; items: string[] }[] = [
       "Per diem — the meal-allowance deduction",
       "Deadhead",
       "Fuel economy (MPG)",
+      "Latest tank — last fill-up scored",
       "Diesel price — you vs national",
       "Fuel vs revenue — is the surcharge covering your fuel?",
     ],
@@ -889,6 +890,28 @@ const GuidePage = () => {
               full tank; smaller top-offs roll into the next full. Measuring
               full-to-full is why it's honest — actual pump gallons against
               actual odometer miles.
+            </Why>
+          </Metric>
+
+          <Metric
+            title="Latest tank — last fill-up scored"
+            answers="How your most recent full tank did against your own history."
+            sources={[{ label: "Fuel", to: "/fuel-entries" }]}
+          >
+            <Why>
+              The card at the top of the Fuel page scores your latest full tank:{" "}
+              <span className="text-light">MPG</span> against your average (with
+              vs-last-tank as a side note),{" "}
+              <span className="text-light">fuel cost per mile</span> — the number
+              that feeds your break-even, $/gal ÷ MPG — and the tank's{" "}
+              <span className="text-light">$/gal versus the national price</span>.
+              Green is better, red is worse. It leans on your{" "}
+              <span className="text-light">average</span> rather than just the
+              last tank on purpose, so one heavy oversize run doesn't read as a
+              slump. Beat your best MPG and it stamps a{" "}
+              <span style={{ color: "#f5a623" }}>NEW BEST</span> (with a sound);
+              string together tanks at or above your average and it tallies the
+              streak.
             </Why>
           </Metric>
 


### PR DESCRIPTION
A card at the top of the Fuel page recapping the most recently completed tank, scored against his own history — the "how did my last fill-up do?" that the aggregate KPIs and trend chart don't answer.

## What's included
- **`latestTankRecap`** (`lib/metrics/fuelEconomy`) — derived from the existing `mpgWindows` + `fuelStats`: tank MPG vs average (and vs last tank), fuel **$/mile** vs average, tank **$/gal vs the national EIA price**, a strict-beat MPG **record** flag, and a consecutive-tanks-at-or-above-average **streak**. Pure, unit-tested.
- **`LatestTankCard`** (`components/fuel`) — hero MPG with signed/colored deltas (green better, red worse), the three secondary stats, a **"NEW BEST"** stamp, and a streak line. The record **sound** fires only when a new record-setting tank first appears (ref-guarded), never on a passive reload.
- Wired into `FuelEntriesPage` above the KPI row; **Guide** section added.
- **Fix:** the Fuelly import stores `"--"` as a placeholder state, which rendered a stray "· --" on the card — filtered out.

Frontend-only, no migration.

## Design notes
MPG headlines against the **average**, not just the previous tank, so one heavy oversize run doesn't read as a slump. Cost/gal leads with **vs-national** since pump price is mostly the market moving.

## Verification
- Strict build clean · **431 tests pass** (+5 for the recap math).
- Live dev check, both states: a normal dip (red, not celebrated) and a record (amber MPG + NEW BEST stamp + El Paso location). No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)