### PR TITLE
feat: Fleet tab — the rig at a glance (v1.138.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.137.0",
+  "version": "1.138.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/FleetTab.tsx
+++ b/frontend/src/components/dashboard/FleetTab.tsx
@@ -1,0 +1,320 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import type { Load } from "@/types/load";
+import { useFleetData } from "@/hooks/useFleetData";
+import { computeTruckMetrics } from "@/lib/metrics/truckMetrics";
+import { computeDue, fleetHealth, type Due, type DueLevel } from "@/lib/metrics/maintenance";
+import { shopSpend, fleetHeatmap, type DayStatus } from "@/lib/metrics/fleet";
+import { hometimeStatus } from "@/lib/metrics/hometime";
+import { itemToCheckable, cdlToCheckable, computeComplianceDue, type ComplianceLevel } from "@/lib/metrics/compliance";
+import { mpgWindows, monthlyFuelPrice } from "@/lib/metrics/fuelEconomy";
+import { money, rpm, dieselPrice } from "@/lib/format";
+
+const C = { background: "#0f1622", border: "1px solid #26304a" } as const;
+const TILE = { background: "#121a27", border: "1px solid #26304a" } as const;
+const HOME_TARGET = 14;
+
+const DAY_FILL: Record<DayStatus, string> = { underload: "#2f7d55", home: "#3a5170", idle: "#232c3d" };
+const DUE_DOT: Record<DueLevel, string> = { overdue: "#f87171", soon: "#f5a623", ok: "#2f7d55", unknown: "#5b6577" };
+const DUE_RANK: Record<DueLevel, number> = { overdue: 0, soon: 1, ok: 2, unknown: 3 };
+const COMP: Record<ComplianceLevel, { cls: string }> = {
+  expired: { cls: "text-status-negative-text" }, expiring: { cls: "text-status-aware-text" },
+  valid: { cls: "text-status-positive-text" }, unknown: { cls: "text-muted-text" },
+};
+
+const Tile = ({ label, value, sub, color, warn }: { label: string; value: string; sub: string; color?: string; warn?: boolean }) => (
+  <div className="rounded-xl px-3.5 py-3" style={warn ? { background: "#1c1408", border: "1px solid #7a3b12" } : TILE}>
+    <p className="text-[9.5px] uppercase tracking-wide text-muted-text">{label}</p>
+    <p className="text-[17px] font-bold mt-0.5 leading-tight truncate" style={{ color }}>{value}</p>
+    <p className="text-[10px] text-muted-text mt-0.5 truncate">{sub}</p>
+  </div>
+);
+
+const H3 = ({ children, right }: { children: React.ReactNode; right?: React.ReactNode }) => (
+  <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5 flex justify-between items-center">
+    {children}
+    {right}
+  </h3>
+);
+
+// miles preferred, else days; sign → overdue / remaining
+const remain = (d: Due): string => {
+  if (d.milesRemaining != null)
+    return d.milesRemaining < 0
+      ? `overdue ${Math.abs(Math.round(d.milesRemaining)).toLocaleString()} mi`
+      : `in ${Math.round(d.milesRemaining).toLocaleString()} mi`;
+  if (d.daysRemaining != null)
+    return d.daysRemaining < 0 ? `overdue ${Math.abs(Math.round(d.daysRemaining))}d` : `in ${Math.round(d.daysRemaining)}d`;
+  return "";
+};
+
+export const FleetTab = ({ loads }: { loads: Load[] }) => {
+  const now = useMemo(() => new Date(), []);
+  const fleet = useFleetData();
+  const truck = fleet.trucks[0] ?? null;
+  const trailer = fleet.trailers[0] ?? null;
+
+  // single owner-operator: all loads are this truck's
+  const metrics = useMemo(
+    () => (truck ? computeTruckMetrics(truck, loads, fleet.fuel, fleet.services, now, fleet.homeDays) : null),
+    [truck, loads, fleet.fuel, fleet.services, fleet.homeDays, now],
+  );
+  const shop = useMemo(() => shopSpend(fleet.services, now, 12), [fleet.services, now]);
+  const heat = useMemo(() => fleetHeatmap(loads, fleet.homeDays, now, 26), [loads, fleet.homeDays, now]);
+
+  const home = useMemo(() => {
+    const todayKey = now.toISOString().slice(0, 10);
+    const lastHome = fleet.homeDays.filter((d) => d <= todayKey).sort().at(-1) ?? null;
+    return hometimeStatus(lastHome, HOME_TARGET, now);
+  }, [fleet.homeDays, now]);
+
+  const dues = useMemo(() => {
+    const cur = truck ? Number(truck.current_odometer) || null : null;
+    const mpm = metrics?.milesPerMonth ?? null;
+    return fleet.items
+      .filter((i) => i.active)
+      .map((i) => ({ name: i.name, due: computeDue(i, cur, now, mpm) }))
+      .sort((a, b) => DUE_RANK[a.due.level] - DUE_RANK[b.due.level] || (a.due.etaDate ?? "9") < (b.due.etaDate ?? "9") ? -1 : 1);
+  }, [fleet.items, truck, metrics, now]);
+
+  const counts = {
+    overdue: dues.filter((d) => d.due.level === "overdue").length,
+    soon: dues.filter((d) => d.due.level === "soon").length,
+    ok: dues.filter((d) => d.due.level === "ok").length,
+  };
+  const health = fleetHealth(counts);
+  const nextSoon = dues.find((d) => d.due.level === "soon");
+
+  const chips = useMemo(() => {
+    const checkables = [
+      ...fleet.compliance.filter((c) => c.active).map(itemToCheckable),
+      ...fleet.drivers.filter((d) => d.cdl_expiration).map(cdlToCheckable),
+    ];
+    return checkables
+      .map((c) => ({ label: c.label, ...computeComplianceDue(c, now) }))
+      .sort((a, b) => (a.level === "expired" ? 0 : a.level === "expiring" ? 1 : 2) - (b.level === "expired" ? 0 : b.level === "expiring" ? 1 : 2))
+      .slice(0, 6);
+  }, [fleet.compliance, fleet.drivers, now]);
+
+  const mpgSeries = useMemo(() => mpgWindows(fleet.fuel).slice(-8).map((w) => w.mpg), [fleet.fuel]);
+  const paidPerGal = useMemo(() => monthlyFuelPrice(fleet.fuel).at(-1)?.avgPrice ?? null, [fleet.fuel]);
+
+  // Split fuel vs maintenance from the SPEND components (both dollars) so the
+  // shares always sit in 0–100% and the per-mile figures share one denominator.
+  const costPerMile = metrics?.costToRunPerMile ?? null; // (fuel + maint) ÷ total miles
+  const runSpend = (metrics?.fuelSpend ?? 0) + (metrics?.maintSpend ?? 0);
+  const tMiles = metrics?.totalMiles ?? 0;
+  const fuelPerMile = tMiles > 0 ? (metrics?.fuelSpend ?? 0) / tMiles : null;
+  const maintPerMile = tMiles > 0 ? (metrics?.maintSpend ?? 0) / tMiles : null;
+  const fuelPct = runSpend > 0 ? Math.round(((metrics?.fuelSpend ?? 0) / runSpend) * 100) : null;
+  const dieselGap = paidPerGal != null && fleet.nationalDiesel != null ? paidPerGal - fleet.nationalDiesel : null;
+
+  if (fleet.loading)
+    return <div className="text-sm text-muted-text py-12 text-center">Loading your rig…</div>;
+  if (!truck)
+    return (
+      <div className="text-sm text-muted-text py-12 text-center">
+        No truck yet. <Link to="/trucks" className="text-status-info-text hover:underline">Add your truck</Link> to light this up.
+      </div>
+    );
+
+  const rigName = [truck.year, truck.make, truck.model].filter(Boolean).join(" ") || "Your truck";
+  const trailerName = trailer ? [trailer.year, trailer.make, trailer.model].filter(Boolean).join(" ") : null;
+  const util = metrics?.utilization ?? null;
+  const pct = (n: number) => `${Math.round(n * 100)}%`;
+
+  // util breakdown bar widths (guard the empty window)
+  const wd = metrics?.windowDays || 1;
+  const uUL = metrics ? (metrics.underLoadDays / wd) * 100 : 0;
+  const uHome = metrics ? (metrics.homeDays / wd) * 100 : 0;
+  const uIdle = metrics ? (metrics.idleDays / wd) * 100 : 0;
+
+  const mmin = Math.min(...mpgSeries, 0), mmax = Math.max(...mpgSeries, 1);
+  const mpgPts = mpgSeries
+    .map((m, i) => `${8 + (i / Math.max(1, mpgSeries.length - 1)) * 304},${44 - ((m - mmin) / Math.max(0.1, mmax - mmin)) * 34}`)
+    .join(" ");
+
+  const smax = Math.max(...shop.months.map((m) => m.spend), 1);
+  const bw = 400 / shop.months.length;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-xl font-condensed text-light">The fleet</h2>
+        <span className="text-xs text-muted-text">your rig — how hard it runs, how thirsty it is, what it needs</span>
+      </div>
+
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5">
+        <Tile label="Utilization" value={util != null ? pct(util) : "—"}
+          sub={metrics ? `truck under a load · ${metrics.idleDays} idle days` : "no loads yet"}
+          color={util != null && util >= 0.8 ? "#4ade80" : undefined} />
+        <Tile label="Home time"
+          value={home.state === "none" ? "—" : home.daysOut === 0 ? "home today" : `${home.daysOut} days out`}
+          sub={home.state === "none" ? "no home marks yet" : home.state === "over" ? `past your ${home.threshold}-day target` : `${home.toTarget} left to your ${home.threshold}-day target`}
+          color={home.state === "over" ? "#f5a623" : undefined} warn={home.state === "over"} />
+        <Tile label="Fuel economy" value={metrics?.avgMpg != null ? `${metrics.avgMpg.toFixed(1)} mpg` : "—"}
+          sub={metrics?.bestTank != null ? `best tank ${metrics.bestTank.toFixed(1)}` : "log a full tank"} />
+        <Tile label="Next service"
+          value={counts.overdue > 0 ? `${counts.overdue} overdue` : nextSoon ? "due soon" : counts.ok > 0 ? "all good" : "—"}
+          sub={nextSoon ? `${nextSoon.name} ${remain(nextSoon.due)}` : counts.overdue > 0 ? "see road-ready" : "nothing due"}
+          color={counts.overdue > 0 ? "#f5a623" : counts.soon > 0 ? "#f5a623" : undefined} warn={counts.overdue > 0} />
+      </div>
+
+      {/* the rig + road-ready */}
+      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 items-start">
+        <div className="rounded-xl p-3.5 relative overflow-hidden" style={C}>
+          <div className="absolute top-0 right-0 w-24 h-24 pointer-events-none" style={{ backgroundImage: "radial-gradient(#e8940a 1.1px,transparent 1.2px)", backgroundSize: "8px 8px", opacity: 0.06 }} />
+          <H3 right={<span className="normal-case tracking-normal font-normal">under-load · home · idle, {metrics?.windowDays ?? 0}d</span>}>The rig</H3>
+          <p className="text-[13px] font-bold">{rigName} <span className="text-muted-text font-normal text-[11.5px]">· #{truck.unit_number} · {Number(truck.current_odometer).toLocaleString()} mi</span></p>
+          {trailerName && <p className="text-[11px] text-muted-text mt-0.5">pulling a {trailerName} {trailer?.trailer_type} · #{trailer?.unit_number}</p>}
+
+          <div className="flex h-[22px] rounded-md overflow-hidden my-2.5" style={{ border: "1px solid #26304a" }}>
+            {uUL > 0 && <div className="flex items-center justify-center text-[9.5px] font-bold" style={{ width: `${uUL}%`, background: "#2f7d55", color: "#0d1119" }}>{util != null ? pct(util) : ""} rolling</div>}
+            {uHome > 0 && <div style={{ width: `${uHome}%`, background: "#3a5170" }} />}
+            {uIdle > 0 && <div style={{ width: `${uIdle}%`, background: "#8a5a1a" }} />}
+          </div>
+          <div className="flex gap-3.5 text-[10px] text-muted-text">
+            <span><i className="inline-block w-2 h-2 rounded-sm mr-1 align-[-1px]" style={{ background: "#2f7d55" }} />{metrics?.underLoadDays ?? 0} under load</span>
+            <span><i className="inline-block w-2 h-2 rounded-sm mr-1 align-[-1px]" style={{ background: "#3a5170" }} />{metrics?.homeDays ?? 0} home</span>
+            <span><i className="inline-block w-2 h-2 rounded-sm mr-1 align-[-1px]" style={{ background: "#8a5a1a" }} />{metrics?.idleDays ?? 0} idle</span>
+          </div>
+
+          <div className="grid grid-cols-3 gap-2 my-3">
+            {[
+              { v: costPerMile != null ? rpm(costPerMile) : "—", l: "cost to run / mi" },
+              { v: metrics?.revPerMile != null ? rpm(metrics.revPerMile) : "—", l: "revenue / mi", c: "#4ade80" },
+              { v: metrics?.milesPerMonth != null ? Math.round(metrics.milesPerMonth).toLocaleString() : "—", l: "miles / month" },
+            ].map((e) => (
+              <div key={e.l} className="rounded-lg px-2.5 py-1.5" style={{ background: "#121a27", border: "1px solid #22304a" }}>
+                <p className="text-[15px] font-bold" style={{ color: e.c }}>{e.v}</p>
+                <p className="text-[9px] uppercase tracking-wide text-muted-text mt-0.5">{e.l}</p>
+              </div>
+            ))}
+          </div>
+
+          {mpgSeries.length >= 2 && (
+            <div>
+              <div className="flex justify-between text-[10px] uppercase tracking-wide text-muted-text"><span>Fuel economy — last {mpgSeries.length} tanks</span><span className="text-status-positive-text">{metrics?.avgMpg?.toFixed(1)} avg</span></div>
+              <svg viewBox="0 0 320 50" className="w-full mt-1">
+                <polyline fill="none" stroke="#5fd0e0" strokeWidth={2} points={mpgPts} />
+                {mpgSeries.map((_, i) => {
+                  const [x, y] = mpgPts.split(" ")[i].split(",");
+                  return <circle key={i} cx={x} cy={y} r={i === mpgSeries.length - 1 ? 3 : 2.5} fill={i === mpgSeries.length - 1 ? "#4ade80" : "#5fd0e0"} />;
+                })}
+              </svg>
+            </div>
+          )}
+          <Link to={`/trucks/${truck.truck_id}`} className="text-[11px] text-status-info-text hover:underline mt-2 inline-block">Truck details →</Link>
+        </div>
+
+        {/* road-ready */}
+        <div className="rounded-xl p-3.5" style={C}>
+          <H3 right={<span className="text-[9.5px] font-bold px-2 py-0.5 rounded-full" style={{ color: health.color, background: "#1c1408", border: `1px solid ${health.color}55` }}>{health.label}</span>}>Road-ready</H3>
+          {dues.length === 0 ? (
+            <p className="text-xs text-muted-text">No maintenance schedule yet.</p>
+          ) : (
+            dues.slice(0, 4).map((d) => (
+              <div key={d.name} className="flex items-center gap-2 py-1.5 text-[12px] border-t first:border-t-0" style={{ borderColor: "#1a2233" }}>
+                <span className="w-2 h-2 rounded-full shrink-0" style={{ background: DUE_DOT[d.due.level] }} />
+                <span className="truncate">{d.name}</span>
+                <span className="ml-auto text-[11px] whitespace-nowrap" style={{ color: d.due.level === "overdue" ? "#f87171" : d.due.level === "soon" ? "#f5a623" : "#8b93a3" }}>
+                  {d.due.level === "ok" ? "ok" : remain(d.due)}
+                </span>
+              </div>
+            ))
+          )}
+          <Link to="/maintenance" className="text-[11px] text-status-info-text hover:underline mt-2 inline-block">Maintenance →</Link>
+          {chips.length > 0 && (
+            <div className="border-t mt-3 pt-2.5" style={{ borderColor: "#1a2233" }}>
+              <p className="text-[10px] uppercase tracking-wide text-muted-text font-bold mb-1.5">Compliance</p>
+              <div className="flex flex-wrap gap-1.5">
+                {chips.map((c) => (
+                  <span key={c.label} className={`text-[10px] font-semibold px-2 py-0.5 rounded ${COMP[c.level].cls}`} style={{ background: "#0e1420", border: "1px solid #26304a" }}>
+                    {c.label} · {c.level === "expired" ? `expired ${Math.abs(c.daysRemaining ?? 0)}d` : c.level === "expiring" ? `${c.daysRemaining}d` : "ok"}
+                  </span>
+                ))}
+              </div>
+              <Link to="/compliance" className="text-[11px] text-status-info-text hover:underline mt-2 inline-block">Compliance →</Link>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* shop spend + cost to run */}
+      <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-3 items-start">
+        <div className="rounded-xl p-3.5" style={C}>
+          <H3 right={<span className="normal-case tracking-normal font-normal">keeping her running · last 12 months</span>}>Shop spend</H3>
+          <div className="flex items-baseline gap-2.5 mb-1">
+            <span className="text-[28px] font-extrabold leading-none">{money(shop.total)}</span>
+            <span className="text-[11.5px] text-muted-text">{shop.serviceCount} services{metrics?.milesPerMonth ? ` · ${money(shop.total / 12)} / mo` : ""}</span>
+          </div>
+          {shop.total === 0 ? (
+            <p className="text-xs text-muted-text py-3">No shop visits logged in the last 12 months.</p>
+          ) : (
+            <>
+              <svg viewBox="0 0 400 96" className="w-full my-1">
+                <line x1="0" y1="76" x2="400" y2="76" stroke="#1c2536" />
+                {shop.months.map((m, i) => {
+                  const h = m.spend > 0 ? Math.max(3, (m.spend / smax) * 68) : 2;
+                  const x = i * bw + 5, w = bw - 10, big = m.spend === smax && m.spend > 0;
+                  return (
+                    <g key={m.month}>
+                      <rect x={x} y={76 - h} width={w} height={h} rx={2} fill={big ? "#f5b03a" : m.spend > 0 ? "#c8890a" : "#2a3347"} />
+                      <text x={x + w / 2} y={90} textAnchor="middle" fontSize={8} fill="#5b6577">{m.label.charAt(0)}</text>
+                    </g>
+                  );
+                })}
+              </svg>
+              {shop.recent.map((s) => (
+                <div key={s.date + s.description} className="flex items-center gap-2 py-1.5 text-[12px] border-t first:border-t-0" style={{ borderColor: "#1a2233" }}>
+                  <span className="text-muted-text w-9 shrink-0">{new Date(s.date.slice(0, 10) + "T00:00:00Z").toLocaleDateString("en-US", { month: "short", timeZone: "UTC" })}</span>
+                  <span className="truncate">{s.description}</span>
+                  <span className="ml-auto font-bold whitespace-nowrap">{money(s.cost)}</span>
+                </div>
+              ))}
+            </>
+          )}
+          <Link to="/maintenance" className="text-[11px] text-status-info-text hover:underline mt-2 inline-block">Maintenance →</Link>
+        </div>
+
+        <div className="rounded-xl p-3.5" style={C}>
+          <H3 right={<span className="normal-case tracking-normal font-normal">per mile</span>}>Cost to run</H3>
+          {costPerMile == null ? (
+            <p className="text-xs text-muted-text">Not enough miles + fuel logged yet.</p>
+          ) : (
+            <>
+              <div className="flex h-6 rounded-md overflow-hidden mb-2" style={{ border: "1px solid #26304a" }}>
+                {fuelPct != null && <div className="flex items-center justify-center text-[10px] font-bold" style={{ width: `${fuelPct}%`, background: "#c8890a", color: "#0d1119" }}>Fuel {fuelPct}%</div>}
+                {fuelPct != null && <div className="flex items-center justify-center text-[10px] font-bold" style={{ width: `${100 - fuelPct}%`, background: "#5f7fd0", color: "#0d1119" }}>Maint {100 - fuelPct}%</div>}
+              </div>
+              <div className="flex justify-between text-[11.5px] py-0.5"><span><b style={{ color: "#c8890a" }}>{rpm(fuelPerMile)}</b> fuel / mi</span></div>
+              <div className="flex justify-between text-[11.5px] py-0.5"><span><b style={{ color: "#5f7fd0" }}>{rpm(maintPerMile)}</b> maintenance / mi</span><span className="text-muted-text">{fuelPct != null ? `${100 - fuelPct}% of the cost` : ""}</span></div>
+              <div className="flex justify-between text-[11.5px] pt-1.5 mt-1 border-t" style={{ borderColor: "#1a2233" }}><span className="font-bold">{rpm(costPerMile)} total / mi</span><span className="text-muted-text">to keep her rolling</span></div>
+            </>
+          )}
+          {paidPerGal != null && (
+            <p className="text-[11.5px] text-muted-text border-t mt-2.5 pt-2.5" style={{ borderColor: "#1a2233" }}>
+              Diesel you paid <b className="text-status-aware-text">{dieselPrice(paidPerGal)}</b>
+              {fleet.nationalDiesel != null && <> · national <b className="text-light">{dieselPrice(fleet.nationalDiesel)}</b>{dieselGap != null && Math.abs(dieselGap) >= 0.005 && <> · you run <b style={{ color: dieselGap > 0 ? "#f87171" : "#4ade80" }}>{Math.abs(dieselGap * 100).toFixed(0)}¢</b> {dieselGap > 0 ? "over" : "under"}</>}</>}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* the year in days */}
+      <div className="rounded-xl p-3.5" style={C}>
+        <H3 right={<span className="normal-case tracking-normal font-normal">every day, last 26 weeks — the rhythm of the run</span>}>The year in days</H3>
+        <div className="grid gap-[3px] overflow-x-auto" style={{ gridTemplateRows: "repeat(7, 10px)", gridAutoFlow: "column", gridAutoColumns: "10px" }}>
+          {heat.map((s, i) => <span key={i} className="w-2.5 h-2.5 rounded-sm" style={{ background: DAY_FILL[s] }} />)}
+        </div>
+        <div className="flex gap-3.5 text-[10.5px] text-muted-text mt-2.5">
+          <span><i className="inline-block w-2.5 h-2.5 rounded-sm mr-1.5 align-[-1px]" style={{ background: "#2f7d55" }} />under a load (earning)</span>
+          <span><i className="inline-block w-2.5 h-2.5 rounded-sm mr-1.5 align-[-1px]" style={{ background: "#3a5170" }} />home</span>
+          <span><i className="inline-block w-2.5 h-2.5 rounded-sm mr-1.5 align-[-1px]" style={{ background: "#232c3d" }} />idle</span>
+          <span className="ml-auto">← 26 weeks · today →</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/hooks/useFleetData.ts
+++ b/frontend/src/hooks/useFleetData.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import type { Truck } from "@/types/truck";
+import type { Trailer } from "@/types/trailer";
+import type { FuelEntry } from "@/types/fuelEntry";
+import type { MaintenanceItem, MaintenanceService } from "@/types/maintenance";
+import type { ComplianceItem } from "@/types/compliance";
+import type { Driver } from "@/types/driver";
+import { getTrucks } from "@/services/trucksService";
+import { getTrailers } from "@/services/trailersService";
+import { getFuelEntries, getNationalDiesel } from "@/services/fuelService";
+import { getMaintenanceItems, getMaintenanceServices } from "@/services/maintenanceService";
+import { getHomeDays } from "@/services/perDiemService";
+import { getComplianceItems } from "@/services/complianceService";
+import { getDrivers } from "@/services/driversService";
+
+// Everything the Fleet tab needs, fetched once when the tab opens (it only mounts
+// when Fleet is the active dashboard tab, so these calls are lazy). Raw data —
+// the tab computes the metrics from it so the math stays pure and testable.
+export interface FleetData {
+  loading: boolean;
+  trucks: Truck[];
+  trailers: Trailer[];
+  fuel: FuelEntry[];
+  items: MaintenanceItem[];
+  services: MaintenanceService[];
+  homeDays: string[];
+  compliance: ComplianceItem[];
+  drivers: Driver[];
+  nationalDiesel: number | null; // $/gal
+}
+
+const EMPTY: Omit<FleetData, "loading"> = {
+  trucks: [], trailers: [], fuel: [], items: [], services: [], homeDays: [], compliance: [], drivers: [], nationalDiesel: null,
+};
+
+export const useFleetData = (): FleetData => {
+  const [data, setData] = useState(EMPTY);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const [trucks, trailers, fuel, items, services, homeDays, compliance, drivers, nat] =
+          await Promise.all([
+            getTrucks(),
+            getTrailers(),
+            getFuelEntries(),
+            getMaintenanceItems(),
+            getMaintenanceServices(),
+            getHomeDays(),
+            getComplianceItems(),
+            getDrivers(),
+            getNationalDiesel().catch(() => null),
+          ]);
+        if (!alive) return;
+        setData({
+          trucks, trailers, fuel, items, services, homeDays, compliance, drivers,
+          nationalDiesel: nat?.value ?? null,
+        });
+      } catch {
+        /* leave empty — the tab shows an empty state */
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return { loading, ...data };
+};

--- a/frontend/src/lib/metrics/fleet.test.ts
+++ b/frontend/src/lib/metrics/fleet.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Load } from "@/types/load";
+import type { MaintenanceService } from "@/types/maintenance";
+import { shopSpend, fleetHeatmap } from "./fleet";
+
+const NOW = new Date("2026-08-15T12:00:00Z");
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+afterEach(() => vi.useRealTimers());
+
+const svc = (over: Partial<MaintenanceService>): MaintenanceService => ({
+  service_id: "s",
+  unit: "tractor",
+  service_date: "2026-08-01",
+  odometer: null,
+  trailer_hub: null,
+  vendor: null,
+  location: null,
+  description: "PM",
+  cost: 100,
+  invoice_number: null,
+  notes: null,
+  item_ids: [],
+  ...over,
+});
+
+describe("shopSpend", () => {
+  it("buckets cost by month across the window and totals the window only", () => {
+    const services = [
+      svc({ service_date: "2026-08-02", cost: 1840, description: "Brake job" }),
+      svc({ service_date: "2026-07-10", cost: 420, description: "PM" }),
+      svc({ service_date: "2026-08-20", cost: 60, description: "Wash" }), // same month, still counts
+      svc({ service_date: "2024-01-01", cost: 999, description: "Ancient" }), // before window → excluded
+    ];
+    const r = shopSpend(services, NOW, 12);
+    expect(r.months).toHaveLength(12);
+    expect(r.months.at(-1)).toMatchObject({ month: "2026-08", spend: 1900 }); // 1840 + 60
+    expect(r.months.at(-2)).toMatchObject({ month: "2026-07", spend: 420 });
+    expect(r.total).toBe(2320); // 1840 + 60 + 420; window excludes the 2024 service
+    expect(r.serviceCount).toBe(3);
+  });
+
+  it("recent = most recent first, capped at 4", () => {
+    const services = ["2026-08-10", "2026-06-01", "2026-07-15", "2026-05-01", "2026-04-01"].map(
+      (d, i) => svc({ service_date: d, cost: 100 + i, description: `svc-${d}` }),
+    );
+    const r = shopSpend(services, NOW, 12);
+    expect(r.recent.map((s) => s.date)).toEqual(["2026-08-10", "2026-07-15", "2026-06-01", "2026-05-01"]);
+  });
+
+  it("coerces numeric-string / null costs", () => {
+    const r = shopSpend(
+      [svc({ cost: "250.50" as unknown as number }), svc({ cost: null })],
+      NOW,
+      12,
+    );
+    expect(r.total).toBeCloseTo(250.5, 2);
+  });
+});
+
+const load = (pickup: string, delivery: string): Load =>
+  ({ load_status: "delivered", pickup_date: pickup, delivery_date: delivery } as Load);
+
+describe("fleetHeatmap", () => {
+  it("returns weeks*7 days, oldest→newest, classifying each", () => {
+    // a 2-day haul ending yesterday, and a home mark
+    const loads = [load("2026-08-13", "2026-08-14")];
+    const homeDays = ["2026-08-10"];
+    const grid = fleetHeatmap(loads, homeDays, NOW, 4); // 28 days, ends 2026-08-15
+    expect(grid).toHaveLength(28);
+    // last entry = today (idle — no load, no home mark)
+    expect(grid.at(-1)).toBe("idle");
+    // the two haul days
+    expect(grid.at(-2)).toBe("underload"); // 08-14
+    expect(grid.at(-3)).toBe("underload"); // 08-13
+    // the home mark (08-10) is 5 days before today → index 27-5 = 22
+    expect(grid[22]).toBe("home");
+  });
+
+  it("under-load beats a home mark on the same day", () => {
+    const loads = [load("2026-08-14", "2026-08-14")];
+    const grid = fleetHeatmap(loads, ["2026-08-14"], NOW, 4);
+    expect(grid.at(-2)).toBe("underload");
+  });
+});

--- a/frontend/src/lib/metrics/fleet.ts
+++ b/frontend/src/lib/metrics/fleet.ts
@@ -1,0 +1,105 @@
+import type { Load } from "@/types/load";
+import type { MaintenanceService } from "@/types/maintenance";
+import { underLoadDaySet } from "./underLoad";
+
+// Fleet-tab metrics: what a single owner-operator's rig has cost in the shop, and
+// the day-by-day rhythm of how it ran. Pure — the clock comes in as `now`.
+
+const DAY = 86_400_000;
+const dayKey = (d: Date): string => d.toISOString().slice(0, 10);
+
+// ---- SHOP SPEND ---- (maintenance $ by month over a window, + recent services)
+export interface ShopMonth {
+  month: string; // 'YYYY-MM'
+  label: string; // short month, e.g. "Jul"
+  spend: number;
+}
+export interface ShopService {
+  date: string; // 'YYYY-MM-DD'
+  description: string;
+  cost: number;
+  unit: string; // tractor / trailer / both
+}
+export interface ShopSpend {
+  months: ShopMonth[]; // the window, oldest → newest
+  total: number;
+  serviceCount: number;
+  recent: ShopService[]; // most recent first
+}
+
+export const shopSpend = (
+  services: MaintenanceService[],
+  now: Date,
+  months = 12,
+): ShopSpend => {
+  const buckets: ShopMonth[] = [];
+  const idx = new Map<string, number>();
+  for (let i = months - 1; i >= 0; i--) {
+    const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1));
+    const month = d.toISOString().slice(0, 7);
+    idx.set(month, buckets.length);
+    buckets.push({
+      month,
+      label: d.toLocaleDateString("en-US", { month: "short", timeZone: "UTC" }),
+      spend: 0,
+    });
+  }
+  const startMonth = buckets[0].month;
+
+  let total = 0;
+  let serviceCount = 0;
+  const inWindow: MaintenanceService[] = [];
+  for (const s of services) {
+    const month = (s.service_date ?? "").slice(0, 7);
+    if (month < startMonth) continue;
+    const i = idx.get(month);
+    if (i == null) continue; // future-dated / malformed — skip
+    const cost = Number(s.cost) || 0;
+    buckets[i].spend += cost;
+    total += cost;
+    serviceCount++;
+    inWindow.push(s);
+  }
+
+  const recent = [...inWindow]
+    .sort((a, b) => (a.service_date < b.service_date ? 1 : -1))
+    .slice(0, 4)
+    .map((s) => ({
+      date: s.service_date,
+      description: s.description,
+      cost: Number(s.cost) || 0,
+      unit: s.unit,
+    }));
+
+  return { months: buckets, total, serviceCount, recent };
+};
+
+// ---- THE YEAR IN DAYS ---- (per-day status for the utilization heatmap)
+export type DayStatus = "underload" | "home" | "idle";
+
+// One entry per day for the last `weeks` weeks, oldest → newest. under-load wins
+// over home (you were working), home wins over idle (chosen time off vs. no
+// freight) — the same honest hierarchy utilization uses.
+export const fleetHeatmap = (
+  loads: Load[],
+  homeDays: string[],
+  now: Date,
+  weeks = 26,
+): DayStatus[] => {
+  const total = weeks * 7;
+  const end = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const start = new Date(end.getTime() - (total - 1) * DAY);
+  const under = underLoadDaySet(loads, dayKey(start), dayKey(end));
+  const home = new Set(homeDays);
+
+  const out: DayStatus[] = [];
+  const cur = new Date(start);
+  for (let i = 0; i < total; i++) {
+    const k = dayKey(cur);
+    out.push(under.has(k) ? "underload" : home.has(k) ? "home" : "idle");
+    cur.setUTCDate(cur.getUTCDate() + 1);
+  }
+  return out;
+};

--- a/frontend/src/lib/metrics/truckMetrics.ts
+++ b/frontend/src/lib/metrics/truckMetrics.ts
@@ -24,6 +24,8 @@ export interface TruckMetrics {
   fuelPerMile: number | null;
   revPerMile: number | null;
   costToRunPerMile: number | null; // (fuel + maintenance) ÷ miles
+  fuelSpend: number; // fuel $ over the window (for the fuel-vs-maintenance split)
+  maintSpend: number; // maintenance $ attributable to the truck
   milesPerMonth: number | null;
   totalMiles: number;
   netRevenue: number;
@@ -133,6 +135,8 @@ export const computeTruckMetrics = (
     fuelPerMile: fs.costPerMile,
     revPerMile: totalMiles > 0 ? netRevenue / totalMiles : null,
     costToRunPerMile: totalMiles > 0 ? (fuelSpend + maintSpend) / totalMiles : null,
+    fuelSpend,
+    maintSpend,
     milesPerMonth: monthsInService ? totalMiles / monthsInService : null,
     totalMiles,
     netRevenue,

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -11,11 +11,12 @@ import { AwardPopHost } from "@/components/comic/AwardPopHost";
 import { DEMO_AWARDS } from "@/lib/metrics/awards";
 import { latestRecapWithData } from "@/lib/metrics/recap";
 import { MarketChip } from "@/components/dashboard/MarketChip";
-import { DashboardShell, TabStub, type DashTab } from "@/components/dashboard/DashboardShell";
+import { DashboardShell, type DashTab } from "@/components/dashboard/DashboardShell";
 import { AgentsTab } from "@/components/dashboard/agents/AgentsTab";
 import { PulseTab } from "@/components/dashboard/PulseTab";
 import { MoneyTab } from "@/components/dashboard/MoneyTab";
 import { LanesTab } from "@/components/dashboard/LanesTab";
+import { FleetTab } from "@/components/dashboard/FleetTab";
 import { isDispatcher } from "@/lib/roles";
 import DispatchDashboard from "./DispatchDashboard";
 
@@ -101,15 +102,7 @@ const OwnerDashboard = () => {
           ) : active === "agents" ? (
             <AgentsTab loads={loads} />
           ) : (
-            <TabStub
-              title="Fleet"
-              blurb="Asset health."
-              points={[
-                "Truck / driver utilization",
-                "Fuel MPG trend",
-                "Next service due",
-              ]}
-            />
+            <FleetTab loads={loads} />
           )
         }
       </DashboardShell>

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -567,9 +567,11 @@ const GuidePage = () => {
                 the live quarter board, revenue concentration (so no one agent owns
                 too much of your book), and who's going cold.
               </TabLine>
-              <TabLine name="Fleet" q="Asset health">
-                Truck and driver utilization, fuel MPG trend, and next service due.
-                <span style={{ color: AMBER }}> Coming soon.</span>
+              <TabLine name="Fleet" q="Is my rig ready to roll?">
+                Your rig at a glance — utilization (how hard the truck runs), home
+                time (days out), fuel economy, and what's due for service or
+                compliance. Plus shop spend across the year, cost-to-run per mile,
+                and a day-by-day heatmap of earning vs. home vs. idle.
               </TabLine>
             </div>
           </Section>


### PR DESCRIPTION
The fifth and final tab of the dashboard redesign — a single owner-operator's rig at a glance. Design-first mockup approved.

## What's on it
- **KPIs** — utilization, home time (days out), fuel economy, next service.
- **The rig** — truck + trailer identity, the under-load / home / idle breakdown, cost & revenue per mile, MPG trend.
- **Road-ready** — maintenance due + live compliance chips (items + driver CDL), links to Maintenance / Compliance.
- **Shop spend** — 12-month maintenance-$ bars + recent services.
- **Cost to run** — fuel-vs-maintenance split + diesel paid vs national (EIA).
- **The year in days** — per-day earning/home/idle heatmap.

Summarizes and links out to the detail pages rather than duplicating them.

## Notable
- `truckMetrics`: exposed `fuelSpend`/`maintSpend` — `fuelPerMile` and `costToRunPerMile` use different mile denominators, so subtracting them for the split produced "Fuel 971% / Maint -871%". Now computed from the raw spend, per-mile values use the `$/mi` formatter.
- New pure metrics `shopSpend` + `fleetHeatmap` (tested). `useFleetData` fetches lazily (only when Fleet is the active tab).
- Guide's Fleet section updated from "coming soon."

Verified on dev against real truck/fuel/maintenance/compliance data. Build clean, 476 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)