### PR TITLE
feat: dispatcher season cards, period trophies, Backhaul Boss (v1.131.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.130.0",
+  "version": "1.131.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dispatch/DispatcherSeasonCard.tsx
+++ b/frontend/src/components/dispatch/DispatcherSeasonCard.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from "react";
+import { Trophy, Lock } from "lucide-react";
+import type { Load } from "@/types/load";
+import type { RateLadder } from "@/lib/metrics/rateTargets";
+import type { RecapScope } from "@/lib/metrics/recap";
+import {
+  currentSeason,
+  dispatchSeasonLog,
+  type SeasonTrophy,
+} from "@/lib/metrics/dispatcherSeason";
+import { SegmentedTabs } from "@/components/ui/SegmentedTabs";
+import { money, rpm as fmtRpm } from "@/lib/format";
+
+const GOLD = "#fcd34d";
+
+const Stat = ({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: React.ReactNode;
+}) => (
+  <div>
+    <p className="text-[10.5px] uppercase tracking-wide text-muted-text">
+      {label}
+    </p>
+    <p className="text-lg font-semibold mt-0.5">{value}</p>
+    {sub && <p className="text-[11px] mt-0.5">{sub}</p>}
+  </div>
+);
+
+const TrophyTile = ({ t }: { t: SeasonTrophy }) => (
+  <div
+    className="rounded-xl p-3 text-center border"
+    style={
+      t.earned
+        ? { background: "#2a2410", borderColor: "#f5a623" }
+        : { background: "#121a26", borderColor: "#232d43", opacity: 0.75 }
+    }
+  >
+    <div className="flex justify-center" style={{ color: t.earned ? GOLD : "#586b86" }}>
+      {t.earned ? <Trophy size={22} /> : <Lock size={20} />}
+    </div>
+    <p className="text-[12.5px] font-semibold mt-1.5">{t.name}</p>
+    <p
+      className="text-[11px] mt-0.5"
+      style={{ color: t.earned ? GOLD : "#8b97a8" }}
+    >
+      {t.detail}
+    </p>
+  </div>
+);
+
+const SCOPE_TABS = [
+  { value: "month" as RecapScope, label: "Month" },
+  { value: "quarter" as RecapScope, label: "Quarter" },
+  { value: "year" as RecapScope, label: "Year" },
+];
+
+// A dispatcher's month/quarter/year season: this period's booked-load recap plus
+// the three earnable period trophies, and a strip of recent finished periods.
+export const DispatcherSeasonCard = ({
+  loads,
+  userId,
+  ladder,
+  freeHours,
+  now = new Date(),
+}: {
+  loads: Load[];
+  userId: string;
+  ladder: RateLadder;
+  freeHours: number;
+  now?: Date;
+}) => {
+  // Land on the grandest current period that has data (year → quarter → month).
+  const defaultScope = useMemo<RecapScope>(() => {
+    for (const s of ["year", "quarter", "month"] as RecapScope[])
+      if (currentSeason(loads, userId, s, ladder, freeHours, now).hasData) return s;
+    return "month";
+  }, [loads, userId, ladder, freeHours, now]);
+
+  const [scope, setScope] = useState<RecapScope>(defaultScope);
+  const season = useMemo(
+    () => currentSeason(loads, userId, scope, ladder, freeHours, now),
+    [loads, userId, scope, ladder, freeHours, now],
+  );
+  const log = useMemo(
+    () => dispatchSeasonLog(loads, userId, scope, ladder, freeHours, now),
+    [loads, userId, scope, ladder, freeHours, now],
+  );
+
+  const target = ladder.target;
+  const rateColor =
+    season.avgRpm != null && target != null
+      ? season.avgRpm >= target
+        ? "#4ade80"
+        : "#f5a623"
+      : undefined;
+
+  return (
+    <section
+      className="rounded-2xl border p-4 mt-4"
+      style={{ background: "#141a26", borderColor: "#2a3347" }}
+    >
+      <div className="flex items-center gap-2 flex-wrap mb-3">
+        <span className="text-[11px] tracking-[1.5px] text-muted-text uppercase">
+          Season
+        </span>
+        <span className="text-xs text-muted-text">· {season.label}</span>
+        <div className="ml-auto">
+          <SegmentedTabs
+            size="sm"
+            ariaLabel="Season period"
+            tabs={SCOPE_TABS}
+            value={scope}
+            onChange={setScope}
+          />
+        </div>
+      </div>
+
+      {!season.hasData ? (
+        <p className="text-sm text-muted-text py-4">
+          No loads booked this {scope} yet — they'll show up here as you book.
+        </p>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3 mb-4">
+            <Stat label="Loads booked" value={String(season.loadsBooked)} />
+            <Stat label="Gross booked" value={money(season.grossBooked)} />
+            <Stat
+              label="Avg rate"
+              value={fmtRpm(season.avgRpm)}
+              sub={
+                season.avgRpm != null && target != null ? (
+                  <span style={{ color: rateColor }}>
+                    {season.avgRpm >= target ? "over" : "under"} {fmtRpm(target)}{" "}
+                    target
+                  </span>
+                ) : undefined
+              }
+            />
+            <Stat
+              label="On-time"
+              value={
+                season.onTimePct == null
+                  ? "—"
+                  : `${Math.round(season.onTimePct * 100)}%`
+              }
+            />
+            <Stat
+              label="Best load"
+              value={season.bestLoad == null ? "—" : money(season.bestLoad)}
+            />
+          </div>
+
+          <div className="grid grid-cols-3 gap-2.5">
+            {season.trophies.map((t) => (
+              <TrophyTile key={t.key} t={t} />
+            ))}
+          </div>
+        </>
+      )}
+
+      {log.some((e) => e.loads > 0) && (
+        <div className="flex items-center gap-2 flex-wrap mt-4">
+          <span className="text-[11px] tracking-wide text-muted-text uppercase mr-1">
+            Season log
+          </span>
+          {log.map((e) => (
+            <span
+              key={e.label}
+              className="inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-[11px]"
+              style={{
+                background: "#0f1622",
+                borderColor: "#26304a",
+                color: "#9fb0c9",
+              }}
+            >
+              {e.label}
+              {e.trophies > 0 && (
+                <span style={{ color: GOLD }} className="inline-flex gap-0.5">
+                  {Array.from({ length: e.trophies }, (_, i) => (
+                    <Trophy key={i} size={12} />
+                  ))}
+                </span>
+              )}
+            </span>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/frontend/src/hooks/useDispatcherAwardPops.ts
+++ b/frontend/src/hooks/useDispatcherAwardPops.ts
@@ -4,6 +4,7 @@ import {
   dispatcherEarnedAwards,
   type DispatcherAwardInput,
 } from "@/lib/awards/dispatcherAwards";
+import { dispatcherSeasonAwards } from "@/lib/metrics/dispatcherSeason";
 
 // The dispatcher's awards keep their OWN per-device seen store, separate from the
 // driver's — so a device that already baselined the driver set doesn't flood a
@@ -42,7 +43,18 @@ export const useDispatcherAwardPops = (
     if (!input || input.loads.length === 0 || done) return;
     setDone(true);
 
-    const earned = dispatcherEarnedAwards(input);
+    // Patches + medals (incl. Backhaul Boss) plus the current-period season
+    // trophies — all through one seen-store so day-one baselines silently.
+    const earned = [
+      ...dispatcherEarnedAwards(input),
+      ...dispatcherSeasonAwards(
+        input.loads,
+        input.userId,
+        input.ladder,
+        input.freeHours,
+        new Date(),
+      ),
+    ];
     const currentIds = earned.map((a) => a.id);
     const store = read();
 

--- a/frontend/src/lib/awards/dispatcherAwards.test.ts
+++ b/frontend/src/lib/awards/dispatcherAwards.test.ts
@@ -111,6 +111,18 @@ describe("dispatcherPatches", () => {
     const deal = dispatcherPatches(input(loads)).find((p) => p.key === "disp-deal-closer")!;
     expect(deal.badge).toBe("×1"); // only the one non-cancelled load she booked
   });
+
+  it("Backhaul Boss chains loads whose origin market = the prior load's delivery market", () => {
+    const loads = [
+      mk({ load_id: "1", pickup_date: "2026-06-01T04:00:00.000Z", origin_market_id: "m", destination_market_id: "m2" }),
+      mk({ load_id: "2", pickup_date: "2026-06-05T04:00:00.000Z", origin_market_id: "m2", destination_market_id: "m3" }), // chains off #1
+      mk({ load_id: "3", pickup_date: "2026-06-10T04:00:00.000Z", origin_market_id: "m3", destination_market_id: "m4" }), // chains off #2
+      mk({ load_id: "4", pickup_date: "2026-06-15T04:00:00.000Z", origin_market_id: "zzz", destination_market_id: "m5" }), // breaks it
+    ];
+    const bh = dispatcherPatches(input(loads)).find((p) => p.key === "disp-backhaul-boss")!;
+    expect(bh.badge).toBe("×2"); // two consecutive market matches
+    expect(bh.reached).toBe(0); // 2 < first milestone (3)
+  });
 });
 
 describe("dispatcherEarnedAwards", () => {

--- a/frontend/src/lib/awards/dispatcherAwards.ts
+++ b/frontend/src/lib/awards/dispatcherAwards.ts
@@ -89,6 +89,7 @@ interface Stats {
   perfectWeeks: number;
   grandSlam: number;
   bestWeekLoads: number;
+  backhaul: number;
 }
 
 const computeStats = (input: DispatcherAwardInput): Stats => {
@@ -150,6 +151,19 @@ const computeStats = (input: DispatcherAwardInput): Stats => {
     if (w.length > 0 && w.every((l) => rpm(l) >= target)) perfectWeeks++;
   }
 
+  // Backhaul chains: booked loads whose origin market is where the PREVIOUS
+  // booked load delivered — a booked return leg, not a deadhead reset. Market
+  // (metro) match, since exact-city never lines up. Sequenced by pickup.
+  const seq = [...mine]
+    .filter((l) => l.pickup_date)
+    .sort((a, b) => (a.pickup_date < b.pickup_date ? -1 : 1));
+  let backhaul = 0;
+  for (let i = 1; i < seq.length; i++) {
+    const prevDest = seq[i - 1].destination_market_id;
+    const origin = seq[i].origin_market_id;
+    if (origin && prevDest && origin === prevDest) backhaul++;
+  }
+
   return {
     loadsBooked: mine.length,
     gross: mine.reduce((s, l) => s + loadGross(l), 0),
@@ -172,6 +186,7 @@ const computeStats = (input: DispatcherAwardInput): Stats => {
       (l) => isSteal(l) && bothOnTime(l) && (deadheadPct(l) ?? 1) <= 0.1,
     ).length,
     bestWeekLoads,
+    backhaul,
   };
 };
 
@@ -228,6 +243,7 @@ export const dispatcherPatches = (input: DispatcherAwardInput): GrindPatch[] => 
     grindPatch("disp-quick-turn", "Quick Turn", "arrows-horizontal", s.quickTurn, [15, 50, 125], x),
     grindPatch("disp-oversize", "Oversize Ace", "truck", s.oversize, [5, 15, 40], x),
     grindPatch("disp-lean", "Lean Machine", "route", s.lean, [25, 75, 200], x),
+    grindPatch("disp-backhaul-boss", "Backhaul Boss", "road", s.backhaul, [3, 10, 25, 50], x),
   ];
 };
 

--- a/frontend/src/lib/metrics/dispatcherSeason.test.ts
+++ b/frontend/src/lib/metrics/dispatcherSeason.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { RateLadder } from "./rateTargets";
+import {
+  currentSeason,
+  dispatcherSeasonAwards,
+  BOOKING_BAR,
+} from "./dispatcherSeason";
+
+// now = mid-June 2026 → current month "Jun 2026", quarter "Q2 2026", year "2026".
+const now = new Date("2026-06-15T00:00:00Z");
+const ladder: RateLadder = { walkAway: 4, minimum: 4.5, target: 5, strong: 6 };
+
+const base: Load = {
+  load_id: "L",
+  load_number: "1",
+  load_type: "standard flatbed",
+  load_status: "delivered",
+  broker_id: "b",
+  broker: "B",
+  agent_id: "a1",
+  agent: "A",
+  agent_email: null,
+  pickup_date: "2026-06-10T04:00:00.000Z",
+  origin_market_id: "m",
+  origin_city: "X",
+  origin_state: "TX",
+  origin_market: "Dallas",
+  destination_market_id: "m2",
+  destination_city: "Y",
+  destination_state: "TN",
+  delivery_market: "Memphis",
+  delivery_date: "2026-06-12T04:00:00.000Z",
+  deadhead_miles: 0,
+  loaded_miles: 1000,
+  linehaul: "5000",
+  fuel_surcharge: "0",
+  total_accessorials: "0",
+  commodity: null,
+  odometer_start: null,
+  odometer_end: null,
+  payment_status: "paid",
+  booked_by: "me",
+  detention_paid: false,
+  created_at: "",
+  updated_at: "",
+};
+// A booked load at a chosen gross $/mile (1000 loaded miles).
+const atRpm = (r: number, o: Partial<Load> = {}): Load => ({
+  ...base,
+  loaded_miles: 1000,
+  linehaul: String(r * 1000),
+  ...o,
+});
+
+describe("dispatchSeason trophies", () => {
+  it("Booking Champion earns at the month bar and shows progress below it", () => {
+    const eight = Array.from({ length: BOOKING_BAR.month }, (_, i) =>
+      atRpm(5, { load_id: `b${i}` }),
+    );
+    const won = currentSeason(eight, "me", "month", ladder, 2, now).trophies.find(
+      (t) => t.key === "booking",
+    )!;
+    expect(won.earned).toBe(true);
+    expect(won.detail).toBe("8 loads booked");
+
+    const short = currentSeason(eight.slice(0, 7), "me", "month", ladder, 2, now)
+      .trophies.find((t) => t.key === "booking")!;
+    expect(short.earned).toBe(false);
+    expect(short.detail).toBe("7 / 8 loads");
+  });
+
+  it("Rate Champion earns when the period averages at/above target", () => {
+    const over = [atRpm(6, { load_id: "a" }), atRpm(5, { load_id: "b" })]; // avg 5.5
+    expect(
+      currentSeason(over, "me", "month", ladder, 2, now).trophies.find(
+        (t) => t.key === "rate",
+      )!.earned,
+    ).toBe(true);
+    const under = [atRpm(4, { load_id: "a" }), atRpm(4, { load_id: "b" })];
+    expect(
+      currentSeason(under, "me", "month", ladder, 2, now).trophies.find(
+        (t) => t.key === "rate",
+      )!.earned,
+    ).toBe(false);
+  });
+
+  it("Perfect Period needs every load at/above target and counts the misses", () => {
+    const perfect = [atRpm(5, { load_id: "a" }), atRpm(6, { load_id: "b" })];
+    expect(
+      currentSeason(perfect, "me", "month", ladder, 2, now).trophies.find(
+        (t) => t.key === "perfect",
+      )!.earned,
+    ).toBe(true);
+    const oneUnder = [atRpm(5, { load_id: "a" }), atRpm(4, { load_id: "b" })];
+    const p = currentSeason(oneUnder, "me", "month", ladder, 2, now).trophies.find(
+      (t) => t.key === "perfect",
+    )!;
+    expect(p.earned).toBe(false);
+    expect(p.detail).toBe("1 load under target");
+  });
+
+  it("scopes to the person's own non-cancelled loads inside the period", () => {
+    const loads = [
+      atRpm(5, { load_id: "mine" }),
+      atRpm(5, { load_id: "other", booked_by: "someone" }),
+      atRpm(5, { load_id: "cx", load_status: "cancelled" }),
+      atRpm(5, { load_id: "old", pickup_date: "2026-01-05T04:00:00.000Z" }),
+    ];
+    const s = currentSeason(loads, "me", "month", ladder, 2, now);
+    expect(s.loadsBooked).toBe(1);
+    expect(s.grossBooked).toBe(5000);
+  });
+});
+
+describe("dispatcherSeasonAwards", () => {
+  it("emits only earned trophies keyed by scope + period; empty when none", () => {
+    const eight = Array.from({ length: 8 }, (_, i) => atRpm(6, { load_id: `b${i}` }));
+    const ids = dispatcherSeasonAwards(eight, "me", ladder, 2, now).map((a) => a.id);
+    // Month: 8 loads, avg 6 ≥ target, all at target → all three.
+    expect(ids).toContain("trophy:disp-booking:month:Jun 2026");
+    expect(ids).toContain("trophy:disp-rate:month:Jun 2026");
+    expect(ids).toContain("trophy:disp-perfect:month:Jun 2026");
+    // Quarter: rate/perfect earn, but 8 < 24 so no booking champion.
+    expect(ids).toContain("trophy:disp-rate:quarter:Q2 2026");
+    expect(ids).not.toContain("trophy:disp-booking:quarter:Q2 2026");
+    expect(dispatcherSeasonAwards([], "me", ladder, 2, now)).toEqual([]);
+  });
+});

--- a/frontend/src/lib/metrics/dispatcherSeason.ts
+++ b/frontend/src/lib/metrics/dispatcherSeason.ts
@@ -1,0 +1,238 @@
+// Per-dispatcher SEASON — a month/quarter/year recap of one person's booked
+// loads, plus three earnable period trophies. Scoped by booked_by, all GROSS
+// (see agents/lanes principle), reusing the recap RecapScope/range machinery.
+// Pure; `now`/ranges are passed in so it's testable.
+import type { Load } from "@/types/load";
+import { loadGross, type RateLadder } from "./rateTargets";
+import { agentStops, scoreStops } from "./stopScore";
+import { rangeFor, resolvePeriod, type RecapScope, type RecapRange } from "./recap";
+import type { Award } from "./awards";
+
+const isReal = (l: Load) => l.load_status !== "cancelled";
+
+const inRange = (iso: string | null | undefined, r: RecapRange): boolean => {
+  if (!iso) return false;
+  const t = new Date(iso.slice(0, 10) + "T00:00:00Z").getTime();
+  return t >= r.start.getTime() && t < r.end.getTime();
+};
+
+// A dispatcher's loads inside a period — booked by them, not cancelled, and
+// picked up in the range (credit follows when the load actually ran).
+const loadsInPeriod = (loads: Load[], userId: string, r: RecapRange): Load[] =>
+  loads.filter(
+    (l) => l.booked_by === userId && isReal(l) && inRange(l.pickup_date, r),
+  );
+
+// Gross $/loaded-mile over a set (matches the dispatcher card's avgBookedRate).
+const grossPerMile = (loads: Load[]): number | null => {
+  const withMiles = loads.filter((l) => Number(l.loaded_miles) > 0);
+  const miles = withMiles.reduce((s, l) => s + Number(l.loaded_miles), 0);
+  return miles > 0 ? withMiles.reduce((s, l) => s + loadGross(l), 0) / miles : null;
+};
+const rpm = (l: Load): number => {
+  const m = Number(l.loaded_miles) || 0;
+  return m > 0 ? loadGross(l) / m : 0;
+};
+
+// "Booking Champion" bar scales with the period length.
+export const BOOKING_BAR: Record<RecapScope, number> = {
+  month: 8,
+  quarter: 24,
+  year: 90,
+};
+
+export type SeasonTrophyKey = "booking" | "rate" | "perfect";
+export interface SeasonTrophy {
+  key: SeasonTrophyKey;
+  name: string;
+  earned: boolean;
+  detail: string; // earned blurb, or what's still missing
+}
+
+export interface DispatchSeason {
+  scope: RecapScope;
+  label: string;
+  loadsBooked: number;
+  grossBooked: number;
+  avgRpm: number | null;
+  onTimePct: number | null;
+  bestLoad: number | null;
+  topAgent: string | null;
+  topLane: string | null;
+  trophies: SeasonTrophy[];
+  hasData: boolean;
+}
+
+// The period CONTAINING now (the current, in-progress month/quarter/year) — the
+// season card's default. (recap's resolvePeriod only looks at finished periods.)
+export const currentRange = (scope: RecapScope, now: Date): RecapRange => {
+  const y = now.getUTCFullYear();
+  if (scope === "year") return rangeFor("year", y, 0);
+  if (scope === "quarter")
+    return rangeFor("quarter", y, Math.floor(now.getUTCMonth() / 3));
+  return rangeFor("month", y, now.getUTCMonth());
+};
+
+const topBy = (loads: Load[], keyOf: (l: Load) => string): string | null => {
+  const m = new Map<string, number>();
+  for (const l of loads) {
+    const k = keyOf(l);
+    if (k) m.set(k, (m.get(k) ?? 0) + 1);
+  }
+  let best: string | null = null;
+  let n = 0;
+  for (const [k, c] of m) if (c > n) ((n = c), (best = k));
+  return best;
+};
+
+const trophiesFor = (
+  scope: RecapScope,
+  mine: Load[],
+  avgRpm: number | null,
+  ladder: RateLadder,
+): SeasonTrophy[] => {
+  const target = ladder.target;
+  const withMiles = mine.filter((l) => Number(l.loaded_miles) > 0);
+  const underTarget =
+    target != null ? withMiles.filter((l) => rpm(l) < target).length : 0;
+  const bar = BOOKING_BAR[scope];
+
+  return [
+    {
+      key: "booking",
+      name: "Booking Champion",
+      earned: mine.length >= bar,
+      detail:
+        mine.length >= bar
+          ? `${mine.length} loads booked`
+          : `${mine.length} / ${bar} loads`,
+    },
+    {
+      key: "rate",
+      name: "Rate Champion",
+      earned: avgRpm != null && target != null && avgRpm >= target,
+      detail:
+        avgRpm == null || target == null
+          ? "no rate yet"
+          : avgRpm >= target
+            ? `$${avgRpm.toFixed(2)} avg rate`
+            : `$${avgRpm.toFixed(2)} vs $${target.toFixed(2)} target`,
+    },
+    {
+      key: "perfect",
+      name: "Perfect Period",
+      earned: target != null && withMiles.length > 0 && underTarget === 0,
+      detail:
+        target == null
+          ? "no target set"
+          : withMiles.length === 0
+            ? "no loads yet"
+            : underTarget === 0
+              ? "every load at target"
+              : `${underTarget} load${underTarget === 1 ? "" : "s"} under target`,
+    },
+  ];
+};
+
+export const dispatchSeason = (
+  loads: Load[],
+  userId: string,
+  scope: RecapScope,
+  range: RecapRange,
+  ladder: RateLadder,
+  freeHours: number,
+): DispatchSeason => {
+  const mine = loadsInPeriod(loads, userId, range);
+  const avgRpm = grossPerMile(mine);
+  const delivered = mine.filter((l) => l.load_status === "delivered");
+  const onTimePct = delivered.length
+    ? scoreStops(agentStops(delivered, freeHours)).onTimePct
+    : null;
+  return {
+    scope,
+    label: range.label,
+    loadsBooked: mine.length,
+    grossBooked: mine.reduce((s, l) => s + loadGross(l), 0),
+    avgRpm,
+    onTimePct,
+    bestLoad: mine.length ? Math.max(...mine.map(loadGross)) : null,
+    topAgent: topBy(mine, (l) => l.agent),
+    topLane: topBy(mine, (l) =>
+      l.origin_market && l.delivery_market
+        ? `${l.origin_market} → ${l.delivery_market}`
+        : "",
+    ),
+    trophies: trophiesFor(scope, mine, avgRpm, ladder),
+    hasData: mine.length > 0,
+  };
+};
+
+// The current in-progress period (what the card shows by default per scope).
+export const currentSeason = (
+  loads: Load[],
+  userId: string,
+  scope: RecapScope,
+  ladder: RateLadder,
+  freeHours: number,
+  now: Date,
+): DispatchSeason =>
+  dispatchSeason(loads, userId, scope, currentRange(scope, now), ladder, freeHours);
+
+// Recent COMPLETED periods for the history strip: label + trophies won + loads.
+export interface SeasonLogEntry {
+  label: string;
+  trophies: number;
+  loads: number;
+}
+export const dispatchSeasonLog = (
+  loads: Load[],
+  userId: string,
+  scope: RecapScope,
+  ladder: RateLadder,
+  freeHours: number,
+  now: Date,
+  count = 4,
+): SeasonLogEntry[] => {
+  const out: SeasonLogEntry[] = [];
+  for (let ago = count - 1; ago >= 0; ago--) {
+    const r = resolvePeriod(scope, ago, now);
+    const s = dispatchSeason(loads, userId, scope, r, ladder, freeHours);
+    out.push({
+      label: r.label,
+      trophies: s.trophies.filter((t) => t.earned).length,
+      loads: s.loadsBooked,
+    });
+  }
+  return out;
+};
+
+// Award pops for newly-earned CURRENT-period trophies (month/quarter/year). Each
+// fires once per period via its label-keyed id; tier "record" = a corner
+// slide-in, not the owner's full-screen takeover.
+export const dispatcherSeasonAwards = (
+  loads: Load[],
+  userId: string,
+  ladder: RateLadder,
+  freeHours: number,
+  now: Date,
+): Award[] => {
+  const out: Award[] = [];
+  const ICON: Record<SeasonTrophyKey, string> = {
+    booking: "trophy",
+    rate: "trophy",
+    perfect: "medal",
+  };
+  for (const scope of ["month", "quarter", "year"] as RecapScope[]) {
+    const s = currentSeason(loads, userId, scope, ladder, freeHours, now);
+    for (const t of s.trophies)
+      if (t.earned)
+        out.push({
+          id: `trophy:disp-${t.key}:${scope}:${s.label}`,
+          tier: "record",
+          name: `${t.name} · ${s.label}`,
+          detail: t.detail,
+          icon: ICON[t.key],
+        });
+  }
+  return out;
+};

--- a/frontend/src/pages/DispatcherPage.tsx
+++ b/frontend/src/pages/DispatcherPage.tsx
@@ -12,6 +12,7 @@ import {
   type DispatcherAwardInput,
 } from "@/lib/awards/dispatcherAwards";
 import { DispatcherCard } from "@/components/playercard/DispatcherCard";
+import { DispatcherSeasonCard } from "@/components/dispatch/DispatcherSeasonCard";
 import { DispatcherPatchBoard } from "@/components/awards/DispatcherPatchBoard";
 import { MedalBadge } from "@/components/awards/MedalBadge";
 import { EntityAvatar } from "@/components/fleet/EntityAvatar";
@@ -141,6 +142,13 @@ const DispatcherPage = () => {
           avatar={avatar}
           card={card}
           medals={earnedMedals}
+        />
+
+        <DispatcherSeasonCard
+          loads={loads}
+          userId={id}
+          ladder={targets.bookingLadder}
+          freeHours={freeHours}
         />
 
         {/* Career ladder */}

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -383,6 +383,7 @@ const NAV: { group: string; items: string[] }[] = [
       "Agents &amp; lanes are graded on gross",
       "The Dispatcher Card",
       "Dispatcher achievements — patches &amp; medals",
+      "Dispatcher season &amp; trophies",
     ],
   },
 ];
@@ -1773,8 +1774,9 @@ const GuidePage = () => {
               way the driver's do. <span className="text-light">Patches</span>{" "}
               are the everyday grind — Deal Closer, Rainmaker, Rate Hawk,
               Clockwork (on-time), Quick Turn, Oversize Ace, Lean Machine,
-              Bounty Hunter, Right Hand, Iron Booker — each climbs a ×count and
-              celebrates at milestones as she books.{" "}
+              Bounty Hunter, Right Hand, Iron Booker, and Backhaul&nbsp;Boss
+              (loads booked out of the market where the last one delivered) —
+              each climbs a ×count and celebrates at milestones as she books.{" "}
               <span className="text-light">Medals</span> are the rare, hard
               feats you can't just grind out — Steal (a load the scorer rates a
               steal), Double-Up (2× break-even), Superload, Whale (a huge single
@@ -1803,6 +1805,42 @@ const GuidePage = () => {
                 Deadhead
               </a>
               ).
+            </Why>
+          </Section>
+
+          <Section
+            title="Dispatcher season &amp; trophies"
+            sources={[{ label: "Dispatch board", to: "/dashboard" }]}
+          >
+            <p className="text-sm text-muted-text">
+              Her page also carries a{" "}
+              <span className="text-light">season card</span> — a month, quarter,
+              or year recap of the loads she booked (gross, on her bookings
+              only): loads, gross, average rate against target, on-time, and her
+              best load. Three <span className="text-light">period trophies</span>{" "}
+              sit under it, each tracked against a personal bar:
+            </p>
+            <div className="flex flex-col gap-1.5 mt-3">
+              <p className="text-sm text-muted-text">
+                <span className="text-light">Booking Champion</span> — a
+                big-volume period (8 loads a month, 24 a quarter, 90 a year).
+              </p>
+              <p className="text-sm text-muted-text">
+                <span className="text-light">Rate Champion</span> — the period
+                averaged at or above your target rate.
+              </p>
+              <p className="text-sm text-muted-text">
+                <span className="text-light">Perfect Period</span> — every load
+                in the period at or above target. The hard one.
+              </p>
+            </div>
+            <Why>
+              A locked trophy shows what's still missing ("3 loads under
+              target"), so it reads as a goal, not a scold. They're personal on
+              purpose: with one person booking most of the freight, a
+              head-to-head "champion" would just be the same name every period —
+              these reward your own best month instead. Earn one and it pops like
+              a patch does.
             </Why>
           </Section>
         </main>


### PR DESCRIPTION
Finishes the dispatcher-gamification epic (#277 Phase 3b-2). Frontend-only, no migration.

## What's included
- **Season card** (`components/dispatch/DispatcherSeasonCard`) — month/quarter/year recap of one person's booked loads (scoped by `booked_by`, GROSS): loads, gross, avg rate vs target, on-time, best load. Segmented scope switch + season-log strip; defaults to the grandest period with data.
- **`lib/metrics/dispatcherSeason`** — reuses recap's `RecapScope`/`rangeFor`. Three **personal** period trophies (a cross-person "champion" is meaningless at a 2-person shop where one person books ~everything): **Booking Champion** (8/24/90 by scope), **Rate Champion** (period avg ≥ ladder target), **Perfect Period** (every load ≥ target; locked shows the miss count). `dispatcherSeasonAwards` emits earned trophies as `tier:record` slide-in pops.
- **Backhaul Boss** grind patch — consecutive booked loads whose origin **market** is the prior load's delivery market, milestones `[3,10,25,50]`. Market match (exact-city never lines up in the real data — 10 vs 0 on prod).
- Trophy pops merge into `useDispatcherAwardPops` (one seen-store, day-one silent). Guide section added.

## Verification
- Strict build clean · **437 tests** pass (+6).
- Live dev (139 booked loads, 2024–26): card renders, tabs reflow every stat, the earned gold trophy shows in the log (Q2 2026 → Booking Champion), Backhaul Boss patch on the board, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)