### PR TITLE
fix: dashboard natural height, not forced-fit (v1.136.1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.136.0",
+  "version": "1.136.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/DashboardShell.tsx
+++ b/frontend/src/components/dashboard/DashboardShell.tsx
@@ -30,7 +30,7 @@ export const DashboardShell = ({
 
   return (
     <div
-      className="rounded-2xl overflow-hidden lg:flex-1 lg:flex lg:flex-col lg:min-h-0"
+      className="rounded-2xl overflow-hidden"
       style={{ background: "#0b111b", border: "1px solid #26304a" }}
     >
       <div
@@ -56,9 +56,7 @@ export const DashboardShell = ({
         ))}
         {right && <div className="ml-auto flex items-center gap-3">{right}</div>}
       </div>
-      <div className="p-4 sm:p-5 lg:flex-1 lg:flex lg:flex-col lg:min-h-0">
-        {children(active)}
-      </div>
+      <div className="p-4 sm:p-5">{children(active)}</div>
     </div>
   );
 };
@@ -75,8 +73,8 @@ export const TabStub = ({
   points: string[];
 }) => (
   <div
-    className="rounded-xl p-6 text-center flex flex-col items-center justify-center lg:flex-1 lg:min-h-0"
-    style={{ background: "#0f1622", border: "1px dashed #2a3347", minHeight: 260 }}
+    className="rounded-xl p-6 text-center flex flex-col items-center justify-center"
+    style={{ background: "#0f1622", border: "1px dashed #2a3347", minHeight: 360 }}
   >
     <p className="font-condensed text-2xl text-light">{title}</p>
     <p className="text-sm text-muted-text mt-1 mb-4">{blurb}</p>

--- a/frontend/src/components/dashboard/LanesTab.tsx
+++ b/frontend/src/components/dashboard/LanesTab.tsx
@@ -58,7 +58,7 @@ export const LanesTab = ({ loads }: { loads: Load[] }) => {
   const rate = summary.topRpmLane;
 
   return (
-    <div className="flex flex-col gap-3 lg:flex-1 lg:min-h-0">
+    <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-3 flex-wrap">
         <div>
           <h2 className="text-xl font-condensed text-light leading-none">The lanes</h2>
@@ -96,9 +96,9 @@ export const LanesTab = ({ loads }: { loads: Load[] }) => {
         />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 lg:flex-1 lg:min-h-0">
+      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 items-start">
         {/* the map (real shipped component, flat for the dashboard) */}
-        <div className="min-h-0 min-w-0">
+        <div className="min-w-0">
           <LanesMap
             data={mapData}
             level={level}
@@ -109,13 +109,13 @@ export const LanesTab = ({ loads }: { loads: Load[] }) => {
           />
         </div>
 
-        <div className="flex flex-col gap-3 lg:min-h-0">
+        <div className="flex flex-col gap-3">
           {/* top lanes by gross */}
-          <div className="rounded-xl p-3.5 flex flex-col lg:flex-1 lg:min-h-0" style={C}>
+          <div className="rounded-xl p-3.5 flex flex-col" style={C}>
             <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-1 flex justify-between">
               Top lanes <span className="normal-case tracking-normal font-normal">by gross · {windowDays}d</span>
             </h3>
-            <div className="flex-1 min-h-0 flex flex-col justify-between py-1">
+            <div className="flex flex-col">
               {topLanes.length === 0 ? (
                 <p className="text-xs text-muted-text py-4">No delivered lanes in this window.</p>
               ) : (

--- a/frontend/src/components/dashboard/MoneyTab.tsx
+++ b/frontend/src/components/dashboard/MoneyTab.tsx
@@ -78,7 +78,7 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
   const x0 = (620 - colW * bars.length) / 2;
 
   return (
-    <div className="flex flex-col gap-3 lg:flex-1 lg:min-h-0">
+    <div className="flex flex-col gap-3">
       <div className="flex items-baseline justify-between">
         <h2 className="text-xl font-condensed text-light">The money</h2>
         <span className="text-xs text-muted-text">P&amp;L · margin · where it goes — {year} to date</span>
@@ -96,13 +96,13 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
         <Tile label="Best month" value={best ? `${monthShort(best.month)} · ${Math.round(best.margin * 100)}%` : "—"} sub={best ? `${money(best.profit)} profit` : ""} />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 lg:flex-1 lg:min-h-0">
+      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3">
         {/* monthly P&L */}
-        <div className="rounded-xl p-3 pb-2.5 flex flex-col" style={C}>
+        <div className="rounded-xl p-3 pb-2.5" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-1 flex justify-between">
             Monthly P&amp;L <span className="normal-case tracking-normal text-muted-text font-normal">income = kept + spent</span>
           </h3>
-          <svg viewBox="0 0 620 168" className="w-full lg:flex-1 lg:min-h-0" preserveAspectRatio="xMidYMid meet">
+          <svg viewBox="0 0 620 168" className="w-full">
             <line x1="0" y1="140" x2="620" y2="140" stroke="#1c2536" />
             {bars.map((r, i) => {
               const incH = Math.max(2, (r.income / barMax) * H);
@@ -132,9 +132,9 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
         </div>
 
         {/* margin trend */}
-        <div className="rounded-xl p-3 flex flex-col" style={C}>
+        <div className="rounded-xl p-3" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">Margin trend</h3>
-          <svg viewBox="0 0 320 140" className="w-full lg:flex-1 lg:min-h-0" preserveAspectRatio="xMidYMid meet">
+          <svg viewBox="0 0 320 140" className="w-full">
             {marginGoal != null && (
               <>
                 <line x1="8" y1={120 - marginGoal * 220} x2="312" y2={120 - marginGoal * 220} stroke="#4ade80" strokeDasharray="4 4" opacity={0.5} />
@@ -156,8 +156,8 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
       </div>
 
       {/* where it goes (year to date, by category) + pipeline */}
-      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 lg:flex-1 lg:min-h-0">
-        <div className="rounded-xl p-3.5 flex flex-col" style={C}>
+      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3">
+        <div className="rounded-xl p-3.5" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5 flex justify-between">
             Where it goes · {year}
             <span className="normal-case tracking-normal font-normal">{money(ytdIncome)} income</span>
@@ -193,7 +193,7 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
           )}
         </div>
 
-        <div className="rounded-xl p-3.5 flex flex-col justify-center" style={C}>
+        <div className="rounded-xl p-3.5" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">Settlement pipeline</h3>
           <p className="text-[26px] font-extrabold" style={{ color: "#4ade80" }}>{money(pipeline)}</p>
           <p className="text-[11px] text-muted-text mt-1">Delivered, POD in, not yet settled — landing on your upcoming weekly settlement(s). No aging: it clears every week.</p>

--- a/frontend/src/components/dashboard/PulseTab.tsx
+++ b/frontend/src/components/dashboard/PulseTab.tsx
@@ -96,7 +96,7 @@ export const PulseTab = ({
   const paceMeta = PACE[pace.verdict];
 
   return (
-    <div className="flex flex-col gap-3 lg:flex-1 lg:min-h-0">
+    <div className="flex flex-col gap-3">
       <AlertBanners alerts={alerts} />
 
       {/* hero — the pay week */}
@@ -149,13 +149,13 @@ export const PulseTab = ({
         <Tile label="Earned · MTD" value={money(mtd)} sub="gross delivered" />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[1.55fr_1fr] gap-3 lg:flex-1 lg:min-h-0">
+      <div className="grid grid-cols-1 lg:grid-cols-[1.55fr_1fr] gap-3">
         {/* weekly earnings */}
-        <div className="rounded-xl p-3.5 flex flex-col" style={C}>
+        <div className="rounded-xl p-3.5" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2 flex justify-between">
             Weekly earnings <span className="normal-case tracking-normal">last 8 weeks · gross</span>
           </h3>
-          <svg viewBox="0 0 620 150" className="w-full lg:flex-1 lg:min-h-0" preserveAspectRatio="xMidYMid meet">
+          <svg viewBox="0 0 620 150" className="w-full">
             {weeklyTarget && (
               <>
                 <line x1="0" y1={140 - (weeklyTarget / weekMax) * 120} x2="620" y2={140 - (weeklyTarget / weekMax) * 120} stroke="#4ade80" strokeWidth={1} strokeDasharray="4 4" opacity={0.6} />
@@ -179,7 +179,7 @@ export const PulseTab = ({
         </div>
 
         {/* rate vs floor gauge */}
-        <div className="rounded-xl p-3.5 flex flex-col justify-center" style={C}>
+        <div className="rounded-xl p-3.5" style={C}>
           <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-4">Rate vs your floor</h3>
           <div className="relative h-6 rounded-md" style={{ background: "linear-gradient(90deg,#3a1a1a,#3a2a0a 40%,#12261a)", border: "1px solid #26304a" }}>
             {(["walkAway", "target", "strong"] as const).map((k, i) =>
@@ -214,8 +214,8 @@ export const PulseTab = ({
       </div>
 
       {/* what's next + the grind */}
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr] gap-3 lg:flex-1 lg:min-h-0">
-        <div className="rounded-xl p-4 flex flex-col" style={C}>
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr] gap-3">
+        <div className="rounded-xl p-4" style={C}>
           <p className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">What's next · booked</p>
           <WhatsNext loads={upcoming} />
         </div>

--- a/frontend/src/components/dashboard/agents/AgentScatter.tsx
+++ b/frontend/src/components/dashboard/agents/AgentScatter.tsx
@@ -63,7 +63,7 @@ export const AgentScatter = ({ points }: { points: ScatterPoint[] }) => {
     );
 
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} className="w-full lg:flex-1 lg:min-h-0" preserveAspectRatio="xMidYMid meet">
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full">
       {/* gridlines */}
       {geom.yTicks.map((t, i) => (
         <g key={i}>

--- a/frontend/src/components/dashboard/agents/AgentsTab.tsx
+++ b/frontend/src/components/dashboard/agents/AgentsTab.tsx
@@ -143,7 +143,7 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
   const elseShare = Math.max(0, 1 - topShares.reduce((s, x) => s + x.share, 0));
 
   return (
-    <div className="flex flex-col gap-3 lg:flex-1 lg:min-h-0">
+    <div className="flex flex-col gap-3">
       <div className="flex items-baseline justify-between">
         <h2 className="text-xl font-condensed text-light">Your agent bench</h2>
         <span className="text-xs text-muted-text">
@@ -190,7 +190,7 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
       </div>
 
       {/* hero scatter */}
-      <div className="rounded-xl p-3 flex flex-col lg:flex-1 lg:min-h-0" style={C.card}>
+      <div className="rounded-xl p-3" style={C.card}>
         <div className="flex items-center justify-between mb-1">
           <span className="text-[13px] font-bold text-light">Who to call — rate × volume</span>
           <span className="text-[11px] text-muted-text">bubble = revenue · click to open an agent</span>

--- a/frontend/src/components/lanes/LanesMap.tsx
+++ b/frontend/src/components/lanes/LanesMap.tsx
@@ -176,7 +176,7 @@ export const LanesMap = ({ data, level, windowDays, selected, onSelect, noir = t
   const drillHint = level === "state" ? "click a state to drill in" : "click a region to drill in";
 
   return (
-    <Panel ref={containerRef} noir={noir} className="p-4 relative h-full flex flex-col">
+    <Panel ref={containerRef} noir={noir} className="p-4 relative">
       <div className="text-xs text-muted-text mb-2 flex items-center gap-2 flex-wrap">
         <span>Shade by</span>
         {toggle("rate", "your $/mi")}
@@ -186,7 +186,7 @@ export const LanesMap = ({ data, level, windowDays, selected, onSelect, noir = t
         </span>
         <span>· grouped by {levelWord} · {drillHint}</span>
       </div>
-      <svg viewBox="0 0 900 560" className="w-full flex-1 min-h-0" preserveAspectRatio="xMidYMid meet">
+      <svg viewBox="0 0 900 560" className="w-full">
         {shapes.map((s, i) => {
           const datum = data[s.key];
           const isSel = selected === s.key;

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -16,7 +16,7 @@ const AppLayout = () => {
               sideways. Wide content that must scroll keeps its own overflow-x-auto
               scroller, so this only clips true page-level overflow, never a table.
               overflow-y stays auto, so vertical scroll and sticky children work. */}
-          <main className="flex-1 min-w-0 flex flex-col overflow-y-auto overflow-x-hidden bg-background text-foreground">
+          <main className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden bg-background text-foreground">
             <div className="p-3 border-b border-border">
               <SidebarTrigger />
             </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -75,7 +75,7 @@ const OwnerDashboard = () => {
     );
 
   return (
-    <div className="p-6 bg-iron text-light min-h-screen font-body lg:flex lg:flex-col lg:flex-1 lg:min-h-0">
+    <div className="p-6 bg-iron text-light min-h-screen font-body">
       <AwardPopHost pops={awardDemo ? DEMO_AWARDS : pops} truckAvatarUrl={truckAvatarUrl} />
       <DashboardShell
         tabs={DASH_TABS}


### PR DESCRIPTION
Hotfix for v1.136.0. The "fill the viewport" work used flexbox (`lg:flex-1` + `min-h-0` on rows and SVG charts) to force each tab into the exact viewport height. On any viewport shorter than the content, that **compressed** everything to fit — charts squished, the agent scatter collapsed into a line, panels overlapping.

Reverts to natural document flow: main content sits above the fold, the rest scrolls below (the actual intent). Charts render at natural aspect (bigger now that the dashboard is full-width, never forced). Kept full-width + the compact AlertBanners from v1.136.0.

Verified all four tabs at a 1366×768 laptop viewport — no crunch, no overlap, main content above the fold, secondary content scrolls. Build clean, 470 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)