### PR TITLE
feat: auto-format phone inputs to (XXX) XXX-XXXX (v1.132.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.131.0",
+  "version": "1.132.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/LoadForm.tsx
+++ b/frontend/src/components/LoadForm.tsx
@@ -32,6 +32,7 @@ import { Button } from "@/components/ui/button";
 import { Input, inputClass } from "@/components/ui/input";
 import CityAutocomplete from "@/components/CityAutocomplete";
 import { Label } from "@/components/ui/label";
+import { formatPhone } from "@/lib/phone";
 import {
   Select,
   SelectContent,
@@ -615,8 +616,12 @@ const LoadForm = ({
                   <Input
                     name="phone"
                     id="new_broker_phone"
+                    value={newBroker.phone ?? ""}
                     onChange={(e) =>
-                      setNewBroker({ ...newBroker, phone: e.target.value })
+                      setNewBroker({
+                        ...newBroker,
+                        phone: formatPhone(e.target.value),
+                      })
                     }
                   />
                 </div>
@@ -727,8 +732,12 @@ const LoadForm = ({
                   <Label htmlFor="new_agent_phone">Phone</Label>
                   <Input
                     id="new_agent_phone"
+                    value={newAgent.phone ?? ""}
                     onChange={(e) =>
-                      setNewAgent({ ...newAgent, phone: e.target.value })
+                      setNewAgent({
+                        ...newAgent,
+                        phone: formatPhone(e.target.value),
+                      })
                     }
                   />
                 </div>

--- a/frontend/src/components/fleet/EntityForm.tsx
+++ b/frontend/src/components/fleet/EntityForm.tsx
@@ -9,6 +9,7 @@ export interface FormField {
   options?: string[];
   required?: boolean;
   placeholder?: string;
+  format?: (value: string) => string; // normalize on input (e.g. phone)
 }
 
 interface Props {
@@ -78,7 +79,9 @@ export const EntityForm = ({
                 type={f.type === "date" ? "date" : "text"}
                 inputMode={f.type === "number" ? "numeric" : undefined}
                 value={values[f.name] ?? ""}
-                onChange={(e) => set(f.name, e.target.value)}
+                onChange={(e) =>
+                  set(f.name, f.format ? f.format(e.target.value) : e.target.value)
+                }
                 placeholder={f.placeholder}
               />
             )}

--- a/frontend/src/components/vendors/VendorForm.tsx
+++ b/frontend/src/components/vendors/VendorForm.tsx
@@ -8,6 +8,7 @@ import { VENDOR_CATEGORIES } from "@/lib/constants/vendorCategories";
 import { VENDOR_RATING_OPTIONS } from "@/lib/metrics/vendorRatingLabels";
 import { Field, SelectControl } from "@/components/ui/FormControls";
 import CityAutocomplete from "@/components/CityAutocomplete";
+import { formatPhone } from "@/lib/phone";
 
 interface VendorFormProps {
   vendor?: Vendor; // present → edit mode
@@ -189,7 +190,7 @@ const VendorForm = ({ vendor, onSuccess, onClose }: VendorFormProps) => {
             className="ds-input"
             placeholder="(956) 555-0142"
             value={phone}
-            onChange={(e) => setPhone(e.target.value)}
+            onChange={(e) => setPhone(formatPhone(e.target.value))}
           />
         </Field>
 

--- a/frontend/src/lib/phone.test.ts
+++ b/frontend/src/lib/phone.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { formatPhone } from "./phone";
+
+describe("formatPhone", () => {
+  it("formats a 10-digit number to the US standard", () => {
+    expect(formatPhone("9565550142")).toBe("(956) 555-0142");
+  });
+
+  it("is idempotent on an already-formatted number", () => {
+    expect(formatPhone("(956) 555-0142")).toBe("(956) 555-0142");
+  });
+
+  it("drops a leading US country code", () => {
+    expect(formatPhone("19565550142")).toBe("(956) 555-0142");
+    expect(formatPhone("+1 956 555 0142")).toBe("(956) 555-0142");
+  });
+
+  it("formats progressively as digits are typed", () => {
+    expect(formatPhone("")).toBe("");
+    expect(formatPhone("956")).toBe("(956");
+    expect(formatPhone("9565")).toBe("(956) 5");
+    expect(formatPhone("956555")).toBe("(956) 555");
+    expect(formatPhone("9565550")).toBe("(956) 555-0");
+  });
+
+  it("keeps extra digits as an extension rather than mangling them", () => {
+    expect(formatPhone("956555014299")).toBe("(956) 555-0142 x99");
+  });
+});

--- a/frontend/src/lib/phone.ts
+++ b/frontend/src/lib/phone.ts
@@ -1,0 +1,13 @@
+// Format a phone number to the US standard "(XXX) XXX-XXXX" as the user types,
+// so what lands in the database is consistent no matter how they key it in. A
+// leading US country code is dropped; a partial number formats progressively;
+// extra digits past ten are kept as an extension rather than mangled.
+export const formatPhone = (input: string): string => {
+  const raw = input.replace(/\D/g, "");
+  const d = raw.length === 11 && raw.startsWith("1") ? raw.slice(1) : raw;
+  if (d.length === 0) return "";
+  if (d.length <= 3) return `(${d}`;
+  if (d.length <= 6) return `(${d.slice(0, 3)}) ${d.slice(3)}`;
+  const base = `(${d.slice(0, 3)}) ${d.slice(3, 6)}-${d.slice(6, 10)}`;
+  return d.length <= 10 ? base : `${base} x${d.slice(10)}`;
+};

--- a/frontend/src/pages/DriversPage.tsx
+++ b/frontend/src/pages/DriversPage.tsx
@@ -8,11 +8,12 @@ import { EntityForm, type FormField } from "@/components/fleet/EntityForm";
 import { MilestoneBurst } from "@/components/fleet/MilestoneBurst";
 import { mileMilestone } from "@/lib/metrics/mileClub";
 import { useLoads } from "@/hooks/useLoads";
+import { formatPhone } from "@/lib/phone";
 
 const FIELDS: FormField[] = [
   { name: "first_name", label: "First name", required: true },
   { name: "last_name", label: "Last name", required: true },
-  { name: "phone", label: "Phone" },
+  { name: "phone", label: "Phone", format: formatPhone },
   { name: "email", label: "Email" },
   { name: "cdl_number", label: "CDL #" },
   { name: "cdl_state", label: "CDL state", placeholder: "AL" },


### PR DESCRIPTION
Phone numbers now standardize as the user types, so what lands in the DB is consistent regardless of how they key it in.

## Changes
- **`lib/phone.ts` `formatPhone`** — strips a leading US country code, formats progressively while typing, keeps extra digits as an extension rather than mangling them. +5 unit tests.
- Applied to every editable phone field: **VendorForm**, the **LoadForm** new-broker + new-agent quick-adds (made controlled so the formatting shows live), and the **driver form** via a new reusable `format` hook on `EntityForm`'s `FormField`.

## Verification
- Strict build clean · **442 tests** pass (+5).
- Live browser check: typing `9565550142` renders `(956) 555-0142`.

## Note — mobile overflow (the other half of the ask)
Audited all ~25 pages at 375px and the tightest at 320px, plus the Create-load form: **zero** document horizontal overflow anywhere, no `overflow-x: hidden` masking clipped content. Layouts are responsive; the wide data tables scroll inside their own `overflow-x-auto` container. Held pending a pointer to the specific page/data — likely a long broker/agent name or a big number on real data that dev's short fixtures don't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)