### PR TITLE
feat: Pulse tab to spec — What's Next + On-time, no redundant tiles (v1.137.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.136.1",
+  "version": "1.137.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/PulseTab.tsx
+++ b/frontend/src/components/dashboard/PulseTab.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/metrics/dashboard";
 import { loadRevenue } from "@/lib/metrics/loads";
 import { getQuarterPace } from "@/lib/metrics/quarterPace";
+import { agentStops, scoreStops } from "@/lib/metrics/stopScore";
 import { AlertBanners } from "@/components/dashboard/AlertBanners";
 import type { Alert } from "@/types/alert";
 import { GrindMeter } from "@/components/dashboard/GrindMeter";
@@ -72,6 +73,20 @@ export const PulseTab = ({
     [loads],
   );
 
+  // Your delivery punctuality — did YOU hit the appointment at the dock — over the
+  // last 90 days of delivered loads. freeHours doesn't affect on-time (it grades
+  // detention, not the appointment), so a default is fine here. null until 3 graded.
+  const onTimePct = useMemo(() => {
+    const cutoff = now.getTime() - 90 * 86_400_000;
+    const recent = loads.filter(
+      (l) =>
+        l.load_status === "delivered" &&
+        l.delivery_date &&
+        new Date(l.delivery_date).getTime() >= cutoff,
+    );
+    return scoreStops(agentStops(recent, 3)).onTimePct;
+  }, [loads, now]);
+
   // Last 8 pay-weeks of gross earned, anchored to the configured week start.
   const weeks = useMemo(() => {
     const anchor: Date = targets.weekStart ? new Date(targets.weekStart) : now;
@@ -117,9 +132,6 @@ export const PulseTab = ({
             ) : null}
             <b style={{ color: "#4ade80" }}>{money(committed)}</b> committed & booked ahead
           </p>
-          <p className="text-[11.5px] text-muted-text mt-1.5">
-            Landing on settlement: <b style={{ color: "#4ade80" }}>{money(pipeline)}</b> (delivered, POD in)
-          </p>
         </div>
         <div className="md:border-l md:pl-4 flex flex-col justify-center gap-2.5" style={{ borderColor: "#26304a" }}>
           <div>
@@ -146,7 +158,12 @@ export const PulseTab = ({
         <Tile label="Deadhead" value={deadhead != null ? `${Math.round(deadhead * 100)}%` : "—"} sub="odometer-true" color={deadhead != null && deadhead <= 0.2 ? "#4ade80" : "#f5a623"} />
         <Tile label="Avg net $/mi" value={targets.rollingRpm != null ? fmtRpm(targets.rollingRpm) : "—"} sub={targets.basis?.breakEvenRpm != null ? `break-even ${fmtRpm(targets.basis.breakEvenRpm)}` : "3-mo blended"} />
         <Tile label="Pipeline" value={money(pipeline)} sub="delivered, not yet settled" />
-        <Tile label="Earned · MTD" value={money(mtd)} sub="gross delivered" />
+        <Tile
+          label="On-time"
+          value={onTimePct != null ? `${Math.round(onTimePct * 100)}%` : "—"}
+          sub={onTimePct != null ? "you hit the appointment · 90d" : "needs 3+ timed stops"}
+          color={onTimePct == null ? undefined : onTimePct >= 0.9 ? "#4ade80" : onTimePct >= 0.75 ? undefined : "#f5a623"}
+        />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-[1.55fr_1fr] gap-3">
@@ -216,7 +233,9 @@ export const PulseTab = ({
       {/* what's next + the grind */}
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr] gap-3">
         <div className="rounded-xl p-4" style={C}>
-          <p className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">What's next · booked</p>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2 flex justify-between">
+            What's next <span className="normal-case tracking-normal font-normal">booked · picking up</span>
+          </h3>
           <WhatsNext loads={upcoming} />
         </div>
         <GrindMeter loads={loads} />

--- a/frontend/src/components/dashboard/WhatsNext.tsx
+++ b/frontend/src/components/dashboard/WhatsNext.tsx
@@ -1,17 +1,28 @@
 import { Link } from "react-router-dom";
 import type { UpcomingLoad } from "@/lib/metrics/dashboard";
+import { money } from "@/lib/format";
 
 interface Props {
   loads: UpcomingLoad[];
 }
 
-// Format in UTC to avoid the local-timezone day-shift on date-only strings.
+// Weekday + date, in UTC to avoid the local-timezone day-shift on date-only strings.
 const fmtDate = (iso: string): string =>
   new Date(iso).toLocaleDateString("en-US", {
+    weekday: "short",
     month: "short",
     day: "numeric",
     timeZone: "UTC",
   });
+
+const OVR = () => (
+  <span
+    className="text-[8px] font-extrabold tracking-wide px-1.5 py-0.5 rounded"
+    style={{ color: "#f5b03a", background: "#3a2408", border: "1px solid #85560b" }}
+  >
+    OVR
+  </span>
+);
 
 export const WhatsNext = ({ loads }: Props) => {
   if (loads.length === 0)
@@ -23,13 +34,19 @@ export const WhatsNext = ({ loads }: Props) => {
         <Link
           key={load.load_id}
           to={`/loads/${load.load_id}`}
-          className="flex justify-between text-sm py-1.5 border-t border-steel first:border-t-0 hover:opacity-80"
+          className="flex items-start justify-between gap-2 py-1.5 hover:opacity-80 border-t first:border-t-0"
+          style={{ borderColor: "#1a2233" }}
         >
-          <span className="text-light truncate">
-            #{load.load_number} · {load.lane}
+          <span className="min-w-0 flex flex-col">
+            <span className="text-[12px] text-light truncate flex items-center gap-1.5">
+              {load.lane}
+              {load.oversize && <OVR />}
+            </span>
+            <span className="text-[10px] text-muted-text truncate">{load.agent}</span>
           </span>
-          <span className="text-muted-text whitespace-nowrap ml-2">
-            {fmtDate(load.pickup_date)}
+          <span className="shrink-0 text-right flex flex-col">
+            <span className="text-[12px] font-bold">{money(load.gross)}</span>
+            <span className="text-[10px] text-muted-text">{fmtDate(load.pickup_date)}</span>
           </span>
         </Link>
       ))}

--- a/frontend/src/lib/metrics/dashboard.test.ts
+++ b/frontend/src/lib/metrics/dashboard.test.ts
@@ -347,6 +347,35 @@ describe("getUpcomingLoads", () => {
     expect(up.map((u) => u.load_number)).toEqual(["A", "B"]);
     expect(up[0].pickup_date).toBe("2026-07-05");
   });
+
+  it("carries agent, all-in gross, and the oversize flag", () => {
+    const loads = [
+      makeLoad({
+        load_number: "X",
+        load_status: "booked",
+        pickup_date: "2026-07-20",
+        agent: "Jane Doe",
+        load_type: "Oversize / permit",
+        linehaul: "2000.00",
+        fuel_surcharge: "300.00",
+        total_accessorials: "150.00",
+      }),
+      makeLoad({
+        load_number: "Y",
+        load_status: "booked",
+        pickup_date: "2026-07-21",
+        agent: "Bob Roe",
+        load_type: "standard flatbed",
+        linehaul: "1000",
+        fuel_surcharge: "0",
+        total_accessorials: "0",
+      }),
+    ];
+    const up = getUpcomingLoads(loads, 5);
+    // gross = linehaul + fuel_surcharge + accessorials (numeric strings coerced)
+    expect(up[0]).toMatchObject({ agent: "Jane Doe", gross: 2450, oversize: true });
+    expect(up[1]).toMatchObject({ agent: "Bob Roe", gross: 1000, oversize: false });
+  });
 });
 
 // ---- GET REVENUE MTD TEST ----

--- a/frontend/src/lib/metrics/dashboard.ts
+++ b/frontend/src/lib/metrics/dashboard.ts
@@ -468,6 +468,9 @@ export interface UpcomingLoad {
   load_number: string;
   lane: string;
   pickup_date: string;
+  agent: string; // who booked it
+  gross: number; // all-in booked value (market rate, matches "committed & booked")
+  oversize: boolean; // load_type reads oversize → OVR badge
 }
 
 export const getUpcomingLoads = (loads: Load[], limit = 5): UpcomingLoad[] => {
@@ -484,6 +487,12 @@ export const getUpcomingLoads = (loads: Load[], limit = 5): UpcomingLoad[] => {
     load_number: load.load_number,
     lane: `${load.origin_market} → ${load.delivery_market}`,
     pickup_date: load.pickup_date,
+    agent: load.agent,
+    gross:
+      Number(load.linehaul) +
+      Number(load.fuel_surcharge) +
+      Number(load.total_accessorials),
+    oversize: /over/i.test(load.load_type ?? ""),
   }));
 };
 


### PR DESCRIPTION
Brings the Pulse tab back in line with the approved mockup and removes two KPI redundancies Jason caught.

**What's Next** — now matches the mockup: lane + **OVR badge** (oversize) + **agent** + **all-in gross** + pickup day, instead of `#load · lane · date`. `getUpcomingLoads` carries agent/gross/oversize (unit-tested).

**KPI strip** — two tiles just echoed the hero:
- **Earned·MTD** (identical number) → replaced with **On-time %** — your own dock punctuality (did *you* hit the appointment), last 90 days.
- **Pipeline** (hero said "landing on settlement $X") → kept the scannable tile, dropped the duplicate hero line.

**The Grind** stays the comic GrindMeter (Jason's call). Utilization was proposed and rejected — it's a fleet metric, going on the Fleet tab.

Verified on dev at a 1366×768 laptop viewport. Build clean, 470 tests pass (+1 for the enriched upcoming-loads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)