### PR TITLE
feat: agent roster analytics — Go-to score, specialty, dwell (v1.135.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.134.0",
+  "version": "1.135.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/agents/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard.tsx
@@ -1,17 +1,26 @@
 import { Link } from "react-router";
+import { TriangleAlert } from "lucide-react";
 import type { Agent } from "@/types/agent";
 import type {
   AgentHonors,
   AgentStat,
   LiveStanding,
 } from "@/lib/metrics/agentLeaderboard";
+import type { AgentScorecard } from "@/lib/metrics/agentScorecard";
 import { agentPrestige } from "@/lib/metrics/agentLeaderboard";
 import { RatingMedallion } from "./RatingMedallion";
-import { PrestigeBadge, PRESTIGE_META } from "./PrestigeBadge";
-import { money } from "@/lib/format";
+import { PrestigeBadge } from "./PrestigeBadge";
+import {
+  TIER_META,
+  SPECIALTY_META,
+  dwellStatus,
+  DWELL_TONE,
+  flagText,
+} from "./agentDisplay";
+import { money, rpm as fmtRpm } from "@/lib/format";
 
-// Short live blurb — only shown on the card when the agent is currently on the
-// board this quarter, so it stays a highlight rather than clutter.
+// Short live blurb — only shown when the agent is currently on the board this
+// quarter, so it stays a highlight rather than clutter.
 const liveBlurb = (live: LiveStanding): string | null => {
   if (live.result === "gold") return "leading this quarter";
   if (live.result === "silver") return "running 2nd this quarter";
@@ -34,17 +43,23 @@ export const AgentCard = ({
   stats,
   honors,
   live,
+  card,
   carrierName,
 }: {
   agent: Agent;
   stats?: AgentStat;
   honors?: AgentHonors;
   live?: LiveStanding | null;
+  card?: AgentScorecard;
   carrierName?: string;
 }) => {
   const tier = agentPrestige(honors);
-  const prestige = PRESTIGE_META[tier];
   const blurb = live ? liveBlurb(live) : null;
+  const spec =
+    card && card.specialty.tag !== "standard" ? SPECIALTY_META[card.specialty.tag] : null;
+  const goto = card ? TIER_META[card.tier] : null;
+  const dwell = card ? dwellStatus(card) : null;
+  const flag = card ? flagText(card) : null;
 
   return (
     <Link
@@ -59,9 +74,19 @@ export const AgentCard = ({
           {agent.last_name.charAt(0)}
         </div>
         <div className="min-w-0">
-          <p className="font-condensed text-lg leading-tight truncate">
-            {agent.first_name} {agent.last_name}
-          </p>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <p className="font-condensed text-lg leading-tight truncate">
+              {agent.first_name} {agent.last_name}
+            </p>
+            {spec && (
+              <span
+                className="text-[8.5px] font-bold tracking-wide px-1.5 py-0.5 rounded shrink-0"
+                style={{ color: spec.fg, background: spec.bg, border: `1px solid ${spec.border}` }}
+              >
+                {spec.label}
+              </span>
+            )}
+          </div>
           <p className="text-xs text-muted-text truncate">
             {agent.broker_name}
             {carrierName ? ` · ${carrierName}` : ""}
@@ -71,15 +96,22 @@ export const AgentCard = ({
 
       <div className="flex items-center justify-between gap-2 mt-2.5">
         <RatingMedallion rating={agent.rating} />
-        {prestige.label && (
+        {goto && (
           <span
-            className="text-[13px] font-comic uppercase shrink-0"
-            style={{ color: prestige.fill, letterSpacing: "1px" }}
+            className="text-[10px] font-bold px-2 py-0.5 rounded-md shrink-0"
+            style={{ color: goto.fg, background: goto.bg, border: `1px solid ${goto.border}` }}
           >
-            {prestige.label}
+            {goto.label}
           </span>
         )}
       </div>
+
+      {flag && (
+        <div className="mt-2 flex items-center gap-1.5 text-[11px]" style={{ color: "#f5a623" }}>
+          <TriangleAlert size={12} className="shrink-0" />
+          <span>{flag}</span>
+        </div>
+      )}
 
       {blurb && (
         <div className="mt-2 flex items-center gap-1.5 text-[11px]">
@@ -89,9 +121,23 @@ export const AgentCard = ({
         </div>
       )}
 
-      <div className="mt-2.5 pt-2 border-t border-[#3b4660] text-xs text-muted-text">
-        {stats?.loadCount ?? 0} loads · {money(stats?.revenue ?? 0)} ·{" "}
-        {fmtDate(stats?.lastWorked ?? null)}
+      <div className="mt-2.5 pt-2 border-t border-[#3b4660] text-xs">
+        <div className="flex items-center justify-between">
+          <span className="text-muted-text">
+            {stats?.loadCount ?? 0} loads · {money(stats?.revenue ?? 0)}
+          </span>
+          <span className="font-medium">
+            {card?.medianRpm != null ? `${fmtRpm(card.medianRpm)}/mi` : ""}
+          </span>
+        </div>
+        <div className="flex items-center justify-between mt-1 text-[11px]">
+          {dwell ? (
+            <span style={{ color: DWELL_TONE[dwell.tone] }}>dwell: {dwell.label}</span>
+          ) : (
+            <span />
+          )}
+          <span className="text-muted-text">{fmtDate(stats?.lastWorked ?? null)}</span>
+        </div>
       </div>
     </Link>
   );

--- a/frontend/src/components/agents/AgentTable.tsx
+++ b/frontend/src/components/agents/AgentTable.tsx
@@ -1,0 +1,167 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { TriangleAlert } from "lucide-react";
+import type { Agent } from "@/types/agent";
+import type { AgentScorecard } from "@/lib/metrics/agentScorecard";
+import { money, rpm as fmtRpm } from "@/lib/format";
+import {
+  TIER_META,
+  SPECIALTY_META,
+  dwellStatus,
+  DWELL_TONE,
+  TREND_META,
+} from "./agentDisplay";
+
+export interface AgentRow {
+  agent: Agent;
+  card: AgentScorecard;
+}
+
+type SortKey = "goto" | "rate" | "dwell" | "loads" | "revenue" | "last" | "rating";
+
+const COLS: { key: SortKey; label: string; l?: boolean }[] = [
+  { key: "rating", label: "Rating" },
+  { key: "goto", label: "Go-to" },
+  { key: "rate", label: "$/mi" },
+  { key: "dwell", label: "Dwell" },
+  { key: "loads", label: "Loads" },
+  { key: "revenue", label: "Rev" },
+  { key: "last", label: "Last" },
+];
+
+const stars = (r: number | null | undefined): string =>
+  r == null ? "—" : "★".repeat(r) + "☆".repeat(5 - r);
+
+const shortDate = (d: string | null): string =>
+  d
+    ? new Date(d + "T00:00:00Z").toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      })
+    : "—";
+
+const compare = (a: AgentRow, b: AgentRow, key: SortKey): number => {
+  const A = a.card;
+  const B = b.card;
+  switch (key) {
+    case "rate":
+      return (B.medianRpm ?? -1) - (A.medianRpm ?? -1);
+    case "dwell":
+      return B.moneyLostLoads - A.moneyLostLoads; // worst (most money lost) first
+    case "loads":
+      return B.loadCount - A.loadCount;
+    case "revenue":
+      return B.revenue - A.revenue;
+    case "last":
+      return (b.card.lastWorked ?? "").localeCompare(a.card.lastWorked ?? "");
+    case "rating":
+      return (b.agent.rating ?? -1) - (a.agent.rating ?? -1);
+    case "goto":
+    default:
+      return TIER_META[B.tier].rank - TIER_META[A.tier].rank || B.revenue - A.revenue;
+  }
+};
+
+export const AgentTable = ({ rows }: { rows: AgentRow[] }) => {
+  const navigate = useNavigate();
+  const [sort, setSort] = useState<SortKey>("goto");
+
+  const sorted = useMemo(
+    () => [...rows].sort((a, b) => compare(a, b, sort)),
+    [rows, sort],
+  );
+
+  return (
+    <div className="overflow-x-auto -mx-1 px-1">
+      <table className="w-full text-sm border-collapse" style={{ minWidth: 680 }}>
+        <thead>
+          <tr>
+            <th className="text-left font-normal text-[10px] uppercase tracking-wide text-muted-text py-2 px-2">
+              Agent
+            </th>
+            {COLS.map((c) => (
+              <th
+                key={c.key}
+                onClick={() => setSort(c.key)}
+                className="text-right font-normal text-[10px] uppercase tracking-wide py-2 px-2 cursor-pointer select-none whitespace-nowrap hover:text-light"
+                style={{ color: sort === c.key ? "#f5b03a" : undefined }}
+              >
+                {c.label}
+                {sort === c.key ? " ▼" : ""}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map(({ agent, card }) => {
+            const spec =
+              card.specialty.tag !== "standard" ? SPECIALTY_META[card.specialty.tag] : null;
+            const tier = TIER_META[card.tier];
+            const dwell = dwellStatus(card);
+            const trend = card.trend ? TREND_META[card.trend] : null;
+            const tint =
+              card.tier === "call-first"
+                ? "linear-gradient(90deg,rgba(74,222,128,.06),transparent 45%)"
+                : card.tier === "watch"
+                  ? "linear-gradient(90deg,rgba(245,166,35,.05),transparent 45%)"
+                  : undefined;
+            return (
+              <tr
+                key={agent.agent_id}
+                onClick={() => navigate(`/agents/${agent.agent_id}`)}
+                className="cursor-pointer hover:bg-plate/40"
+                style={{ background: tint, borderTop: "0.5px solid rgba(255,255,255,0.06)" }}
+              >
+                <td className="py-2 px-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="font-medium text-light truncate">
+                      {agent.first_name} {agent.last_name}
+                    </span>
+                    {spec && (
+                      <span
+                        className="text-[8.5px] font-bold tracking-wide px-1.5 py-0.5 rounded"
+                        style={{ color: spec.fg, background: spec.bg, border: `1px solid ${spec.border}` }}
+                      >
+                        {spec.label}
+                      </span>
+                    )}
+                    {card.ratingFlag && (
+                      <TriangleAlert size={12} style={{ color: "#f5a623", flexShrink: 0 }} />
+                    )}
+                  </div>
+                </td>
+                <td className="text-right py-2 px-2 whitespace-nowrap" style={{ color: "#f5b03a" }}>
+                  {stars(agent.rating)}
+                </td>
+                <td className="text-right py-2 px-2">
+                  <span
+                    className="text-[9.5px] font-bold px-2 py-0.5 rounded-md whitespace-nowrap"
+                    style={{ color: tier.fg, background: tier.bg, border: `1px solid ${tier.border}` }}
+                  >
+                    {tier.label}
+                  </span>
+                </td>
+                <td
+                  className="text-right py-2 px-2 tabular-nums"
+                  style={{ color: card.medianRpm != null && card.tier === "call-first" ? "#4ade80" : undefined }}
+                >
+                  {card.medianRpm != null ? fmtRpm(card.medianRpm) : "—"}
+                </td>
+                <td className="text-right py-2 px-2 whitespace-nowrap" style={{ color: DWELL_TONE[dwell.tone] }}>
+                  {dwell.label}
+                </td>
+                <td className="text-right py-2 px-2 text-muted-text tabular-nums">{card.loadCount}</td>
+                <td className="text-right py-2 px-2 tabular-nums">{money(card.revenue)}</td>
+                <td className="text-right py-2 px-2 whitespace-nowrap">
+                  {trend ? <span style={{ color: trend.fg }}>{trend.glyph}</span> : <span className="text-muted-text">·</span>}{" "}
+                  <span className="text-muted-text text-xs">{shortDate(card.lastWorked)}</span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/frontend/src/components/agents/agentDisplay.ts
+++ b/frontend/src/components/agents/agentDisplay.ts
@@ -1,0 +1,64 @@
+// Shared display metadata for the agent roster — tier chips, specialty badges,
+// and the Dwell status — so the card and the table read identically.
+import type {
+  GoToTier,
+  SpecialtyTag,
+  AgentScorecard,
+} from "@/lib/metrics/agentScorecard";
+
+export const TIER_META: Record<
+  GoToTier,
+  { label: string; fg: string; bg: string; border: string; rank: number }
+> = {
+  "call-first": { label: "Top pick", fg: "#4ade80", bg: "#123020", border: "#1f6e4a", rank: 4 },
+  solid: { label: "Solid", fg: "#6cc6e6", bg: "#12222e", border: "#245b70", rank: 3 },
+  watch: { label: "Watch", fg: "#f5a623", bg: "#241a06", border: "#85560b", rank: 2 },
+  cold: { label: "Cold", fg: "#9aa4b5", bg: "#171c26", border: "#2a3347", rank: 1 },
+  thin: { label: "Thin data", fg: "#6b7688", bg: "#0b111c", border: "#1a2130", rank: 0 },
+};
+
+export const SPECIALTY_META: Record<
+  Exclude<SpecialtyTag, "standard">,
+  { label: string; fg: string; bg: string; border: string }
+> = {
+  oversize: { label: "OVERSIZE", fg: "#f5b03a", bg: "#3a2408", border: "#85560b" },
+  specialty: { label: "SPECIALTY", fg: "#5fd0e0", bg: "#0f2c3a", border: "#1d5e70" },
+};
+
+export type DwellTone = "bad" | "good" | "none";
+export interface DwellStatus {
+  label: string;
+  tone: DwellTone;
+}
+
+// Dwell reads as MONEY, not raw sitting: only confirmed-billable-and-unpaid
+// detention ("$ sat") counts against an agent. Priced-in oversize crane time
+// (never confirmed) shows as "clean".
+export const dwellStatus = (c: AgentScorecard): DwellStatus => {
+  if (c.moneyLostLoads > 0)
+    return { label: `$ sat · ${c.moneyLostLoads}`, tone: "bad" };
+  if (c.collectedLoads > 0) return { label: "collected", tone: "good" };
+  return { label: "clean", tone: "none" };
+};
+
+export const DWELL_TONE: Record<DwellTone, string> = {
+  bad: "#f87171",
+  good: "#4ade80",
+  none: "#8b93a3",
+};
+
+// The single most useful nudge for a card/row: the gut-vs-data disagreement, or
+// a going-cold reminder. null = nothing worth flagging.
+export const flagText = (c: AgentScorecard): string | null => {
+  if (c.ratingFlag === "under") return "you rate low — data says keeper";
+  if (c.ratingFlag === "over") return "you rate high — data runs cooler";
+  if (c.tier === "cold" && c.daysSince != null)
+    return `going cold · ${c.daysSince}d quiet`;
+  return null;
+};
+
+export const TREND_META = {
+  up: { glyph: "▲", fg: "#4ade80" },
+  down: { glyph: "▼", fg: "#f87171" },
+  flat: { glyph: "—", fg: "#8b93a3" },
+} as const;

--- a/frontend/src/lib/metrics/agentScorecard.test.ts
+++ b/frontend/src/lib/metrics/agentScorecard.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Load } from "@/types/load";
+import type { Agent } from "@/types/agent";
+import {
+  classifySpecialty,
+  buildAgentScorecards,
+  agentRosterAnalytics,
+} from "./agentScorecard";
+
+const load = (over: Partial<Load>): Load =>
+  ({
+    load_id: "L",
+    load_status: "delivered",
+    load_type: "standard flatbed",
+    agent_id: "a",
+    delivery_date: "2026-07-15",
+    loaded_miles: 1000,
+    linehaul: "2000",
+    fuel_surcharge: "0",
+    total_accessorials: "0",
+    detention_billable: null,
+    detention_paid: false,
+    ...over,
+  }) as Load;
+
+const agent = (id: string, rating: number | null): Agent =>
+  ({ agent_id: id, rating, first_name: id, last_name: "X", broker_name: "B" }) as Agent;
+
+describe("classifySpecialty", () => {
+  it("labels oversize when oversize/heavy-haul is the majority (2+)", () => {
+    const m = classifySpecialty([
+      load({ load_type: "oversize" }),
+      load({ load_type: "heavy haul" }),
+      load({ load_type: "standard flatbed" }),
+    ]);
+    expect(m.tag).toBe("oversize");
+    expect(m.oversizeShare).toBeCloseTo(2 / 3, 5);
+    expect(m.oversizeCount).toBe(2);
+  });
+
+  it("labels specialty for a non-standard (hazmat) majority that isn't oversize", () => {
+    const m = classifySpecialty([load({ load_type: "hazmat" }), load({ load_type: "hazmat" })]);
+    expect(m.tag).toBe("specialty");
+    expect(m.oversizeShare).toBe(0);
+  });
+
+  it("stays standard for a single oversize load (count < 2 → don't crown)", () => {
+    expect(classifySpecialty([load({ load_type: "oversize" })]).tag).toBe("standard");
+  });
+
+  it("standard when standard flatbed dominates", () => {
+    expect(classifySpecialty([load({}), load({}), load({ load_type: "oversize" })]).tag).toBe(
+      "standard",
+    );
+  });
+});
+
+describe("buildAgentScorecards", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-06T12:00:00Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  // Three oversize agents at distinct $/mi so the cohort (3) can be graded.
+  const rpmLoads = (id: string, rpm: number, n: number, date = "2026-07-20"): Load[] =>
+    Array.from({ length: n }, () =>
+      load({ agent_id: id, load_type: "oversize", linehaul: String(rpm * 1000), delivery_date: date }),
+    );
+
+  it("computes rate/volume and grades rate within the specialty cohort → tiers", () => {
+    const agents = [agent("hi", 3), agent("mid", 3), agent("lo", 4)];
+    const loads = [...rpmLoads("hi", 10, 3), ...rpmLoads("mid", 6, 3), ...rpmLoads("lo", 3, 3)];
+    const cards = buildAgentScorecards(agents, loads);
+
+    expect(cards.get("hi")!.medianRpm).toBeCloseTo(10, 5);
+    expect(cards.get("hi")!.revenue).toBe(30000); // 3 × $10k gross
+    expect(cards.get("hi")!.tier).toBe("call-first"); // top of the oversize cohort
+    expect(cards.get("mid")!.tier).toBe("solid"); // middle
+    expect(cards.get("lo")!.tier).toBe("watch"); // weakest rate in cohort
+  });
+
+  it("money-lost detention = CONFIRMED billable + unpaid; unconfirmed (oversize priced-in) never counts", () => {
+    const loads = [
+      ...rpmLoads("x", 8, 2),
+      load({ agent_id: "x", load_type: "oversize", detention_billable: true, detention_paid: false }), // money lost
+      load({ agent_id: "x", load_type: "oversize", detention_billable: true, detention_paid: true }), // collected
+      load({ agent_id: "x", load_type: "oversize", detention_billable: null, detention_paid: false }), // sat, not confirmed → ignored
+    ];
+    const c = buildAgentScorecards([agent("x", 3)], loads).get("x")!;
+    expect(c.moneyLostLoads).toBe(1);
+    expect(c.collectedLoads).toBe(1);
+    expect(c.collectRate).toBeCloseTo(0.5, 5); // 1 of 2 confirmed
+    expect(c.tier).toBe("watch"); // any money lost → watch, regardless of rate
+  });
+
+  it("thin data under 2 loads; cold after 90 quiet days", () => {
+    const cards = buildAgentScorecards(
+      [agent("thin", 5), agent("cold", 4)],
+      [
+        load({ agent_id: "thin" }),
+        ...Array.from({ length: 3 }, () => load({ agent_id: "cold", delivery_date: "2026-03-01" })),
+      ],
+    );
+    expect(cards.get("thin")!.tier).toBe("thin");
+    expect(cards.get("cold")!.tier).toBe("cold"); // last worked ~5 months ago
+    expect(cards.get("cold")!.daysSince).toBeGreaterThan(90);
+  });
+
+  it("flags gut-vs-data both ways", () => {
+    // 'lo' is weakest-rate oversize → watch, but rated 4 → 'over'-rated.
+    // 'under' is a solid standard agent rated 2 → 'under'-rated (the Jamie case).
+    const agents = [agent("hi", 3), agent("mid", 3), agent("lo", 4), agent("under", 2)];
+    const loads = [
+      ...rpmLoads("hi", 10, 3),
+      ...rpmLoads("mid", 6, 3),
+      ...rpmLoads("lo", 3, 3),
+      ...Array.from({ length: 2 }, () => load({ agent_id: "under", linehaul: "3000" })), // standard, solid
+    ];
+    const cards = buildAgentScorecards(agents, loads);
+    expect(cards.get("lo")!.tier).toBe("watch");
+    expect(cards.get("lo")!.ratingFlag).toBe("over");
+    expect(cards.get("under")!.ratingFlag).toBe("under");
+  });
+});
+
+describe("agentRosterAnalytics", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-06T12:00:00Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("summarizes rate leader, oversize bench, concentration, and the best cold agent", () => {
+    const agents = [agent("a", 4), agent("b", 3), agent("c", 3)];
+    const loads = [
+      // a: oversize specialist, biggest earner, but cold (worked in March)
+      ...Array.from({ length: 3 }, () =>
+        load({ agent_id: "a", load_type: "oversize", linehaul: "9000", delivery_date: "2026-03-10" }),
+      ),
+      // b: oversize, recent, rate leader
+      ...Array.from({ length: 2 }, () =>
+        load({ agent_id: "b", load_type: "oversize", linehaul: "12000", delivery_date: "2026-07-30" }),
+      ),
+      // c: standard, small
+      ...Array.from({ length: 2 }, () => load({ agent_id: "c", linehaul: "2000", delivery_date: "2026-07-30" })),
+    ];
+    const r = agentRosterAnalytics(buildAgentScorecards(agents, loads));
+    expect(r.rateLeader?.agentId).toBe("b");
+    expect(r.rateLeader?.medianRpm).toBeCloseTo(12, 5);
+    expect(r.oversizeBench).toBe(2); // a and b
+    expect(r.goingCold?.agentId).toBe("a"); // the cold, high-value one
+    expect(r.concentrationPct).toBeGreaterThan(0.5);
+  });
+});

--- a/frontend/src/lib/metrics/agentScorecard.ts
+++ b/frontend/src/lib/metrics/agentScorecard.ts
@@ -1,0 +1,266 @@
+// Per-agent decision analytics for the roster: the three axes that actually
+// decide who to book — Rate ($/mi they pay), Volume (loads + trend), and Dwell
+// (money lost to CONFIRMED-but-uncollected detention) — plus a data-derived
+// specialty label and a "Go-to" tier that complements (never replaces) the
+// owner's star rating. Gross throughout (agents are a market-value lens), and
+// small samples stay unscored so one lucky load can't crown anyone.
+import type { Load } from "@/types/load";
+import type { Agent } from "@/types/agent";
+import { loadRevenue } from "./loads"; // GROSS per load
+import { median } from "./stats";
+import { detentionOwed, detentionCollected } from "@/lib/detention";
+
+// Below this many delivered loads an agent is "thin data" — shown, never scored.
+export const MIN_SCORE_LOADS = 2;
+const COLD_DAYS = 90; // no delivered load in this many days → "cold"
+const MS_DAY = 86_400_000;
+// Cohort rate spread (inter-percentile, $/mi) below which rates count as "the
+// same" — no strong/weak grading on sub-dime noise.
+const RATE_SPREAD_FLOOR = 0.1;
+
+// ---- specialty (data-derived from load mix) ----
+export type SpecialtyTag = "oversize" | "specialty" | "standard";
+const OVERSIZE_TYPES = new Set(["oversize", "heavy haul"]);
+const STANDARD_TYPE = "standard flatbed";
+
+export interface SpecialtyMix {
+  tag: SpecialtyTag;
+  oversizeShare: number; // 0..1 of delivered loads that are oversize/heavy-haul
+  specialtyShare: number; // 0..1 that are non-standard (incl. hazmat)
+  oversizeCount: number;
+}
+
+// Majority + a real count → a label; otherwise standard (or thin). The manual
+// pin (fast-follow) will let the owner override this.
+export const classifySpecialty = (delivered: Load[]): SpecialtyMix => {
+  const n = delivered.length;
+  const oversizeCount = delivered.filter((l) => OVERSIZE_TYPES.has(l.load_type)).length;
+  const specialtyCount = delivered.filter((l) => l.load_type !== STANDARD_TYPE).length;
+  const oversizeShare = n ? oversizeCount / n : 0;
+  const specialtyShare = n ? specialtyCount / n : 0;
+  let tag: SpecialtyTag = "standard";
+  if (oversizeCount >= 2 && oversizeShare >= 0.5) tag = "oversize";
+  else if (specialtyCount >= 2 && specialtyShare >= 0.5) tag = "specialty";
+  return { tag, oversizeShare, specialtyShare, oversizeCount };
+};
+
+// ---- one agent's raw metrics (pre-tier) ----
+export type Trend = "up" | "down" | "flat";
+export type GoToTier = "call-first" | "solid" | "watch" | "cold" | "thin";
+export type RatingFlag = "under" | "over"; // your star rating disagrees with the data
+
+export interface AgentScorecard {
+  agentId: string;
+  loadCount: number; // delivered
+  revenue: number; // delivered gross
+  medianRpm: number | null; // gross ÷ loaded mile, the typical load
+  trend: Trend | null; // last 90d revenue vs the prior 90d
+  lastWorked: string | null;
+  daysSince: number | null;
+  moneyLostLoads: number; // detentionOwed — confirmed billable, still unpaid
+  collectedLoads: number; // detentionCollected
+  collectRate: number | null; // collected ÷ (owed + collected), null if none confirmed
+  specialty: SpecialtyMix;
+  tier: GoToTier;
+  ratingFlag: RatingFlag | null;
+}
+
+const loadRpm = (l: Load): number | null => {
+  const miles = Number(l.loaded_miles);
+  if (!(miles > 0)) return null;
+  return loadRevenue(l) / miles;
+};
+
+const trendOf = (delivered: Load[], now: number): Trend | null => {
+  const recent = now - 90 * MS_DAY;
+  const prior = now - 180 * MS_DAY;
+  let r = 0;
+  let p = 0;
+  for (const l of delivered) {
+    if (!l.delivery_date) continue;
+    const t = new Date(l.delivery_date).getTime();
+    if (t >= recent && t <= now) r += loadRevenue(l);
+    else if (t >= prior && t < recent) p += loadRevenue(l);
+  }
+  if (p === 0 && r === 0) return null;
+  if (p === 0) return "up";
+  const ratio = r / p;
+  return ratio >= 1.15 ? "up" : ratio <= 0.85 ? "down" : "flat";
+};
+
+// Raw per-agent metrics for one agent's loads (already filtered to that agent).
+const rawScorecard = (
+  agentId: string,
+  loads: Load[],
+  now: number,
+): Omit<AgentScorecard, "tier" | "ratingFlag"> => {
+  const delivered = loads.filter((l) => l.load_status === "delivered");
+  const rpms = delivered.map(loadRpm).filter((r): r is number => r !== null);
+  const revenue = delivered.reduce((s, l) => s + loadRevenue(l), 0);
+
+  let lastWorked: string | null = null;
+  for (const l of delivered) {
+    if (!l.delivery_date) continue;
+    const d = l.delivery_date.slice(0, 10);
+    if (!lastWorked || d > lastWorked) lastWorked = d;
+  }
+  const daysSince = lastWorked
+    ? Math.floor((now - new Date(lastWorked + "T00:00:00Z").getTime()) / MS_DAY)
+    : null;
+
+  // Money lost to sitting = CONFIRMED-billable detention that never got paid.
+  // Oversize crane time stays an unconfirmed candidate → never counted here.
+  const moneyLostLoads = delivered.filter((l) => detentionOwed(l)).length;
+  const collectedLoads = delivered.filter((l) => detentionCollected(l)).length;
+  const confirmed = moneyLostLoads + collectedLoads;
+
+  return {
+    agentId,
+    loadCount: delivered.length,
+    revenue,
+    medianRpm: rpms.length ? median(rpms) : null,
+    trend: trendOf(delivered, now),
+    lastWorked,
+    daysSince,
+    moneyLostLoads,
+    collectedLoads,
+    collectRate: confirmed > 0 ? collectedLoads / confirmed : null,
+    specialty: classifySpecialty(delivered),
+  };
+};
+
+// Rate is only fair WITHIN a specialty type (oversize pays more per mile). Grade
+// an agent's rate against same-type peers: top third strong, bottom third weak —
+// but only when the cohort is big enough (3+) to rank meaningfully.
+type RateGrade = "strong" | "weak" | "neutral";
+const rateGrades = (
+  cards: Omit<AgentScorecard, "tier" | "ratingFlag">[],
+): Map<string, RateGrade> => {
+  const grades = new Map<string, RateGrade>();
+  const byType = new Map<SpecialtyTag, Omit<AgentScorecard, "tier" | "ratingFlag">[]>();
+  for (const c of cards) {
+    if (c.loadCount < MIN_SCORE_LOADS || c.medianRpm == null) continue;
+    const t = c.specialty.tag;
+    (byType.get(t) ?? byType.set(t, []).get(t)!).push(c);
+  }
+  for (const cohort of byType.values()) {
+    if (cohort.length < 3) {
+      for (const c of cohort) grades.set(c.agentId, "neutral");
+      continue;
+    }
+    // Grade by rate VALUE (not index), so tied rates get the SAME grade. And
+    // only when the cohort has a MEANINGFUL spread — a roster where everyone
+    // pays ~the same $/mi (within a dime) is all-neutral, never split on cents.
+    const vals = cohort.map((c) => c.medianRpm as number).sort((a, b) => a - b);
+    const n = vals.length;
+    const loVal = vals[Math.floor((n - 1) * 0.34)];
+    const hiVal = vals[Math.ceil((n - 1) * 0.66)];
+    const meaningful = hiVal - loVal >= RATE_SPREAD_FLOOR;
+    for (const c of cohort) {
+      const r = c.medianRpm as number;
+      let g: RateGrade = "neutral";
+      if (meaningful) {
+        if (r >= hiVal) g = "strong";
+        else if (r <= loVal) g = "weak";
+      }
+      grades.set(c.agentId, g);
+    }
+  }
+  return grades;
+};
+
+const tierOf = (
+  c: Omit<AgentScorecard, "tier" | "ratingFlag">,
+  rate: RateGrade,
+): GoToTier => {
+  if (c.loadCount < MIN_SCORE_LOADS) return "thin";
+  if (c.daysSince != null && c.daysSince > COLD_DAYS) return "cold";
+  const hasMoneyLost = c.moneyLostLoads > 0;
+  if (rate === "weak" || hasMoneyLost) return "watch";
+  if (rate === "strong") return "call-first";
+  return "solid";
+};
+
+// The gut-vs-data flag: surfaces where the owner's star rating and the data
+// pull in opposite directions — a low-rated agent the numbers like ("under"-
+// rated), or a high-rated one the numbers don't ("over"-rated).
+const ratingFlagOf = (rating: number | null | undefined, tier: GoToTier): RatingFlag | null => {
+  if (rating == null) return null;
+  if (rating <= 2 && (tier === "call-first" || tier === "solid")) return "under";
+  if (rating >= 4 && tier === "watch") return "over";
+  return null;
+};
+
+// Build every agent's scorecard in two passes (raw metrics, then cohort-relative
+// rate grade → tier). Keyed by agent_id.
+export const buildAgentScorecards = (
+  agents: Agent[],
+  loads: Load[],
+  now: Date = new Date(),
+): Map<string, AgentScorecard> => {
+  const nowMs = now.getTime();
+  const byAgent = new Map<string, Load[]>();
+  for (const l of loads) {
+    if (!l.agent_id) continue;
+    (byAgent.get(l.agent_id) ?? byAgent.set(l.agent_id, []).get(l.agent_id)!).push(l);
+  }
+  const raw = agents.map((a) => rawScorecard(a.agent_id, byAgent.get(a.agent_id) ?? [], nowMs));
+  const grades = rateGrades(raw);
+  const ratingById = new Map(agents.map((a) => [a.agent_id, a.rating]));
+
+  const out = new Map<string, AgentScorecard>();
+  for (const c of raw) {
+    const tier = tierOf(c, grades.get(c.agentId) ?? "neutral");
+    out.set(c.agentId, {
+      ...c,
+      tier,
+      ratingFlag: ratingFlagOf(ratingById.get(c.agentId), tier),
+    });
+  }
+  return out;
+};
+
+// ---- roster-level analytics for the KPI row ----
+export interface RosterAnalytics {
+  rateLeader: { agentId: string; medianRpm: number } | null;
+  oversizeBench: number; // agents labeled oversize
+  specCapable: number; // agents with any oversize/heavy-haul load
+  concentrationPct: number | null; // top-3 revenue ÷ total delivered revenue
+  goingCold: { agentId: string; revenue: number; daysSince: number } | null; // best cold agent
+  moneyLostAgents: number; // agents with any confirmed-unpaid detention
+}
+
+export const agentRosterAnalytics = (
+  cards: Map<string, AgentScorecard>,
+): RosterAnalytics => {
+  const list = [...cards.values()];
+  const scored = list.filter((c) => c.loadCount >= MIN_SCORE_LOADS);
+
+  let rateLeader: RosterAnalytics["rateLeader"] = null;
+  for (const c of scored) {
+    if (c.medianRpm == null) continue;
+    if (!rateLeader || c.medianRpm > rateLeader.medianRpm)
+      rateLeader = { agentId: c.agentId, medianRpm: c.medianRpm };
+  }
+
+  const totalRev = list.reduce((s, c) => s + c.revenue, 0);
+  const top3 = [...list].sort((a, b) => b.revenue - a.revenue).slice(0, 3);
+  const top3Rev = top3.reduce((s, c) => s + c.revenue, 0);
+
+  // The most valuable agent who's gone quiet — worth a call.
+  let goingCold: RosterAnalytics["goingCold"] = null;
+  for (const c of list) {
+    if (c.tier !== "cold") continue;
+    if (!goingCold || c.revenue > goingCold.revenue)
+      goingCold = { agentId: c.agentId, revenue: c.revenue, daysSince: c.daysSince ?? 0 };
+  }
+
+  return {
+    rateLeader,
+    oversizeBench: list.filter((c) => c.specialty.tag === "oversize").length,
+    specCapable: list.filter((c) => c.specialty.oversizeCount > 0).length,
+    concentrationPct: totalRev > 0 ? top3Rev / totalRev : null,
+    goingCold,
+    moneyLostAgents: list.filter((c) => c.moneyLostLoads > 0).length,
+  };
+};

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -4,23 +4,23 @@ import { useAgents } from "@/hooks/useAgents";
 import { useLoads } from "@/hooks/useLoads";
 import { Kpi } from "@/components/Kpi";
 import { AgentCard } from "@/components/agents/AgentCard";
+import { AgentTable } from "@/components/agents/AgentTable";
+import { TIER_META } from "@/components/agents/agentDisplay";
 import { useCarrierName } from "@/hooks/useCarrierName";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   computeHonors,
   perAgentStats,
-  rosterKpis,
   currentQuarterStandings,
 } from "@/lib/metrics/agentLeaderboard";
-import { money } from "@/lib/format";
+import {
+  buildAgentScorecards,
+  agentRosterAnalytics,
+} from "@/lib/metrics/agentScorecard";
+import { money, rpm as fmtRpm } from "@/lib/format";
 
-type SortKey = "rating" | "revenue" | "recent";
-const SORTS: [SortKey, string][] = [
-  ["rating", "Rating"],
-  ["revenue", "Revenue"],
-  ["recent", "Recently worked"],
-];
+type Filter = "all" | "oversize" | "specialty" | "standard" | "call-first" | "cold";
 
 const plural = (n: number) => (n !== 1 ? "s" : "");
 
@@ -29,48 +29,61 @@ const AgentsPage = () => {
   const { loads, isLoading: loadsLoading } = useLoads(0);
 
   const [search, setSearch] = useState("");
-  const [sort, setSort] = useState<SortKey>("rating");
+  const [filter, setFilter] = useState<Filter>("all");
+  const [view, setView] = useState<"table" | "cards">("table");
   const carrierName = useCarrierName();
+  const now = useMemo(() => new Date(), []);
 
-  const honors = useMemo(() => computeHonors(loads ?? [], new Date()), [loads]);
+  const honors = useMemo(() => computeHonors(loads ?? [], now), [loads, now]);
   const stats = useMemo(() => perAgentStats(loads ?? []), [loads]);
-  const standings = useMemo(
-    () => currentQuarterStandings(loads ?? [], new Date()),
-    [loads],
+  const standings = useMemo(() => currentQuarterStandings(loads ?? [], now), [loads, now]);
+  const scorecards = useMemo(
+    () => buildAgentScorecards(agents ?? [], loads ?? [], now),
+    [agents, loads, now],
   );
-  const kpis = useMemo(
-    () => rosterKpis(agents ?? [], loads ?? [], new Date()),
-    [agents, loads],
+  const roster = useMemo(() => agentRosterAnalytics(scorecards), [scorecards]);
+
+  const byId = useMemo(
+    () => new Map((agents ?? []).map((a) => [a.agent_id, a])),
+    [agents],
   );
 
-  const shown = useMemo(() => {
+  const counts = useMemo(() => {
+    const c = { all: 0, oversize: 0, specialty: 0, standard: 0, "call-first": 0, cold: 0 };
+    for (const card of scorecards.values()) {
+      c.all += 1;
+      c[card.specialty.tag] += 1;
+      if (card.tier === "call-first") c["call-first"] += 1;
+      if (card.tier === "cold") c.cold += 1;
+    }
+    return c;
+  }, [scorecards]);
+
+  const rows = useMemo(() => {
     const q = search.trim().toLowerCase();
-    const filtered = (agents ?? []).filter(
-      (a) =>
-        !q ||
-        `${a.first_name} ${a.last_name} ${a.broker_name}`
-          .toLowerCase()
-          .includes(q),
-    );
-    const rev = (id: string) => stats.get(id)?.revenue ?? 0;
-    const worked = (id: string) => stats.get(id)?.lastWorked ?? "";
-    // Break rating ties by career achievement so the more decorated agent
-    // (e.g. the Champion) leads within a tier.
-    const honorScore = (id: string) => {
-      const h = honors.get(id);
-      return h ? h.gold * 10000 + h.silver * 100 + h.board : 0;
-    };
-    return [...filtered].sort((a, b) => {
-      if (sort === "revenue") return rev(b.agent_id) - rev(a.agent_id);
-      if (sort === "recent")
-        return worked(b.agent_id).localeCompare(worked(a.agent_id));
-      return (
-        (b.rating ?? -1) - (a.rating ?? -1) ||
-        honorScore(b.agent_id) - honorScore(a.agent_id) ||
-        rev(b.agent_id) - rev(a.agent_id)
+    return (agents ?? [])
+      .map((a) => ({ agent: a, card: scorecards.get(a.agent_id)! }))
+      .filter(({ agent, card }) => {
+        if (!card) return false;
+        if (
+          q &&
+          !`${agent.first_name} ${agent.last_name} ${agent.broker_name}`
+            .toLowerCase()
+            .includes(q)
+        )
+          return false;
+        if (filter === "oversize" || filter === "specialty" || filter === "standard")
+          return card.specialty.tag === filter;
+        if (filter === "call-first") return card.tier === "call-first";
+        if (filter === "cold") return card.tier === "cold";
+        return true;
+      })
+      .sort(
+        (a, b) =>
+          TIER_META[b.card.tier].rank - TIER_META[a.card.tier].rank ||
+          b.card.revenue - a.card.revenue,
       );
-    });
-  }, [agents, stats, honors, search, sort]);
+  }, [agents, scorecards, search, filter]);
 
   if (isLoading || loadsLoading)
     return (
@@ -92,94 +105,126 @@ const AgentsPage = () => {
       </div>
     );
 
-  const top = kpis.topEarner
-    ? (agents ?? []).find((a) => a.agent_id === kpis.topEarner!.agentId)
-    : null;
+  const rateLeader = roster.rateLeader ? byId.get(roster.rateLeader.agentId) : null;
+  const cold = roster.goingCold ? byId.get(roster.goingCold.agentId) : null;
+
+  const CHIPS: [Filter, string, number][] = [
+    ["all", "All", counts.all],
+    ["oversize", "Oversize", counts.oversize],
+    ["specialty", "Specialty", counts.specialty],
+    ["standard", "Standard", counts.standard],
+    ["call-first", "Top pick", counts["call-first"]],
+    ["cold", "Cold", counts.cold],
+  ];
 
   return (
     <div className="p-6 bg-iron text-light font-body min-h-screen">
       <div className="flex justify-between items-baseline mb-6">
         <h1 className="text-3xl font-condensed text-light">Agents</h1>
-        <Link
-          to="/guide"
-          className="text-xs text-muted-text hover:text-amber-light"
-        >
+        <Link to="/guide" className="text-xs text-muted-text hover:text-amber-light">
           How this works →
         </Link>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <Kpi
-          label="Roster"
-          value={String(kpis.total)}
-          sub={`${kpis.rated} rated`}
-        />
-        <Kpi
-          label="Go-to bench"
-          value={String(kpis.callFirst)}
-          valueClass="text-amber"
-          sub={`call first · ${kpis.avoid} to avoid`}
-        />
-        {top ? (
-          <Link to={`/agents/${top.agent_id}`}>
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        {rateLeader && roster.rateLeader ? (
+          <Link to={`/agents/${rateLeader.agent_id}`}>
             <Kpi
-              label="Top earner"
-              value={`${top.first_name.charAt(0)}. ${top.last_name}`}
-              sub={`${money(kpis.topEarner!.revenue)} · 90 days`}
+              label="Rate leader"
+              value={fmtRpm(roster.rateLeader.medianRpm)}
+              valueClass="text-status-good-text"
+              sub={`${rateLeader.first_name.charAt(0)}. ${rateLeader.last_name} · $/mi`}
             />
           </Link>
         ) : (
-          <Kpi label="Top earner" value="—" sub="no delivered loads · 90 days" />
+          <Kpi label="Rate leader" value="—" sub="need 2+ loads" />
         )}
         <Kpi
-          label="Active agents"
-          value={String(kpis.activeCount)}
-          sub="worked · last 90 days"
+          label="Oversize bench"
+          value={String(roster.oversizeBench)}
+          valueClass="text-amber"
+          sub={`specialists · ${roster.specCapable} spec-capable`}
         />
+        <Kpi
+          label="Concentration"
+          value={roster.concentrationPct != null ? `${Math.round(roster.concentrationPct * 100)}%` : "—"}
+          sub="top 3 of your revenue"
+        />
+        {cold && roster.goingCold ? (
+          <Link to={`/agents/${cold.agent_id}`}>
+            <Kpi
+              label="Going cold"
+              value={`${cold.first_name.charAt(0)}. ${cold.last_name}`}
+              valueClass="text-amber"
+              sub={`${money(roster.goingCold.revenue)} · ${roster.goingCold.daysSince}d quiet`}
+            />
+          </Link>
+        ) : (
+          <Kpi label="Going cold" value="—" sub="all recently active" />
+        )}
+        <Kpi label="Roster" value={String(counts.all)} sub={`${roster.oversizeBench + counts.specialty} specialty`} />
       </div>
 
-      <div className="flex flex-wrap items-center gap-2 mt-4 mb-4">
-        <input
-          className="bg-plate rounded px-3 py-2 text-sm flex-1 min-w-[180px] text-light placeholder:text-muted-text"
-          placeholder="Search name or broker"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
-        <div className="flex gap-1 bg-plate rounded-lg p-1">
-          {SORTS.map(([key, label]) => (
+      <div className="flex flex-wrap items-center justify-between gap-2 mt-5 mb-4">
+        <div className="flex flex-wrap gap-1.5">
+          {CHIPS.map(([key, label, n]) => (
             <button
               key={key}
-              onClick={() => setSort(key)}
-              className={`px-2.5 py-1 rounded text-sm ${
-                sort === key
-                  ? "bg-amber text-steel font-semibold"
-                  : "text-muted-text"
+              onClick={() => setFilter(key)}
+              className="text-[11.5px] rounded-full px-2.5 py-1 border transition-colors"
+              style={
+                filter === key
+                  ? { background: "#e8940a", borderColor: "#e8940a", color: "#12151b", fontWeight: 700 }
+                  : { borderColor: "#2a3347", color: "#9aa4b5" }
+              }
+            >
+              {label} <span className="opacity-70">{n}</span>
+            </button>
+          ))}
+        </div>
+        <div className="flex gap-1 bg-plate rounded-lg p-1">
+          {(["table", "cards"] as const).map((v) => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={`px-2.5 py-1 rounded text-sm capitalize ${
+                view === v ? "bg-steel text-light font-semibold" : "text-muted-text"
               }`}
             >
-              {label}
+              {v}
             </button>
           ))}
         </div>
       </div>
 
-      {shown.length === 0 ? (
+      <input
+        className="bg-plate rounded px-3 py-2 text-sm w-full max-w-md text-light placeholder:text-muted-text mb-4"
+        placeholder="Search name or broker"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+
+      {rows.length === 0 ? (
         (agents ?? []).length === 0 ? (
           <EmptyState
             title="No agents yet"
             hint="Add an agent to track who books your freight and how they pay."
           />
         ) : (
-          <p className="text-muted-text text-sm">No agents match your search.</p>
+          <p className="text-muted-text text-sm">No agents match.</p>
         )
+      ) : view === "table" ? (
+        <AgentTable rows={rows} />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {shown.map((agent) => (
+          {rows.map(({ agent, card }) => (
             <AgentCard
               key={agent.agent_id}
               agent={agent}
               stats={stats.get(agent.agent_id)}
               honors={honors.get(agent.agent_id)}
               live={standings.get(agent.agent_id)}
+              card={card}
               carrierName={carrierName}
             />
           ))}
@@ -187,7 +232,8 @@ const AgentsPage = () => {
       )}
 
       <p className="text-xs text-muted-text mt-6">
-        {shown.length} agent{plural(shown.length)}
+        {rows.length} agent{plural(rows.length)}
+        {filter !== "all" ? ` · ${filter}` : ""}
       </p>
     </div>
   );

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -366,6 +366,7 @@ const NAV: { group: string; items: string[] }[] = [
     group: "Agents",
     items: [
       "Agent ratings",
+      "Reading the roster — the Go-to score",
       "The quarterly leaderboard",
       "Trophies",
       "Career rank",
@@ -1515,6 +1516,53 @@ const GuidePage = () => {
                 </div>
               ))}
             </div>
+          </Section>
+
+          <Section
+            title="Reading the roster — the Go-to score"
+            sources={[{ label: "Agents", to: "/agents" }]}
+          >
+            <p className="text-sm text-muted-text mb-3">
+              Your stars are your gut. The <span className="text-light">Go-to
+              score</span> is the data's read, sitting right next to them —{" "}
+              <span className="text-light">Top pick · Solid · Watch · Cold</span>{" "}
+              — built from three axes:
+            </p>
+            <ul className="text-sm text-muted-text space-y-2 mb-3 list-disc pl-5">
+              <li>
+                <span className="text-light">Rate</span> — the typical $/mi they
+                pay, graded <span className="text-light">within specialty type</span>{" "}
+                (oversize pays more per mile, so an oversize agent is measured
+                against other oversize agents — a strong standard-freight agent
+                isn't buried under them).
+              </li>
+              <li>
+                <span className="text-light">Volume</span> — loads and gross, with
+                an up/down trend vs the prior 90 days.
+              </li>
+              <li>
+                <span className="text-light">Dwell</span> — money lost to sitting.
+                This counts detention you <span className="text-light">confirmed
+                billable but never collected</span> — not raw wait time. Priced-in
+                oversize crane time (which you never confirm billable) stays a
+                candidate and <span className="text-light">never dings the agent</span>.
+              </li>
+            </ul>
+            <p className="text-sm text-muted-text mb-3">
+              The <span className="text-light">specialty label</span> is derived
+              from each agent's load mix — an oversize / heavy-haul majority earns{" "}
+              <span className="text-light">OVERSIZE</span>, other non-standard
+              (hazmat) earns <span className="text-light">SPECIALTY</span> — so you
+              can filter straight to your oversize bench. And a{" "}
+              <span style={{ color: "#f5a623" }}>⚠ flag</span> marks where your
+              stars and the data disagree: a low-rated agent the numbers like, or a
+              high-rated one they don't.
+            </p>
+            <p className="text-sm text-muted-text">
+              An agent stays <span className="text-light">"thin data" (unscored)</span>{" "}
+              until they've run 2+ delivered loads, so one lucky run never crowns
+              anyone — the same restraint the lane and rate metrics use.
+            </p>
           </Section>
 
           <Section


### PR DESCRIPTION
The agents page becomes a **decision tool**, not just a rated list.

### What's new
- **Go-to tier** (`Top pick / Solid / Watch / Cold`) — a data read that sits *next to* your star rating, never replacing it. A ⚠ **gut-vs-data flag** surfaces where they disagree (a low-rated agent the numbers like, or vice versa).
- **Three axes** (`agentScorecard.ts`):
  - **Rate** — typical $/mi, graded **within specialty type** (oversize pays more per mile), by rate *value* not rank, and only when the cohort has a **meaningful spread (≥10¢/mi)** — a uniform roster reads all-Solid, never split on cents.
  - **Volume** — loads + gross + 90-day trend.
  - **Dwell** — money lost to sitting = detention you **confirmed billable but never collected**. Priced-in oversize crane time (never confirmed) never counts. Reuses your detention model's `detention_billable` flag as the switch.
- **Specialty label** — data-derived from load mix (oversize/heavy-haul majority → `OVERSIZE`, other non-standard → `SPECIALTY`). Manual pin is a planned fast-follow. Filter the roster to your oversize bench.
- **Sortable table ⇄ enriched cards** toggle, sharper KPI row (rate leader, oversize bench, concentration, going-cold), specialty/tier filters.
- Small samples stay **"thin data" (unscored)** under 2 delivered loads.

### Files
- New: `agentScorecard.ts` (+ 9 tests), `agentDisplay.ts`, `AgentTable.tsx`. Enhanced `AgentCard.tsx`, `AgentsPage.tsx`. Guide section added. **463 tests** total.

### Verified on dev
The dev-DB verify caught a real bug: the uniform-$3.00 seed was crowning/burying agents on thousandths of a cent (biggest earner wrongly "Watch"). Fixed — value-based grading + a meaningful-spread floor — so uniform rates read all-Solid. Rate differentiation + specialty badges are proven by the design mockup on real prod data (varied rates, oversize agents) and the unit tests.

Design + metric approach approved before build (data-derived first; "Dwell" wording; oversize handled by the billable flag; top tier renamed "Top pick" to avoid clashing with the 5★ rating medallion's "CALL FIRST").

🤖 Generated with [Claude Code](https://claude.com/claude-code)