### PR TITLE
feat: driver-card quarter pace + season = calendar quarter (v1.133.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.132.0",
+  "version": "1.133.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/playercard/PlayerCard.tsx
+++ b/frontend/src/components/playercard/PlayerCard.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { Truck, Maximize2, Weight, Home, Gauge } from "lucide-react";
 import type { Grade, CareerRank, SeasonStats, Lever } from "@/lib/metrics/playerCard";
+import type { QuarterPace } from "@/lib/metrics/quarterPace";
+import { QuarterPaceCard } from "./QuarterPaceCard";
 import { bottleneckLevers, allLeversOnTarget } from "@/lib/metrics/playerCard";
 import { STRIP_MIN_COUNT, type TypeMix } from "@/lib/metrics/loadMix";
 import type { Hometime } from "@/lib/metrics/hometime";
@@ -203,6 +205,7 @@ export interface PlayerCardProps {
   oversize?: TypeMix; // oversize equipment mix; strip hidden when count is 0
   heavyHaul?: TypeMix; // heavy-haul mix — a distinct discipline from oversize
   hometime?: Hometime; // days-since-home status; strip hidden when not provided
+  pace?: QuarterPace | null; // current-quarter-vs-previous pace; hidden when absent
 }
 
 export const PlayerCard = ({
@@ -220,6 +223,7 @@ export const PlayerCard = ({
   oversize,
   heavyHaul,
   hometime,
+  pace,
 }: PlayerCardProps) => {
   const stars = "★".repeat(rank.index + 1) + "☆".repeat(RANK_TIERS.length - rank.index - 1);
 
@@ -351,11 +355,13 @@ export const PlayerCard = ({
         </div>
       </div>
 
+      {pace && <QuarterPaceCard pace={pace} />}
+
       <div className="flex items-baseline gap-2 mt-5 mb-2">
         <span className="font-comic text-lg" style={{ color: "#f5b03a" }}>
           LAST SEASON
         </span>
-        <span className="text-[11px] text-muted-text">· {season.label} · your last 3 complete months</span>
+        <span className="text-[11px] text-muted-text">· {season.label} · the last complete quarter</span>
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
         <Stat label="Net revenue" value={money(season.netRevenue)} sub="net of carrier cut" />

--- a/frontend/src/components/playercard/QuarterPaceCard.tsx
+++ b/frontend/src/components/playercard/QuarterPaceCard.tsx
@@ -1,0 +1,175 @@
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
+import type { QuarterPace } from "@/lib/metrics/quarterPace";
+
+const k = (n: number): string =>
+  n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${Math.round(n)}`;
+const pct = (n: number): string =>
+  `${n >= 0 ? "+" : "−"}${Math.abs(Math.round(n * 100))}%`;
+
+const Cell = ({
+  label,
+  value,
+  sub,
+  color,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  color?: string;
+}) => (
+  <div
+    className="rounded-lg p-2.5"
+    style={{ background: "#141b28", border: "1px solid #26304a" }}
+  >
+    <p className="text-[10px] uppercase tracking-wide text-muted-text">{label}</p>
+    <p className="text-base font-semibold mt-0.5" style={color ? { color } : undefined}>
+      {value}
+    </p>
+    {sub && <p className="text-[10.5px] text-muted-text mt-0.5">{sub}</p>}
+  </div>
+);
+
+// "Am I on track to beat last quarter?" — the current quarter's running net,
+// paced against the previous quarter's own same-point curve (see getQuarterPace).
+export const QuarterPaceCard = ({ pace }: { pace: QuarterPace }) => {
+  const {
+    verdict,
+    label,
+    prevLabel,
+    currentNet,
+    currentLoads,
+    prevSamePointNet,
+    prevFinalNet,
+    prevFinalLoads,
+    projectedNet,
+    projectedLoads,
+    pacePct,
+    daysElapsed,
+    daysTotal,
+  } = pace;
+  const hasProjection =
+    verdict === "beat" || verdict === "behind" || verdict === "even";
+
+  const META: Record<QuarterPace["verdict"], { text: string; color: string }> = {
+    beat: { text: `On track to beat ${prevLabel}`, color: "#4ade80" },
+    behind: { text: `On track to finish under ${prevLabel}`, color: "#f87171" },
+    even: { text: `On pace with ${prevLabel}`, color: "#f5a623" },
+    early: { text: "Too early to call · building", color: "#9fb0c9" },
+    "no-prior": { text: "No prior quarter to compare yet", color: "#9fb0c9" },
+  };
+  const meta = META[verdict];
+  const Icon =
+    verdict === "beat" ? TrendingUp : verdict === "behind" ? TrendingDown : Minus;
+
+  const barMax = Math.max(projectedNet ?? 0, prevFinalNet, currentNet) * 1.08 || 1;
+  const fillPct = (currentNet / barMax) * 100;
+  const projPct = ((projectedNet ?? currentNet) / barMax) * 100;
+  const goalPct = (prevFinalNet / barMax) * 100;
+
+  return (
+    <section
+      className="rounded-xl border p-4 mt-5"
+      style={{ background: "#0f1622", borderColor: "#26304a" }}
+    >
+      <div className="flex items-center gap-2 flex-wrap mb-2">
+        <span className="text-[11px] tracking-[1.5px] text-muted-text uppercase">
+          This quarter
+        </span>
+        <span className="text-xs text-muted-text">
+          · {label} · day {daysElapsed} of {daysTotal}
+        </span>
+        <span
+          className="ml-auto inline-flex items-center gap-1.5 font-comic text-sm rounded-md px-2.5 py-1 border-2"
+          style={{ color: meta.color, borderColor: meta.color }}
+        >
+          {hasProjection && <Icon size={14} />} {meta.text}
+        </span>
+      </div>
+
+      <div className="flex items-end gap-2 flex-wrap">
+        <span className="text-[30px] font-condensed leading-none">{k(currentNet)}</span>
+        <span className="text-sm text-muted-text mb-1">
+          net so far · {currentLoads} loads
+        </span>
+        {hasProjection && pacePct != null && (
+          <span
+            className="text-sm mb-1 ml-1"
+            style={{ color: pacePct >= 0 ? "#4ade80" : "#f87171" }}
+          >
+            {pacePct >= 0 ? "▲" : "▼"} {pct(pacePct)} vs {prevLabel}'s pace
+          </span>
+        )}
+      </div>
+
+      {hasProjection ? (
+        <>
+          <div
+            className="relative h-4 rounded-full mt-3 mb-1.5"
+            style={{ background: "#0b111c", border: "1px solid #26304a" }}
+          >
+            <div
+              className="absolute inset-y-0 left-0 rounded-full"
+              style={{ width: `${Math.min(100, fillPct)}%`, background: "#4ade80" }}
+            />
+            {projPct > fillPct && (
+              <div
+                className="absolute inset-y-0 rounded-r-full"
+                style={{
+                  left: `${fillPct}%`,
+                  width: `${Math.min(100 - fillPct, projPct - fillPct)}%`,
+                  background: "#2f7d55",
+                  opacity: 0.65,
+                }}
+              />
+            )}
+            <div
+              className="absolute -top-1 -bottom-1"
+              style={{ left: `${Math.min(100, goalPct)}%`, width: 2, background: "#f5a623" }}
+            />
+          </div>
+          <div className="flex justify-between text-[11px] text-muted-text gap-2">
+            <span>◆ so far {k(currentNet)}</span>
+            <span
+              className="text-right"
+              style={{
+                color: (projectedNet ?? 0) >= prevFinalNet ? "#4ade80" : "#f87171",
+              }}
+            >
+              projected {k(projectedNet ?? 0)} · {prevLabel} finished {k(prevFinalNet)}
+            </span>
+          </div>
+          <div className="grid grid-cols-3 gap-2.5 mt-3">
+            <Cell label={`By this day, ${prevLabel}`} value={k(prevSamePointNet)} />
+            <Cell
+              label="Loads"
+              value={String(currentLoads)}
+              sub={
+                projectedLoads != null
+                  ? `on pace for ~${projectedLoads} vs ${prevFinalLoads}`
+                  : undefined
+              }
+            />
+            <Cell
+              label="Pace"
+              value={pacePct != null ? pct(pacePct) : "—"}
+              color={
+                pacePct != null
+                  ? pacePct >= 0
+                    ? "#4ade80"
+                    : "#f87171"
+                  : undefined
+              }
+              sub={`vs ${prevLabel}`}
+            />
+          </div>
+        </>
+      ) : (
+        <p className="text-xs text-muted-text mt-2">
+          {verdict === "early"
+            ? "Pace needs more of the quarter before it means anything — the read switches on once you're a couple weeks and a few loads in."
+            : "Once you've got a full quarter behind you, this shows whether you're on track to beat it."}
+        </p>
+      )}
+    </section>
+  );
+};

--- a/frontend/src/lib/metrics/awards.ts
+++ b/frontend/src/lib/metrics/awards.ts
@@ -85,7 +85,7 @@ export const earnedAwards = (i: AwardInputs): Award[] => {
 
   // ---- Medals (tier-up): the fixed milestone ladder + a career rank-up ----
   const del = i.loads.filter((l) => l.load_status === "delivered");
-  const season = getSeasonStats(i.periods, i.loads, i.trips, i.now, 3, i.obligationsDebtMonthly);
+  const season = getSeasonStats(i.periods, i.loads, i.trips, i.now, i.obligationsDebtMonthly);
   const medals = computeMedals({
     lifetimeMiles: i.lifetimeMiles,
     deliveredCount: del.length,

--- a/frontend/src/lib/metrics/playerCard.test.ts
+++ b/frontend/src/lib/metrics/playerCard.test.ts
@@ -155,7 +155,7 @@ describe("getSeasonStats", () => {
     mkLoad({ load_id: "c", delivery_date: "2026-07-05", loaded_miles: 500, linehaul: "9999" }), // in-progress month — excluded
   ];
 
-  it("blends the 3 complete months, excludes the in-progress one", () => {
+  it("is the last complete calendar quarter (Q2 = Apr–Jun), not a rolling window", () => {
     const s = getSeasonStats(periods, loads, [], NOW);
     expect(s.months).toBe(3);
     expect(s.netRevenue).toBeCloseTo(79346.84, 2);
@@ -163,8 +163,17 @@ describe("getSeasonStats", () => {
     expect(s.loads).toBe(2);
     expect(s.label).toBe("Apr–Jun 2026");
   });
+  it("stays on the completed quarter deep into the next one (Aug → Q2, not May–Jul)", () => {
+    // A rolling 3-month window would drift to May–Jul and straddle the quarter
+    // line; the season must hold on Q2 (Apr–Jun) until Q3 finishes.
+    const AUG = new Date("2026-08-15T00:00:00Z");
+    const s = getSeasonStats(periods, loads, [], AUG);
+    expect(s.label).toBe("Apr–Jun 2026");
+    expect(s.loads).toBe(2); // the Jul load is excluded
+    expect(s.netRevenue).toBeCloseTo(79346.84, 2);
+  });
   it("subtracts only debt obligations for True Net (draws excluded upstream)", () => {
-    const s = getSeasonStats(periods, loads, [], NOW, 3, 2411); // $2,411/mo debt
+    const s = getSeasonStats(periods, loads, [], NOW, 2411); // $2,411/mo debt
     expect(s.netProfit).toBeCloseTo(18774.33, 2); // operating unchanged
     expect(s.trueNet).toBeCloseTo(18774.33 - 2411 * 3, 2); // − 3 months of debt
     expect(s.trueNetMargin).toBeCloseTo((18774.33 - 7233) / 79346.84, 4);

--- a/frontend/src/lib/metrics/playerCard.ts
+++ b/frontend/src/lib/metrics/playerCard.ts
@@ -7,11 +7,8 @@ import type { Trip } from "@/types/trip";
 import type { ExpensePeriod } from "@/types/expense";
 import type { FuelEntry } from "@/types/fuelEntry";
 import { deadheadPctOver } from "./deadhead";
-import {
-  loadRevenue,
-  completeMonthsBefore,
-  type RateLadder,
-} from "./rateTargets";
+import { loadRevenue, type RateLadder } from "./rateTargets";
+import { resolvePeriod } from "./recap";
 import { mileMilestone } from "./mileClub";
 import { fuelStats } from "./fuelEconomy";
 import { RANK_TIERS, MARGIN_BANDS } from "@/lib/constants/playerCard";
@@ -147,17 +144,26 @@ const inWindow = (
   );
 };
 
+// A "season" is always a calendar QUARTER — the last COMPLETE one (Q1 Jan–Mar,
+// Q2 Apr–Jun, Q3 Jul–Sep, Q4 Oct–Dec), matching the recap. Never a rolling
+// window that drifts across a quarter line.
+const lastQuarterMonths = (now: Date): { year: number; month: number }[] => {
+  const start = resolvePeriod("quarter", 0, now).start;
+  const y = start.getUTCFullYear();
+  const m = start.getUTCMonth();
+  return [0, 1, 2].map((i) => ({ year: y, month: m + i }));
+};
+
 export const getSeasonStats = (
   periods: ExpensePeriod[],
   loads: Load[],
   trips: Trip[],
   now: Date,
-  monthsBack = 3,
   // Monthly DEBT obligations (owner draws excluded) — subtracted from operating
   // profit to get True Net over the same months the P&L covers.
   obligationsDebtMonthly = 0,
 ): SeasonStats => {
-  const months = completeMonthsBefore(now, monthsBack);
+  const months = lastQuarterMonths(now);
 
   let income = 0;
   let cost = 0;

--- a/frontend/src/lib/metrics/quarterPace.test.ts
+++ b/frontend/src/lib/metrics/quarterPace.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import { getQuarterPace } from "./quarterPace";
+
+const load = (delivery_date: string, net: number): Load => ({
+  load_id: delivery_date + ":" + net,
+  load_number: "1",
+  load_type: "standard flatbed",
+  load_status: "delivered",
+  broker_id: "b",
+  broker: "B",
+  agent_id: "a",
+  agent: "A",
+  agent_email: null,
+  pickup_date: delivery_date,
+  origin_market_id: "m",
+  origin_city: "X",
+  origin_state: "TX",
+  origin_market: "M",
+  destination_market_id: "m2",
+  destination_city: "Y",
+  destination_state: "TN",
+  delivery_market: "M2",
+  delivery_date,
+  deadhead_miles: 0,
+  loaded_miles: 1000,
+  linehaul: "0",
+  fuel_surcharge: "0",
+  total_accessorials: "0",
+  net_revenue: String(net),
+  commodity: null,
+  payment_status: "paid",
+  created_at: "",
+  updated_at: "",
+});
+
+// Q2 = Apr–Jun (previous), Q3 = Jul–Sep (current). NOW = day 37 of Q3.
+const NOW = new Date("2026-08-06T12:00:00Z");
+// Two Q2 loads inside its first 37 days (→ same-point $20k), two later (→ final $40k).
+const q2 = [
+  load("2026-04-15", 10000),
+  load("2026-04-20", 10000),
+  load("2026-05-20", 10000),
+  load("2026-06-10", 10000),
+];
+
+describe("getQuarterPace", () => {
+  it("projects off last quarter's same-point pace and calls a beat", () => {
+    // $24k over 3 loads by day 37 vs Q2's $20k by day 37 → +20% → projects $48k.
+    const q3 = [
+      load("2026-07-10", 8000),
+      load("2026-07-20", 8000),
+      load("2026-08-01", 8000),
+    ];
+    const p = getQuarterPace([...q2, ...q3], NOW);
+    expect(p.label).toBe("Q3 2026");
+    expect(p.prevLabel).toBe("Q2 2026");
+    expect(p.currentNet).toBe(24000);
+    expect(p.currentLoads).toBe(3);
+    expect(p.prevSamePointNet).toBe(20000);
+    expect(p.prevFinalNet).toBe(40000);
+    expect(p.pacePct).toBeCloseTo(0.2, 5);
+    expect(p.projectedNet).toBeCloseTo(48000, 2);
+    expect(p.verdict).toBe("beat");
+  });
+
+  it("calls behind when pacing under last quarter", () => {
+    const q3 = [
+      load("2026-07-10", 5000),
+      load("2026-07-20", 5000),
+      load("2026-08-01", 6000),
+    ]; // $16k vs $20k same-point → 0.8 → projects $32k < $40k
+    const p = getQuarterPace([...q2, ...q3], NOW);
+    expect(p.projectedNet).toBeCloseTo(32000, 2);
+    expect(p.verdict).toBe("behind");
+  });
+
+  it("calls even inside the ±2% band", () => {
+    const q3 = [
+      load("2026-07-10", 6700),
+      load("2026-07-20", 6700),
+      load("2026-08-01", 6700),
+    ]; // $20.1k ≈ $20k same-point → ~+0.5% → even
+    expect(getQuarterPace([...q2, ...q3], NOW).verdict).toBe("even");
+  });
+
+  it("holds back a verdict while it's too early to call", () => {
+    const early = new Date("2026-07-06T12:00:00Z"); // day 6 of Q3
+    const q3 = [load("2026-07-02", 8000), load("2026-07-04", 8000)];
+    const p = getQuarterPace([...q2, ...q3], early);
+    expect(p.verdict).toBe("early");
+    expect(p.projectedNet).toBeNull();
+  });
+
+  it("has no verdict when there's no prior quarter to compare", () => {
+    const q3 = [
+      load("2026-07-10", 8000),
+      load("2026-07-20", 8000),
+      load("2026-08-01", 8000),
+    ];
+    const p = getQuarterPace(q3, NOW); // no Q2 loads
+    expect(p.verdict).toBe("no-prior");
+    expect(p.prevFinalNet).toBe(0);
+  });
+});

--- a/frontend/src/lib/metrics/quarterPace.ts
+++ b/frontend/src/lib/metrics/quarterPace.ts
@@ -1,0 +1,120 @@
+// "Am I on track to beat last quarter?" — paces the in-progress quarter against
+// the PREVIOUS one. The honest engine: don't flat-pro-rate by calendar days
+// (freight isn't earned evenly). Instead compare against last quarter's OWN
+// curve — how far you'd got by this same point of last quarter — and project the
+// finish by scaling last quarter's final by that ratio. Paces a REAL-TIME metric
+// (net from delivered loads + load count), never the laggy P&L profit.
+import type { Load } from "@/types/load";
+import { loadRevenue } from "./rateTargets";
+import { rangeFor, resolvePeriod } from "./recap";
+
+const MS_DAY = 86_400_000;
+
+// Net (per-load, settlement-schedule) over delivered loads delivered in
+// [start, cutoff). Cumulative — pass the quarter end for a final, `now` for
+// to-date, or start+elapsed for a same-point comparison.
+const aggregate = (
+  loads: Load[],
+  start: Date,
+  cutoff: Date,
+): { net: number; loads: number } => {
+  let net = 0;
+  let n = 0;
+  const s = start.getTime();
+  const c = cutoff.getTime();
+  for (const l of loads) {
+    if (l.load_status !== "delivered" || !l.delivery_date) continue;
+    const t = new Date(l.delivery_date.slice(0, 10) + "T00:00:00Z").getTime();
+    if (t >= s && t < c) {
+      net += loadRevenue(l);
+      n++;
+    }
+  }
+  return { net, loads: n };
+};
+
+export type PaceVerdict = "beat" | "behind" | "even" | "early" | "no-prior";
+
+export interface QuarterPace {
+  label: string; // current quarter, e.g. "Q3 2026"
+  prevLabel: string; // previous quarter, e.g. "Q2 2026"
+  daysElapsed: number; // day N of the quarter (1-based)
+  daysTotal: number; // days in the quarter
+  currentNet: number; // net from delivered loads so far this quarter
+  currentLoads: number;
+  prevSamePointNet: number; // prev quarter's net through the same elapsed point
+  prevFinalNet: number; // prev quarter's final net
+  prevFinalLoads: number;
+  projectedNet: number | null; // projected finish (null while too early / no prior)
+  projectedLoads: number | null;
+  pacePct: number | null; // net vs prev same-point, e.g. +0.09 = 9% ahead
+  verdict: PaceVerdict;
+}
+
+// Below either floor, the projection is too noisy to call — one big load swings it.
+const CONFIDENCE_DAYS = 14;
+const CONFIDENCE_LOADS = 3;
+const EVEN_BAND = 0.02; // within ±2% of prior pace reads as "on pace"
+
+export const getQuarterPace = (loads: Load[], now: Date): QuarterPace => {
+  const cur = rangeFor(
+    "quarter",
+    now.getUTCFullYear(),
+    Math.floor(now.getUTCMonth() / 3),
+  );
+  const prev = resolvePeriod("quarter", 0, now); // the completed quarter before `cur`
+
+  const elapsedMs = Math.max(0, now.getTime() - cur.start.getTime());
+  const daysTotal = Math.round((cur.end.getTime() - cur.start.getTime()) / MS_DAY);
+  const daysElapsed = Math.min(daysTotal, Math.floor(elapsedMs / MS_DAY) + 1);
+
+  const curAgg = aggregate(loads, cur.start, now);
+  const prevSame = aggregate(loads, prev.start, new Date(prev.start.getTime() + elapsedMs));
+  const prevFull = aggregate(loads, prev.start, prev.end);
+
+  const hasPrior = prevFull.net > 0 || prevFull.loads > 0;
+
+  let projectedNet: number | null = null;
+  let projectedLoads: number | null = null;
+  let pacePct: number | null = null;
+  let verdict: PaceVerdict;
+
+  if (!hasPrior) {
+    verdict = "no-prior";
+  } else if (daysElapsed < CONFIDENCE_DAYS || curAgg.loads < CONFIDENCE_LOADS) {
+    verdict = "early";
+  } else {
+    // Loads project on a simple run-rate (a secondary number); net uses last
+    // quarter's shape when we have a same-point to anchor to, else run-rate.
+    projectedLoads = Math.round(curAgg.loads * (daysTotal / daysElapsed));
+    if (prevSame.net > 0) {
+      const ratio = curAgg.net / prevSame.net;
+      pacePct = ratio - 1;
+      projectedNet = prevFull.net * ratio;
+    } else {
+      projectedNet = curAgg.net * (daysTotal / daysElapsed);
+    }
+    verdict =
+      projectedNet > prevFull.net * (1 + EVEN_BAND)
+        ? "beat"
+        : projectedNet < prevFull.net * (1 - EVEN_BAND)
+          ? "behind"
+          : "even";
+  }
+
+  return {
+    label: cur.label,
+    prevLabel: prev.label,
+    daysElapsed,
+    daysTotal,
+    currentNet: curAgg.net,
+    currentLoads: curAgg.loads,
+    prevSamePointNet: prevSame.net,
+    prevFinalNet: prevFull.net,
+    prevFinalLoads: prevFull.loads,
+    projectedNet,
+    projectedLoads,
+    pacePct,
+    verdict,
+  };
+};

--- a/frontend/src/pages/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage.tsx
@@ -42,6 +42,7 @@ import {
   utilizationGrade,
   personalBests,
 } from "@/lib/metrics/playerCard";
+import { getQuarterPace } from "@/lib/metrics/quarterPace";
 import { computeGrind } from "@/lib/metrics/grind";
 import { loadTypeMix } from "@/lib/metrics/loadMix";
 import { underLoadDaySet, firstDeliveredPickup } from "@/lib/metrics/underLoad";
@@ -145,7 +146,7 @@ const DriverDetailPage = () => {
     );
     const basis = getCostBasis(periods, obligationsDebt, driverLoads, now);
     const ladder = getRateLadder(basis.breakEvenRpm, tiers);
-    const season = getSeasonStats(periods, driverLoads, driverTrips, now, 3, obligationsDebt);
+    const season = getSeasonStats(periods, driverLoads, driverTrips, now, obligationsDebt);
     const rpmG = rpmGrade(basis.windowRpm, ladder);
     const marginG = marginGrade(season.netMargin);
     // Driver utilization (days-based) — under-load days ÷ days since first load.
@@ -185,6 +186,7 @@ const DriverDetailPage = () => {
     return {
       rank: careerRank(lifetimeMiles),
       season,
+      pace: getQuarterPace(driverLoads, now),
       rpmGrade: rpmG,
       marginGrade: marginG,
       utilization,
@@ -263,6 +265,7 @@ const DriverDetailPage = () => {
             avatar={avatar}
             rank={card.rank}
             season={card.season}
+            pace={card.pace}
             rpmGrade={card.rpmGrade}
             marginGrade={card.marginGrade}
             utilization={card.utilization}

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -338,6 +338,7 @@ const NAV: { group: string; items: string[] }[] = [
     group: "The driver card",
     items: [
       "Bottleneck — your three profit levers",
+      "This quarter — on track to beat last?",
       "Equipment mix — oversize &amp; heavy haul",
       "Hometime — days since you were home",
     ],
@@ -1142,6 +1143,35 @@ const GuidePage = () => {
               still nets mediocre — so the card names whichever is lagging and
               what to do about it. When all three reach Target, it reads{" "}
               <span style={{ color: "#4ade80" }}>Firing on all cylinders</span>.
+            </Why>
+          </Metric>
+
+          <Metric
+            title="This quarter — on track to beat last?"
+            answers="Whether the quarter you're in is pacing ahead of or behind the last one — projected, not just the raw running total."
+            sources={[{ label: "Driver card", to: "/drivers" }]}
+          >
+            <Formula>
+              projected finish = last quarter's final × (this quarter so far ÷
+              last quarter by the same day)
+            </Formula>
+            <Why>
+              A season is a calendar quarter (Q1 Jan–Mar … Q4 Oct–Dec). The{" "}
+              <span className="text-light">This Quarter</span> card paces the one
+              you're in against the last complete one — but not by flat day-math,
+              because freight isn't earned evenly. It compares where you sit now
+              to where you sat by the{" "}
+              <span className="text-light">same day of last quarter</span> and
+              projects the finish by scaling last quarter's final by that ratio.
+              Ahead of pace →{" "}
+              <span style={{ color: "#4ade80" }}>on track to beat</span>; behind →{" "}
+              <span style={{ color: "#f87171" }}>on track to finish under</span>.
+              It paces your{" "}
+              <span className="text-light">net from delivered loads</span> (which
+              updates in real time), not the P&amp;L profit (which lags a monthly
+              upload) — and for the first couple weeks it reads{" "}
+              <span className="text-light">"too early to call"</span> rather than
+              swing on a single big load.
             </Why>
           </Metric>
 


### PR DESCRIPTION
Two changes to the driver card's "season".

## Fix — season is a calendar quarter
A season is now always the **last complete calendar quarter** (Q1 Jan–Mar … Q4 Oct–Dec), not a rolling "last 3 complete months" window that straddled quarter lines (it drifted to May–Jul by August). `getSeasonStats` reuses the recap's quarter logic; the July-based fixtures stay green and a new August test pins it to Q2.

## Feat — "This Quarter" pace panel
Above the Last Season card: is the in-progress quarter on track to **beat**, **match**, or **finish under** the previous one?
- `lib/metrics/quarterPace.ts` projects the finish by scaling last quarter's final by how you're pacing vs its **own same-point** — not flat day-pro-rating, because freight isn't earned evenly.
- Paces **net-from-delivered-loads + load count** (real-time), never the laggy P&L profit.
- **Confidence-gated:** "too early to call" for the first ~2 weeks / <3 loads; "no prior quarter" when there's nothing to compare.
- `QuarterPaceCard` renders the verdict badge, a pace bar (fill + projection + Q-final goal line), and same-point / loads / pace cells. Guide section added.

## Verification
- Strict build clean · **448 tests** pass (+10).
- Live dev (loads temporarily assigned to a driver, then reverted): panel renders "On track to beat Q2 2026" — $23.9k so far, +40% vs Q2's same-point, projected $84.5k vs Q2's $60.3k — placed above the (now Apr–Jun 2026) Last Season card, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)