### PR TITLE
fix: dashboard metric-logic pass — on-time, home-time, heatmap (v1.138.1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.138.0",
+  "version": "1.138.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/FleetTab.tsx
+++ b/frontend/src/components/dashboard/FleetTab.tsx
@@ -12,7 +12,7 @@ import { money, rpm, dieselPrice } from "@/lib/format";
 
 const C = { background: "#0f1622", border: "1px solid #26304a" } as const;
 const TILE = { background: "#121a27", border: "1px solid #26304a" } as const;
-const HOME_TARGET = 14;
+const HOME_TARGET_FALLBACK = 42; // only if the settlement-schedule setting is missing
 
 const DAY_FILL: Record<DayStatus, string> = { underload: "#2f7d55", home: "#3a5170", idle: "#232c3d" };
 const DUE_DOT: Record<DueLevel, string> = { overdue: "#f87171", soon: "#f5a623", ok: "#2f7d55", unknown: "#5b6577" };
@@ -62,11 +62,10 @@ export const FleetTab = ({ loads }: { loads: Load[] }) => {
   const shop = useMemo(() => shopSpend(fleet.services, now, 12), [fleet.services, now]);
   const heat = useMemo(() => fleetHeatmap(loads, fleet.homeDays, now, 26), [loads, fleet.homeDays, now]);
 
-  const home = useMemo(() => {
-    const todayKey = now.toISOString().slice(0, 10);
-    const lastHome = fleet.homeDays.filter((d) => d <= todayKey).sort().at(-1) ?? null;
-    return hometimeStatus(lastHome, HOME_TARGET, now);
-  }, [fleet.homeDays, now]);
+  const home = useMemo(
+    () => hometimeStatus(fleet.lastHome, fleet.hometimeThreshold ?? HOME_TARGET_FALLBACK, now),
+    [fleet.lastHome, fleet.hometimeThreshold, now],
+  );
 
   const dues = useMemo(() => {
     const cur = truck ? Number(truck.current_odometer) || null : null;
@@ -74,7 +73,11 @@ export const FleetTab = ({ loads }: { loads: Load[] }) => {
     return fleet.items
       .filter((i) => i.active)
       .map((i) => ({ name: i.name, due: computeDue(i, cur, now, mpm) }))
-      .sort((a, b) => DUE_RANK[a.due.level] - DUE_RANK[b.due.level] || (a.due.etaDate ?? "9") < (b.due.etaDate ?? "9") ? -1 : 1);
+      .sort(
+        (a, b) =>
+          DUE_RANK[a.due.level] - DUE_RANK[b.due.level] ||
+          (a.due.etaDate ?? "9999").localeCompare(b.due.etaDate ?? "9999"),
+      );
   }, [fleet.items, truck, metrics, now]);
 
   const counts = {
@@ -304,15 +307,26 @@ export const FleetTab = ({ loads }: { loads: Load[] }) => {
 
       {/* the year in days */}
       <div className="rounded-xl p-3.5" style={C}>
-        <H3 right={<span className="normal-case tracking-normal font-normal">every day, last 26 weeks — the rhythm of the run</span>}>The year in days</H3>
-        <div className="grid gap-[3px] overflow-x-auto" style={{ gridTemplateRows: "repeat(7, 10px)", gridAutoFlow: "column", gridAutoColumns: "10px" }}>
-          {heat.map((s, i) => <span key={i} className="w-2.5 h-2.5 rounded-sm" style={{ background: DAY_FILL[s] }} />)}
+        <H3 right={<span className="normal-case tracking-normal font-normal">each column = one week (Sun→Sat) · oldest left → this week right</span>}>The year in days</H3>
+        <div className="overflow-x-auto">
+          <div style={{ width: heat.weeks * 13 }}>
+            <div className="relative h-3.5 mb-1">
+              {heat.months.map((m) => (
+                <span key={m.col} className="absolute text-[9px] text-muted-text" style={{ left: m.col * 13 }}>{m.label}</span>
+              ))}
+            </div>
+            <div className="grid gap-[3px]" style={{ gridTemplateRows: "repeat(7, 10px)", gridAutoFlow: "column", gridAutoColumns: "10px", width: heat.weeks * 13 }}>
+              {heat.cells.map((c) => (
+                <span key={c.date} title={`${c.date} · ${c.future ? "—" : c.status}`} className="w-2.5 h-2.5 rounded-sm"
+                  style={{ background: c.future ? "transparent" : DAY_FILL[c.status] }} />
+              ))}
+            </div>
+          </div>
         </div>
-        <div className="flex gap-3.5 text-[10.5px] text-muted-text mt-2.5">
+        <div className="flex gap-3.5 text-[10.5px] text-muted-text mt-2.5 flex-wrap">
           <span><i className="inline-block w-2.5 h-2.5 rounded-sm mr-1.5 align-[-1px]" style={{ background: "#2f7d55" }} />under a load (earning)</span>
           <span><i className="inline-block w-2.5 h-2.5 rounded-sm mr-1.5 align-[-1px]" style={{ background: "#3a5170" }} />home</span>
           <span><i className="inline-block w-2.5 h-2.5 rounded-sm mr-1.5 align-[-1px]" style={{ background: "#232c3d" }} />idle</span>
-          <span className="ml-auto">← 26 weeks · today →</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/dashboard/PulseTab.tsx
+++ b/frontend/src/components/dashboard/PulseTab.tsx
@@ -76,7 +76,7 @@ export const PulseTab = ({
   // Your delivery punctuality — did YOU hit the appointment at the dock — over the
   // last 90 days of delivered loads. freeHours doesn't affect on-time (it grades
   // detention, not the appointment), so a default is fine here. null until 3 graded.
-  const onTimePct = useMemo(() => {
+  const onTime = useMemo(() => {
     const cutoff = now.getTime() - 90 * 86_400_000;
     const recent = loads.filter(
       (l) =>
@@ -84,7 +84,7 @@ export const PulseTab = ({
         l.delivery_date &&
         new Date(l.delivery_date).getTime() >= cutoff,
     );
-    return scoreStops(agentStops(recent, 3)).onTimePct;
+    return scoreStops(agentStops(recent, 3));
   }, [loads, now]);
 
   // Last 8 pay-weeks of gross earned, anchored to the configured week start.
@@ -160,9 +160,9 @@ export const PulseTab = ({
         <Tile label="Pipeline" value={money(pipeline)} sub="delivered, not yet settled" />
         <Tile
           label="On-time"
-          value={onTimePct != null ? `${Math.round(onTimePct * 100)}%` : "—"}
-          sub={onTimePct != null ? "you hit the appointment · 90d" : "needs 3+ timed stops"}
-          color={onTimePct == null ? undefined : onTimePct >= 0.9 ? "#4ade80" : onTimePct >= 0.75 ? undefined : "#f5a623"}
+          value={onTime.onTimePct != null ? `${Math.round(onTime.onTimePct * 100)}%` : "—"}
+          sub={onTime.onTimePct != null ? `${onTime.gradedStops} timed stops · 90d` : "needs 3+ timed stops"}
+          color={onTime.onTimePct == null ? undefined : onTime.onTimePct >= 0.9 ? "#4ade80" : onTime.onTimePct >= 0.75 ? undefined : "#f5a623"}
         />
       </div>
 

--- a/frontend/src/hooks/useFleetData.ts
+++ b/frontend/src/hooks/useFleetData.ts
@@ -9,9 +9,10 @@ import { getTrucks } from "@/services/trucksService";
 import { getTrailers } from "@/services/trailersService";
 import { getFuelEntries, getNationalDiesel } from "@/services/fuelService";
 import { getMaintenanceItems, getMaintenanceServices } from "@/services/maintenanceService";
-import { getHomeDays } from "@/services/perDiemService";
+import { getHomeDays, getLastHomeDay } from "@/services/perDiemService";
 import { getComplianceItems } from "@/services/complianceService";
 import { getDrivers } from "@/services/driversService";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
 
 // Everything the Fleet tab needs, fetched once when the tab opens (it only mounts
 // when Fleet is the active dashboard tab, so these calls are lazy). Raw data —
@@ -27,10 +28,13 @@ export interface FleetData {
   compliance: ComplianceItem[];
   drivers: Driver[];
   nationalDiesel: number | null; // $/gal
+  lastHome: string | null; // most recent "home" per-diem mark, 'YYYY-MM-DD'
+  hometimeThreshold: number | null; // days-out target (settlement schedule setting)
 }
 
 const EMPTY: Omit<FleetData, "loading"> = {
   trucks: [], trailers: [], fuel: [], items: [], services: [], homeDays: [], compliance: [], drivers: [], nationalDiesel: null,
+  lastHome: null, hometimeThreshold: null,
 };
 
 export const useFleetData = (): FleetData => {
@@ -41,7 +45,7 @@ export const useFleetData = (): FleetData => {
     let alive = true;
     (async () => {
       try {
-        const [trucks, trailers, fuel, items, services, homeDays, compliance, drivers, nat] =
+        const [trucks, trailers, fuel, items, services, homeDays, compliance, drivers, nat, lastHome, sched] =
           await Promise.all([
             getTrucks(),
             getTrailers(),
@@ -52,11 +56,15 @@ export const useFleetData = (): FleetData => {
             getComplianceItems(),
             getDrivers(),
             getNationalDiesel().catch(() => null),
+            getLastHomeDay().catch(() => null),
+            getSettlementSchedule().catch(() => null),
           ]);
         if (!alive) return;
         setData({
           trucks, trailers, fuel, items, services, homeDays, compliance, drivers,
           nationalDiesel: nat?.value ?? null,
+          lastHome: lastHome ?? null,
+          hometimeThreshold: sched?.hometime_threshold_days ?? null,
         });
       } catch {
         /* leave empty — the tab shows an empty state */

--- a/frontend/src/lib/metrics/fleet.test.ts
+++ b/frontend/src/lib/metrics/fleet.test.ts
@@ -64,24 +64,30 @@ const load = (pickup: string, delivery: string): Load =>
   ({ load_status: "delivered", pickup_date: pickup, delivery_date: delivery } as Load);
 
 describe("fleetHeatmap", () => {
-  it("returns weeks*7 days, oldest→newest, classifying each", () => {
-    // a 2-day haul ending yesterday, and a home mark
-    const loads = [load("2026-08-13", "2026-08-14")];
-    const homeDays = ["2026-08-10"];
-    const grid = fleetHeatmap(loads, homeDays, NOW, 4); // 28 days, ends 2026-08-15
-    expect(grid).toHaveLength(28);
-    // last entry = today (idle — no load, no home mark)
-    expect(grid.at(-1)).toBe("idle");
-    // the two haul days
-    expect(grid.at(-2)).toBe("underload"); // 08-14
-    expect(grid.at(-3)).toBe("underload"); // 08-13
-    // the home mark (08-10) is 5 days before today → index 27-5 = 22
-    expect(grid[22]).toBe("home");
+  const cellFor = (h: ReturnType<typeof fleetHeatmap>, date: string) =>
+    h.cells.find((c) => c.date === date);
+
+  it("returns 7×weeks cells, classifies each, labels months", () => {
+    const loads = [load("2026-08-13", "2026-08-14")]; // 2-day haul
+    const h = fleetHeatmap(loads, ["2026-08-10"], NOW, 4);
+    expect(h.cells).toHaveLength(28);
+    expect(h.weeks).toBe(4);
+    expect(h.months.length).toBeGreaterThan(0);
+    expect(cellFor(h, "2026-08-14")?.status).toBe("underload");
+    expect(cellFor(h, "2026-08-13")?.status).toBe("underload");
+    expect(cellFor(h, "2026-08-10")?.status).toBe("home");
+    expect(cellFor(h, "2026-08-15")?.status).toBe("idle"); // today, nothing
   });
 
-  it("under-load beats a home mark on the same day", () => {
-    const loads = [load("2026-08-14", "2026-08-14")];
-    const grid = fleetHeatmap(loads, ["2026-08-14"], NOW, 4);
-    expect(grid.at(-2)).toBe("underload");
+  it("an explicit home mark WINS over a load span covering it", () => {
+    const loads = [load("2026-08-10", "2026-08-14")]; // span covers 08-14
+    const h = fleetHeatmap(loads, ["2026-08-14"], NOW, 4);
+    expect(cellFor(h, "2026-08-14")?.status).toBe("home"); // home overrides under-load
+    expect(cellFor(h, "2026-08-13")?.status).toBe("underload"); // still hauling
+  });
+
+  it("marks days after today as future (blank)", () => {
+    const h = fleetHeatmap([], [], NOW, 4);
+    h.cells.filter((c) => c.future).forEach((c) => expect(c.date > "2026-08-15").toBe(true));
   });
 });

--- a/frontend/src/lib/metrics/fleet.ts
+++ b/frontend/src/lib/metrics/fleet.ts
@@ -74,32 +74,54 @@ export const shopSpend = (
   return { months: buckets, total, serviceCount, recent };
 };
 
-// ---- THE YEAR IN DAYS ---- (per-day status for the utilization heatmap)
+// ---- THE YEAR IN DAYS ---- (calendar heatmap of how the truck ran)
 export type DayStatus = "underload" | "home" | "idle";
+export interface HeatCell {
+  date: string; // 'YYYY-MM-DD'
+  status: DayStatus;
+  future: boolean; // after today — rendered blank
+}
+export interface Heatmap {
+  cells: HeatCell[]; // 7 × weeks, column-major: each column is a week, row = weekday (Sun→Sat)
+  weeks: number;
+  months: { col: number; label: string }[]; // a label at the column where each month begins
+}
 
-// One entry per day for the last `weeks` weeks, oldest → newest. under-load wins
-// over home (you were working), home wins over idle (chosen time off vs. no
-// freight) — the same honest hierarchy utilization uses.
+// A GitHub-style calendar: columns are weeks (aligned to Sunday so rows are real
+// weekdays), oldest on the left, this week on the right. A "home" mark WINS over
+// a load's pickup→delivery envelope — if you said you were home, you weren't
+// hauling — then under-load, then idle.
 export const fleetHeatmap = (
   loads: Load[],
   homeDays: string[],
   now: Date,
   weeks = 26,
-): DayStatus[] => {
-  const total = weeks * 7;
-  const end = new Date(
+): Heatmap => {
+  const today = new Date(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
   );
-  const start = new Date(end.getTime() - (total - 1) * DAY);
-  const under = underLoadDaySet(loads, dayKey(start), dayKey(end));
+  const thisWeekSunday = new Date(today.getTime() - today.getUTCDay() * DAY);
+  const start = new Date(thisWeekSunday.getTime() - (weeks - 1) * 7 * DAY);
+  const todayKey = dayKey(today);
+  const under = underLoadDaySet(loads, dayKey(start), todayKey);
   const home = new Set(homeDays);
 
-  const out: DayStatus[] = [];
+  const cells: HeatCell[] = [];
+  const months: { col: number; label: string }[] = [];
   const cur = new Date(start);
-  for (let i = 0; i < total; i++) {
+  let lastMonth = -1;
+  for (let i = 0; i < weeks * 7; i++) {
     const k = dayKey(cur);
-    out.push(under.has(k) ? "underload" : home.has(k) ? "home" : "idle");
+    const future = k > todayKey;
+    const status: DayStatus = future
+      ? "idle"
+      : home.has(k) ? "home" : under.has(k) ? "underload" : "idle";
+    cells.push({ date: k, status, future });
+    if (i % 7 === 0 && cur.getUTCMonth() !== lastMonth) {
+      months.push({ col: i / 7, label: cur.toLocaleDateString("en-US", { month: "short", timeZone: "UTC" }) });
+      lastMonth = cur.getUTCMonth();
+    }
     cur.setUTCDate(cur.getUTCDate() + 1);
   }
-  return out;
+  return { cells, weeks, months };
 };

--- a/frontend/src/lib/metrics/stopScore.test.ts
+++ b/frontend/src/lib/metrics/stopScore.test.ts
@@ -46,6 +46,18 @@ describe("facilityStops + scoreStops", () => {
     expect(score.gradedStops).toBe(3); // the no-appt stop isn't graded
     expect(score.onTimePct).toBeCloseTo(2 / 3, 5); // 2 of 3 graded were on-time
   });
+
+  it("counts an early arrival (before the window) as on-time, not against", () => {
+    // window 09:00–12:00: early / within = made it; only after-the-end is late
+    const loads = [
+      shipLoad({ shipper_in: "07:00", shipper_out: "10:00", pickup_appt_start: "09:00", pickup_appt_end: "12:00" }), // early → waited
+      shipLoad({ shipper_in: "10:00", shipper_out: "11:00", pickup_appt_start: "09:00", pickup_appt_end: "12:00" }), // within → on-time
+      shipLoad({ shipper_in: "13:00", shipper_out: "14:00", pickup_appt_start: "09:00", pickup_appt_end: "12:00" }), // after end → late
+    ];
+    const score = scoreStops(facilityStops(loads, "FAC", 3));
+    expect(score.gradedStops).toBe(3);
+    expect(score.onTimePct).toBeCloseTo(2 / 3, 5); // early + within count; only the true-late one drags it
+  });
 });
 
 describe("agentStops", () => {

--- a/frontend/src/lib/metrics/stopScore.ts
+++ b/frontend/src/lib/metrics/stopScore.ts
@@ -136,7 +136,11 @@ export const scoreStops = (stops: Stop[]): StopScore => {
   const timed = stops.filter((s) => s.dwellMin != null);
   const dwells = timed.map((s) => s.dwellMin as number);
   const graded = stops.filter((s) => s.onTime != null);
-  const onTimeN = graded.filter((s) => s.onTime === "on-time").length;
+  // "waited" = you arrived BEFORE the window opened — early. You still made the
+  // appointment, so it counts as on-time; only genuine "late" counts against.
+  const onTimeN = graded.filter(
+    (s) => s.onTime === "on-time" || s.onTime === "waited",
+  ).length;
   const detStops = timed.filter((s) => s.detentionMin > 0);
   const enough = timed.length >= MIN_STOPS;
 

--- a/frontend/src/lib/metrics/truckMetrics.test.ts
+++ b/frontend/src/lib/metrics/truckMetrics.test.ts
@@ -48,11 +48,12 @@ describe("computeTruckMetrics — days-based utilization", () => {
     expect(m.underLoadDays).toBe(2); // only 01-06 and 01-07
   });
 
-  it("does not count a home day that was also under a load", () => {
+  it("a home mark WINS over a load span that covers it", () => {
     const truck = { in_service_date: "2026-01-01", current_odometer: 0 } as Truck;
-    const loads = [load("2026-01-05", "2026-01-07")];
-    const m = run(truck, loads, ["2026-01-06"]); // home marked mid-haul
-    expect(m.homeDays).toBe(0); // 01-06 is under load, not a home gap
+    const loads = [load("2026-01-05", "2026-01-07")]; // span 05–07
+    const m = run(truck, loads, ["2026-01-06"]); // you marked 01-06 home
+    expect(m.homeDays).toBe(1); // it counts as home, not hauling
+    expect(m.underLoadDays).toBe(2); // 01-05 + 01-07 only — 01-06 removed
   });
 });
 

--- a/frontend/src/lib/metrics/truckMetrics.ts
+++ b/frontend/src/lib/metrics/truckMetrics.ts
@@ -103,21 +103,18 @@ export const computeTruckMetrics = (
     : 0;
 
   const underLoadSet = underLoadDaySet(truckLoads, windowStart, nowDay);
-  const underLoadDays = underLoadSet.size;
+  // An explicit "home" mark wins over a load's pickup→delivery envelope: if you
+  // said you were home that day, you weren't hauling — even if a multi-day load's
+  // span technically covers it. So home days are removed from under-load, not the
+  // other way around. Home still counts against utilization (costs accrue) — this
+  // only labels why the truck wasn't earning.
+  const homeSet = new Set(
+    homeDays.filter((d) => (!windowStart || d >= windowStart) && d <= nowDay),
+  );
+  const underLoadDays = [...underLoadSet].filter((d) => !homeSet.has(d)).length;
+  const homeDayCount = homeSet.size;
   const utilization =
     windowDays > 0 ? Math.min(1, underLoadDays / windowDays) : null;
-
-  // Split the non-working days: home (marked home, not under load) vs truly idle.
-  // Home days still count against utilization (the truck's costs accrue) — this
-  // only labels why it wasn't earning.
-  const homeDayCount = new Set(
-    homeDays.filter(
-      (d) =>
-        (!windowStart || d >= windowStart) &&
-        d <= nowDay &&
-        !underLoadSet.has(d),
-    ),
-  ).size;
   const idleDays = Math.max(0, windowDays - underLoadDays - homeDayCount);
 
   const monthsInService = inService


### PR DESCRIPTION
Audit of the dashboard tabs against real prod data, per Jason. Real bugs found and fixed:

- **On-time (Pulse):** early arrivals ("waited") were counted *against* on-time — you still made the appointment. Now only genuine "late" counts. Jason's on-time: ~58% → ~92%. Shared fix (agent on-time too). Tile shows the sample ("N timed stops · 90d") since only loads with logged in-times are scored, not all loads.
- **Home-time target (Fleet):** was hardcoded 14; now reads `hometime_threshold_days` from the settlement schedule (Jason's = 42). Uses `getLastHomeDay`.
- **Home overrides under-load** (`truckMetrics` + `fleetHeatmap`): an explicit "home" mark now wins over a load's pickup→delivery envelope. 5 of 6 July home days fell inside a long load span and were mislabeled "under load" (hidden on the heatmap, inflating utilization).
- **Heatmap:** rebuilt as a week/weekday-aligned calendar with month labels + a direction note; future days blank.
- **Road-ready order:** fixed a comparator precedence bug (`a-b || cond ? -1 : 1`).

Verified against prod via SQL. Every other metric reviewed and sound (oversize `load_type` detection, Money YTD, Lanes gross, Agents concentration). Build clean, 478 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)