### PR TITLE
feat: tabbed dashboard redesign — Pulse / Money / Lanes / Agents, full-height (v1.136.0)

### DIFF
--- a/backend/src/routes/expenseRoutes.js
+++ b/backend/src/routes/expenseRoutes.js
@@ -4,6 +4,7 @@ import {
   saveExpensePeriod,
   getExpensePeriods,
   getExpensePeriod,
+  getExpenseCategoryRollup,
   getCategoryDefaults,
   addExpenseLine,
   patchExpenseLine,
@@ -30,6 +31,17 @@ router.get("/defaults", async (req, res) => {
   try {
     const defaults = await getCategoryDefaults(req.user.user_id);
     return res.status(200).json({ defaults });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+// ---- YTD CATEGORY ROLLUP ---- (before "/:period_id" so it isn't matched as one)
+router.get("/categories", async (req, res) => {
+  try {
+    const year = req.query.year ?? new Date().getUTCFullYear();
+    const categories = await getExpenseCategoryRollup(req.user.user_id, year);
+    return res.status(200).json({ categories });
   } catch (err) {
     return handleError(res, err);
   }

--- a/backend/src/services/expenseServices.js
+++ b/backend/src/services/expenseServices.js
@@ -153,6 +153,32 @@ export async function getExpensePeriod(user_id, period_id) {
   return { ...periodRes.rows[0], lines: linesRes.rows };
 }
 
+// ---- GET YTD CATEGORY ROLLUP ----
+// Spending by category across one calendar year (all sections). One GROUP BY so
+// the dashboard's "where it goes" card doesn't have to pull every month's lines
+// and re-sum them client-side. Amount comes back as a numeric string — coerce.
+export async function getExpenseCategoryRollup(user_id, year) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const y = Number(year);
+  if (!Number.isInteger(y) || y < 2000 || y > 3000)
+    throw new ValidationError("year must be a 4-digit year");
+
+  const start = `${y}-01-01`;
+  const end = `${y + 1}-01-01`;
+  const result = await db.query(
+    `SELECT l.category, l.section, SUM(l.amount) AS amount
+       FROM expense_lines l
+       JOIN expense_periods p ON p.period_id = l.period_id
+      WHERE l.user_id = $1
+        AND p.period_month >= $2::date
+        AND p.period_month <  $3::date
+      GROUP BY l.category, l.section
+      ORDER BY SUM(l.amount) DESC`,
+    [user_id, start, end],
+  );
+  return result.rows;
+}
+
 // ---- GET CATEGORY DEFAULTS ---- (category → type, for upload auto-classify)
 export async function getCategoryDefaults(user_id) {
   if (!user_id) throw new ValidationError("Missing user_id");

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.135.0",
+  "version": "1.136.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/agents/AgentTable.tsx
+++ b/frontend/src/components/agents/AgentTable.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { TriangleAlert } from "lucide-react";
 import type { Agent } from "@/types/agent";
-import type { AgentScorecard } from "@/lib/metrics/agentScorecard";
+import { type AgentScorecard, SINGLE_CAP } from "@/lib/metrics/agentScorecard";
 import { money, rpm as fmtRpm } from "@/lib/format";
 import {
   TIER_META,
@@ -17,7 +17,7 @@ export interface AgentRow {
   card: AgentScorecard;
 }
 
-type SortKey = "goto" | "rate" | "dwell" | "loads" | "revenue" | "last" | "rating";
+type SortKey = "goto" | "rate" | "dwell" | "loads" | "revenue" | "book" | "last" | "rating";
 
 const COLS: { key: SortKey; label: string; l?: boolean }[] = [
   { key: "rating", label: "Rating" },
@@ -26,6 +26,7 @@ const COLS: { key: SortKey; label: string; l?: boolean }[] = [
   { key: "dwell", label: "Dwell" },
   { key: "loads", label: "Loads" },
   { key: "revenue", label: "Rev" },
+  { key: "book", label: "% book" },
   { key: "last", label: "Last" },
 ];
 
@@ -63,13 +64,26 @@ const compare = (a: AgentRow, b: AgentRow, key: SortKey): number => {
   }
 };
 
-export const AgentTable = ({ rows }: { rows: AgentRow[] }) => {
+export const AgentTable = ({
+  rows,
+  shareByAgent,
+}: {
+  rows: AgentRow[];
+  shareByAgent?: Map<string, number>;
+}) => {
   const navigate = useNavigate();
   const [sort, setSort] = useState<SortKey>("goto");
+  const shareOf = (id: string) => shareByAgent?.get(id) ?? 0;
 
   const sorted = useMemo(
-    () => [...rows].sort((a, b) => compare(a, b, sort)),
-    [rows, sort],
+    () =>
+      [...rows].sort((a, b) =>
+        sort === "book"
+          ? (shareByAgent?.get(b.agent.agent_id) ?? 0) -
+            (shareByAgent?.get(a.agent.agent_id) ?? 0)
+          : compare(a, b, sort),
+      ),
+    [rows, sort, shareByAgent],
   );
 
   return (
@@ -153,6 +167,13 @@ export const AgentTable = ({ rows }: { rows: AgentRow[] }) => {
                 </td>
                 <td className="text-right py-2 px-2 text-muted-text tabular-nums">{card.loadCount}</td>
                 <td className="text-right py-2 px-2 tabular-nums">{money(card.revenue)}</td>
+                <td
+                  className="text-right py-2 px-2 tabular-nums"
+                  style={{ color: shareOf(agent.agent_id) > SINGLE_CAP ? "#f5a623" : "#8b93a3" }}
+                  title="share of your last-90-day book"
+                >
+                  {shareOf(agent.agent_id) > 0 ? `${Math.round(shareOf(agent.agent_id) * 100)}%` : "—"}
+                </td>
                 <td className="text-right py-2 px-2 whitespace-nowrap">
                   {trend ? <span style={{ color: trend.fg }}>{trend.glyph}</span> : <span className="text-muted-text">·</span>}{" "}
                   <span className="text-muted-text text-xs">{shortDate(card.lastWorked)}</span>

--- a/frontend/src/components/dashboard/AlertBanners.tsx
+++ b/frontend/src/components/dashboard/AlertBanners.tsx
@@ -1,9 +1,11 @@
-import { Wrench, ShieldAlert } from "lucide-react";
+import { useState } from "react";
+import { Wrench, ShieldAlert, ChevronDown } from "lucide-react";
 import { Link } from "react-router-dom";
 import type { Alert } from "@/types/alert";
 
 interface Props {
   alerts: Alert[];
+  collapsedCount?: number; // how many to show before folding the rest
 }
 
 const styleFor = (severity: Alert["severity"]): string =>
@@ -13,32 +15,57 @@ const styleFor = (severity: Alert["severity"]): string =>
 
 const IconFor = ({ kind }: { kind: Alert["kind"] }) =>
   kind === "maintenance" ? (
-    <Wrench size={16} className="shrink-0" aria-hidden="true" />
+    <Wrench size={15} className="shrink-0" aria-hidden="true" />
   ) : (
-    <ShieldAlert size={16} className="shrink-0" aria-hidden="true" />
+    <ShieldAlert size={15} className="shrink-0" aria-hidden="true" />
   );
 
-// Reserved dashboard region. Renders nothing when there are no alerts, so it
-// costs no space until something (maintenance, compliance) feeds it.
-export const AlertBanners = ({ alerts }: Props) => {
+const Row = ({ alert }: { alert: Alert }) => (
+  <div className={`flex items-center gap-2 rounded-lg px-3 py-1.5 text-[13px] ${styleFor(alert.severity)}`}>
+    <IconFor kind={alert.kind} />
+    <span className="flex-1 truncate">{alert.message}</span>
+    {alert.actionHref && (
+      <Link to={alert.actionHref} className="underline whitespace-nowrap text-xs">
+        View
+      </Link>
+    )}
+  </div>
+);
+
+// Reserved dashboard region. Renders nothing with no alerts. Critical items sort
+// first; only the top few show, the rest fold behind a summary toggle so a long
+// overdue list can't swallow the whole glance.
+export const AlertBanners = ({ alerts, collapsedCount = 2 }: Props) => {
+  const [open, setOpen] = useState(false);
   if (alerts.length === 0) return null;
 
+  const sorted = [...alerts].sort(
+    (a, b) => (b.severity === "critical" ? 1 : 0) - (a.severity === "critical" ? 1 : 0),
+  );
+  const shown = open ? sorted : sorted.slice(0, collapsedCount);
+  const hidden = sorted.length - shown.length;
+  const maint = alerts.filter((a) => a.kind === "maintenance").length;
+  const comp = alerts.length - maint;
+
   return (
-    <div className="flex flex-col gap-2 mb-4">
-      {alerts.map((alert) => (
-        <div
-          key={alert.id}
-          className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm ${styleFor(alert.severity)}`}
+    <div className="flex flex-col gap-1.5">
+      <div className={open ? "flex flex-col gap-1.5 max-h-52 overflow-y-auto pr-1" : "flex flex-col gap-1.5"}>
+        {shown.map((alert) => (
+          <Row key={alert.id} alert={alert} />
+        ))}
+      </div>
+      {(hidden > 0 || open) && (
+        <button
+          onClick={() => setOpen((o) => !o)}
+          className="flex items-center justify-center gap-1.5 text-[11.5px] text-muted-text hover:text-light rounded-lg py-1"
+          style={{ background: "#131a27", border: "1px solid #26304a" }}
         >
-          <IconFor kind={alert.kind} />
-          <span className="flex-1">{alert.message}</span>
-          {alert.actionHref && (
-            <Link to={alert.actionHref} className="underline whitespace-nowrap">
-              View
-            </Link>
-          )}
-        </div>
-      ))}
+          <ChevronDown size={13} className={`transition-transform ${open ? "rotate-180" : ""}`} />
+          {open
+            ? "Show less"
+            : `+${hidden} more · ${maint} maintenance, ${comp} compliance`}
+        </button>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/dashboard/DashboardShell.tsx
+++ b/frontend/src/components/dashboard/DashboardShell.tsx
@@ -1,0 +1,92 @@
+import { useState, type ReactNode } from "react";
+
+// The tabbed dashboard frame ("shell") — the tab bar + content container every
+// dashboard tab plugs into. Styled at mockup fidelity (dark bar, amber active
+// pill). Active tab persists so a refresh keeps you where you were.
+export interface DashTab {
+  key: string;
+  label: string;
+}
+
+export const DashboardShell = ({
+  tabs,
+  storageKey = "dash-tab",
+  right,
+  children,
+}: {
+  tabs: DashTab[];
+  storageKey?: string;
+  right?: ReactNode;
+  children: (active: string) => ReactNode;
+}) => {
+  const [active, setActive] = useState<string>(() => {
+    const saved = localStorage.getItem(storageKey);
+    return saved && tabs.some((t) => t.key === saved) ? saved : tabs[0].key;
+  });
+  const pick = (k: string) => {
+    setActive(k);
+    localStorage.setItem(storageKey, k);
+  };
+
+  return (
+    <div
+      className="max-w-[1100px] mx-auto rounded-2xl overflow-hidden"
+      style={{ background: "#0b111b", border: "1px solid #26304a" }}
+    >
+      <div
+        className="flex items-center gap-1 px-4 py-2.5 flex-wrap"
+        style={{ background: "#0d131f", borderBottom: "1px solid #26304a" }}
+      >
+        <span className="font-condensed font-bold text-[15px] mr-3 tracking-wide text-light">
+          Dashboard
+        </span>
+        {tabs.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => pick(t.key)}
+            className="text-[12.5px] font-semibold px-3.5 py-1.5 rounded-lg transition-colors"
+            style={
+              active === t.key
+                ? { background: "#e8940a", color: "#12151b" }
+                : { color: "#8b93a3" }
+            }
+          >
+            {t.label}
+          </button>
+        ))}
+        {right && <div className="ml-auto flex items-center gap-3">{right}</div>}
+      </div>
+      <div className="p-4 sm:p-5">{children(active)}</div>
+    </div>
+  );
+};
+
+// A clean placeholder for a tab that's being built out next — previews what
+// will live there so the structure reads even before the content lands.
+export const TabStub = ({
+  title,
+  blurb,
+  points,
+}: {
+  title: string;
+  blurb: string;
+  points: string[];
+}) => (
+  <div
+    className="rounded-xl p-6 text-center"
+    style={{ background: "#0f1622", border: "1px dashed #2a3347", minHeight: 260 }}
+  >
+    <p className="font-condensed text-2xl text-light">{title}</p>
+    <p className="text-sm text-muted-text mt-1 mb-4">{blurb}</p>
+    <div className="inline-flex flex-col gap-1.5 text-left">
+      {points.map((p) => (
+        <span key={p} className="text-[12.5px] text-muted-text">
+          <span style={{ color: "#e8940a" }}>•</span> {p}
+        </span>
+      ))}
+    </div>
+    <p className="text-[11px] mt-5" style={{ color: "#5b6577" }}>
+      building this next — the mockup you approved
+    </p>
+  </div>
+);

--- a/frontend/src/components/dashboard/DashboardShell.tsx
+++ b/frontend/src/components/dashboard/DashboardShell.tsx
@@ -30,7 +30,7 @@ export const DashboardShell = ({
 
   return (
     <div
-      className="max-w-[1100px] mx-auto rounded-2xl overflow-hidden"
+      className="rounded-2xl overflow-hidden lg:flex-1 lg:flex lg:flex-col lg:min-h-0"
       style={{ background: "#0b111b", border: "1px solid #26304a" }}
     >
       <div
@@ -56,7 +56,9 @@ export const DashboardShell = ({
         ))}
         {right && <div className="ml-auto flex items-center gap-3">{right}</div>}
       </div>
-      <div className="p-4 sm:p-5">{children(active)}</div>
+      <div className="p-4 sm:p-5 lg:flex-1 lg:flex lg:flex-col lg:min-h-0">
+        {children(active)}
+      </div>
     </div>
   );
 };
@@ -73,7 +75,7 @@ export const TabStub = ({
   points: string[];
 }) => (
   <div
-    className="rounded-xl p-6 text-center"
+    className="rounded-xl p-6 text-center flex flex-col items-center justify-center lg:flex-1 lg:min-h-0"
     style={{ background: "#0f1622", border: "1px dashed #2a3347", minHeight: 260 }}
   >
     <p className="font-condensed text-2xl text-light">{title}</p>

--- a/frontend/src/components/dashboard/LanesTab.tsx
+++ b/frontend/src/components/dashboard/LanesTab.tsx
@@ -1,0 +1,176 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import type { Load } from "@/types/load";
+import {
+  getRecentLoads,
+  getRegionRollup,
+  getLanesSummary,
+  getAreaMapData,
+  getLoadTypeMix,
+  getTopOrigin,
+  levelForWindow,
+  type LaneStat,
+} from "@/lib/metrics/lanes";
+import { LanesMap } from "@/components/lanes/LanesMap";
+import { SegmentedTabs } from "@/components/ui/SegmentedTabs";
+import { money, rpm as fmtRpm } from "@/lib/format";
+
+const C = { background: "#0f1622", border: "1px solid #26304a" } as const;
+const TILE = { background: "#121a27", border: "1px solid #26304a" } as const;
+const WINDOWS = [30, 60, 90];
+// oversize forced to amber (his specialty); the rest cycle a steel/cyan/violet set.
+const MIX_COLORS = ["#6f7b93", "#5fd0e0", "#a06ad0", "#5f7fd0"];
+const mixColor = (type: string, i: number) =>
+  /over/i.test(type) ? "#e8940a" : MIX_COLORS[i % MIX_COLORS.length];
+
+const Tile = ({ label, value, sub, color }: { label: string; value: string; sub: string; color?: string }) => (
+  <div className="rounded-xl px-3.5 py-3" style={TILE}>
+    <p className="text-[9.5px] uppercase tracking-wide text-muted-text">{label}</p>
+    <p className="text-[15px] font-bold mt-0.5 leading-tight truncate" style={{ color }}>{value}</p>
+    <p className="text-[10px] text-muted-text mt-0.5 truncate">{sub}</p>
+  </div>
+);
+
+export const LanesTab = ({ loads }: { loads: Load[] }) => {
+  const navigate = useNavigate();
+  const [windowDays, setWindowDays] = useState(90);
+
+  const level = levelForWindow(windowDays);
+  const windowLoads = useMemo(() => getRecentLoads(loads, windowDays), [loads, windowDays]);
+  const mapData = useMemo(() => getAreaMapData(loads, windowDays, level), [loads, windowDays, level]);
+  const summary = useMemo(() => getLanesSummary(windowLoads), [windowLoads]);
+  const topOrigin = useMemo(() => getTopOrigin(mapData), [mapData]);
+  const mix = useMemo(() => getLoadTypeMix(windowLoads), [windowLoads]);
+
+  const topLanes = useMemo<LaneStat[]>(() => {
+    const lanes = getRegionRollup(windowLoads).flatMap((r) => r.markets.flatMap((m) => m.lanes));
+    return [...lanes].sort((a, b) => b.gross - a.gross).slice(0, 5);
+  }, [windowLoads]);
+
+  const mixTotal = mix.reduce((s, m) => s + m.gross, 0);
+  const oversize = mix.find((m) => /over/i.test(m.type));
+  const mixKpi = oversize ?? mix[0] ?? null;
+  // top 4 slices; fold the rest into one "Other"
+  const mixShown = mix.slice(0, 4);
+  const mixOther = mix.slice(4).reduce((s, m) => s + m.gross, 0);
+
+  const busy = summary.highestVolumeLane;
+  const rate = summary.topRpmLane;
+
+  return (
+    <div className="flex flex-col gap-3 lg:flex-1 lg:min-h-0">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="text-xl font-condensed text-light leading-none">The lanes</h2>
+          <p className="text-[11.5px] text-muted-text mt-1">where your freight runs — last {windowDays} days</p>
+        </div>
+        <SegmentedTabs
+          ariaLabel="Lane window"
+          tabs={WINDOWS.map((w) => ({ value: w, label: `${w}d` }))}
+          value={windowDays}
+          onChange={setWindowDays}
+        />
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5">
+        <Tile
+          label="Top origin"
+          value={topOrigin ? topOrigin.key : "—"}
+          sub={topOrigin ? `${money(topOrigin.gross)} · ${Math.round(topOrigin.loadShare * 100)}% of loads` : "no loads in window"}
+        />
+        <Tile
+          label="Busiest lane"
+          value={busy ? busy.lane : "—"}
+          sub={busy ? `${busy.loadCount} loads · ${fmtRpm(busy.medianRpm)}/mi` : "no loads in window"}
+        />
+        <Tile
+          label="Top $/mi lane"
+          value={rate ? rate.lane : "—"}
+          sub={rate ? `${fmtRpm(rate.medianRpm)} typical · ${rate.loadCount} loads` : "needs 3+ loads on a lane"}
+        />
+        <Tile
+          label={mixKpi && /over/i.test(mixKpi.type) ? "Oversize share" : "Top load type"}
+          value={mixKpi ? `${Math.round((mixKpi.gross / (mixTotal || 1)) * 100)}% of gross` : "—"}
+          sub={mixKpi ? (/over/i.test(mixKpi.type) ? "your specialty" : mixKpi.type) : "no loads in window"}
+          color={mixKpi && /over/i.test(mixKpi.type) ? "#e8940a" : undefined}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 lg:flex-1 lg:min-h-0">
+        {/* the map (real shipped component, flat for the dashboard) */}
+        <div className="min-h-0 min-w-0">
+          <LanesMap
+            data={mapData}
+            level={level}
+            windowDays={windowDays}
+            selected={null}
+            onSelect={() => navigate("/lanes")}
+            noir={false}
+          />
+        </div>
+
+        <div className="flex flex-col gap-3 lg:min-h-0">
+          {/* top lanes by gross */}
+          <div className="rounded-xl p-3.5 flex flex-col lg:flex-1 lg:min-h-0" style={C}>
+            <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-1 flex justify-between">
+              Top lanes <span className="normal-case tracking-normal font-normal">by gross · {windowDays}d</span>
+            </h3>
+            <div className="flex-1 min-h-0 flex flex-col justify-between py-1">
+              {topLanes.length === 0 ? (
+                <p className="text-xs text-muted-text py-4">No delivered lanes in this window.</p>
+              ) : (
+                topLanes.map((l) => (
+                  <div key={l.lane} className="flex items-center justify-between py-[7px] text-[12px]" style={{ borderBottom: "1px solid #1a2233" }}>
+                    <span className="truncate pr-2">{l.lane}</span>
+                    <span className="text-muted-text whitespace-nowrap">
+                      <b style={{ color: "#4ade80" }}>{money(l.gross)}</b> · {l.loadCount} · {fmtRpm(l.medianRpm)}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+            <button onClick={() => navigate("/lanes")} className="text-[11px] text-status-info-text hover:underline mt-1.5 text-left">
+              All lanes →
+            </button>
+          </div>
+
+          {/* load-type mix */}
+          <div className="rounded-xl p-3.5 flex flex-col" style={C}>
+            <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2 flex justify-between">
+              Load-type mix <span className="normal-case tracking-normal font-normal">{money(mixTotal)} gross</span>
+            </h3>
+            {mix.length === 0 ? (
+              <p className="text-xs text-muted-text">No delivered loads in this window.</p>
+            ) : (
+              <>
+                <div className="flex h-6 rounded-md overflow-hidden mb-2" style={{ border: "1px solid #26304a" }}>
+                  {mixShown.map((m, i) => (
+                    <div key={m.type} style={{ width: `${(m.gross / (mixTotal || 1)) * 100}%`, background: mixColor(m.type, i) }} title={`${m.type} ${money(m.gross)}`} />
+                  ))}
+                  {mixOther > 0 && <div style={{ width: `${(mixOther / (mixTotal || 1)) * 100}%`, background: "#2a3347" }} title={`Other ${money(mixOther)}`} />}
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  {mixShown.map((m, i) => (
+                    <div key={m.type} className="flex items-center justify-between text-[11.5px]">
+                      <span className="truncate flex items-center gap-1.5">
+                        <span className="inline-block w-2 h-2 rounded-sm" style={{ background: mixColor(m.type, i) }} />
+                        {m.type}
+                      </span>
+                      <span className="text-muted-text whitespace-nowrap">{money(m.gross)} · {Math.round(m.share * 100)}%</span>
+                    </div>
+                  ))}
+                  {mixOther > 0 && (
+                    <div className="flex items-center justify-between text-[11.5px]">
+                      <span className="flex items-center gap-1.5"><span className="inline-block w-2 h-2 rounded-sm" style={{ background: "#2a3347" }} />Other</span>
+                      <span className="text-muted-text">{money(mixOther)} · {Math.round((mixOther / (mixTotal || 1)) * 100)}%</span>
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/dashboard/MoneyTab.tsx
+++ b/frontend/src/components/dashboard/MoneyTab.tsx
@@ -78,13 +78,13 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
   const x0 = (620 - colW * bars.length) / 2;
 
   return (
-    <div>
-      <div className="flex items-baseline justify-between mb-3">
+    <div className="flex flex-col gap-3 lg:flex-1 lg:min-h-0">
+      <div className="flex items-baseline justify-between">
         <h2 className="text-xl font-condensed text-light">The money</h2>
         <span className="text-xs text-muted-text">P&amp;L · margin · where it goes — {year} to date</span>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5 mb-3">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5">
         <Tile label={`Income · ${year}`} value={money(ytdIncome)} sub={`${ytd.length} months · net of carrier cut`} />
         <Tile label="Operating profit" value={money(ytdProfit)} color="#4ade80" sub="income − COGS − expenses" />
         <Tile
@@ -96,13 +96,13 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
         <Tile label="Best month" value={best ? `${monthShort(best.month)} · ${Math.round(best.margin * 100)}%` : "—"} sub={best ? `${money(best.profit)} profit` : ""} />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 mb-3">
+      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 lg:flex-1 lg:min-h-0">
         {/* monthly P&L */}
-        <div className="rounded-xl p-3 pb-2.5" style={C}>
+        <div className="rounded-xl p-3 pb-2.5 flex flex-col" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-1 flex justify-between">
             Monthly P&amp;L <span className="normal-case tracking-normal text-muted-text font-normal">income = kept + spent</span>
           </h3>
-          <svg viewBox="0 0 620 168" className="w-full">
+          <svg viewBox="0 0 620 168" className="w-full lg:flex-1 lg:min-h-0" preserveAspectRatio="xMidYMid meet">
             <line x1="0" y1="140" x2="620" y2="140" stroke="#1c2536" />
             {bars.map((r, i) => {
               const incH = Math.max(2, (r.income / barMax) * H);
@@ -132,9 +132,9 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
         </div>
 
         {/* margin trend */}
-        <div className="rounded-xl p-3" style={C}>
+        <div className="rounded-xl p-3 flex flex-col" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">Margin trend</h3>
-          <svg viewBox="0 0 320 140" className="w-full">
+          <svg viewBox="0 0 320 140" className="w-full lg:flex-1 lg:min-h-0" preserveAspectRatio="xMidYMid meet">
             {marginGoal != null && (
               <>
                 <line x1="8" y1={120 - marginGoal * 220} x2="312" y2={120 - marginGoal * 220} stroke="#4ade80" strokeDasharray="4 4" opacity={0.5} />
@@ -156,8 +156,8 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
       </div>
 
       {/* where it goes (year to date, by category) + pipeline */}
-      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3">
-        <div className="rounded-xl p-3.5" style={C}>
+      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 lg:flex-1 lg:min-h-0">
+        <div className="rounded-xl p-3.5 flex flex-col" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5 flex justify-between">
             Where it goes · {year}
             <span className="normal-case tracking-normal font-normal">{money(ytdIncome)} income</span>
@@ -193,7 +193,7 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
           )}
         </div>
 
-        <div className="rounded-xl p-3.5" style={C}>
+        <div className="rounded-xl p-3.5 flex flex-col justify-center" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">Settlement pipeline</h3>
           <p className="text-[26px] font-extrabold" style={{ color: "#4ade80" }}>{money(pipeline)}</p>
           <p className="text-[11px] text-muted-text mt-1">Delivered, POD in, not yet settled — landing on your upcoming weekly settlement(s). No aging: it clears every week.</p>

--- a/frontend/src/components/dashboard/MoneyTab.tsx
+++ b/frontend/src/components/dashboard/MoneyTab.tsx
@@ -1,0 +1,204 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import type { Load } from "@/types/load";
+import { useExpensePeriods } from "@/hooks/useExpensePeriods";
+import { topCategoriesWithOther } from "@/lib/metrics/expenses";
+import { loadRevenue } from "@/lib/metrics/loads";
+import { money } from "@/lib/format";
+
+const C = { background: "#0f1622", border: "1px solid #26304a" } as const;
+const TILE = { background: "#121a27", border: "1px solid #26304a" } as const;
+const CAT_COLORS = ["#c8890a", "#5fd0e0", "#a06ad0", "#5f7fd0", "#d05f8a", "#6ad0a0"];
+const OTHER_COLOR = "#2a3347";
+const segColor = (category: string, i: number) =>
+  category === "Other" ? OTHER_COLOR : CAT_COLORS[i % CAT_COLORS.length];
+
+const monthShort = (m: string) =>
+  new Date(m.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", { month: "short", timeZone: "UTC" });
+
+const Tile = ({ label, value, sub, color }: { label: string; value: string; sub: string; color?: string }) => (
+  <div className="rounded-xl px-3.5 py-3" style={TILE}>
+    <p className="text-[9.5px] uppercase tracking-wide text-muted-text">{label}</p>
+    <p className="text-[17px] font-bold mt-0.5 leading-tight" style={{ color }}>{value}</p>
+    <p className="text-[10px] text-muted-text mt-0.5">{sub}</p>
+  </div>
+);
+
+export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: number | null }) => {
+  const { periods, categoriesYTD, loading } = useExpensePeriods();
+  const year = new Date().getUTCFullYear();
+
+  const rows = useMemo(
+    () =>
+      [...periods]
+        .filter((p) => p.income_total != null)
+        .sort((a, b) => (a.period_month < b.period_month ? -1 : 1))
+        .map((p) => {
+          const income = p.income_total ?? 0;
+          const cost = (p.cogs_total ?? 0) + (p.expense_total ?? 0);
+          return { month: p.period_month, income, cost, profit: income - cost, margin: income > 0 ? (income - cost) / income : 0 };
+        }),
+    [periods],
+  );
+  const ytd = useMemo(() => rows.filter((r) => r.month.startsWith(String(year))), [rows, year]);
+  const ytdIncome = ytd.reduce((s, r) => s + r.income, 0);
+  const ytdProfit = ytd.reduce((s, r) => s + r.profit, 0);
+  const ytdMargin = ytdIncome > 0 ? ytdProfit / ytdIncome : null;
+  const best = ytd.reduce<(typeof ytd)[number] | null>((b, r) => (!b || r.margin > b.margin ? r : b), null);
+
+  // "Where it goes" — the year's spending by category (backend rollup), top 6 +
+  // Other. Profit is derived from the same category total so the bar sums to 100%.
+  const cats = useMemo(() => topCategoriesWithOther(categoriesYTD, 6), [categoriesYTD]);
+  const catCost = useMemo(() => categoriesYTD.reduce((s, c) => s + c.amount, 0), [categoriesYTD]);
+  const catProfit = Math.max(0, ytdIncome - catCost);
+  // Widths share a denominator so profit + categories always sum to 100% — even
+  // in the rare month where booked cost outruns counted income.
+  const denom = Math.max(ytdIncome, catCost);
+  const pctOf = (amt: number) => (denom > 0 ? (amt / denom) * 100 : 0);
+
+  const pipeline = useMemo(
+    () => loads.filter((l) => l.load_status === "delivered" && l.payment_status !== "paid").reduce((s, l) => s + loadRevenue(l), 0),
+    [loads],
+  );
+
+  if (loading) return <div className="text-sm text-muted-text py-12 text-center">Loading your P&amp;L…</div>;
+  if (rows.length === 0)
+    return (
+      <div className="text-sm text-muted-text py-12 text-center">
+        No P&amp;L yet. <Link to="/expenses" className="text-status-info-text hover:underline">Add a month on the Expenses page</Link> to light this up.
+      </div>
+    );
+
+  const barMax = Math.max(...rows.map((r) => r.income), 1);
+  const H = 128;
+  const bars = rows.slice(-8);
+  // Cap the column width so a 1–2 month view doesn't render giant bars; center
+  // the group when there are fewer than a full year of months.
+  const colW = Math.min(96, 620 / bars.length);
+  const x0 = (620 - colW * bars.length) / 2;
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-3">
+        <h2 className="text-xl font-condensed text-light">The money</h2>
+        <span className="text-xs text-muted-text">P&amp;L · margin · where it goes — {year} to date</span>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5 mb-3">
+        <Tile label={`Income · ${year}`} value={money(ytdIncome)} sub={`${ytd.length} months · net of carrier cut`} />
+        <Tile label="Operating profit" value={money(ytdProfit)} color="#4ade80" sub="income − COGS − expenses" />
+        <Tile
+          label="Margin"
+          value={ytdMargin != null ? `${Math.round(ytdMargin * 100)}%` : "—"}
+          color={ytdMargin != null && marginGoal != null ? (ytdMargin >= marginGoal ? "#4ade80" : "#f5a623") : undefined}
+          sub={marginGoal != null ? `${ytdMargin != null && ytdMargin >= marginGoal ? "▲ above" : "vs"} ${Math.round(marginGoal * 100)}% goal` : "operating margin"}
+        />
+        <Tile label="Best month" value={best ? `${monthShort(best.month)} · ${Math.round(best.margin * 100)}%` : "—"} sub={best ? `${money(best.profit)} profit` : ""} />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 mb-3">
+        {/* monthly P&L */}
+        <div className="rounded-xl p-3 pb-2.5" style={C}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-1 flex justify-between">
+            Monthly P&amp;L <span className="normal-case tracking-normal text-muted-text font-normal">income = kept + spent</span>
+          </h3>
+          <svg viewBox="0 0 620 168" className="w-full">
+            <line x1="0" y1="140" x2="620" y2="140" stroke="#1c2536" />
+            {bars.map((r, i) => {
+              const incH = Math.max(2, (r.income / barMax) * H);
+              const proH = Math.max(0, (Math.max(0, r.profit) / barMax) * H);
+              const x = x0 + i * colW + colW * 0.14;
+              const w = colW * 0.72;
+              const cx = x0 + i * colW + colW / 2;
+              const isNow = i === bars.length - 1;
+              const profitFill = r.profit < 0 ? "#8a3b3b" : isNow ? "#4ade80" : "#2f7d55";
+              return (
+                <g key={r.month} textAnchor="middle" fontSize={8.5}>
+                  <rect x={x} y={140 - incH} width={w} height={incH} rx={4} fill="#2a3347" />
+                  {r.profit > 0 && <rect x={x} y={140 - proH} width={w} height={proH} rx={4} fill={profitFill} />}
+                  <text x={cx} y={152} fill={isNow ? "#f5b03a" : "#5b6577"}>{monthShort(r.month)}</text>
+                  <text x={cx} y={163} fill={r.margin < 0.2 ? "#f87171" : r.margin >= 0.3 ? "#4ade80" : "#8b93a3"} fontWeight={isNow ? 700 : 400}>
+                    {Math.round(r.margin * 100)}%
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+          <div className="flex gap-3 text-[10px] text-muted-text mt-0.5">
+            <span><span className="inline-block w-2.5 h-2.5 rounded-sm mr-1 align-[-1px]" style={{ background: "#2f7d55" }} />profit kept</span>
+            <span><span className="inline-block w-2.5 h-2.5 rounded-sm mr-1 align-[-1px]" style={{ background: "#2a3347" }} />COGS + expenses</span>
+            <span>bar = income · % = margin</span>
+          </div>
+        </div>
+
+        {/* margin trend */}
+        <div className="rounded-xl p-3" style={C}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">Margin trend</h3>
+          <svg viewBox="0 0 320 140" className="w-full">
+            {marginGoal != null && (
+              <>
+                <line x1="8" y1={120 - marginGoal * 220} x2="312" y2={120 - marginGoal * 220} stroke="#4ade80" strokeDasharray="4 4" opacity={0.5} />
+                <text x="310" y={120 - marginGoal * 220 - 3} textAnchor="end" fontSize={8.5} fill="#4ade80">{Math.round(marginGoal * 100)}% goal</text>
+              </>
+            )}
+            <polyline
+              fill="none"
+              stroke="#f5b03a"
+              strokeWidth={2}
+              points={rows.map((r, i) => `${8 + (i / Math.max(1, rows.length - 1)) * 304},${120 - Math.max(0, r.margin) * 220}`).join(" ")}
+            />
+            {rows.map((r, i) => (
+              <circle key={r.month} cx={8 + (i / Math.max(1, rows.length - 1)) * 304} cy={120 - Math.max(0, r.margin) * 220} r={3} fill={r.margin < 0.2 ? "#f87171" : i === rows.length - 1 ? "#4ade80" : "#f5b03a"} />
+            ))}
+          </svg>
+          <p className="text-[11px] text-muted-text mt-1">Your operating margin, month by month{best ? ` — best was ${monthShort(best.month)} at ${Math.round(best.margin * 100)}%` : ""}.</p>
+        </div>
+      </div>
+
+      {/* where it goes (year to date, by category) + pipeline */}
+      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3">
+        <div className="rounded-xl p-3.5" style={C}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5 flex justify-between">
+            Where it goes · {year}
+            <span className="normal-case tracking-normal font-normal">{money(ytdIncome)} income</span>
+          </h3>
+          {cats.length === 0 ? (
+            <p className="text-xs text-muted-text">No categorized lines yet this year.</p>
+          ) : (
+            <>
+              <div className="flex h-7 rounded-md overflow-hidden mb-2.5" style={{ border: "1px solid #26304a" }}>
+                {catProfit > 0 && (
+                  <div className="h-full flex items-center justify-center text-[9px] font-bold" style={{ width: `${pctOf(catProfit)}%`, background: "#4ade80", color: "#0d1119" }}>
+                    profit
+                  </div>
+                )}
+                {cats.map((c, i) => (
+                  <div key={c.category} className="h-full" style={{ width: `${pctOf(c.amount)}%`, background: segColor(c.category, i) }} title={`${c.category} ${money(c.amount)}`} />
+                ))}
+              </div>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                {cats.map((c, i) => (
+                  <div key={c.category} className="flex items-center justify-between text-[11.5px]">
+                    <span className="truncate flex items-center gap-1.5">
+                      <span className="inline-block w-2 h-2 rounded-sm" style={{ background: segColor(c.category, i) }} />
+                      {c.category}
+                      {c.section === "cogs" && <span className="text-[8px] text-muted-text">COGS</span>}
+                    </span>
+                    <span className="text-muted-text whitespace-nowrap">{money(c.amount)} · {Math.round(pctOf(c.amount))}%</span>
+                  </div>
+                ))}
+              </div>
+              <Link to="/expenses" className="text-[11px] text-status-info-text hover:underline mt-2.5 inline-block">Full P&amp;L →</Link>
+            </>
+          )}
+        </div>
+
+        <div className="rounded-xl p-3.5" style={C}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">Settlement pipeline</h3>
+          <p className="text-[26px] font-extrabold" style={{ color: "#4ade80" }}>{money(pipeline)}</p>
+          <p className="text-[11px] text-muted-text mt-1">Delivered, POD in, not yet settled — landing on your upcoming weekly settlement(s). No aging: it clears every week.</p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/dashboard/PulseTab.tsx
+++ b/frontend/src/components/dashboard/PulseTab.tsx
@@ -1,0 +1,226 @@
+import { useMemo } from "react";
+import type { Load } from "@/types/load";
+import type { Trip } from "@/types/trip";
+import { getWeekGrossEarned } from "@/lib/metrics/rateTargets";
+import {
+  getRevenueMTD,
+  getMonthlyDeadhead,
+  getLoadsMonthly,
+  getUpcomingLoads,
+} from "@/lib/metrics/dashboard";
+import { loadRevenue } from "@/lib/metrics/loads";
+import { getQuarterPace } from "@/lib/metrics/quarterPace";
+import { AlertBanners } from "@/components/dashboard/AlertBanners";
+import type { Alert } from "@/types/alert";
+import { GrindMeter } from "@/components/dashboard/GrindMeter";
+import { WhatsNext } from "@/components/dashboard/WhatsNext";
+import { money, rpm as fmtRpm } from "@/lib/format";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Targets = any; // the useRateTargets shape (weekEarned/weekBooked/gross/bookingLadder/grossRate)
+
+const C = { background: "#0f1622", border: "1px solid #26304a" } as const;
+const TILE = { background: "#121a27", border: "1px solid #26304a" } as const;
+
+const Tile = ({ label, value, sub, color }: { label: string; value: string; sub: string; color?: string }) => (
+  <div className="rounded-xl px-3.5 py-3" style={TILE}>
+    <p className="text-[9.5px] uppercase tracking-wide text-muted-text">{label}</p>
+    <p className="text-base font-bold mt-0.5 leading-tight" style={{ color }}>{value}</p>
+    <p className="text-[9.5px] text-muted-text mt-0.5">{sub}</p>
+  </div>
+);
+
+const PACE = {
+  beat: { text: "on track to beat", color: "#4ade80", glyph: "▲" },
+  behind: { text: "on track to finish under", color: "#f87171", glyph: "▼" },
+  even: { text: "on pace with", color: "#f5a623", glyph: "—" },
+  early: { text: "too early to call vs", color: "#9fb0c9", glyph: "·" },
+  "no-prior": { text: "first quarter — no", color: "#9fb0c9", glyph: "·" },
+} as const;
+
+export const PulseTab = ({
+  loads,
+  trips,
+  targets,
+  alerts,
+}: {
+  loads: Load[];
+  trips: Trip[];
+  targets: Targets;
+  alerts: Alert[];
+}) => {
+  const now = useMemo(() => new Date(), []);
+
+  const earned = targets.weekEarned ?? 0;
+  const committed = targets.weekBooked ?? 0;
+  const weeklyTarget: number | null = targets.gross?.weeklyTarget ?? null;
+  const progress = weeklyTarget && weeklyTarget > 0 ? Math.min(1, earned / weeklyTarget) : null;
+
+  const mtd = getRevenueMTD(loads);
+  const deadhead = getMonthlyDeadhead(loads, trips).thisMonth;
+  const loadsM = getLoadsMonthly(loads);
+  const upcoming = getUpcomingLoads(loads);
+  const pace = useMemo(() => getQuarterPace(loads, now), [loads, now]);
+
+  // Settlement pipeline: delivered but not yet paid = landing on the next
+  // settlement(s). No aging — POD-in (delivered) is the gate, and it clears weekly.
+  const pipeline = useMemo(
+    () =>
+      loads
+        .filter((l) => l.load_status === "delivered" && l.payment_status !== "paid")
+        .reduce((s, l) => s + loadRevenue(l), 0),
+    [loads],
+  );
+
+  // Last 8 pay-weeks of gross earned, anchored to the configured week start.
+  const weeks = useMemo(() => {
+    const anchor: Date = targets.weekStart ? new Date(targets.weekStart) : now;
+    const out: { earned: number; now: boolean }[] = [];
+    for (let i = 7; i >= 0; i--) {
+      const s = new Date(anchor);
+      s.setUTCDate(anchor.getUTCDate() - i * 7);
+      const e = new Date(s);
+      e.setUTCDate(s.getUTCDate() + 7);
+      out.push({ earned: getWeekGrossEarned(loads, s, e), now: i === 0 });
+    }
+    return out;
+  }, [loads, targets.weekStart, now]);
+  const weekMax = Math.max(weeklyTarget ?? 0, ...weeks.map((w) => w.earned), 1);
+
+  const ladder = targets.bookingLadder ?? {};
+  const cur: number | null = targets.grossRate ?? null;
+  const gaugeMax = Math.max(ladder.strong ?? 0, cur ?? 0, ladder.target ?? 0) * 1.15 || 1;
+  const pos = (v: number | null | undefined) => (v == null ? 0 : Math.min(100, (v / gaugeMax) * 100));
+  const overFloor = cur != null && ladder.walkAway != null ? cur - ladder.walkAway : null;
+
+  const paceMeta = PACE[pace.verdict];
+
+  return (
+    <div>
+      <AlertBanners alerts={alerts} />
+
+      {/* hero — the pay week */}
+      <div className="grid grid-cols-1 md:grid-cols-[1.5fr_1fr] gap-4 rounded-xl p-4 mt-3 mb-3" style={C}>
+        <div>
+          <p className="text-[10.5px] uppercase tracking-wide text-muted-text">This pay week</p>
+          <p className="text-[32px] font-extrabold leading-none mt-1">
+            {money(earned)} <span className="text-sm text-muted-text font-semibold">earned</span>
+          </p>
+          {progress != null && (
+            <div className="h-2 rounded mt-2.5 mb-1.5 overflow-hidden" style={{ background: "#0b111c", border: "1px solid #26304a" }}>
+              <div className="h-full rounded" style={{ width: `${progress * 100}%`, background: "#4ade80" }} />
+            </div>
+          )}
+          <p className="text-[11.5px] text-muted-text">
+            {progress != null && weeklyTarget ? (
+              <><b className="text-light">{Math.round(progress * 100)}%</b> of your <b className="text-light">{money(weeklyTarget)}</b> weekly target · </>
+            ) : null}
+            <b style={{ color: "#4ade80" }}>{money(committed)}</b> committed & booked ahead
+          </p>
+          <p className="text-[11.5px] text-muted-text mt-1.5">
+            Landing on settlement: <b style={{ color: "#4ade80" }}>{money(pipeline)}</b> (delivered, POD in)
+          </p>
+        </div>
+        <div className="md:border-l md:pl-4 flex flex-col justify-center gap-2.5" style={{ borderColor: "#26304a" }}>
+          <div>
+            <p className="text-[18px] font-extrabold leading-none" style={{ color: overFloor != null && overFloor >= 0 ? "#4ade80" : undefined }}>
+              {cur != null ? `${fmtRpm(cur)}/mi` : "—"}
+            </p>
+            <p className="text-[9.5px] uppercase tracking-wide text-muted-text">
+              gross rate{overFloor != null ? ` · ${overFloor >= 0 ? "+" : "−"}${fmtRpm(Math.abs(overFloor))} vs floor` : ""}
+            </p>
+          </div>
+          <div>
+            <p className="text-[18px] font-extrabold leading-none">{money(mtd)}</p>
+            <p className="text-[9.5px] uppercase tracking-wide text-muted-text">earned month-to-date</p>
+          </div>
+          <p className="text-[11px] font-bold" style={{ color: paceMeta.color }}>
+            {paceMeta.glyph} {pace.label} {paceMeta.text} {pace.prevLabel}
+          </p>
+        </div>
+      </div>
+
+      {/* vital signs */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-2.5 mb-3">
+        <Tile label="Loads · MTD" value={String(loadsM.thisMonth)} sub={`last month ${loadsM.lastMonth}`} />
+        <Tile label="Deadhead" value={deadhead != null ? `${Math.round(deadhead * 100)}%` : "—"} sub="odometer-true" color={deadhead != null && deadhead <= 0.2 ? "#4ade80" : "#f5a623"} />
+        <Tile label="Avg net $/mi" value={targets.rollingRpm != null ? fmtRpm(targets.rollingRpm) : "—"} sub={targets.basis?.breakEvenRpm != null ? `break-even ${fmtRpm(targets.basis.breakEvenRpm)}` : "3-mo blended"} />
+        <Tile label="Pipeline" value={money(pipeline)} sub="delivered, not yet settled" />
+        <Tile label="Earned · MTD" value={money(mtd)} sub="gross delivered" />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[1.55fr_1fr] gap-3 mb-3">
+        {/* weekly earnings */}
+        <div className="rounded-xl p-3.5" style={C}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2 flex justify-between">
+            Weekly earnings <span className="normal-case tracking-normal">last 8 weeks · gross</span>
+          </h3>
+          <svg viewBox="0 0 620 150" className="w-full">
+            {weeklyTarget && (
+              <>
+                <line x1="0" y1={140 - (weeklyTarget / weekMax) * 120} x2="620" y2={140 - (weeklyTarget / weekMax) * 120} stroke="#4ade80" strokeWidth={1} strokeDasharray="4 4" opacity={0.6} />
+                <text x="616" y={140 - (weeklyTarget / weekMax) * 120 - 4} textAnchor="end" fontSize={9} fill="#4ade80">target {money(weeklyTarget)}</text>
+              </>
+            )}
+            {weeks.map((w, i) => {
+              const h = Math.max(2, (w.earned / weekMax) * 120);
+              const x = 10 + i * 76;
+              const hit = weeklyTarget ? w.earned >= weeklyTarget : false;
+              return (
+                <g key={i}>
+                  <rect x={x} y={140 - h} width={56} height={h} rx={4} fill={w.now ? "#f5b03a" : hit ? "#e8940a" : "#2a3347"} />
+                  <text x={x + 28} y={148} textAnchor="middle" fontSize={8.5} fill={w.now ? "#f5b03a" : "#5b6577"}>
+                    {w.now ? "now" : `$${(w.earned / 1000).toFixed(1)}`}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+
+        {/* rate vs floor gauge */}
+        <div className="rounded-xl p-3.5" style={C}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-4">Rate vs your floor</h3>
+          <div className="relative h-6 rounded-md" style={{ background: "linear-gradient(90deg,#3a1a1a,#3a2a0a 40%,#12261a)", border: "1px solid #26304a" }}>
+            {(["walkAway", "target", "strong"] as const).map((k, i) =>
+              ladder[k] != null ? (
+                <div key={k} className="absolute -top-1 -bottom-1" style={{ left: `${pos(ladder[k])}%`, width: 2, background: ["#a04a2a", "#a0862a", "#2f7d55"][i] }} />
+              ) : null,
+            )}
+            {cur != null && (
+              <>
+                <div className="absolute -top-2 -bottom-2" style={{ left: `${pos(cur)}%`, width: 3, background: "#fff", borderRadius: 2 }} />
+                <div className="absolute text-[11px] font-extrabold" style={{ left: `${pos(cur)}%`, top: -22, transform: "translateX(-50%)", color: "#4ade80" }}>{fmtRpm(cur)}</div>
+              </>
+            )}
+          </div>
+          <div className="flex justify-between text-[9px] text-muted-text mt-1.5">
+            <span>floor {ladder.walkAway != null ? fmtRpm(ladder.walkAway) : "—"}</span>
+            <span>target {ladder.target != null ? fmtRpm(ladder.target) : "—"}</span>
+            <span>strong {ladder.strong != null ? fmtRpm(ladder.strong) : "—"}</span>
+          </div>
+          <p className="text-[11px] text-muted-text mt-3">
+            {overFloor != null ? (
+              overFloor >= 0 ? (
+                <>Booking <b style={{ color: "#4ade80" }}>{fmtRpm(overFloor)}/mi over break-even</b> — one soft lane pulls this down fast.</>
+              ) : (
+                <>Booking <b style={{ color: "#f87171" }}>{fmtRpm(Math.abs(overFloor))}/mi under break-even</b> — you're losing money at this rate.</>
+              )
+            ) : (
+              "Set your cost basis to see where your rate lands."
+            )}
+          </p>
+        </div>
+      </div>
+
+      {/* what's next + the grind */}
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr] gap-3">
+        <div className="rounded-xl p-4" style={C}>
+          <p className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">What's next · booked</p>
+          <WhatsNext loads={upcoming} />
+        </div>
+        <GrindMeter loads={loads} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/dashboard/PulseTab.tsx
+++ b/frontend/src/components/dashboard/PulseTab.tsx
@@ -96,11 +96,11 @@ export const PulseTab = ({
   const paceMeta = PACE[pace.verdict];
 
   return (
-    <div>
+    <div className="flex flex-col gap-3 lg:flex-1 lg:min-h-0">
       <AlertBanners alerts={alerts} />
 
       {/* hero — the pay week */}
-      <div className="grid grid-cols-1 md:grid-cols-[1.5fr_1fr] gap-4 rounded-xl p-4 mt-3 mb-3" style={C}>
+      <div className="grid grid-cols-1 md:grid-cols-[1.5fr_1fr] gap-4 rounded-xl p-4" style={C}>
         <div>
           <p className="text-[10.5px] uppercase tracking-wide text-muted-text">This pay week</p>
           <p className="text-[32px] font-extrabold leading-none mt-1">
@@ -141,7 +141,7 @@ export const PulseTab = ({
       </div>
 
       {/* vital signs */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-2.5 mb-3">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-2.5">
         <Tile label="Loads · MTD" value={String(loadsM.thisMonth)} sub={`last month ${loadsM.lastMonth}`} />
         <Tile label="Deadhead" value={deadhead != null ? `${Math.round(deadhead * 100)}%` : "—"} sub="odometer-true" color={deadhead != null && deadhead <= 0.2 ? "#4ade80" : "#f5a623"} />
         <Tile label="Avg net $/mi" value={targets.rollingRpm != null ? fmtRpm(targets.rollingRpm) : "—"} sub={targets.basis?.breakEvenRpm != null ? `break-even ${fmtRpm(targets.basis.breakEvenRpm)}` : "3-mo blended"} />
@@ -149,13 +149,13 @@ export const PulseTab = ({
         <Tile label="Earned · MTD" value={money(mtd)} sub="gross delivered" />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[1.55fr_1fr] gap-3 mb-3">
+      <div className="grid grid-cols-1 lg:grid-cols-[1.55fr_1fr] gap-3 lg:flex-1 lg:min-h-0">
         {/* weekly earnings */}
-        <div className="rounded-xl p-3.5" style={C}>
+        <div className="rounded-xl p-3.5 flex flex-col" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2 flex justify-between">
             Weekly earnings <span className="normal-case tracking-normal">last 8 weeks · gross</span>
           </h3>
-          <svg viewBox="0 0 620 150" className="w-full">
+          <svg viewBox="0 0 620 150" className="w-full lg:flex-1 lg:min-h-0" preserveAspectRatio="xMidYMid meet">
             {weeklyTarget && (
               <>
                 <line x1="0" y1={140 - (weeklyTarget / weekMax) * 120} x2="620" y2={140 - (weeklyTarget / weekMax) * 120} stroke="#4ade80" strokeWidth={1} strokeDasharray="4 4" opacity={0.6} />
@@ -179,7 +179,7 @@ export const PulseTab = ({
         </div>
 
         {/* rate vs floor gauge */}
-        <div className="rounded-xl p-3.5" style={C}>
+        <div className="rounded-xl p-3.5 flex flex-col justify-center" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-4">Rate vs your floor</h3>
           <div className="relative h-6 rounded-md" style={{ background: "linear-gradient(90deg,#3a1a1a,#3a2a0a 40%,#12261a)", border: "1px solid #26304a" }}>
             {(["walkAway", "target", "strong"] as const).map((k, i) =>
@@ -214,8 +214,8 @@ export const PulseTab = ({
       </div>
 
       {/* what's next + the grind */}
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr] gap-3">
-        <div className="rounded-xl p-4" style={C}>
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr] gap-3 lg:flex-1 lg:min-h-0">
+        <div className="rounded-xl p-4 flex flex-col" style={C}>
           <p className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">What's next · booked</p>
           <WhatsNext loads={upcoming} />
         </div>

--- a/frontend/src/components/dashboard/agents/AgentScatter.tsx
+++ b/frontend/src/components/dashboard/agents/AgentScatter.tsx
@@ -63,7 +63,7 @@ export const AgentScatter = ({ points }: { points: ScatterPoint[] }) => {
     );
 
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} className="w-full">
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full lg:flex-1 lg:min-h-0" preserveAspectRatio="xMidYMid meet">
       {/* gridlines */}
       {geom.yTicks.map((t, i) => (
         <g key={i}>

--- a/frontend/src/components/dashboard/agents/AgentScatter.tsx
+++ b/frontend/src/components/dashboard/agents/AgentScatter.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import type { Agent } from "@/types/agent";
+import type { AgentScorecard } from "@/lib/metrics/agentScorecard";
+import { MIN_SCORE_LOADS } from "@/lib/metrics/agentScorecard";
+import { median } from "@/lib/metrics/stats";
+
+export interface ScatterPoint {
+  agent: Agent;
+  card: AgentScorecard;
+}
+
+const SPEC_FILL: Record<string, { fill: string; stroke: string; text: string }> = {
+  oversize: { fill: "rgba(232,148,10,0.32)", stroke: "#f5b03a", text: "#ffe6bf" },
+  specialty: { fill: "rgba(95,208,224,0.26)", stroke: "#5fd0e0", text: "#cfe8ee" },
+  standard: { fill: "rgba(125,139,163,0.22)", stroke: "#8b93a3", text: "#cdd4e0" },
+};
+
+const W = 1000;
+const H = 380;
+const PAD = { l: 66, t: 26, r: 28, b: 46 };
+const plotW = W - PAD.l - PAD.r;
+const plotH = H - PAD.t - PAD.b;
+
+// Rate (↑) × volume (→), bubble = revenue, color = specialty. The "who to call"
+// quadrant: top-right (high rate AND high volume) is where you want an agent.
+export const AgentScatter = ({ points }: { points: ScatterPoint[] }) => {
+  const navigate = useNavigate();
+  const scored = useMemo(
+    () =>
+      points.filter(
+        (p) => p.card.loadCount >= MIN_SCORE_LOADS && p.card.medianRpm != null,
+      ),
+    [points],
+  );
+
+  const geom = useMemo(() => {
+    if (scored.length < 2) return null;
+    const loads = scored.map((p) => p.card.loadCount);
+    const rpms = scored.map((p) => p.card.medianRpm as number);
+    const xMax = Math.max(...loads) * 1.25 || 1;
+    const yMax = Math.max(...rpms) * 1.14 || 1;
+    const xs = (v: number) => PAD.l + (v / xMax) * plotW;
+    const ys = (v: number) => PAD.t + plotH - (v / yMax) * plotH;
+    const rOf = (rev: number) => Math.max(9, Math.min(26, 9 + Math.sqrt(rev / 1000) * 1.5));
+    return {
+      xMax,
+      yMax,
+      xs,
+      ys,
+      rOf,
+      xMed: xs(median(loads) ?? 0),
+      yMed: ys(median(rpms) ?? 0),
+      yTicks: [0.25, 0.5, 0.75].map((f) => yMax * f),
+    };
+  }, [scored]);
+
+  if (!geom)
+    return (
+      <div className="text-sm text-muted-text py-12 text-center">
+        Not enough scored agents yet — an agent needs 2+ delivered loads to plot.
+      </div>
+    );
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full">
+      {/* gridlines */}
+      {geom.yTicks.map((t, i) => (
+        <g key={i}>
+          <line x1={PAD.l} y1={geom.ys(t)} x2={W - PAD.r} y2={geom.ys(t)} stroke="#1c2536" strokeWidth={1} />
+          <text x={PAD.l - 8} y={geom.ys(t) + 3} textAnchor="end" fontSize={10} fill="#8b93a3">
+            ${t < 10 ? t.toFixed(1) : Math.round(t)}
+          </text>
+        </g>
+      ))}
+      <line x1={PAD.l} y1={PAD.t} x2={PAD.l} y2={H - PAD.b} stroke="#1c2536" strokeWidth={1} />
+      <text x={PAD.l - 40} y={PAD.t + 4} fontSize={10} fill="#8b93a3">$/mi</text>
+
+      {/* median quadrant split + sweet-spot */}
+      <line x1={geom.xMed} y1={PAD.t} x2={geom.xMed} y2={H - PAD.b} stroke="#2f3b52" strokeWidth={1} strokeDasharray="4 4" />
+      <line x1={PAD.l} y1={geom.yMed} x2={W - PAD.r} y2={geom.yMed} stroke="#2f3b52" strokeWidth={1} strokeDasharray="4 4" />
+      <text x={W - PAD.r} y={PAD.t + 12} textAnchor="end" fontSize={11} fill="#4ade80" fontWeight={700}>
+        money agents ↗
+      </text>
+      <text x={W - PAD.r} y={H - PAD.b - 6} textAnchor="end" fontSize={10} fill="#5b6577">volume →</text>
+
+      {/* bubbles */}
+      {scored.map(({ agent, card }) => {
+        const spec = SPEC_FILL[card.specialty.tag] ?? SPEC_FILL.standard;
+        const cold = card.tier === "cold";
+        const cx = geom.xs(card.loadCount);
+        const cy = geom.ys(card.medianRpm as number);
+        const r = geom.rOf(card.revenue);
+        const initials = `${agent.first_name.charAt(0)}${agent.last_name.charAt(0)}`;
+        return (
+          <g
+            key={agent.agent_id}
+            style={{ cursor: "pointer" }}
+            onClick={() => navigate(`/agents/${agent.agent_id}`)}
+          >
+            <title>
+              {agent.first_name} {agent.last_name} · {card.loadCount} loads · $
+              {(card.medianRpm as number).toFixed(2)}/mi · {Math.round(card.revenue / 100) / 10}k
+            </title>
+            <circle
+              cx={cx}
+              cy={cy}
+              r={r}
+              fill={cold ? "rgba(160,106,30,0.14)" : spec.fill}
+              stroke={cold ? "#a06a1e" : spec.stroke}
+              strokeWidth={1.6}
+              strokeDasharray={cold ? "3 3" : undefined}
+            />
+            <text x={cx} y={cy + 3.5} textAnchor="middle" fontSize={r >= 13 ? 10 : 8.5} fill={cold ? "#d9c19a" : spec.text} fontWeight={700}>
+              {initials}
+            </text>
+            <text x={cx} y={cy - r - 4} textAnchor="middle" fontSize={9.5} fill="#9aa4b5">
+              {agent.first_name}
+              {card.ratingFlag ? " ⚠" : ""}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+};

--- a/frontend/src/components/dashboard/agents/AgentsTab.tsx
+++ b/frontend/src/components/dashboard/agents/AgentsTab.tsx
@@ -143,8 +143,8 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
   const elseShare = Math.max(0, 1 - topShares.reduce((s, x) => s + x.share, 0));
 
   return (
-    <div>
-      <div className="flex items-baseline justify-between mb-3">
+    <div className="flex flex-col gap-3 lg:flex-1 lg:min-h-0">
+      <div className="flex items-baseline justify-between">
         <h2 className="text-xl font-condensed text-light">Your agent bench</h2>
         <span className="text-xs text-muted-text">
           who pays · who volumes · who to call — {quarterKey(now.toISOString())}
@@ -152,7 +152,7 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
       </div>
 
       {/* KPI strip */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5 mb-3">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5">
         <KpiTile
           label="Rate leader"
           value={roster.rateLeader ? `${fmtRpm(roster.rateLeader.medianRpm)}/mi` : "—"}
@@ -190,7 +190,7 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
       </div>
 
       {/* hero scatter */}
-      <div className="rounded-xl p-3 mb-3" style={C.card}>
+      <div className="rounded-xl p-3 flex flex-col lg:flex-1 lg:min-h-0" style={C.card}>
         <div className="flex items-center justify-between mb-1">
           <span className="text-[13px] font-bold text-light">Who to call — rate × volume</span>
           <span className="text-[11px] text-muted-text">bubble = revenue · click to open an agent</span>
@@ -204,7 +204,7 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
       </div>
 
       {/* momentum + live board */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 mb-3">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <div className="rounded-xl p-3.5" style={C.card}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5">
             Momentum — last 90d vs prior

--- a/frontend/src/components/dashboard/agents/AgentsTab.tsx
+++ b/frontend/src/components/dashboard/agents/AgentsTab.tsx
@@ -1,0 +1,328 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { TriangleAlert } from "lucide-react";
+import type { Load } from "@/types/load";
+import { useAgents } from "@/hooks/useAgents";
+import {
+  buildAgentScorecards,
+  agentRosterAnalytics,
+  concentrationAnalytics,
+  agentMomentum,
+  MIN_SCORE_LOADS,
+} from "@/lib/metrics/agentScorecard";
+import { currentQuarterStandings, quarterKey } from "@/lib/metrics/agentLeaderboard";
+import { SPECIALTY_META, flagText } from "@/components/agents/agentDisplay";
+import { money, rpm as fmtRpm } from "@/lib/format";
+import { AgentScatter, type ScatterPoint } from "./AgentScatter";
+
+const C = {
+  card: { background: "#0f1622", border: "1px solid #26304a" },
+  tile: { background: "#121a27", border: "1px solid #26304a" },
+};
+
+const KpiTile = ({
+  label,
+  value,
+  sub,
+  valueColor,
+  warn,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+  valueColor?: string;
+  warn?: boolean;
+}) => (
+  <div
+    className="rounded-xl px-3.5 py-3"
+    style={warn ? { background: "#1c1408", border: "1px solid #7a3b12" } : C.tile}
+  >
+    <p className="text-[10px] uppercase tracking-wide text-muted-text">{label}</p>
+    <p className="text-lg font-bold mt-0.5 leading-tight" style={{ color: valueColor }}>
+      {value}
+    </p>
+    <p className="text-[10.5px] text-muted-text mt-0.5">{sub}</p>
+  </div>
+);
+
+const MomBar = ({ pct }: { pct: number | null }) => {
+  if (pct == null) return <div className="h-4" />;
+  const up = pct >= 0;
+  const w = Math.min(48, Math.abs(pct) * 50);
+  return (
+    <div className="relative h-4 rounded" style={{ background: "#0c1119", border: "1px solid #1c2536" }}>
+      <div className="absolute top-0 bottom-0" style={{ left: "50%", width: 1, background: "#2f3b52" }} />
+      <div
+        className="absolute top-[2px] bottom-[2px]"
+        style={
+          up
+            ? { left: "50%", width: `${w}%`, background: "#2f7d55", borderRadius: "0 3px 3px 0" }
+            : { right: "50%", width: `${w}%`, background: "#8a3b3b", borderRadius: "3px 0 0 3px" }
+        }
+      />
+    </div>
+  );
+};
+
+const Badge = ({ tag }: { tag: "oversize" | "specialty" }) => {
+  const m = SPECIALTY_META[tag];
+  return (
+    <span
+      className="text-[8px] font-bold tracking-wide px-1.5 py-0.5 rounded"
+      style={{ color: m.fg, background: m.bg, border: `1px solid ${m.border}` }}
+    >
+      {tag === "oversize" ? "OVR" : "SPEC"}
+    </span>
+  );
+};
+
+export const AgentsTab = ({ loads }: { loads: Load[] }) => {
+  const { agents } = useAgents();
+  const now = useMemo(() => new Date(), []);
+
+  const scorecards = useMemo(
+    () => buildAgentScorecards(agents ?? [], loads, now),
+    [agents, loads, now],
+  );
+  const roster = useMemo(() => agentRosterAnalytics(scorecards), [scorecards]);
+  const conc = useMemo(() => concentrationAnalytics(loads, now), [loads, now]);
+  const momentum = useMemo(() => agentMomentum(loads, now), [loads, now]);
+  const standings = useMemo(() => currentQuarterStandings(loads, now), [loads, now]);
+  const byId = useMemo(
+    () => new Map((agents ?? []).map((a) => [a.agent_id, a])),
+    [agents],
+  );
+
+  const rows = useMemo(
+    () =>
+      (agents ?? [])
+        .map((a) => ({ agent: a, card: scorecards.get(a.agent_id)! }))
+        .filter((r) => r.card),
+    [agents, scorecards],
+  );
+  const scatterPoints: ScatterPoint[] = rows;
+
+  const name = (id: string) => {
+    const a = byId.get(id);
+    return a ? `${a.first_name} ${a.last_name}` : "—";
+  };
+
+  // momentum: top agents by revenue that have a reading
+  const momRows = useMemo(
+    () =>
+      rows
+        .filter((r) => r.card.loadCount >= MIN_SCORE_LOADS && momentum.get(r.agent.agent_id) != null)
+        .sort((a, b) => b.card.revenue - a.card.revenue)
+        .slice(0, 6),
+    [rows, momentum],
+  );
+
+  const board = useMemo(
+    () =>
+      [...standings.entries()]
+        .sort((a, b) => b[1].revenue - a[1].revenue)
+        .slice(0, 3),
+    [standings],
+  );
+
+  const cold = useMemo(
+    () =>
+      rows
+        .filter((r) => r.card.tier === "cold")
+        .sort((a, b) => b.card.revenue - a.card.revenue)
+        .slice(0, 4),
+    [rows],
+  );
+
+  const flags = useMemo(() => rows.filter((r) => r.card.ratingFlag), [rows]);
+
+  const rateLeader = roster.rateLeader ? byId.get(roster.rateLeader.agentId) : null;
+  const coldTop = roster.goingCold ? byId.get(roster.goingCold.agentId) : null;
+  const RANK = ["#f5b03a", "#c3ccd6", "#c78a3a"];
+  const topShares = conc.shares.slice(0, 3);
+  const elseShare = Math.max(0, 1 - topShares.reduce((s, x) => s + x.share, 0));
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-3">
+        <h2 className="text-xl font-condensed text-light">Your agent bench</h2>
+        <span className="text-xs text-muted-text">
+          who pays · who volumes · who to call — {quarterKey(now.toISOString())}
+        </span>
+      </div>
+
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5 mb-3">
+        <KpiTile
+          label="Rate leader"
+          value={roster.rateLeader ? `${fmtRpm(roster.rateLeader.medianRpm)}/mi` : "—"}
+          valueColor="#4ade80"
+          sub={rateLeader ? `${rateLeader.first_name} ${rateLeader.last_name}` : "need 2+ loads"}
+        />
+        <KpiTile
+          label="Oversize bench"
+          value={String(roster.oversizeBench)}
+          valueColor="#f5b03a"
+          sub={`specialists · ${roster.specCapable} spec-capable`}
+        />
+        <KpiTile
+          label="Concentration"
+          value={conc.top3Pct != null ? `${Math.round(conc.top3Pct * 100)}%` : "—"}
+          valueColor={conc.overSingleCap ? "#f5a623" : undefined}
+          warn={conc.overSingleCap}
+          sub={
+            conc.overSingleCap && conc.singleMax
+              ? `⚠ ${byId.get(conc.singleMax.agentId)?.last_name ?? "one"} ${Math.round(conc.singleMax.share * 100)}% — over 30%`
+              : "top 3 · last 90 days"
+          }
+        />
+        <KpiTile
+          label="Going cold"
+          value={coldTop ? `${coldTop.first_name.charAt(0)}. ${coldTop.last_name}` : "—"}
+          valueColor={coldTop ? "#f5a623" : undefined}
+          warn={!!coldTop}
+          sub={
+            roster.goingCold
+              ? `${money(roster.goingCold.revenue)} · ${roster.goingCold.daysSince}d quiet`
+              : "all recently active"
+          }
+        />
+      </div>
+
+      {/* hero scatter */}
+      <div className="rounded-xl p-3 mb-3" style={C.card}>
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-[13px] font-bold text-light">Who to call — rate × volume</span>
+          <span className="text-[11px] text-muted-text">bubble = revenue · click to open an agent</span>
+        </div>
+        <AgentScatter points={scatterPoints} />
+        <div className="flex gap-3.5 text-[10.5px] text-muted-text mt-1">
+          <span><span className="inline-block w-2.5 h-2.5 rounded-full mr-1 align-[-1px]" style={{ background: "#e8940a" }} />Oversize</span>
+          <span><span className="inline-block w-2.5 h-2.5 rounded-full mr-1 align-[-1px]" style={{ background: "#5fd0e0" }} />Specialty</span>
+          <span>◯ dashed = cold · ⚠ = gut≠data</span>
+        </div>
+      </div>
+
+      {/* momentum + live board */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 mb-3">
+        <div className="rounded-xl p-3.5" style={C.card}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5">
+            Momentum — last 90d vs prior
+          </h3>
+          {momRows.length === 0 ? (
+            <p className="text-xs text-muted-text">Not enough recent history to trend yet.</p>
+          ) : (
+            momRows.map(({ agent, card }) => {
+              const pct = momentum.get(agent.agent_id)!;
+              const up = (pct ?? 0) >= 0;
+              return (
+                <div key={agent.agent_id} className="grid items-center gap-2 py-[3px]" style={{ gridTemplateColumns: "108px 1fr 46px" }}>
+                  <span className="text-[11.5px] truncate">
+                    {agent.first_name.charAt(0)}. {agent.last_name}
+                    {card.specialty.tag !== "standard" && <> <Badge tag={card.specialty.tag} /></>}
+                  </span>
+                  <MomBar pct={pct} />
+                  <span className="text-[11px] font-bold text-right" style={{ color: up ? "#4ade80" : "#f87171" }}>
+                    {up ? "+" : "−"}
+                    {Math.round(Math.abs(pct ?? 0) * 100)}%
+                  </span>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div className="rounded-xl p-3.5" style={C.card}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5 flex justify-between">
+            Live board · {quarterKey(now.toISOString())}
+            <span className="inline-flex items-center gap-1.5 text-[9.5px]" style={{ color: "#f5a623" }}>
+              <span className="w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: "#f5a623" }} />
+              LIVE
+            </span>
+          </h3>
+          {board.length === 0 ? (
+            <p className="text-xs text-muted-text">No delivered loads this quarter yet.</p>
+          ) : (
+            board.map(([id, s], i) => (
+              <Link
+                key={id}
+                to={`/agents/${id}`}
+                className="flex items-center gap-2.5 py-1.5 border-t first:border-t-0"
+                style={{ borderColor: "#1a2233" }}
+              >
+                <span className="w-5 h-5 rounded-full flex items-center justify-center text-[11px] font-extrabold" style={{ background: RANK[i], color: "#0d1119" }}>
+                  {i + 1}
+                </span>
+                <span className="flex-1 font-semibold text-light truncate">{name(id)}</span>
+                <span className="font-bold">{money(s.revenue)}</span>
+              </Link>
+            ))
+          )}
+          <p className="text-[10.5px] text-muted-text mt-2">Provisional — the board agents earn medals on, not yet official.</p>
+        </div>
+      </div>
+
+      {/* concentration + going cold + gut-vs-data */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+        <div className="rounded-xl p-3.5" style={C.card}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5">Revenue concentration · 90d</h3>
+          {conc.total > 0 ? (
+            <>
+              <div className="flex h-6 rounded-md overflow-hidden mb-2" style={{ border: "1px solid #26304a" }}>
+                {topShares.map((s, i) => (
+                  <div key={s.agentId} className="h-full flex items-center justify-center text-[9px] font-bold" style={{ width: `${s.share * 100}%`, background: ["#e8940a", "#f5b03a", "#c8890a"][i], color: "#0d1119" }}>
+                    {Math.round(s.share * 100)}%
+                  </div>
+                ))}
+                <div className="h-full flex items-center justify-center text-[9px]" style={{ width: `${elseShare * 100}%`, background: "#2a3347", color: "#9aa4b5" }}>
+                  rest
+                </div>
+              </div>
+              <p className="text-[11px] text-muted-text">
+                Top 3 = <b style={{ color: conc.overSingleCap ? "#f5a623" : "#f5b03a" }}>{Math.round((conc.top3Pct ?? 0) * 100)}%</b> of your recent book.
+                Rule of thumb: no single agent over <span className="text-light">30%</span>, top 3 under <span className="text-light">65%</span>.
+              </p>
+            </>
+          ) : (
+            <p className="text-xs text-muted-text">No delivered revenue in the last 90 days.</p>
+          )}
+        </div>
+
+        <div className="rounded-xl p-3.5" style={C.card}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5">Going cold — worth a call</h3>
+          {cold.length === 0 ? (
+            <p className="text-xs text-muted-text">Everyone's been active lately.</p>
+          ) : (
+            cold.map(({ agent, card }) => (
+              <Link key={agent.agent_id} to={`/agents/${agent.agent_id}`} className="flex items-center justify-between py-1.5 text-[12px] border-t first:border-t-0" style={{ borderColor: "#1a2233" }}>
+                <span className="truncate">
+                  {agent.first_name} {agent.last_name}
+                  {card.specialty.tag !== "standard" && <> <Badge tag={card.specialty.tag} /></>}
+                </span>
+                <span style={{ color: "#f5a623" }} className="whitespace-nowrap">
+                  {card.daysSince}d · {money(card.revenue)}
+                </span>
+              </Link>
+            ))
+          )}
+        </div>
+
+        <div className="rounded-xl p-3.5" style={C.card}>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5">Gut vs. data ⚠</h3>
+          {flags.length === 0 ? (
+            <p className="text-xs text-muted-text">Your star ratings track the numbers — nothing to flag.</p>
+          ) : (
+            flags.slice(0, 4).map(({ agent, card }) => (
+              <Link key={agent.agent_id} to={`/agents/${agent.agent_id}`} className="flex gap-2 items-start py-1.5 text-[11.5px] border-t first:border-t-0" style={{ borderColor: "#1a2233" }}>
+                <TriangleAlert size={13} style={{ color: "#f5a623", flexShrink: 0, marginTop: 1 }} />
+                <span>
+                  <span className="font-semibold">{agent.first_name} {agent.last_name}</span> — {flagText(card)}
+                </span>
+              </Link>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/lanes/LanesMap.tsx
+++ b/frontend/src/components/lanes/LanesMap.tsx
@@ -15,6 +15,7 @@ interface Props {
   windowDays: number;
   selected: string | null;
   onSelect: (key: string) => void;
+  noir?: boolean; // the standalone page uses the comic-noir panel; the dashboard tab is flat
 }
 
 type Mode = "rate" | "volume";
@@ -58,7 +59,7 @@ interface HoverState {
   datum: AreaMapDatum;
 }
 
-export const LanesMap = ({ data, level, windowDays, selected, onSelect }: Props) => {
+export const LanesMap = ({ data, level, windowDays, selected, onSelect, noir = true }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [hover, setHover] = useState<HoverState | null>(null);
   const [mode, setMode] = useState<Mode>("rate");
@@ -175,7 +176,7 @@ export const LanesMap = ({ data, level, windowDays, selected, onSelect }: Props)
   const drillHint = level === "state" ? "click a state to drill in" : "click a region to drill in";
 
   return (
-    <Panel ref={containerRef} noir className="p-4 relative">
+    <Panel ref={containerRef} noir={noir} className="p-4 relative h-full flex flex-col">
       <div className="text-xs text-muted-text mb-2 flex items-center gap-2 flex-wrap">
         <span>Shade by</span>
         {toggle("rate", "your $/mi")}
@@ -185,7 +186,7 @@ export const LanesMap = ({ data, level, windowDays, selected, onSelect }: Props)
         </span>
         <span>· grouped by {levelWord} · {drillHint}</span>
       </div>
-      <svg viewBox="0 0 900 560" className="w-full">
+      <svg viewBox="0 0 900 560" className="w-full flex-1 min-h-0" preserveAspectRatio="xMidYMid meet">
         {shapes.map((s, i) => {
           const datum = data[s.key];
           const isSel = selected === s.key;

--- a/frontend/src/hooks/useExpensePeriods.ts
+++ b/frontend/src/hooks/useExpensePeriods.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import type { ExpensePeriod, CategorySpend } from "@/types/expense";
+import {
+  getExpensePeriods,
+  getExpenseCategoryRollup,
+} from "@/services/expensesService";
+
+// P&L data for the Money tab: the period list (aggregates — feeds the monthly
+// P&L chart, margin trend, and YTD KPIs) plus the current year's spending rolled
+// up by category (the backend does the GROUP BY) for the "where it goes" card.
+// Newest-first.
+export const useExpensePeriods = () => {
+  const [periods, setPeriods] = useState<ExpensePeriod[]>([]);
+  const [categoriesYTD, setCategoriesYTD] = useState<CategorySpend[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    const year = new Date().getUTCFullYear();
+    (async () => {
+      try {
+        const [list, cats] = await Promise.all([
+          getExpensePeriods(),
+          getExpenseCategoryRollup(year),
+        ]);
+        if (!alive) return;
+        setPeriods(
+          [...list].sort((a, b) => (a.period_month < b.period_month ? 1 : -1)),
+        );
+        setCategoriesYTD(cats);
+      } catch {
+        /* leave empty — the tab shows an empty state */
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return { periods, categoriesYTD, loading };
+};

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -16,7 +16,7 @@ const AppLayout = () => {
               sideways. Wide content that must scroll keeps its own overflow-x-auto
               scroller, so this only clips true page-level overflow, never a table.
               overflow-y stays auto, so vertical scroll and sticky children work. */}
-          <main className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden bg-background text-foreground">
+          <main className="flex-1 min-w-0 flex flex-col overflow-y-auto overflow-x-hidden bg-background text-foreground">
             <div className="p-3 border-b border-border">
               <SidebarTrigger />
             </div>

--- a/frontend/src/lib/metrics/agentScorecard.test.ts
+++ b/frontend/src/lib/metrics/agentScorecard.test.ts
@@ -5,6 +5,7 @@ import {
   classifySpecialty,
   buildAgentScorecards,
   agentRosterAnalytics,
+  concentrationAnalytics,
 } from "./agentScorecard";
 
 const load = (over: Partial<Load>): Load =>
@@ -151,5 +152,37 @@ describe("agentRosterAnalytics", () => {
     expect(r.oversizeBench).toBe(2); // a and b
     expect(r.goingCold?.agentId).toBe("a"); // the cold, high-value one
     expect(r.concentrationPct).toBeGreaterThan(0.5);
+  });
+});
+
+describe("concentrationAnalytics (windowed + per-agent)", () => {
+  const NOW = new Date("2026-08-06T12:00:00Z");
+  it("windows out cold agents and flags a single agent over the cap", () => {
+    const loads = [
+      load({ agent_id: "big", linehaul: "10000" }), // in-window $10k
+      load({ agent_id: "big", linehaul: "6000" }), //  in-window $6k  → big = $16k
+      load({ agent_id: "s1", linehaul: "4000" }), //   in-window $4k
+      load({ agent_id: "s2", linehaul: "3000" }), //   in-window $3k
+      load({ agent_id: "cold", linehaul: "20000", delivery_date: "2026-04-01" }), // 127d → dropped
+    ];
+    const c = concentrationAnalytics(loads, NOW); // default 90d window
+    expect(c.total).toBe(23000); // cold's $20k excluded
+    expect(c.shares.find((s) => s.agentId === "cold")).toBeUndefined();
+    expect(c.singleMax?.agentId).toBe("big");
+    expect(c.singleMax?.share).toBeCloseTo(16000 / 23000, 5); // ~0.70
+    expect(c.overSingleCap).toBe(true); // 70% > 30%
+    expect(c.top3Pct).toBeCloseTo(1, 5); // only 3 agents in-window
+  });
+
+  it("no over-cap when revenue is spread", () => {
+    const loads = [
+      load({ agent_id: "a", linehaul: "5000" }),
+      load({ agent_id: "b", linehaul: "5000" }),
+      load({ agent_id: "c", linehaul: "5000" }),
+      load({ agent_id: "d", linehaul: "5000" }),
+    ];
+    const c = concentrationAnalytics(loads, NOW);
+    expect(c.overSingleCap).toBe(false); // each 25% < 30%
+    expect(c.singleMax?.share).toBeCloseTo(0.25, 5);
   });
 });

--- a/frontend/src/lib/metrics/agentScorecard.test.ts
+++ b/frontend/src/lib/metrics/agentScorecard.test.ts
@@ -6,6 +6,7 @@ import {
   buildAgentScorecards,
   agentRosterAnalytics,
   concentrationAnalytics,
+  agentMomentum,
 } from "./agentScorecard";
 
 const load = (over: Partial<Load>): Load =>
@@ -184,5 +185,21 @@ describe("concentrationAnalytics (windowed + per-agent)", () => {
     const c = concentrationAnalytics(loads, NOW);
     expect(c.overSingleCap).toBe(false); // each 25% < 30%
     expect(c.singleMax?.share).toBeCloseTo(0.25, 5);
+  });
+});
+
+describe("agentMomentum", () => {
+  const NOW = new Date("2026-08-06T12:00:00Z");
+  it("computes recent-vs-prior % change; surging-from-zero caps at +1", () => {
+    const loads = [
+      load({ agent_id: "up", delivery_date: "2026-07-15", linehaul: "8000" }), // recent
+      load({ agent_id: "up", delivery_date: "2026-03-15", linehaul: "4000" }), // prior
+      load({ agent_id: "new", delivery_date: "2026-07-15", linehaul: "5000" }), // recent only
+      load({ agent_id: "gone", delivery_date: "2026-03-15", linehaul: "5000" }), // prior only
+    ];
+    const m = agentMomentum(loads, NOW);
+    expect(m.get("up")).toBeCloseTo(1.0, 5); // 8k/4k − 1
+    expect(m.get("new")).toBe(1); // from zero prior
+    expect(m.get("gone")).toBeCloseTo(-1, 5); // 0/5k − 1
   });
 });

--- a/frontend/src/lib/metrics/agentScorecard.ts
+++ b/frontend/src/lib/metrics/agentScorecard.ts
@@ -286,6 +286,35 @@ export interface Concentration {
   singleCap: number;
 }
 
+// ---- momentum (booking velocity: recent 90d vs the prior 90d) ----
+// Per-agent gross-revenue % change, recent-vs-prior. null = no activity either
+// window; +1 (capped) when they're new/surging from a zero prior. Feeds the
+// diverging momentum bars — who's heating up, who's falling off.
+export const agentMomentum = (
+  loads: Load[],
+  now: Date = new Date(),
+): Map<string, number | null> => {
+  const nowMs = now.getTime();
+  const recentCut = nowMs - 90 * MS_DAY;
+  const priorCut = nowMs - 180 * MS_DAY;
+  const acc = new Map<string, { r: number; p: number }>();
+  for (const l of loads) {
+    if (l.load_status !== "delivered" || !l.agent_id || !l.delivery_date) continue;
+    const t = new Date(l.delivery_date).getTime();
+    const cur = acc.get(l.agent_id) ?? { r: 0, p: 0 };
+    if (t >= recentCut && t <= nowMs) cur.r += loadRevenue(l);
+    else if (t >= priorCut && t < recentCut) cur.p += loadRevenue(l);
+    acc.set(l.agent_id, cur);
+  }
+  const out = new Map<string, number | null>();
+  for (const [id, { r, p }] of acc) {
+    if (r === 0 && p === 0) out.set(id, null);
+    else if (p === 0) out.set(id, 1); // new / surging from nothing
+    else out.set(id, r / p - 1);
+  }
+  return out;
+};
+
 // Concentration over a RECENT window (default 90d, matching the "cold" line) so
 // an agent who's gone quiet drops out — a dependency you haven't felt in months
 // isn't a dependency. Per-agent shares let you watch the single-agent cap.

--- a/frontend/src/lib/metrics/agentScorecard.ts
+++ b/frontend/src/lib/metrics/agentScorecard.ts
@@ -264,3 +264,56 @@ export const agentRosterAnalytics = (
     moneyLostAgents: list.filter((c) => c.moneyLostLoads > 0).length,
   };
 };
+
+// ---- revenue concentration (WINDOWED — current dependency, not lifetime) ----
+// Healthy guideline for a one-truck bench: no single agent over ~30% of your
+// book, top-3 under ~65%. Tunable in settings.
+export const SINGLE_CAP = 0.3;
+export const TOP3_CAP = 0.65;
+
+export interface ConcentrationShare {
+  agentId: string;
+  revenue: number;
+  share: number; // 0..1 of the windowed book
+}
+export interface Concentration {
+  windowDays: number;
+  total: number;
+  shares: ConcentrationShare[]; // every contributing agent, revenue desc
+  top3Pct: number | null;
+  singleMax: ConcentrationShare | null;
+  overSingleCap: boolean; // any single agent over the cap
+  singleCap: number;
+}
+
+// Concentration over a RECENT window (default 90d, matching the "cold" line) so
+// an agent who's gone quiet drops out — a dependency you haven't felt in months
+// isn't a dependency. Per-agent shares let you watch the single-agent cap.
+export const concentrationAnalytics = (
+  loads: Load[],
+  now: Date = new Date(),
+  windowDays = COLD_DAYS,
+  singleCap = SINGLE_CAP,
+): Concentration => {
+  const cutoff = now.getTime() - windowDays * MS_DAY;
+  const rev = new Map<string, number>();
+  for (const l of loads) {
+    if (l.load_status !== "delivered" || !l.agent_id || !l.delivery_date) continue;
+    if (new Date(l.delivery_date).getTime() < cutoff) continue;
+    rev.set(l.agent_id, (rev.get(l.agent_id) ?? 0) + loadRevenue(l));
+  }
+  const total = [...rev.values()].reduce((a, b) => a + b, 0);
+  const shares: ConcentrationShare[] = [...rev.entries()]
+    .map(([agentId, revenue]) => ({ agentId, revenue, share: total > 0 ? revenue / total : 0 }))
+    .sort((a, b) => b.revenue - a.revenue);
+  const singleMax = shares[0] ?? null;
+  return {
+    windowDays,
+    total,
+    shares,
+    top3Pct: total > 0 ? shares.slice(0, 3).reduce((s, x) => s + x.share, 0) : null,
+    singleMax,
+    overSingleCap: !!singleMax && singleMax.share > singleCap,
+    singleCap,
+  };
+};

--- a/frontend/src/lib/metrics/expenses.test.ts
+++ b/frontend/src/lib/metrics/expenses.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from "vitest";
-import type { ExpensePeriod, ExpenseLine } from "@/types/expense";
+import type {
+  ExpensePeriod,
+  ExpenseLine,
+  CategorySpend,
+} from "@/types/expense";
 import {
   getExpenseMetrics,
   pctOfRevenue,
+  topCategoriesWithOther,
   getCashMetrics,
   getTrueMonthly,
 } from "./expenses";
@@ -104,5 +109,48 @@ describe("getTrueMonthly", () => {
     const t = getTrueMonthly(8000, 0, 0);
     expect(t.trueMonthlyCost).toBe(8000);
     expect(t.trueNetMargin).toBeNull();
+  });
+});
+
+describe("topCategoriesWithOther", () => {
+  const cat = (category: string, amount: number): CategorySpend => ({
+    category,
+    amount,
+    section: "expenses",
+  });
+  const cats = [
+    cat("Payroll", 7644),
+    cat("Repairs", 4990),
+    cat("Fuel", 4128),
+    cat("Loan fee", 1040),
+    cat("Insurance", 795),
+    cat("Utilities", 748),
+    cat("Tolls", 300),
+    cat("Supplies", 120),
+  ];
+
+  it("keeps the top n and folds the rest into one Other slice", () => {
+    const c = topCategoriesWithOther(cats, 6);
+    expect(c.map((x) => x.category)).toEqual([
+      "Payroll", "Repairs", "Fuel", "Loan fee", "Insurance", "Utilities", "Other",
+    ]);
+    // Other = Tolls + Supplies = 420
+    expect(c[6]).toMatchObject({ category: "Other", amount: 420 });
+  });
+
+  it("adds no Other slice when categories already fit", () => {
+    const c = topCategoriesWithOther(cats.slice(0, 4), 6);
+    expect(c).toHaveLength(4);
+    expect(c.some((x) => x.category === "Other")).toBe(false);
+  });
+
+  it("sorts defensively before slicing", () => {
+    const c = topCategoriesWithOther([cat("a", 10), cat("b", 90), cat("c", 50)], 1);
+    expect(c[0]).toMatchObject({ category: "b", amount: 90 });
+    expect(c[1]).toMatchObject({ category: "Other", amount: 60 });
+  });
+
+  it("empty in, empty out", () => {
+    expect(topCategoriesWithOther([], 6)).toEqual([]);
   });
 });

--- a/frontend/src/lib/metrics/expenses.ts
+++ b/frontend/src/lib/metrics/expenses.ts
@@ -1,4 +1,20 @@
-import type { ExpensePeriod } from "@/types/expense";
+import type { ExpensePeriod, CategorySpend } from "@/types/expense";
+
+// Keep the biggest `n` categories and fold everything smaller into one "Other"
+// slice, so the "where it goes" bar always sums to the whole — no unlabeled gap
+// for the long tail. Sorts defensively (the API already sends largest-first).
+export const topCategoriesWithOther = (
+  cats: CategorySpend[],
+  n: number,
+): CategorySpend[] => {
+  const sorted = [...cats].sort((a, b) => b.amount - a.amount);
+  if (sorted.length <= n) return sorted;
+  const otherAmount = sorted.slice(n).reduce((s, c) => s + c.amount, 0);
+  return [
+    ...sorted.slice(0, n),
+    { category: "Other", amount: otherAmount, section: "expenses" },
+  ];
+};
 
 // Derived numbers for the Expenses page. Cost comes from the stored month's
 // lines; miles + income come from loads (passed in) so this stays pure.

--- a/frontend/src/lib/metrics/lanes.ts
+++ b/frontend/src/lib/metrics/lanes.ts
@@ -21,6 +21,7 @@ export interface LaneStat {
   origin: string;
   destination: string;
   loadCount: number;
+  gross: number; // all-in gross over the lane's loads (market value)
   avgRpm: number | null;
   medianRpm: number | null;
 }
@@ -152,6 +153,7 @@ export const getRegionRollup = (loads: Load[]): RegionStat[] => {
           origin: first.origin_market,
           destination: first.delivery_market,
           loadCount: laneLoads.length,
+          gross: grossRevenue(laneLoads),
           avgRpm: avgRpm(laneLoads),
           medianRpm: medianRpm(laneLoads),
         });
@@ -240,6 +242,7 @@ export const groupKeyForStateName = (
 export interface AreaMapDatum {
   key: string; // state name, or region / macro label
   loadCount: number; // delivered loads in the window
+  gross: number; // all-in gross originating here (market value)
   avgRpm: number | null; // blended gross ÷ loaded mile
   medianRpm: number | null; // typical single-load $/mi (drives rate shading)
   members: string[]; // origin markets (state level) or member states (grouped)
@@ -273,12 +276,54 @@ export const getAreaMapData = (
     out[key] = {
       key,
       loadCount: group.length,
+      gross: grossRevenue(group),
       avgRpm: avgRpm(group),
       medianRpm: medianRpm(group),
       members,
     };
   }
   return out;
+};
+
+// ---- LOAD-TYPE MIX ---- (delivered loads grouped by load_type, by gross)
+export interface LoadTypeSlice {
+  type: string;
+  gross: number;
+  loadCount: number;
+  share: number; // 0..1 of total gross
+}
+export const getLoadTypeMix = (loads: Load[]): LoadTypeSlice[] => {
+  const delivered = deliveredOnly(loads);
+  const total = grossRevenue(delivered);
+  const slices: LoadTypeSlice[] = [];
+  for (const [type, ls] of groupBy(delivered, (l) => l.load_type?.trim() || "Other")) {
+    const g = grossRevenue(ls);
+    slices.push({ type, gross: g, loadCount: ls.length, share: total > 0 ? g / total : 0 });
+  }
+  return slices.sort((a, b) => b.gross - a.gross);
+};
+
+// The single origin area (state / region / macro) contributing the most gross in
+// the window, with its share of the book — for the "top origin" KPI.
+export interface TopOrigin {
+  key: string;
+  gross: number;
+  loadCount: number;
+  loadShare: number; // 0..1 of delivered loads in the window
+}
+export const getTopOrigin = (
+  mapData: Record<string, AreaMapDatum>,
+): TopOrigin | null => {
+  const areas = Object.values(mapData);
+  if (areas.length === 0) return null;
+  const totalLoads = areas.reduce((s, a) => s + a.loadCount, 0);
+  const top = areas.reduce((b, a) => (a.gross > b.gross ? a : b));
+  return {
+    key: top.key,
+    gross: top.gross,
+    loadCount: top.loadCount,
+    loadShare: totalLoads > 0 ? top.loadCount / totalLoads : 0,
+  };
 };
 
 // ---- STATE DRILL-DOWN ----
@@ -332,6 +377,7 @@ const buildDetail = (
       origin: first.origin_market,
       destination: first.delivery_market,
       loadCount: laneLoads.length,
+      gross: grossRevenue(laneLoads),
       avgRpm: avgRpm(laneLoads),
       medianRpm: medianRpm(laneLoads),
     });

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -17,6 +17,7 @@ import {
 import {
   buildAgentScorecards,
   agentRosterAnalytics,
+  concentrationAnalytics,
 } from "@/lib/metrics/agentScorecard";
 import { money, rpm as fmtRpm } from "@/lib/format";
 
@@ -42,6 +43,13 @@ const AgentsPage = () => {
     [agents, loads, now],
   );
   const roster = useMemo(() => agentRosterAnalytics(scorecards), [scorecards]);
+  // Concentration is WINDOWED (recent 90d) so a cold agent isn't counted as a
+  // current dependency; per-agent shares feed the table's "% book" column.
+  const conc = useMemo(() => concentrationAnalytics(loads ?? [], now), [loads, now]);
+  const shareByAgent = useMemo(
+    () => new Map(conc.shares.map((s) => [s.agentId, s.share])),
+    [conc],
+  );
 
   const byId = useMemo(
     () => new Map((agents ?? []).map((a) => [a.agent_id, a])),
@@ -147,8 +155,13 @@ const AgentsPage = () => {
         />
         <Kpi
           label="Concentration"
-          value={roster.concentrationPct != null ? `${Math.round(roster.concentrationPct * 100)}%` : "—"}
-          sub="top 3 of your revenue"
+          value={conc.top3Pct != null ? `${Math.round(conc.top3Pct * 100)}%` : "—"}
+          valueClass={conc.overSingleCap ? "text-amber" : undefined}
+          sub={
+            conc.overSingleCap && conc.singleMax
+              ? `⚠ ${byId.get(conc.singleMax.agentId)?.last_name ?? "one agent"} ${Math.round(conc.singleMax.share * 100)}% — over 30%`
+              : "top 3 · last 90 days"
+          }
         />
         {cold && roster.goingCold ? (
           <Link to={`/agents/${cold.agent_id}`}>
@@ -214,7 +227,7 @@ const AgentsPage = () => {
           <p className="text-muted-text text-sm">No agents match.</p>
         )
       ) : view === "table" ? (
-        <AgentTable rows={rows} />
+        <AgentTable rows={rows} shareByAgent={shareByAgent} />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           {rows.map(({ agent, card }) => (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -15,6 +15,7 @@ import { DashboardShell, TabStub, type DashTab } from "@/components/dashboard/Da
 import { AgentsTab } from "@/components/dashboard/agents/AgentsTab";
 import { PulseTab } from "@/components/dashboard/PulseTab";
 import { MoneyTab } from "@/components/dashboard/MoneyTab";
+import { LanesTab } from "@/components/dashboard/LanesTab";
 import { isDispatcher } from "@/lib/roles";
 import DispatchDashboard from "./DispatchDashboard";
 
@@ -74,7 +75,7 @@ const OwnerDashboard = () => {
     );
 
   return (
-    <div className="p-6 bg-iron text-light min-h-screen font-body">
+    <div className="p-6 bg-iron text-light min-h-screen font-body lg:flex lg:flex-col lg:flex-1 lg:min-h-0">
       <AwardPopHost pops={awardDemo ? DEMO_AWARDS : pops} truckAvatarUrl={truckAvatarUrl} />
       <DashboardShell
         tabs={DASH_TABS}
@@ -96,15 +97,7 @@ const OwnerDashboard = () => {
           ) : active === "money" ? (
             <MoneyTab loads={loads} marginGoal={targets.marginGoal ?? null} />
           ) : active === "lanes" ? (
-            <TabStub
-              title="Lanes"
-              blurb="Where your freight comes from."
-              points={[
-                "The granularity map (macro / region / state)",
-                "Best lanes and regions",
-                "Load-type mix",
-              ]}
-            />
+            <LanesTab loads={loads} />
           ) : active === "agents" ? (
             <AgentsTab loads={loads} />
           ) : (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -38,6 +38,15 @@ import { RpmChart } from "@/components/RpmChart";
 import { OutstandingLoadsList } from "@/components/OutstandingLoadsList";
 import { AlertBanners } from "@/components/dashboard/AlertBanners";
 import { TopAgents } from "@/components/dashboard/TopAgents";
+import { DashboardShell, TabStub, type DashTab } from "@/components/dashboard/DashboardShell";
+
+const DASH_TABS: DashTab[] = [
+  { key: "pulse", label: "Pulse" },
+  { key: "money", label: "Money" },
+  { key: "lanes", label: "Lanes" },
+  { key: "agents", label: "Agents" },
+  { key: "fleet", label: "Fleet" },
+];
 import { WhatsNext } from "@/components/dashboard/WhatsNext";
 import { RecentLoads } from "@/components/dashboard/RecentLoads";
 import { isDispatcher } from "@/lib/roles";
@@ -144,21 +153,24 @@ const OwnerDashboard = () => {
   return (
     <div className="p-6 bg-iron text-light min-h-screen font-body">
       <AwardPopHost pops={awardDemo ? DEMO_AWARDS : pops} truckAvatarUrl={truckAvatarUrl} />
-
-      <div className="flex items-center justify-between mb-6 gap-3">
-        <h1 className="text-3xl font-condensed">Dashboard</h1>
-        <div className="flex items-center gap-3">
-          <MarketChip />
-          <Link
-            to="/recap"
-            className="text-sm text-status-info-text hover:underline whitespace-nowrap"
-          >
-            Your {latestRecap ? `${latestRecap.label} ` : ""}recap →
-          </Link>
-        </div>
-      </div>
-
-      <AlertBanners alerts={alerts} />
+      <DashboardShell
+        tabs={DASH_TABS}
+        right={
+          <>
+            <MarketChip />
+            <Link
+              to="/recap"
+              className="text-sm text-status-info-text hover:underline whitespace-nowrap"
+            >
+              {latestRecap ? `${latestRecap.label} ` : ""}recap →
+            </Link>
+          </>
+        }
+      >
+        {(active) =>
+          active === "pulse" ? (
+            <>
+              <AlertBanners alerts={alerts} />
 
       {/* KPI STRIP */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
@@ -237,6 +249,50 @@ const OwnerDashboard = () => {
         </Panel>
         <OutstandingLoadsList loads={outstanding} />
       </div>
+            </>
+          ) : active === "money" ? (
+            <TabStub
+              title="Money"
+              blurb="Your profitability at a glance."
+              points={[
+                "Pay-week earned vs target + settlement pipeline (no aging)",
+                "Revenue trend vs target",
+                "Rate vs your break-even floor",
+              ]}
+            />
+          ) : active === "lanes" ? (
+            <TabStub
+              title="Lanes"
+              blurb="Where your freight comes from."
+              points={[
+                "The granularity map (macro / region / state)",
+                "Best lanes and regions",
+                "Load-type mix",
+              ]}
+            />
+          ) : active === "agents" ? (
+            <TabStub
+              title="Agents"
+              blurb="Who to call."
+              points={[
+                "Rate × volume 'who to call' scatter",
+                "Momentum + the live quarterly board",
+                "Windowed concentration + gut-vs-data flags",
+              ]}
+            />
+          ) : (
+            <TabStub
+              title="Fleet"
+              blurb="Asset health."
+              points={[
+                "Truck / driver utilization",
+                "Fuel MPG trend",
+                "Next service due",
+              ]}
+            />
+          )
+        }
+      </DashboardShell>
     </div>
   );
 };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -14,6 +14,7 @@ import { MarketChip } from "@/components/dashboard/MarketChip";
 import { DashboardShell, TabStub, type DashTab } from "@/components/dashboard/DashboardShell";
 import { AgentsTab } from "@/components/dashboard/agents/AgentsTab";
 import { PulseTab } from "@/components/dashboard/PulseTab";
+import { MoneyTab } from "@/components/dashboard/MoneyTab";
 import { isDispatcher } from "@/lib/roles";
 import DispatchDashboard from "./DispatchDashboard";
 
@@ -93,15 +94,7 @@ const OwnerDashboard = () => {
           active === "pulse" ? (
             <PulseTab loads={loads} trips={trips} targets={targets} alerts={alerts} />
           ) : active === "money" ? (
-            <TabStub
-              title="Money"
-              blurb="Your profitability at a glance."
-              points={[
-                "Pay-week earned vs target + settlement pipeline (no aging)",
-                "Revenue trend vs target",
-                "Rate vs your break-even floor",
-              ]}
-            />
+            <MoneyTab loads={loads} marginGoal={targets.marginGoal ?? null} />
           ) : active === "lanes" ? (
             <TabStub
               title="Lanes"

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,27 +2,7 @@ import { useState } from "react";
 import { useLoads } from "@/hooks/useLoads";
 import { useTrips } from "@/hooks/useTrips";
 import { Link } from "react-router-dom";
-import { KpiCard } from "@/components/KpiCard";
-import { Panel } from "@/components/ui/Panel";
 import { Skeleton } from "@/components/ui/skeleton";
-import { BREAK_EVEN_RPM, DEADHEAD_TARGET } from "@/lib/constants/targets";
-import {
-  getRevenueMTD,
-  getRevenueLastMonth,
-  getRevenueYTD,
-  getMonthlyDeadhead,
-  getMonthlyRevenue,
-  getMonthlyRPM,
-  getOutstandingLoads,
-  getLoadsMonthly,
-  getTopAgentsByRevenue,
-  getUpcomingLoads,
-  getRecentDeliveredLoads,
-} from "@/lib/metrics/dashboard";
-import {
-  computeHonors,
-  currentQuarterStandings,
-} from "@/lib/metrics/agentLeaderboard";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { useMaintenanceAlerts } from "@/hooks/useMaintenanceAlerts";
 import { useComplianceAlerts } from "@/hooks/useComplianceAlerts";
@@ -30,16 +10,12 @@ import { useAwardPops } from "@/hooks/useAwardPops";
 import { AwardPopHost } from "@/components/comic/AwardPopHost";
 import { DEMO_AWARDS } from "@/lib/metrics/awards";
 import { latestRecapWithData } from "@/lib/metrics/recap";
-import { RateTargetsCard } from "@/components/dashboard/RateTargetsCard";
 import { MarketChip } from "@/components/dashboard/MarketChip";
-import { GrindMeter } from "@/components/dashboard/GrindMeter";
-import { RevenueChart } from "@/components/RevenueChart";
-import { RpmChart } from "@/components/RpmChart";
-import { OutstandingLoadsList } from "@/components/OutstandingLoadsList";
-import { AlertBanners } from "@/components/dashboard/AlertBanners";
-import { TopAgents } from "@/components/dashboard/TopAgents";
 import { DashboardShell, TabStub, type DashTab } from "@/components/dashboard/DashboardShell";
 import { AgentsTab } from "@/components/dashboard/agents/AgentsTab";
+import { PulseTab } from "@/components/dashboard/PulseTab";
+import { isDispatcher } from "@/lib/roles";
+import DispatchDashboard from "./DispatchDashboard";
 
 const DASH_TABS: DashTab[] = [
   { key: "pulse", label: "Pulse" },
@@ -48,24 +24,6 @@ const DASH_TABS: DashTab[] = [
   { key: "agents", label: "Agents" },
   { key: "fleet", label: "Fleet" },
 ];
-import { WhatsNext } from "@/components/dashboard/WhatsNext";
-import { RecentLoads } from "@/components/dashboard/RecentLoads";
-import { isDispatcher } from "@/lib/roles";
-import DispatchDashboard from "./DispatchDashboard";
-import { money, rpm } from "@/lib/format";
-
-// helpers
-const formatPercent = (ratio: number | null): string =>
-  ratio === null ? "—" : `${(ratio * 100).toFixed(1)}%`;
-
-const computeDelta = (current: number | null, previous: number | null) => {
-  if (current === null || previous === null || previous === 0) return null;
-  const percent = ((current - previous) / previous) * 100;
-  return {
-    percent,
-    direction: percent >= 0 ? ("up" as const) : ("down" as const),
-  };
-};
 
 const OwnerDashboard = () => {
   const [refreshKey] = useState(0);
@@ -114,43 +72,6 @@ const OwnerDashboard = () => {
       </div>
     );
 
-  // ---- compute KPI values ----
-  const revenueMTD = getRevenueMTD(loads);
-  const revenueLastMonth = getRevenueLastMonth(loads);
-  const revenueYTD = getRevenueYTD(loads);
-  const avgRpm = targets.rollingRpm; // rolling 3-complete-month blended RPM
-  const deadhead = getMonthlyDeadhead(loads, trips);
-  const loadsMonthly = getLoadsMonthly(loads);
-
-  const mtdDelta = computeDelta(revenueMTD, revenueLastMonth);
-  const loadsDelta = computeDelta(loadsMonthly.thisMonth, loadsMonthly.lastMonth);
-  const monthlyRevenue = getMonthlyRevenue(loads);
-  const monthlyRpm = getMonthlyRPM(loads);
-  const revenueTrend = monthlyRevenue.map((d) => d.revenue);
-  const rpmTrend = monthlyRpm
-    .map((d) => d.rpm)
-    .filter((r): r is number => r != null);
-  const outstanding = getOutstandingLoads(loads);
-  const topAgents = getTopAgentsByRevenue(loads);
-  const now = new Date();
-  const agentHonors = computeHonors(loads, now);
-  const agentStandings = currentQuarterStandings(loads, now);
-  const upcoming = getUpcomingLoads(loads);
-  const recentLoads = getRecentDeliveredLoads(loads);
-
-  // ---- threshold-based status ----
-  // Live break-even (true cost ÷ loaded miles, last 3 complete months); falls
-  // back to the constant until there's enough P&L history.
-  const liveBreakEven = targets.basis.breakEvenRpm ?? BREAK_EVEN_RPM;
-  const rpmStatus =
-    avgRpm === null ? "neutral" : avgRpm >= liveBreakEven ? "good" : "bad";
-  const deadheadStatus =
-    deadhead.thisMonth === null
-      ? "neutral"
-      : deadhead.thisMonth <= DEADHEAD_TARGET
-        ? "good"
-        : "bad"; // inverted: low is good
-
   return (
     <div className="p-6 bg-iron text-light min-h-screen font-body">
       <AwardPopHost pops={awardDemo ? DEMO_AWARDS : pops} truckAvatarUrl={truckAvatarUrl} />
@@ -170,87 +91,7 @@ const OwnerDashboard = () => {
       >
         {(active) =>
           active === "pulse" ? (
-            <>
-              <AlertBanners alerts={alerts} />
-
-      {/* KPI STRIP */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-        <KpiCard
-          label="Net revenue · MTD"
-          value={money(revenueMTD)}
-          delta={mtdDelta}
-        />
-        <KpiCard
-          label="Net revenue · YTD"
-          value={money(revenueYTD)}
-          trend={revenueTrend}
-        />
-        <KpiCard
-          label="Net RPM · 3mo"
-          value={rpm(avgRpm)}
-          status={rpmStatus}
-          trend={rpmTrend}
-          subtext={
-            avgRpm === null
-              ? undefined
-              : `${avgRpm >= liveBreakEven ? "above" : "below"} $${liveBreakEven.toFixed(2)} break-even`
-          }
-        />
-        <KpiCard
-          label="Deadhead · MTD"
-          value={formatPercent(deadhead.thisMonth)}
-          status={deadheadStatus}
-          subtext={`Last month: ${formatPercent(deadhead.lastMonth)}`}
-        />
-        <KpiCard
-          label="Loads · MTD"
-          value={String(loadsMonthly.thisMonth)}
-          delta={loadsDelta}
-        />
-      </div>
-
-      {/* Rate & pace targets */}
-      <div className="mt-6">
-        <RateTargetsCard targets={targets} />
-      </div>
-
-      {/* The grind — weekly target-beating streak */}
-      <div className="mt-6">
-        <GrindMeter loads={loads} />
-      </div>
-
-      {/* Revenue chart + top agents */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-6">
-        <div className="lg:col-span-2">
-          <RevenueChart data={monthlyRevenue} />
-        </div>
-        <TopAgents
-          agents={topAgents}
-          honors={agentHonors}
-          standings={agentStandings}
-        />
-      </div>
-
-      {/* RPM chart + what's next */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-6">
-        <div className="lg:col-span-2">
-          <RpmChart data={monthlyRpm} breakEven={liveBreakEven} />
-        </div>
-        <Panel noir className="p-4">
-          <p className="text-xs text-muted-text mb-2">What's next · booked</p>
-          <WhatsNext loads={upcoming} />
-        </Panel>
-      </div>
-
-      {/* Recent loads + outstanding */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
-        <Panel noir className="p-4">
-          <p className="text-xs text-muted-text mb-2">Recent loads</p>
-          <RecentLoads loads={recentLoads} />
-        </Panel>
-        <OutstandingLoadsList loads={outstanding} />
-      </div>
-            </>
+            <PulseTab loads={loads} trips={trips} targets={targets} alerts={alerts} />
           ) : active === "money" ? (
             <TabStub
               title="Money"

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -39,6 +39,7 @@ import { OutstandingLoadsList } from "@/components/OutstandingLoadsList";
 import { AlertBanners } from "@/components/dashboard/AlertBanners";
 import { TopAgents } from "@/components/dashboard/TopAgents";
 import { DashboardShell, TabStub, type DashTab } from "@/components/dashboard/DashboardShell";
+import { AgentsTab } from "@/components/dashboard/agents/AgentsTab";
 
 const DASH_TABS: DashTab[] = [
   { key: "pulse", label: "Pulse" },
@@ -271,15 +272,7 @@ const OwnerDashboard = () => {
               ]}
             />
           ) : active === "agents" ? (
-            <TabStub
-              title="Agents"
-              blurb="Who to call."
-              points={[
-                "Rate × volume 'who to call' scatter",
-                "Momentum + the live quarterly board",
-                "Windowed concentration + gut-vs-data flags",
-              ]}
-            />
+            <AgentsTab loads={loads} />
           ) : (
             <TabStub
               title="Fleet"

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1563,6 +1563,16 @@ const GuidePage = () => {
               until they've run 2+ delivered loads, so one lucky run never crowns
               anyone — the same restraint the lane and rate metrics use.
             </p>
+            <p className="text-sm text-muted-text mt-3">
+              <span className="text-light">Concentration</span> is measured over
+              your <span className="text-light">last 90 days</span>, not your
+              lifetime — an agent who's gone cold isn't a dependency you still feel,
+              so they drop out. Each agent's <span className="text-light">% of
+              book</span> is shown in the table; the rule of thumb is no single
+              agent over <span className="text-light">~30%</span> and your top 3
+              under <span className="text-light">~65%</span>, so losing one wouldn't
+              sink you.
+            </p>
           </Section>
 
           <Section

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -91,6 +91,26 @@ const Section = ({
   </section>
 );
 
+// One dashboard tab in the overview: its name, the question it answers, and what
+// lives on it.
+const TabLine = ({
+  name,
+  q,
+  children,
+}: {
+  name: string;
+  q: string;
+  children: ReactNode;
+}) => (
+  <div className="rounded-md p-3" style={{ background: "#0d1119", border: "1px solid #22304a" }}>
+    <p className="text-sm">
+      <span className="font-condensed font-bold" style={{ color: AMBER_HI }}>{name}</span>
+      <span className="text-muted-text"> — {q}</span>
+    </p>
+    <p className="text-xs text-muted-text mt-1">{children}</p>
+  </div>
+);
+
 // One row in the award catalog: emblem + name + how to earn it.
 const AwardLine = ({
   icon,
@@ -302,6 +322,10 @@ const GroupHeading = ({ children }: { children: string }) => (
 // section anchors. Keep this in step with the sections as the guide grows.
 const NAV: { group: string; items: string[] }[] = [
   {
+    group: "The dashboard",
+    items: ["The tabbed dashboard — five views of your operation"],
+  },
+  {
     group: "The money",
     items: [
       "Your net revenue — what you actually keep",
@@ -507,8 +531,52 @@ const GuidePage = () => {
 
         <main className="flex-1 min-w-0 max-w-3xl">
           <h2
-            id={slug("The money")}
+            id={slug("The dashboard")}
             className="font-condensed text-2xl mb-3 scroll-mt-6"
+            style={{ color: AMBER_HI }}
+          >
+            The dashboard
+          </h2>
+
+          <Section title="The tabbed dashboard — five views of your operation">
+            <p className="text-sm text-muted-text mb-3">
+              The dashboard is split into tabs, each answering one question at a
+              glance. Pick a tab and it stays put — dash remembers where you left
+              off next time you open it.
+            </p>
+            <div className="flex flex-col gap-2.5">
+              <TabLine name="Pulse" q="How's my day going?">
+                This pay week's earnings vs your target, your booking rate against
+                your floor, what's booked next, the settlement pipeline, and any
+                overdue maintenance or compliance — the two most urgent show, the
+                rest fold behind a tap.
+              </TabLine>
+              <TabLine name="Money" q="Am I profitable?">
+                Year-to-date income, operating profit and margin against your goal,
+                the monthly P&amp;L, your margin trend, where the money goes by
+                expense category, and what's delivered but not yet settled.
+              </TabLine>
+              <TabLine name="Lanes" q="Where does my freight run?">
+                The U.S. map shaded by your $/mi (fire marks your best-paying
+                markets), your top lanes by gross, and your load-type mix —
+                oversize, flatbed, specialized. The 30/60/90 toggle sets both the
+                window and how finely the map groups.
+              </TabLine>
+              <TabLine name="Agents" q="Who should I call?">
+                Your bench plotted by rate × volume, momentum vs the prior 90 days,
+                the live quarter board, revenue concentration (so no one agent owns
+                too much of your book), and who's going cold.
+              </TabLine>
+              <TabLine name="Fleet" q="Asset health">
+                Truck and driver utilization, fuel MPG trend, and next service due.
+                <span style={{ color: AMBER }}> Coming soon.</span>
+              </TabLine>
+            </div>
+          </Section>
+
+          <h2
+            id={slug("The money")}
+            className="font-condensed text-2xl mb-3 mt-8 scroll-mt-6"
             style={{ color: AMBER_HI }}
           >
             The money

--- a/frontend/src/services/expensesService.ts
+++ b/frontend/src/services/expensesService.ts
@@ -1,6 +1,11 @@
 import api from "./api";
 import { dedupe } from "@/lib/dedupe";
-import type { ExpensePeriod, ExpenseLine, ExpenseType } from "@/types/expense";
+import type {
+  ExpensePeriod,
+  ExpenseLine,
+  ExpenseType,
+  CategorySpend,
+} from "@/types/expense";
 
 // NUMERIC columns arrive as strings — coerce at the boundary.
 const num = (v: unknown): number | null =>
@@ -43,6 +48,24 @@ export const getExpensePeriod = async (id: string): Promise<ExpensePeriod> => {
     return coercePeriod(res.data.period);
   } catch {
     throw new Error("Unable to fetch expense period");
+  }
+};
+
+// Spending by category across a calendar year (all sections, largest first) —
+// the backend does the GROUP BY, we just coerce the numeric amount.
+export const getExpenseCategoryRollup = async (
+  year: number,
+): Promise<CategorySpend[]> => {
+  try {
+    const res = await api.get("/expenses/categories", { params: { year } });
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    return res.data.categories.map((c: any) => ({
+      category: c.category,
+      amount: Number(c.amount),
+      section: c.section,
+    }));
+  } catch {
+    throw new Error("Unable to fetch category spending");
   }
 };
 

--- a/frontend/src/types/expense.ts
+++ b/frontend/src/types/expense.ts
@@ -18,3 +18,10 @@ export interface ExpensePeriod {
   expense_total: number | null;
   lines?: ExpenseLine[];
 }
+
+// One category's total spend over some window (a month, or a year's rollup).
+export interface CategorySpend {
+  category: string;
+  amount: number;
+  section: ExpenseSection;
+}


### PR DESCRIPTION
Redesigns the owner dashboard into a **tabbed, full-height, above-the-fold** layout — each tab a chart-driven view that tells one story at a glance. Ships four real tabs (Pulse, Money, Lanes, Agents) plus a Fleet placeholder. Design-first mockups approved by Jason for each tab.

## Tabs
- **Pulse** — the day: pay-week hero, rate-vs-floor gauge, vital signs, weekly earnings, what's booked, the grind. Overdue maintenance/compliance now compact (two most urgent + a fold).
- **Money** — profitability: YTD P&L KPIs vs margin goal, monthly P&L bars, margin trend, YTD spend by category (new `/expenses/categories` rollup endpoint), settlement pipeline (no aging).
- **Lanes** — geography: the shipped US `$/mi` choropleth (flat variant), top lanes by gross, load-type mix. Gross-per-lane/origin + `getLoadTypeMix` added to `lanes.ts` (frontend).
- **Agents** — the bench: rate×volume scatter, momentum, live quarter board, windowed concentration, going-cold.
- **Fleet** — placeholder ("coming soon"); built next.

## Layout
- `AppLayout` main is a flex column; the dashboard fills the space below the top bar on desktop, stays natural/scrollable on mobile (Brandie's view). Full width like the rest of the app. Charts scale up with aspect preserved.

## Verification
- All four tabs verified on dev (owner) + mobile; overflow 0 on each.
- `/expenses/categories` verified against the dev DB.
- Production build clean; 470 tests pass.
- Guide updated with a "The dashboard" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)