### PR TITLE
fix: label quarter-pace panel as loads-based, distinct from P&L (v1.133.1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.133.0",
+  "version": "1.133.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/playercard/QuarterPaceCard.tsx
+++ b/frontend/src/components/playercard/QuarterPaceCard.tsx
@@ -89,7 +89,7 @@ export const QuarterPaceCard = ({ pace }: { pace: QuarterPace }) => {
       <div className="flex items-end gap-2 flex-wrap">
         <span className="text-[30px] font-condensed leading-none">{k(currentNet)}</span>
         <span className="text-sm text-muted-text mb-1">
-          net so far · {currentLoads} loads
+          net so far · {currentLoads} delivered loads
         </span>
         {hasProjection && pacePct != null && (
           <span
@@ -162,6 +162,11 @@ export const QuarterPaceCard = ({ pace }: { pace: QuarterPace }) => {
               sub={`vs ${prevLabel}`}
             />
           </div>
+          <p className="text-[10.5px] text-muted-text mt-2.5 leading-snug">
+            Counted from your delivered loads (each load's settlement net) so it
+            can track day by day — which is why these figures won't always match
+            the P&amp;L net revenue in Last Season below.
+          </p>
         </>
       ) : (
         <p className="text-xs text-muted-text mt-2">

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1171,7 +1171,13 @@ const GuidePage = () => {
               updates in real time), not the P&amp;L profit (which lags a monthly
               upload) — and for the first couple weeks it reads{" "}
               <span className="text-light">"too early to call"</span> rather than
-              swing on a single big load.
+              swing on a single big load. Because it's summed straight from your
+              loads, these figures won't always match the{" "}
+              <span className="text-light">Net revenue</span> in{" "}
+              <span className="text-light">Last Season</span> — that number is
+              your monthly P&amp;L income, so any month you haven't entered yet
+              (or income booked under a different month than the load delivered)
+              will move the two apart.
             </Why>
           </Metric>
 


### PR DESCRIPTION
The "This Quarter" pace panel is summed bottom-up from **delivered loads** (each load's settlement net) so it can pace day by day. The Last Season card's **"Net revenue"** is the **monthly P&L income**. Both were labeled "net," so when they didn't tie out — e.g. a quarter month with no P&L entered yet — it read as a contradiction.

No math changes. Clarity only:
- Pace headline: `net so far · N loads` → `net so far · N delivered loads`.
- New footnote under the cells: *"Counted from your delivered loads (each load's settlement net) so it can track day by day — which is why these figures won't always match the P&L net revenue in Last Season below."*
- Guide "on track to beat last?" section now names the same reconciliation (missing/other-month P&L rows move the two apart).

## Verification
- Strict build clean · **448 tests** pass (unchanged — pure labeling).
- Root cause confirmed on dev data: Q2 pace = all 20 delivered loads ($60.6k); Last Season Net revenue = May+June P&L only ($56.6k, April P&L not entered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)