### PR TITLE
feat: lanes map granularity follows the window (v1.134.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.133.1",
+  "version": "1.134.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/lanes/LanesMap.tsx
+++ b/frontend/src/components/lanes/LanesMap.tsx
@@ -2,54 +2,107 @@ import { useMemo, useRef, useState } from "react";
 import { Flame } from "lucide-react";
 import { Panel } from "@/components/ui/Panel";
 import { geoAlbersUsa, geoPath } from "d3-geo";
-import { feature } from "topojson-client";
-import type { FeatureCollection, Geometry } from "geojson";
+import { feature, merge } from "topojson-client";
+import type { Feature, FeatureCollection, Geometry, MultiPolygon } from "geojson";
 import statesTopo from "us-atlas/states-10m.json";
-import type { StateMapDatum } from "@/lib/metrics/lanes";
+import type { AreaMapDatum, MapLevel } from "@/lib/metrics/lanes";
+import { groupKeyForStateName } from "@/lib/metrics/lanes";
+import { rpm as fmtRpm } from "@/lib/format";
 
 interface Props {
-  data: Record<string, StateMapDatum>;
+  data: Record<string, AreaMapDatum>;
+  level: MapLevel;
   windowDays: number;
   selected: string | null;
-  onSelect: (state: string) => void;
+  onSelect: (key: string) => void;
 }
 
 type Mode = "rate" | "volume";
-// Below this, a state shades dim in rate mode — one lucky run shouldn't light it up.
-const MIN_STATE_LOADS = 2;
+// Below this, a shape shades dim in rate mode — one lucky run shouldn't light it.
+const MIN_SHAPE_LOADS = 2;
 
-// Parsed once at module load — the topology never changes.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const topo = statesTopo as any;
 const usStates = feature(
-  statesTopo,
-  statesTopo.objects.states,
+  topo,
+  topo.objects.states,
 ) as unknown as FeatureCollection<Geometry, { name: string }>;
 
 const projection = geoAlbersUsa().scale(1100).translate([450, 280]);
 const pathGen = geoPath(projection);
 
-// Volume ramp (amber) → brighter as origin load count rises. Rate ramp (teal→green)
-// → brighter as your median $/mi rises. Distinct hues so the toggle reads clearly.
 const VOL_RAMP = ["#6b4e12", "#9a6c0e", "#c8890a", "#e8940a", "#f5b03a"];
 const RATE_RAMP = ["#134e3a", "#1a6b4e", "#26855f", "#35b07a", "#4ade80"];
 const NO_DATA = "#2a3347";
-const DIM = "#243b33"; // thin state in rate mode (low confidence)
+const DIM = "#243b33"; // thin shape in rate mode (low confidence)
 
-// lucide "flame" path, filled solid for a comic pin on your best-paying states.
 const FLAME_PATH =
   "M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 " +
   ".5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 " +
   "1-3a2.5 2.5 0 0 0 2.5 2.5z";
 
+interface Shape {
+  key: string; // group key (state name, or region / macro label)
+  d: string; // filled path (a single state, or a member state at grouped levels)
+  name: string; // the underlying state name (for keys)
+}
+interface Outline {
+  key: string;
+  d: string;
+  cx: number;
+  cy: number;
+}
 interface HoverState {
   x: number;
   y: number;
-  datum: StateMapDatum;
+  datum: AreaMapDatum;
 }
 
-export const LanesMap = ({ data, windowDays, selected, onSelect }: Props) => {
+export const LanesMap = ({ data, level, windowDays, selected, onSelect }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [hover, setHover] = useState<HoverState | null>(null);
   const [mode, setMode] = useState<Mode>("rate");
+
+  // Every state gets a filled path, tagged with the group it belongs to at this
+  // level (state name / region / macro). Geometry is static → memo on level.
+  const shapes = useMemo<Shape[]>(
+    () =>
+      usStates.features
+        .map((f) => {
+          const name = f.properties.name;
+          const key = groupKeyForStateName(name, level);
+          const d = pathGen(f) ?? "";
+          return key && d ? { key, d, name } : null;
+        })
+        .filter((s): s is Shape => s !== null),
+    [level],
+  );
+
+  // Merged outlines per group (the "bigger region" borders) — only for the
+  // grouped levels; state level draws its own state borders.
+  const outlines = useMemo<Outline[]>(() => {
+    if (level === "state") return [];
+    const buckets = new Map<string, Geometry[]>();
+    for (const g of topo.objects.states.geometries) {
+      const name = g.properties?.name as string | undefined;
+      if (!name) continue;
+      const key = groupKeyForStateName(name, level);
+      if (!key) continue;
+      const arr = buckets.get(key);
+      if (arr) arr.push(g);
+      else buckets.set(key, [g]);
+    }
+    const out: Outline[] = [];
+    for (const [key, geoms] of buckets) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const merged = merge(topo, geoms as any) as MultiPolygon;
+      const geo = { type: "Feature", properties: {}, geometry: merged } as Feature;
+      const d = pathGen(geo);
+      const [cx, cy] = pathGen.centroid(geo);
+      if (d && Number.isFinite(cx)) out.push({ key, d, cx, cy });
+    }
+    return out;
+  }, [level]);
 
   const maxLoads = useMemo(
     () => Math.max(1, ...Object.values(data).map((d) => d.loadCount)),
@@ -60,30 +113,32 @@ export const LanesMap = ({ data, windowDays, selected, onSelect }: Props) => {
       Math.max(
         0.01,
         ...Object.values(data)
-          .filter((d) => d.loadCount >= MIN_STATE_LOADS && d.medianRpm != null)
+          .filter((d) => d.loadCount >= MIN_SHAPE_LOADS && d.medianRpm != null)
           .map((d) => d.medianRpm as number),
       ),
     [data],
   );
 
-  // Top-paying states (by windowed RPM) get a flame pin at their centroid.
-  const hotStates = useMemo(
-    () =>
-      usStates.features
-        .map((f) => ({ f, d: data[f.properties.name] }))
-        .filter((s) => s.d && s.d.avgRpm != null && s.d.loadCount >= 3)
-        .sort((a, b) => (b.d!.avgRpm ?? 0) - (a.d!.avgRpm ?? 0))
-        .slice(0, 3)
-        .map((s) => {
-          const [cx, cy] = pathGen.centroid(s.f);
-          return { name: s.f.properties.name, cx, cy };
-        })
-        .filter((h) => Number.isFinite(h.cx) && Number.isFinite(h.cy)),
-    [data],
-  );
+  // Top-paying groups (>= 3 loads) get a flame at their centroid.
+  const hot = useMemo(() => {
+    const centroid = (key: string): [number, number] => {
+      if (level !== "state") {
+        const o = outlines.find((x) => x.key === key);
+        return o ? [o.cx, o.cy] : [NaN, NaN];
+      }
+      const f = usStates.features.find((s) => s.properties.name === key);
+      return f ? (pathGen.centroid(f) as [number, number]) : [NaN, NaN];
+    };
+    return Object.values(data)
+      .filter((d) => d.medianRpm != null && d.loadCount >= 3)
+      .sort((a, b) => (b.medianRpm as number) - (a.medianRpm as number))
+      .slice(0, 3)
+      .map((d) => ({ key: d.key, c: centroid(d.key) }))
+      .filter((h) => Number.isFinite(h.c[0]));
+  }, [data, outlines, level]);
 
-  const colorFor = (name: string): string => {
-    const datum = data[name];
+  const colorFor = (key: string): string => {
+    const datum = data[key];
     if (!datum) return NO_DATA;
     if (mode === "volume") {
       const idx = Math.min(
@@ -93,7 +148,7 @@ export const LanesMap = ({ data, windowDays, selected, onSelect }: Props) => {
       return VOL_RAMP[idx];
     }
     if (datum.medianRpm == null) return NO_DATA;
-    if (datum.loadCount < MIN_STATE_LOADS) return DIM;
+    if (datum.loadCount < MIN_SHAPE_LOADS) return DIM;
     const idx = Math.min(
       RATE_RAMP.length - 1,
       Math.floor((datum.medianRpm / maxRate) * RATE_RAMP.length),
@@ -115,6 +170,10 @@ export const LanesMap = ({ data, windowDays, selected, onSelect }: Props) => {
     </button>
   );
 
+  const levelWord =
+    level === "macro" ? "macro-regions" : level === "region" ? "freight regions" : "states";
+  const drillHint = level === "state" ? "click a state to drill in" : "click a region to drill in";
+
   return (
     <Panel ref={containerRef} noir className="p-4 relative">
       <div className="text-xs text-muted-text mb-2 flex items-center gap-2 flex-wrap">
@@ -124,77 +183,105 @@ export const LanesMap = ({ data, windowDays, selected, onSelect }: Props) => {
         <span className="flex items-center gap-1">
           · <Flame size={12} style={{ color: "#e8621e" }} /> best-paying
         </span>
-        <span>· click a state to drill in</span>
+        <span>· grouped by {levelWord} · {drillHint}</span>
       </div>
       <svg viewBox="0 0 900 560" className="w-full">
-        {usStates.features.map((f, i) => {
-          const name = f.properties.name;
-          const datum = data[name];
-          const isSel = selected === name;
+        {shapes.map((s, i) => {
+          const datum = data[s.key];
+          const isSel = selected === s.key;
           return (
             <path
               key={i}
-              d={pathGen(f) ?? undefined}
-              fill={colorFor(name)}
-              stroke={isSel ? "#f4f7fb" : "rgba(255,255,255,0.15)"}
-              strokeWidth={isSel ? 2 : 0.6}
+              d={s.d}
+              fill={colorFor(s.key)}
+              stroke={
+                isSel && level === "state"
+                  ? "#f4f7fb"
+                  : "rgba(255,255,255,0.12)"
+              }
+              strokeWidth={isSel && level === "state" ? 2 : 0.5}
               style={{ cursor: datum ? "pointer" : "default" }}
-              onClick={() => datum && onSelect(name)}
+              onClick={() => datum && onSelect(s.key)}
               onMouseMove={(e) => {
                 const rect = containerRef.current?.getBoundingClientRect();
                 if (datum && rect) {
-                  setHover({
-                    x: e.clientX - rect.left,
-                    y: e.clientY - rect.top,
-                    datum,
-                  });
+                  setHover({ x: e.clientX - rect.left, y: e.clientY - rect.top, datum });
                 }
               }}
               onMouseLeave={() => setHover(null)}
             />
           );
         })}
-        {hotStates.map((h) => (
+        {outlines.map((o) => {
+          const lit = !!data[o.key];
+          const isSel = selected === o.key;
+          return (
+            <path
+              key={o.key}
+              d={o.d}
+              fill="none"
+              stroke={isSel ? "#f4f7fb" : lit ? "rgba(244,247,251,0.85)" : "rgba(255,255,255,0.14)"}
+              strokeWidth={isSel ? 2.4 : lit ? 1.6 : 0.8}
+              strokeLinejoin="round"
+              style={{ pointerEvents: "none" }}
+            />
+          );
+        })}
+        {level !== "state" &&
+          outlines.map((o) => {
+            const datum = data[o.key];
+            if (!datum) return null;
+            return (
+              <g key={`lbl-${o.key}`} style={{ pointerEvents: "none" }}>
+                <text
+                  x={o.cx}
+                  y={o.cy}
+                  textAnchor="middle"
+                  style={{ font: "700 12px sans-serif", fill: "#f4f7fb", paintOrder: "stroke", stroke: "#0b0f16", strokeWidth: 3 }}
+                >
+                  {o.key}
+                </text>
+                <text
+                  x={o.cx}
+                  y={o.cy + 13}
+                  textAnchor="middle"
+                  style={{ font: "9.5px sans-serif", fill: "#cdd8e8", paintOrder: "stroke", stroke: "#0b0f16", strokeWidth: 2.5 }}
+                >
+                  {datum.loadCount} {datum.loadCount === 1 ? "load" : "loads"}
+                </text>
+              </g>
+            );
+          })}
+        {hot.map((h) => (
           <g
-            key={h.name}
-            transform={`translate(${h.cx},${h.cy}) scale(0.95) translate(-12,-12)`}
+            key={h.key}
+            transform={`translate(${h.c[0]},${h.c[1]}) scale(0.95) translate(-12,-12)`}
             style={{ pointerEvents: "none" }}
           >
-            <path
-              d={FLAME_PATH}
-              fill="#e8621e"
-              stroke="#0d1117"
-              strokeWidth={1.2}
-              strokeLinejoin="round"
-            />
+            <path d={FLAME_PATH} fill="#e8621e" stroke="#0d1117" strokeWidth={1.2} strokeLinejoin="round" />
           </g>
         ))}
       </svg>
       {hover && (
         <div
           className="absolute pointer-events-none bg-iron border border-plate rounded-md p-2 text-xs text-light z-10"
-          style={{ left: hover.x + 12, top: hover.y + 12, maxWidth: 210 }}
+          style={{ left: hover.x + 12, top: hover.y + 12, maxWidth: 220 }}
         >
-          <div className="font-semibold">{hover.datum.state}</div>
+          <div className="font-semibold">{hover.datum.key}</div>
           <div className="text-muted-text">
-            {hover.datum.loadCount} loads · past year
+            {hover.datum.loadCount} load{hover.datum.loadCount === 1 ? "" : "s"} · {windowDays}d
           </div>
           <div>
-            {hover.datum.avgRpm === null ? (
-              <span className="text-muted-text">no recent loads</span>
+            {hover.datum.medianRpm == null ? (
+              <span className="text-muted-text">no rate</span>
             ) : (
               <>
-                <span className="font-semibold">
-                  ${hover.datum.avgRpm.toFixed(2)}
-                </span>{" "}
-                RPM · {windowDays}d
+                <span className="font-semibold">{fmtRpm(hover.datum.medianRpm)}</span> /mi median
               </>
             )}
           </div>
-          {hover.datum.markets.length > 0 && (
-            <div className="text-muted-text">
-              {hover.datum.markets.join(", ")}
-            </div>
+          {hover.datum.members.length > 0 && (
+            <div className="text-muted-text">{hover.datum.members.join(", ")}</div>
           )}
         </div>
       )}

--- a/frontend/src/lib/constants/states.ts
+++ b/frontend/src/lib/constants/states.ts
@@ -76,3 +76,37 @@ export const getStateName = (
   if (!stateAbbr) return null;
   return STATES[stateAbbr.toUpperCase()]?.name ?? null;
 };
+
+// The 9 freight regions roll up into 4 macro-regions (Census-style super-
+// regions). The lanes map uses this to show coarser geography on shorter
+// windows: macro (≈4) on 30d, region (≈9) on 60d, state (48) on 90d.
+export const REGION_TO_MACRO: Record<string, string> = {
+  Pacific: "West",
+  Mountain: "West",
+  Midwest: "Midwest",
+  Plains: "Midwest",
+  Southeast: "South",
+  Gulf: "South",
+  "Mid-South": "South",
+  Northeast: "Northeast",
+  "New England": "Northeast",
+};
+
+// Macro-region for a 2-letter state code. Unrecognized / blank → UNKNOWN_REGION.
+export const getMacro = (stateAbbr: string | null | undefined): string => {
+  const region = getRegion(stateAbbr);
+  return region === UNKNOWN_REGION
+    ? UNKNOWN_REGION
+    : (REGION_TO_MACRO[region] ?? UNKNOWN_REGION);
+};
+
+const NAME_TO_ABBR: Record<string, string> = Object.fromEntries(
+  Object.entries(STATES).map(([abbr, info]) => [info.name, abbr]),
+);
+
+// 2-letter code for a full state name (inverse of getStateName). The map
+// topology keys on full names; this recovers the code to look up region/macro.
+export const getStateAbbr = (name: string | null | undefined): string | null => {
+  if (!name) return null;
+  return NAME_TO_ABBR[name] ?? null;
+};

--- a/frontend/src/lib/metrics/lanes.test.ts
+++ b/frontend/src/lib/metrics/lanes.test.ts
@@ -6,7 +6,9 @@ import {
   getStateLoadMap,
   getLanesSummary,
   getRecentLoads,
-  getStateMapData,
+  getAreaMapData,
+  getAreaDetail,
+  levelForWindow,
   getStateDetail,
 } from "./lanes";
 
@@ -206,36 +208,90 @@ describe("recency windowing", () => {
     expect(getRecentLoads(loads, 365)).toHaveLength(3);
   });
 
-  it("getStateMapData shades by footprint but rates by the RPM window", () => {
+  it("getAreaMapData windows the loads (no separate footprint)", () => {
     const loads = [
-      // Georgia: one recent load (in the 90-day window) + one old (footprint only)
-      makeLoad({
-        origin_state: "GA",
-        delivery_date: d10,
-        linehaul: "3000",
-        loaded_miles: 1000,
-      }),
-      makeLoad({
-        origin_state: "GA",
-        delivery_date: d200,
-        linehaul: "3000",
-        loaded_miles: 1000,
-      }),
-      // Texas: only an old load — shaded (footprint) but no recent rate
-      makeLoad({
-        origin_state: "TX",
-        origin_market: "Dallas",
-        delivery_date: d200,
-        linehaul: "2000",
-        loaded_miles: 1000,
-      }),
+      makeLoad({ origin_state: "GA", delivery_date: d10, linehaul: "3000", loaded_miles: 1000 }),
+      makeLoad({ origin_state: "GA", delivery_date: d200, linehaul: "3000", loaded_miles: 1000 }),
+      makeLoad({ origin_state: "TX", origin_market: "Dallas", delivery_date: d200, linehaul: "2000", loaded_miles: 1000 }),
     ];
-    const data = getStateMapData(loads, 90, 365);
+    // 90-day window: only GA's recent load counts; TX (200d ago) drops out entirely.
+    const data = getAreaMapData(loads, 90, "state");
+    expect(data["Georgia"].loadCount).toBe(1);
+    expect(data["Georgia"].medianRpm).toBeCloseTo(3.0, 5);
+    expect(data["Texas"]).toBeUndefined();
+  });
+});
 
-    expect(data["Georgia"].loadCount).toBe(2); // footprint = past year
-    expect(data["Georgia"].avgRpm).toBeCloseTo(3.0, 5); // only the recent load
-    expect(data["Texas"].loadCount).toBe(1); // shaded (ran there this year)
-    expect(data["Texas"].avgRpm).toBeNull(); // but nothing in the 90-day window
+describe("granularity map (levelForWindow / getAreaMapData / getAreaDetail)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-08T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const recent = "2026-06-28"; // 10d (in 30/60/90)
+  const mid = "2026-05-20"; // ~49d (in 60/90, out of 30)
+  const old = "2026-04-25"; // ~74d (in 90 only)
+
+  const loads = [
+    makeLoad({ origin_state: "GA", origin_market: "Atlanta", delivery_market: "Dallas", delivery_date: recent, linehaul: "2000", loaded_miles: 1000 }), // Southeast/South, 2.0
+    makeLoad({ origin_state: "TX", origin_market: "Dallas", delivery_market: "Atlanta", delivery_date: recent, linehaul: "3000", loaded_miles: 1000 }), // Gulf/South, 3.0
+    makeLoad({ origin_state: "IL", origin_market: "Chicago", delivery_market: "Miami", delivery_date: mid, linehaul: "2500", loaded_miles: 1000 }), // Midwest, 2.5
+    makeLoad({ origin_state: "CA", origin_market: "LA", delivery_market: "Reno", delivery_date: old, linehaul: "4000", loaded_miles: 1000 }), // Pacific/West, 4.0
+    makeLoad({ origin_state: "GA", delivery_date: recent, load_status: "booked" }), // not delivered → excluded
+  ];
+
+  it("maps each window to a granularity level", () => {
+    expect(levelForWindow(30)).toBe("macro");
+    expect(levelForWindow(60)).toBe("region");
+    expect(levelForWindow(90)).toBe("state");
+  });
+
+  it("30d → macro-regions, over the 30-day window", () => {
+    const d = getAreaMapData(loads, 30, "macro");
+    // only the two 10-day-old loads are in-window; both roll up to South
+    expect(Object.keys(d)).toEqual(["South"]);
+    expect(d["South"].loadCount).toBe(2);
+    expect([...d["South"].members].sort()).toEqual(["Georgia", "Texas"]);
+    expect(d["South"].avgRpm).toBeCloseTo(2.5, 5); // (2000+3000)/2000
+  });
+
+  it("60d → freight regions (adds the 49-day-old Midwest load)", () => {
+    const d = getAreaMapData(loads, 60, "region");
+    expect(new Set(Object.keys(d))).toEqual(new Set(["Southeast", "Gulf", "Midwest"]));
+    expect(d["Midwest"].members).toEqual(["Illinois"]);
+    expect(d["Southeast"].loadCount).toBe(1);
+  });
+
+  it("90d → states; members are origin markets; excludes non-delivered", () => {
+    const d = getAreaMapData(loads, 90, "state");
+    expect(new Set(Object.keys(d))).toEqual(
+      new Set(["Georgia", "Texas", "Illinois", "California"]),
+    );
+    expect(d["Georgia"].loadCount).toBe(1); // booked one excluded
+    expect(d["Georgia"].members).toEqual(["Atlanta"]); // markets, not states
+  });
+
+  it("skips unrecognized origin states", () => {
+    const d = getAreaMapData([makeLoad({ origin_state: "ZZ", delivery_date: recent })], 90, "state");
+    expect(Object.keys(d)).toHaveLength(0);
+  });
+
+  it("getAreaDetail scopes agents + lanes to the clicked group", () => {
+    const region = getAreaDetail(loads, "region", "Gulf", 3, 90);
+    expect(region.state).toBe("Gulf");
+    expect(region.loadCount).toBe(1); // TX only
+    expect(region.lanes[0].lane).toBe("Dallas → Atlanta");
+
+    const macro = getAreaDetail(loads, "macro", "South", 3, 60);
+    expect(macro.loadCount).toBe(2); // GA + TX
+
+    // level 'state' delegates to the state detail
+    const state = getAreaDetail(loads, "state", "Illinois", 3, 90);
+    expect(state.state).toBe("Illinois");
+    expect(state.loadCount).toBe(1);
   });
 });
 

--- a/frontend/src/lib/metrics/lanes.ts
+++ b/frontend/src/lib/metrics/lanes.ts
@@ -1,5 +1,11 @@
 import type { Load } from "@/types/load";
-import { getRegion, getStateName } from "@/lib/constants/states";
+import {
+  getRegion,
+  getStateName,
+  getMacro,
+  getStateAbbr,
+  UNKNOWN_REGION,
+} from "@/lib/constants/states";
 import { median } from "./stats";
 import { agentStops, scoreStops } from "./stopScore";
 
@@ -197,36 +203,79 @@ export const getStateLoadMap = (
   return out;
 };
 
-export interface StateMapDatum {
-  state: string;
-  loadCount: number; // footprint window (drives the volume shading)
-  avgRpm: number | null; // rpm window (null when nothing recent)
-  medianRpm: number | null; // footprint median $/mi (drives the rate shading)
-  markets: string[];
+// ---- GRANULARITY-AWARE MAP DATA ----
+// The map's spatial resolution follows the window: a short (sparse) window
+// groups coarsely so it still reads, a longer window can afford fine detail.
+// State ⊂ freight-region ⊂ macro-region — each level is just a grouping of the
+// same origin-state geography, so no coordinates/geocoding are needed.
+export type MapLevel = "macro" | "region" | "state";
+
+// 30d → macro (≈4 blobs), 60d → freight region (≈9), 90d → state (48).
+export const levelForWindow = (days: number): MapLevel =>
+  days <= 30 ? "macro" : days <= 60 ? "region" : "state";
+
+// The group a load's origin state belongs to at a given level. State level uses
+// the full state NAME (the map topology keys on names); region/macro use the
+// freight-region / macro label. null = unrecognized origin state (skip it).
+export const groupKeyForState = (
+  originStateAbbr: string | null | undefined,
+  level: MapLevel,
+): string | null => {
+  const name = getStateName(originStateAbbr);
+  if (!name) return null;
+  if (level === "state") return name;
+  const key = level === "macro" ? getMacro(originStateAbbr) : getRegion(originStateAbbr);
+  return key === UNKNOWN_REGION ? null : key;
+};
+
+// Same, but from a full state name (what the topology gives the map component).
+export const groupKeyForStateName = (
+  name: string,
+  level: MapLevel,
+): string | null => {
+  if (level === "state") return name;
+  return groupKeyForState(getStateAbbr(name), level);
+};
+
+export interface AreaMapDatum {
+  key: string; // state name, or region / macro label
+  loadCount: number; // delivered loads in the window
+  avgRpm: number | null; // blended gross ÷ loaded mile
+  medianRpm: number | null; // typical single-load $/mi (drives rate shading)
+  members: string[]; // origin markets (state level) or member states (grouped)
 }
 
-// Choropleth data with two windows: load-count "footprint" over a long window
-// (default 1 year) for the shading + markets, but avg RPM over the shorter
-// selected window so the hover rate stays current. A state can be shaded (ran
-// there this year) yet have null avgRpm (nothing in the recent window) — that's
-// meaningful ("run here, not lately"), not a gap to hide.
-export const getStateMapData = (
+// Choropleth data at the level the window implies, over the window itself (no
+// separate footprint — the tab drives both time and grouping). Keyed by group
+// key so the map can shade each shape and list its members on hover.
+export const getAreaMapData = (
   loads: Load[],
-  rpmDays: number,
-  footprintDays: number = 365,
+  days: number,
+  level: MapLevel,
   now: number = Date.now(),
-): Record<string, StateMapDatum> => {
-  const footprint = getStateLoadMap(getRecentLoads(loads, footprintDays, now));
-  const windowed = getStateLoadMap(getRecentLoads(loads, rpmDays, now));
+): Record<string, AreaMapDatum> => {
+  const recent = getRecentLoads(deliveredOnly(loads), days, now);
+  const out: Record<string, AreaMapDatum> = {};
 
-  const out: Record<string, StateMapDatum> = {};
-  for (const [name, fp] of Object.entries(footprint)) {
-    out[name] = {
-      state: name,
-      loadCount: fp.loadCount,
-      markets: fp.markets,
-      avgRpm: windowed[name]?.avgRpm ?? null,
-      medianRpm: fp.medianRpm,
+  for (const [key, group] of groupBy(
+    recent,
+    (l) => groupKeyForState(l.origin_state, level) ?? " ",
+  )) {
+    if (key === " ") continue; // unrecognized origin states
+    const members =
+      level === "state"
+        ? [...new Set(group.map((l) => l.origin_market))]
+        : [
+            ...new Set(
+              group.map((l) => getStateName(l.origin_state)).filter((n): n is string => !!n),
+            ),
+          ];
+    out[key] = {
+      key,
+      loadCount: group.length,
+      avgRpm: avgRpm(group),
+      medianRpm: medianRpm(group),
+      members,
     };
   }
   return out;
@@ -250,23 +299,16 @@ export interface StateDetail {
   lanes: LaneStat[]; // your lanes out of here, most-run first
 }
 
-// Everything you'd want when you click a state: the agents you've booked freight
-// out of it (rate / volume / on-time) and your top lanes from it — all from your
-// delivered loads inside the window. `freeHours` drives on-time (from settlement).
-export const getStateDetail = (
-  loads: Load[],
-  stateName: string,
+// Shared drill-down builder: the agents you've booked out of an already-scoped
+// set of delivered loads (rate / volume / on-time) and your top lanes from it.
+// `freeHours` drives on-time (from settlement). `label` names the area.
+const buildDetail = (
+  scopedLoads: Load[],
+  label: string,
   freeHours: number,
-  days: number,
-  now: number = Date.now(),
 ): StateDetail => {
-  const recent = getRecentLoads(deliveredOnly(loads), days, now);
-  const stateLoads = recent.filter(
-    (l) => getStateName(l.origin_state) === stateName,
-  );
-
   const agents: AgentStat[] = [];
-  for (const [agentId, agentLoads] of groupBy(stateLoads, (l) => l.agent_id)) {
+  for (const [agentId, agentLoads] of groupBy(scopedLoads, (l) => l.agent_id)) {
     agents.push({
       agentId,
       agent: agentLoads[0].agent,
@@ -281,7 +323,7 @@ export const getStateDetail = (
 
   const lanes: LaneStat[] = [];
   for (const [, laneLoads] of groupBy(
-    stateLoads,
+    scopedLoads,
     (l) => `${l.origin_market} → ${l.delivery_market}`,
   )) {
     const first = laneLoads[0];
@@ -299,13 +341,46 @@ export const getStateDetail = (
   );
 
   return {
-    state: stateName,
-    loadCount: stateLoads.length,
-    avgRpm: avgRpm(stateLoads),
-    medianRpm: medianRpm(stateLoads),
+    state: label,
+    loadCount: scopedLoads.length,
+    avgRpm: avgRpm(scopedLoads),
+    medianRpm: medianRpm(scopedLoads),
     agents,
     lanes,
   };
+};
+
+// Drill-down for a clicked origin STATE (the 90d level).
+export const getStateDetail = (
+  loads: Load[],
+  stateName: string,
+  freeHours: number,
+  days: number,
+  now: number = Date.now(),
+): StateDetail => {
+  const recent = getRecentLoads(deliveredOnly(loads), days, now);
+  const stateLoads = recent.filter(
+    (l) => getStateName(l.origin_state) === stateName,
+  );
+  return buildDetail(stateLoads, stateName, freeHours);
+};
+
+// Drill-down for a clicked region / macro blob (the 60d / 30d levels): the same
+// agents-and-lanes read, scoped to every origin state inside that group.
+export const getAreaDetail = (
+  loads: Load[],
+  level: MapLevel,
+  key: string,
+  freeHours: number,
+  days: number,
+  now: number = Date.now(),
+): StateDetail => {
+  if (level === "state") return getStateDetail(loads, key, freeHours, days, now);
+  const recent = getRecentLoads(deliveredOnly(loads), days, now);
+  const areaLoads = recent.filter(
+    (l) => groupKeyForState(l.origin_state, level) === key,
+  );
+  return buildDetail(areaLoads, key, freeHours);
 };
 
 // ---- TOP-LANE KPIs ----

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -775,13 +775,16 @@ const GuidePage = () => {
               here pay," which is the honest basis for deciding where to book.
             </Why>
             <Why>
-              The <span className="text-light">map</span> shades states by your
-              own median $/mi (toggle to volume for footprint) — thin states dim
-              so one fluke doesn't light one up. <span className="text-light">Click
-              a state</span> to see the agents you've booked out of it (rate,
-              volume, on-time, each linking to their page) and your top lanes from
-              it. It's all your own history — who to call for freight out of a
-              region, and how they've paid.
+              The <span className="text-light">map</span> shades by your own
+              median $/mi (toggle to volume for load count) — thin areas dim so
+              one fluke doesn't light one up, and a flame marks your best-paying
+              spots. Its <span className="text-light">detail follows the tab</span>:
+              30d groups the country into a few big macro-regions, 60d into
+              freight regions, 90d down to individual states — coarser when the
+              window's sparse so it still reads, finer once there's enough data to
+              trust. <span className="text-light">Click any area</span> to see the
+              agents you've booked out of it (rate, volume, on-time, each linking
+              to their page) and your top lanes from it — all your own history.
             </Why>
           </Metric>
 

--- a/frontend/src/pages/LanesPage.tsx
+++ b/frontend/src/pages/LanesPage.tsx
@@ -6,8 +6,9 @@ import {
   getRecentLoads,
   getRegionRollup,
   getLanesSummary,
-  getStateMapData,
-  getStateDetail,
+  getAreaMapData,
+  getAreaDetail,
+  levelForWindow,
 } from "@/lib/metrics/lanes";
 import { LanesKpis } from "@/components/lanes/LanesKpis";
 import { LanesMap } from "@/components/lanes/LanesMap";
@@ -23,7 +24,7 @@ const WINDOWS = [30, 60, 90];
 const LanesPage = () => {
   const [refreshKey] = useState(0);
   const [windowDays, setWindowDays] = useState(90);
-  const [selectedState, setSelectedState] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
   const [schedule, setSchedule] = useState<SettlementSchedule | null>(null);
   const { loads, isLoading, error } = useLoads(refreshKey);
 
@@ -48,14 +49,17 @@ const LanesPage = () => {
       </div>
     );
 
-  // Window feeds RPM/rankings; the map applies its own 1-year footprint window.
+  // The tab drives both the time window and the map's spatial granularity:
+  // 30d → macro-regions, 60d → freight regions, 90d → states. Coarser on the
+  // sparser window so it still reads; finer once there's data to justify it.
+  const level = levelForWindow(windowDays);
   const windowLoads = getRecentLoads(loads, windowDays);
   const rollup = getRegionRollup(windowLoads);
   const summary = getLanesSummary(windowLoads);
-  const mapData = getStateMapData(loads, windowDays);
+  const mapData = getAreaMapData(loads, windowDays, level);
   const freeHours = schedule?.detention_free_hours ?? 3;
-  const stateDetail = selectedState
-    ? getStateDetail(loads, selectedState, freeHours, windowDays)
+  const detail = selected
+    ? getAreaDetail(loads, level, selected, freeHours, windowDays)
     : null;
 
   return (
@@ -66,7 +70,10 @@ const LanesPage = () => {
           ariaLabel="Lane window"
           tabs={WINDOWS.map((w) => ({ value: w, label: `${w}d` }))}
           value={windowDays}
-          onChange={setWindowDays}
+          onChange={(w) => {
+            setWindowDays(w);
+            setSelected(null); // a state/region key won't exist at the new level
+          }}
         />
       </div>
 
@@ -75,23 +82,24 @@ const LanesPage = () => {
       <div className="mt-6">
         <LanesMap
           data={mapData}
+          level={level}
           windowDays={windowDays}
-          selected={selectedState}
-          onSelect={setSelectedState}
+          selected={selected}
+          onSelect={setSelected}
         />
       </div>
 
-      {stateDetail ? (
+      {detail ? (
         <StateDetailPanel
-          detail={stateDetail}
+          detail={detail}
           windowDays={windowDays}
-          onClear={() => setSelectedState(null)}
+          onClear={() => setSelected(null)}
         />
       ) : (
         <Panel noir className="mt-6 p-4">
           <p className="text-xs text-muted-text mb-2">
             By region · last {windowDays} days · expand a market for its lanes ·
-            or click a state on the map
+            or click the map to drill in
           </p>
           <LanesTable rollup={rollup} />
         </Panel>


### PR DESCRIPTION
The lanes-page **30/60/90 tab now drives the map's spatial granularity**, not just the time window — coarser on the sparser window so it still reads, finer once there's data to justify it.

| Tab | Grouping | Why |
|----|----|----|
| **30d** | macro-regions (≈4) | few loads → big blobs stay legible |
| **60d** | freight regions (≈9) | medium |
| **90d** | states (48) | enough data for full resolution |

State ⊂ freight-region ⊂ macro-region — every level is just a grouping of the same origin-state geometry, so **no coordinates/geocoding** needed. This also fixes the real issue: the map used a fixed **1-year footprint** for shading, so the tabs barely affected it.

### What carries over / what's new
- Merged region/macro **outlines** computed at runtime (`topojson.merge`, memoized per level), drawn as bold "bigger region" borders with labels.
- Shading (your median $/mi or volume), **best-paying flames** (≥3 loads), and hover tooltips all preserved.
- Clicking a **region/macro blob** drills into that whole area's agents + lanes (`getAreaDetail`, mirroring the state drill-down). Agents link to their pages.

### Code
- `states.ts`: `REGION_TO_MACRO` rollup + `getMacro` / `getStateAbbr`.
- `lanes.ts`: `MapLevel`, `levelForWindow`, `getAreaMapData`, `getAreaDetail` (window-driven); removed `getStateMapData`/footprint.
- Guide updated; **454 tests** (+6).

### Verified on dev
- 90d → states (Texas flamed); 60d → Gulf + Midwest merged blobs with labels/flames; 30d → honest empty state (dev seed has no loads <30d).
- Clicked Gulf → region panel: "8 loads · $3.06/mi median", agents (Mike Sorrentino ×4, Rick Boyd ×2, Dana Cruz ×2) + top lane, each linking out.
- Strict build clean, no console errors.

Design mockup was approved before build (macro→region→state, region detail panel on click).

🤖 Generated with [Claude Code](https://claude.com/claude-code)