### PR TITLE
fix(fleet): per-diem unmarked=home + all-in cost-to-run everywhere (v1.138.2)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.138.1",
+  "version": "1.138.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/FleetTab.tsx
+++ b/frontend/src/components/dashboard/FleetTab.tsx
@@ -4,7 +4,7 @@ import type { Load } from "@/types/load";
 import { useFleetData } from "@/hooks/useFleetData";
 import { computeTruckMetrics } from "@/lib/metrics/truckMetrics";
 import { computeDue, fleetHealth, type Due, type DueLevel } from "@/lib/metrics/maintenance";
-import { shopSpend, fleetHeatmap, type DayStatus } from "@/lib/metrics/fleet";
+import { shopSpend, fleetHeatmap, lastHomeDay, type DayStatus } from "@/lib/metrics/fleet";
 import { hometimeStatus } from "@/lib/metrics/hometime";
 import { itemToCheckable, cdlToCheckable, computeComplianceDue, type ComplianceLevel } from "@/lib/metrics/compliance";
 import { mpgWindows, monthlyFuelPrice } from "@/lib/metrics/fuelEconomy";
@@ -56,16 +56,16 @@ export const FleetTab = ({ loads }: { loads: Load[] }) => {
 
   // single owner-operator: all loads are this truck's
   const metrics = useMemo(
-    () => (truck ? computeTruckMetrics(truck, loads, fleet.fuel, fleet.services, now, fleet.homeDays) : null),
-    [truck, loads, fleet.fuel, fleet.services, fleet.homeDays, now],
+    () => (truck ? computeTruckMetrics(truck, loads, fleet.fuel, fleet.services, now, fleet.homeDays, fleet.travelDays) : null),
+    [truck, loads, fleet.fuel, fleet.services, fleet.homeDays, fleet.travelDays, now],
   );
   const shop = useMemo(() => shopSpend(fleet.services, now, 12), [fleet.services, now]);
-  const heat = useMemo(() => fleetHeatmap(loads, fleet.homeDays, now, 26), [loads, fleet.homeDays, now]);
+  const heat = useMemo(() => fleetHeatmap(loads, fleet.homeDays, fleet.travelDays, now, 26), [loads, fleet.homeDays, fleet.travelDays, now]);
 
-  const home = useMemo(
-    () => hometimeStatus(fleet.lastHome, fleet.hometimeThreshold ?? HOME_TARGET_FALLBACK, now),
-    [fleet.lastHome, fleet.hometimeThreshold, now],
-  );
+  const home = useMemo(() => {
+    const lh = lastHomeDay(loads, fleet.homeDays, fleet.travelDays, now);
+    return hometimeStatus(lh, fleet.hometimeThreshold ?? HOME_TARGET_FALLBACK, now);
+  }, [loads, fleet.homeDays, fleet.travelDays, fleet.hometimeThreshold, now]);
 
   const dues = useMemo(() => {
     const cur = truck ? Number(truck.current_odometer) || null : null;
@@ -102,14 +102,23 @@ export const FleetTab = ({ loads }: { loads: Load[] }) => {
   const mpgSeries = useMemo(() => mpgWindows(fleet.fuel).slice(-8).map((w) => w.mpg), [fleet.fuel]);
   const paidPerGal = useMemo(() => monthlyFuelPrice(fleet.fuel).at(-1)?.avgPrice ?? null, [fleet.fuel]);
 
-  // Split fuel vs maintenance from the SPEND components (both dollars) so the
-  // shares always sit in 0–100% and the per-mile figures share one denominator.
-  const costPerMile = metrics?.costToRunPerMile ?? null; // (fuel + maint) ÷ total miles
-  const runSpend = (metrics?.fuelSpend ?? 0) + (metrics?.maintSpend ?? 0);
+  // Cost to run, all-in: fuel + maintenance (spend ÷ total miles) PLUS the rig's
+  // own note (monthly truck + trailer payment ÷ miles/month). Shares are by
+  // per-mile component so they always sum to 100%.
   const tMiles = metrics?.totalMiles ?? 0;
+  const mpm = metrics?.milesPerMonth ?? null;
   const fuelPerMile = tMiles > 0 ? (metrics?.fuelSpend ?? 0) / tMiles : null;
   const maintPerMile = tMiles > 0 ? (metrics?.maintSpend ?? 0) / tMiles : null;
-  const fuelPct = runSpend > 0 ? Math.round(((metrics?.fuelSpend ?? 0) / runSpend) * 100) : null;
+  const notePerMile = mpm && mpm > 0 && fleet.assetNote > 0 ? fleet.assetNote / mpm : null;
+  const costParts = (
+    [
+      { key: "fuel", label: "fuel", v: fuelPerMile, color: "#c8890a" },
+      { key: "maint", label: "maintenance", v: maintPerMile, color: "#5f7fd0" },
+      { key: "note", label: "truck + trailer note", v: notePerMile, color: "#a06ad0" },
+    ] as { key: string; label: string; v: number | null; color: string }[]
+  ).filter((p): p is { key: string; label: string; v: number; color: string } => p.v != null);
+  const costPerMile = costParts.length ? costParts.reduce((s, p) => s + p.v, 0) : null;
+  const costPct = (v: number) => (costPerMile && costPerMile > 0 ? Math.round((v / costPerMile) * 100) : 0);
   const dieselGap = paidPerGal != null && fleet.nationalDiesel != null ? paidPerGal - fleet.nationalDiesel : null;
 
   if (fleet.loading)
@@ -217,8 +226,8 @@ export const FleetTab = ({ loads }: { loads: Load[] }) => {
           {dues.length === 0 ? (
             <p className="text-xs text-muted-text">No maintenance schedule yet.</p>
           ) : (
-            dues.slice(0, 4).map((d) => (
-              <div key={d.name} className="flex items-center gap-2 py-1.5 text-[12px] border-t first:border-t-0" style={{ borderColor: "#1a2233" }}>
+            dues.slice(0, 4).map((d, i) => (
+              <div key={`${d.name}-${i}`} className="flex items-center gap-2 py-1.5 text-[12px] border-t first:border-t-0" style={{ borderColor: "#1a2233" }}>
                 <span className="w-2 h-2 rounded-full shrink-0" style={{ background: DUE_DOT[d.due.level] }} />
                 <span className="truncate">{d.name}</span>
                 <span className="ml-auto text-[11px] whitespace-nowrap" style={{ color: d.due.level === "overdue" ? "#f87171" : d.due.level === "soon" ? "#f5a623" : "#8b93a3" }}>
@@ -232,8 +241,8 @@ export const FleetTab = ({ loads }: { loads: Load[] }) => {
             <div className="border-t mt-3 pt-2.5" style={{ borderColor: "#1a2233" }}>
               <p className="text-[10px] uppercase tracking-wide text-muted-text font-bold mb-1.5">Compliance</p>
               <div className="flex flex-wrap gap-1.5">
-                {chips.map((c) => (
-                  <span key={c.label} className={`text-[10px] font-semibold px-2 py-0.5 rounded ${COMP[c.level].cls}`} style={{ background: "#0e1420", border: "1px solid #26304a" }}>
+                {chips.map((c, i) => (
+                  <span key={`${c.label}-${i}`} className={`text-[10px] font-semibold px-2 py-0.5 rounded ${COMP[c.level].cls}`} style={{ background: "#0e1420", border: "1px solid #26304a" }}>
                     {c.label} · {c.level === "expired" ? `expired ${Math.abs(c.daysRemaining ?? 0)}d` : c.level === "expiring" ? `${c.daysRemaining}d` : "ok"}
                   </span>
                 ))}
@@ -288,12 +297,22 @@ export const FleetTab = ({ loads }: { loads: Load[] }) => {
           ) : (
             <>
               <div className="flex h-6 rounded-md overflow-hidden mb-2" style={{ border: "1px solid #26304a" }}>
-                {fuelPct != null && <div className="flex items-center justify-center text-[10px] font-bold" style={{ width: `${fuelPct}%`, background: "#c8890a", color: "#0d1119" }}>Fuel {fuelPct}%</div>}
-                {fuelPct != null && <div className="flex items-center justify-center text-[10px] font-bold" style={{ width: `${100 - fuelPct}%`, background: "#5f7fd0", color: "#0d1119" }}>Maint {100 - fuelPct}%</div>}
+                {costParts.map((p) => (
+                  <div key={p.key} className="flex items-center justify-center text-[9px] font-bold" style={{ width: `${costPct(p.v)}%`, background: p.color, color: "#0d1119" }}>
+                    {costPct(p.v) >= 14 ? `${costPct(p.v)}%` : ""}
+                  </div>
+                ))}
               </div>
-              <div className="flex justify-between text-[11.5px] py-0.5"><span><b style={{ color: "#c8890a" }}>{rpm(fuelPerMile)}</b> fuel / mi</span></div>
-              <div className="flex justify-between text-[11.5px] py-0.5"><span><b style={{ color: "#5f7fd0" }}>{rpm(maintPerMile)}</b> maintenance / mi</span><span className="text-muted-text">{fuelPct != null ? `${100 - fuelPct}% of the cost` : ""}</span></div>
-              <div className="flex justify-between text-[11.5px] pt-1.5 mt-1 border-t" style={{ borderColor: "#1a2233" }}><span className="font-bold">{rpm(costPerMile)} total / mi</span><span className="text-muted-text">to keep her rolling</span></div>
+              {costParts.map((p) => (
+                <div key={p.key} className="flex justify-between text-[11.5px] py-0.5">
+                  <span><b style={{ color: p.color }}>{rpm(p.v)}</b> {p.label} / mi</span>
+                  <span className="text-muted-text">{costPct(p.v)}%</span>
+                </div>
+              ))}
+              <div className="flex justify-between text-[11.5px] pt-1.5 mt-1 border-t" style={{ borderColor: "#1a2233" }}>
+                <span className="font-bold">{rpm(costPerMile)} total / mi</span>
+                <span className="text-muted-text">all-in to keep her rolling</span>
+              </div>
             </>
           )}
           {paidPerGal != null && (

--- a/frontend/src/hooks/useFleetData.ts
+++ b/frontend/src/hooks/useFleetData.ts
@@ -9,14 +9,14 @@ import { getTrucks } from "@/services/trucksService";
 import { getTrailers } from "@/services/trailersService";
 import { getFuelEntries, getNationalDiesel } from "@/services/fuelService";
 import { getMaintenanceItems, getMaintenanceServices } from "@/services/maintenanceService";
-import { getHomeDays, getLastHomeDay } from "@/services/perDiemService";
+import { getPerDiemDays } from "@/services/perDiemService";
 import { getComplianceItems } from "@/services/complianceService";
 import { getDrivers } from "@/services/driversService";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import { getObligations } from "@/services/obligationsService";
 
 // Everything the Fleet tab needs, fetched once when the tab opens (it only mounts
-// when Fleet is the active dashboard tab, so these calls are lazy). Raw data —
-// the tab computes the metrics from it so the math stays pure and testable.
+// when Fleet is the active dashboard tab, so these calls are lazy).
 export interface FleetData {
   loading: boolean;
   trucks: Truck[];
@@ -24,17 +24,18 @@ export interface FleetData {
   fuel: FuelEntry[];
   items: MaintenanceItem[];
   services: MaintenanceService[];
-  homeDays: string[];
+  homeDays: string[]; // explicit per-diem "home" marks
+  travelDays: string[]; // per-diem "full"/"half" (on-the-road) marks
   compliance: ComplianceItem[];
   drivers: Driver[];
   nationalDiesel: number | null; // $/gal
-  lastHome: string | null; // most recent "home" per-diem mark, 'YYYY-MM-DD'
-  hometimeThreshold: number | null; // days-out target (settlement schedule setting)
+  hometimeThreshold: number | null; // days-out target (settlement schedule)
+  assetNote: number; // monthly truck + trailer notes (for all-in cost/mile)
 }
 
 const EMPTY: Omit<FleetData, "loading"> = {
-  trucks: [], trailers: [], fuel: [], items: [], services: [], homeDays: [], compliance: [], drivers: [], nationalDiesel: null,
-  lastHome: null, hometimeThreshold: null,
+  trucks: [], trailers: [], fuel: [], items: [], services: [], homeDays: [], travelDays: [],
+  compliance: [], drivers: [], nationalDiesel: null, hometimeThreshold: null, assetNote: 0,
 };
 
 export const useFleetData = (): FleetData => {
@@ -43,28 +44,37 @@ export const useFleetData = (): FleetData => {
 
   useEffect(() => {
     let alive = true;
+    const year = new Date().getUTCFullYear();
     (async () => {
       try {
-        const [trucks, trailers, fuel, items, services, homeDays, compliance, drivers, nat, lastHome, sched] =
+        const [trucks, trailers, fuel, items, services, pdThis, pdPrev, compliance, drivers, nat, sched, obligations] =
           await Promise.all([
             getTrucks(),
             getTrailers(),
             getFuelEntries(),
             getMaintenanceItems(),
             getMaintenanceServices(),
-            getHomeDays(),
+            getPerDiemDays(year),
+            getPerDiemDays(year - 1).catch(() => []),
             getComplianceItems(),
             getDrivers(),
             getNationalDiesel().catch(() => null),
-            getLastHomeDay().catch(() => null),
             getSettlementSchedule().catch(() => null),
+            getObligations().catch(() => []),
           ]);
         if (!alive) return;
+        const perDiem = [...pdThis, ...pdPrev];
         setData({
-          trucks, trailers, fuel, items, services, homeDays, compliance, drivers,
+          trucks, trailers, fuel, items, services, compliance, drivers,
+          homeDays: perDiem.filter((d) => d.status === "home").map((d) => d.day),
+          travelDays: perDiem.filter((d) => d.status === "full" || d.status === "half").map((d) => d.day),
           nationalDiesel: nat?.value ?? null,
-          lastHome: lastHome ?? null,
           hometimeThreshold: sched?.hometime_threshold_days ?? null,
+          // the rig's own notes (truck + trailer); a plain loan like Best Egg isn't
+          // a cost of running the rig, so it's excluded.
+          assetNote: obligations
+            .filter((o) => o.active && !o.is_draw && (o.asset_type === "truck" || o.asset_type === "trailer"))
+            .reduce((s, o) => s + (Number(o.amount) || 0), 0),
         });
       } catch {
         /* leave empty — the tab shows an empty state */

--- a/frontend/src/lib/metrics/fleet.test.ts
+++ b/frontend/src/lib/metrics/fleet.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from "vitest";
 import type { Load } from "@/types/load";
 import type { MaintenanceService } from "@/types/maintenance";
-import { shopSpend, fleetHeatmap } from "./fleet";
+import { shopSpend, fleetHeatmap, lastHomeDay } from "./fleet";
 
 const NOW = new Date("2026-08-15T12:00:00Z");
 beforeEach(() => {
@@ -67,27 +67,61 @@ describe("fleetHeatmap", () => {
   const cellFor = (h: ReturnType<typeof fleetHeatmap>, date: string) =>
     h.cells.find((c) => c.date === date);
 
-  it("returns 7×weeks cells, classifies each, labels months", () => {
+  it("classifies days: under-load, explicit home, travel=idle, unmarked=home", () => {
     const loads = [load("2026-08-13", "2026-08-14")]; // 2-day haul
-    const h = fleetHeatmap(loads, ["2026-08-10"], NOW, 4);
+    const h = fleetHeatmap(loads, ["2026-08-10"], ["2026-08-05"], NOW, 4);
     expect(h.cells).toHaveLength(28);
-    expect(h.weeks).toBe(4);
     expect(h.months.length).toBeGreaterThan(0);
     expect(cellFor(h, "2026-08-14")?.status).toBe("underload");
-    expect(cellFor(h, "2026-08-13")?.status).toBe("underload");
-    expect(cellFor(h, "2026-08-10")?.status).toBe("home");
-    expect(cellFor(h, "2026-08-15")?.status).toBe("idle"); // today, nothing
+    expect(cellFor(h, "2026-08-10")?.status).toBe("home"); // explicit mark
+    expect(cellFor(h, "2026-08-05")?.status).toBe("idle"); // travel, not loaded
+    expect(cellFor(h, "2026-08-12")?.status).toBe("home"); // unmarked → home
   });
 
   it("an explicit home mark WINS over a load span covering it", () => {
     const loads = [load("2026-08-10", "2026-08-14")]; // span covers 08-14
-    const h = fleetHeatmap(loads, ["2026-08-14"], NOW, 4);
-    expect(cellFor(h, "2026-08-14")?.status).toBe("home"); // home overrides under-load
-    expect(cellFor(h, "2026-08-13")?.status).toBe("underload"); // still hauling
+    const h = fleetHeatmap(loads, ["2026-08-14"], [], NOW, 4);
+    expect(cellFor(h, "2026-08-14")?.status).toBe("home");
+    expect(cellFor(h, "2026-08-13")?.status).toBe("underload");
   });
 
   it("marks days after today as future (blank)", () => {
-    const h = fleetHeatmap([], [], NOW, 4);
+    const h = fleetHeatmap([], [], [], NOW, 4);
     h.cells.filter((c) => c.future).forEach((c) => expect(c.date > "2026-08-15").toBe(true));
+  });
+});
+
+describe("lastHomeDay", () => {
+  it("most recent home day, counting unmarked as home", () => {
+    const loads = [load("2026-08-13", "2026-08-15")]; // out (loaded) 13–15
+    const travel = ["2026-08-11", "2026-08-12"]; // on the road 11–12
+    // 08-10 and back are unmarked → home; most recent home is 08-10
+    expect(lastHomeDay(loads, [], travel, NOW)).toBe("2026-08-10");
+  });
+
+  it("returns today when today is unmarked and not under load", () => {
+    expect(lastHomeDay([], [], [], NOW)).toBe("2026-08-15");
+  });
+});
+
+// Regression: the operator's per-diem calendar is in LOCAL days, so "today" must be
+// the local day. On a US evening the UTC date is already tomorrow — an unmarked day
+// that would read as home and falsely reset the counter to "home today."
+describe("lastHomeDay — local-day anchor (timezone)", () => {
+  const orig = process.env.TZ;
+  beforeAll(() => {
+    process.env.TZ = "America/Chicago";
+  });
+  afterAll(() => {
+    process.env.TZ = orig;
+  });
+
+  it("uses the operator's local 'today', not the UTC date", () => {
+    // 2026-08-09T01:00Z = 2026-08-08 20:00 CDT — local day is the 8th, UTC day the 9th.
+    const now = new Date("2026-08-09T01:00:00Z");
+    expect(now.toISOString().slice(0, 10)).toBe("2026-08-09"); // sanity: UTC really is the 9th
+    // nothing marked/loaded → every day is home; the most recent home is TODAY, and
+    // "today" is the operator's local day (the 8th), matching the per-diem calendar.
+    expect(lastHomeDay([], [], [], now)).toBe("2026-08-08");
   });
 });

--- a/frontend/src/lib/metrics/fleet.ts
+++ b/frontend/src/lib/metrics/fleet.ts
@@ -1,6 +1,7 @@
 import type { Load } from "@/types/load";
 import type { MaintenanceService } from "@/types/maintenance";
 import { underLoadDaySet } from "./underLoad";
+import { dayKey as localDayKey } from "@/lib/perDiem";
 
 // Fleet-tab metrics: what a single owner-operator's rig has cost in the shop, and
 // the day-by-day rhythm of how it ran. Pure — the clock comes in as `now`.
@@ -87,24 +88,64 @@ export interface Heatmap {
   months: { col: number; label: string }[]; // a label at the column where each month begins
 }
 
+// Which bucket a single day falls in. The per-diem calendar's default is HOME —
+// an unmarked day means you were home — so home = explicit "home" mark OR
+// unmarked, as long as you weren't under a load. "full"/"half" (travel) days you
+// weren't loaded are idle (out, not earning). A load span you didn't override
+// with a home mark is under-load.
+export const dayStatus = (
+  k: string,
+  under: Set<string>,
+  home: Set<string>,
+  travel: Set<string>,
+): DayStatus =>
+  home.has(k) ? "home" : under.has(k) ? "underload" : travel.has(k) ? "idle" : "home";
+
+// The most recent day you were home (scanning back from today) — home includes
+// unmarked days, so this is the true "last home," not just the last explicit mark.
+export const lastHomeDay = (
+  loads: Load[],
+  homeDays: string[],
+  travelDays: string[],
+  now: Date,
+): string | null => {
+  // Anchor "today" to the operator's LOCAL calendar day. Per-diem marks are local
+  // days, and hometimeStatus measures against the local today — if we used the UTC
+  // date, a US evening (UTC already "tomorrow") is an unmarked day that reads as
+  // home and falsely resets the counter to "home today."
+  const todayKey = localDayKey(now);
+  const under = underLoadDaySet(loads, null, todayKey);
+  const home = new Set(homeDays);
+  const travel = new Set(travelDays);
+  const cur = new Date(`${todayKey}T00:00:00Z`); // UTC-midnight of the local day, to step cleanly
+  for (let i = 0; i < 400; i++) {
+    const k = dayKey(cur);
+    if (dayStatus(k, under, home, travel) === "home") return k;
+    cur.setUTCDate(cur.getUTCDate() - 1);
+  }
+  return null;
+};
+
 // A GitHub-style calendar: columns are weeks (aligned to Sunday so rows are real
-// weekdays), oldest on the left, this week on the right. A "home" mark WINS over
-// a load's pickup→delivery envelope — if you said you were home, you weren't
-// hauling — then under-load, then idle.
+// weekdays), oldest on the left, this week on the right. See dayStatus for the
+// under-load / home / idle rules; future days render blank.
 export const fleetHeatmap = (
   loads: Load[],
   homeDays: string[],
+  travelDays: string[],
   now: Date,
   weeks = 26,
 ): Heatmap => {
-  const today = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-  );
+  // Local calendar "today" (see lastHomeDay) so the week boundary and the "future"
+  // cutoff track the operator's day, not UTC's — otherwise a US evening renders
+  // tomorrow as a real (home) cell instead of blank.
+  const today = new Date(`${localDayKey(now)}T00:00:00Z`);
   const thisWeekSunday = new Date(today.getTime() - today.getUTCDay() * DAY);
   const start = new Date(thisWeekSunday.getTime() - (weeks - 1) * 7 * DAY);
   const todayKey = dayKey(today);
   const under = underLoadDaySet(loads, dayKey(start), todayKey);
   const home = new Set(homeDays);
+  const travel = new Set(travelDays);
 
   const cells: HeatCell[] = [];
   const months: { col: number; label: string }[] = [];
@@ -113,9 +154,7 @@ export const fleetHeatmap = (
   for (let i = 0; i < weeks * 7; i++) {
     const k = dayKey(cur);
     const future = k > todayKey;
-    const status: DayStatus = future
-      ? "idle"
-      : home.has(k) ? "home" : under.has(k) ? "underload" : "idle";
+    const status: DayStatus = future ? "idle" : dayStatus(k, under, home, travel);
     cells.push({ date: k, status, future });
     if (i % 7 === 0 && cur.getUTCMonth() !== lastMonth) {
       months.push({ col: i / 7, label: cur.toLocaleDateString("en-US", { month: "short", timeZone: "UTC" }) });

--- a/frontend/src/lib/metrics/trailerMetrics.ts
+++ b/frontend/src/lib/metrics/trailerMetrics.ts
@@ -1,6 +1,6 @@
 // Trailer-scoped metrics. A trailer has no engine, so there's no fuel line — its
-// cost to run is maintenance alone, and it earns on its own 8% slice of the loads it
-// carried. Pure; take `now` explicitly.
+// cost to run is maintenance plus its own note (passed in as `assetNote`), and it
+// earns on its own 8% slice of the loads it carried. Pure; take `now` explicitly.
 import type { Load } from "@/types/load";
 import type { MaintenanceService } from "@/types/maintenance";
 import type { Trailer } from "@/types/trailer";
@@ -9,7 +9,8 @@ import { loadTrailerNet } from "./rateTargets";
 export interface TrailerMetrics {
   utilization: number | null; // active weeks ÷ weeks in service
   earningsPerMile: number | null; // its 8% share ÷ miles carried
-  costToRunPerMile: number | null; // maintenance ÷ miles (no fuel)
+  costToRunPerMile: number | null; // (maintenance + note) ÷ miles (no fuel) — all-in
+  notePerMile: number | null; // trailer note ÷ miles/month (null when no note passed)
   milesPerMonth: number | null;
   totalMiles: number;
   earnings: number; // cumulative 8% share
@@ -44,6 +45,7 @@ export const computeTrailerMetrics = (
   trailerLoads: Load[],
   services: MaintenanceService[],
   now: Date,
+  assetNote = 0, // monthly trailer note — folds into cost-to-run
 ): TrailerMetrics => {
   const earnedLoads = trailerLoads.filter(
     (l) => l.load_status === "delivered" && l.payment_status === "paid",
@@ -66,12 +68,22 @@ export const computeTrailerMetrics = (
   const monthsInService = inService
     ? Math.max(1, (now.getTime() - inService.getTime()) / (30.44 * DAY))
     : null;
+  const milesPerMonth = monthsInService ? totalMiles / monthsInService : null;
+
+  // All-in: maintenance ÷ miles plus the trailer's own note spread over its monthly
+  // miles. Mirrors the truck's cost-to-run so the label means the same thing.
+  const notePerMile =
+    milesPerMonth && milesPerMonth > 0 && assetNote > 0 ? assetNote / milesPerMonth : null;
+  const operatingPerMile = totalMiles > 0 ? maintSpend / totalMiles : null;
+  const costToRunPerMile =
+    operatingPerMile != null ? operatingPerMile + (notePerMile ?? 0) : null;
 
   return {
     utilization,
     earningsPerMile: totalMiles > 0 ? earnings / totalMiles : null,
-    costToRunPerMile: totalMiles > 0 ? maintSpend / totalMiles : null,
-    milesPerMonth: monthsInService ? totalMiles / monthsInService : null,
+    costToRunPerMile,
+    notePerMile,
+    milesPerMonth,
     totalMiles,
     earnings,
     loads: earnedLoads.length,

--- a/frontend/src/lib/metrics/truckMetrics.test.ts
+++ b/frontend/src/lib/metrics/truckMetrics.test.ts
@@ -19,23 +19,40 @@ const load = (pickup_date: string, delivery_date: string): Load =>
   }) as unknown as Load;
 
 const now = new Date("2026-02-01T00:00:00Z");
-const run = (truck: Truck, loads: Load[], homeDays: string[]) =>
-  computeTruckMetrics(truck, loads, [] as FuelEntry[], [] as MaintenanceService[], now, homeDays);
+const run = (
+  truck: Truck,
+  loads: Load[],
+  homeDays: string[] = [],
+  travelDays: string[] = [],
+  assetNote = 0,
+) =>
+  computeTruckMetrics(
+    truck,
+    loads,
+    [] as FuelEntry[],
+    [] as MaintenanceService[],
+    now,
+    homeDays,
+    travelDays,
+    assetNote,
+  );
 
 describe("computeTruckMetrics — days-based utilization", () => {
-  it("is under-load days ÷ window days, split into under-load / home / idle", () => {
+  it("splits days: under-load / home (incl. unmarked) / idle (travel, unloaded)", () => {
     const truck = { in_service_date: "2026-01-01", current_odometer: 0 } as Truck;
     const loads = [
       load("2026-01-05", "2026-01-07"), // 3 under-load days
       load("2026-01-10", "2026-01-10"), // 1 under-load day
     ];
-    const m = run(truck, loads, ["2026-01-15"]); // 1 home day, not under load
+    // 1 explicit home mark + 2 travel (full/half) days you weren't loaded
+    const m = run(truck, loads, ["2026-01-15"], ["2026-01-20", "2026-01-21"]);
 
-    // window starts at the first pickup (later than in-service), runs to now.
-    expect(m.windowDays).toBe(27); // 2026-01-05 → 2026-02-01
+    // window 2026-01-05 → 2026-02-01 = 27 days. under-load 4, idle 2 (travel-unloaded),
+    // home 21 (1 explicit + 20 unmarked days — the per-diem default).
+    expect(m.windowDays).toBe(27);
     expect(m.underLoadDays).toBe(4);
-    expect(m.homeDays).toBe(1);
-    expect(m.idleDays).toBe(22);
+    expect(m.idleDays).toBe(2);
+    expect(m.homeDays).toBe(21);
     expect(m.underLoadDays + m.homeDays + m.idleDays).toBe(m.windowDays);
     expect(m.utilization).toBeCloseTo(4 / 27);
   });
@@ -48,12 +65,43 @@ describe("computeTruckMetrics — days-based utilization", () => {
     expect(m.underLoadDays).toBe(2); // only 01-06 and 01-07
   });
 
+  it("windowStart === today → 0-day window, split stays consistent (no phantom day)", () => {
+    // Brand-new rig, first (same-day) load: window is [today, today) = 0 days. The
+    // floored-to-1 window used to leave the 3-way split summing to 0 ≠ 1.
+    const truck = { in_service_date: "2026-02-01", current_odometer: 0 } as Truck; // == now's day
+    const m = run(truck, [load("2026-02-01", "2026-02-01")]);
+    expect(m.windowDays).toBe(0);
+    expect(m.underLoadDays + m.homeDays + m.idleDays).toBe(0);
+    expect(m.utilization).toBeNull();
+  });
+
   it("a home mark WINS over a load span that covers it", () => {
     const truck = { in_service_date: "2026-01-01", current_odometer: 0 } as Truck;
     const loads = [load("2026-01-05", "2026-01-07")]; // span 05–07
     const m = run(truck, loads, ["2026-01-06"]); // you marked 01-06 home
-    expect(m.homeDays).toBe(1); // it counts as home, not hauling
-    expect(m.underLoadDays).toBe(2); // 01-05 + 01-07 only — 01-06 removed
+    expect(m.underLoadDays).toBe(2); // 01-05 + 01-07 only — 01-06 removed from hauling
+    expect(m.idleDays).toBe(0); // no travel marks → no idle
+    expect(m.homeDays).toBe(m.windowDays - 2); // 01-06 + every unmarked day is home
+  });
+});
+
+describe("computeTruckMetrics — all-in cost to run (note)", () => {
+  const truck = { in_service_date: "2026-01-01", current_odometer: 0 } as Truck;
+  const loads = [load("2026-01-05", "2026-01-07")]; // 500 loaded miles, delivered+paid
+
+  it("no note passed → notePerMile is null, cost is operating only", () => {
+    const m = run(truck, loads);
+    expect(m.notePerMile).toBeNull();
+    // no fuel/maintenance in the fixtures → operating cost is 0, not the note
+    expect(m.costToRunPerMile).toBe(0);
+  });
+
+  it("folds the monthly note in as note ÷ miles-per-month", () => {
+    const m = run(truck, loads, [], [], 1000); // $1,000/mo note
+    expect(m.milesPerMonth).not.toBeNull();
+    expect(m.notePerMile).toBeCloseTo(1000 / m.milesPerMonth!, 6);
+    // operating (fuel+maint) is 0 here, so the all-in total equals the note slice
+    expect(m.costToRunPerMile).toBeCloseTo(m.notePerMile!, 6);
   });
 });
 

--- a/frontend/src/lib/metrics/truckMetrics.ts
+++ b/frontend/src/lib/metrics/truckMetrics.ts
@@ -1,7 +1,8 @@
 // Truck-scoped operating metrics: how hard the truck runs (utilization, miles),
 // how thirsty it is (fuel economy, fuel $/mi), how much it earns per mile, and what
-// it costs to run (fuel + maintenance per mile — what the truck costs the owner, NOT
-// counting the note, which lives in the payoff tracker). Pure; take `now` explicitly.
+// it costs to run ALL-IN (fuel + maintenance + the rig's note per mile — the true
+// cost of keeping it rolling). The note is passed in (`assetNote`); callers without
+// one get operating cost (fuel + maintenance) only. Pure; take `now` explicitly.
 import type { Load } from "@/types/load";
 import type { FuelEntry } from "@/types/fuelEntry";
 import type { MaintenanceService } from "@/types/maintenance";
@@ -23,9 +24,10 @@ export interface TruckMetrics {
   bestTank: number | null;
   fuelPerMile: number | null;
   revPerMile: number | null;
-  costToRunPerMile: number | null; // (fuel + maintenance) ÷ miles
+  costToRunPerMile: number | null; // (fuel + maintenance + note) ÷ miles — all-in
   fuelSpend: number; // fuel $ over the window (for the fuel-vs-maintenance split)
   maintSpend: number; // maintenance $ attributable to the truck
+  notePerMile: number | null; // asset note ÷ miles/month (null when no note passed)
   milesPerMonth: number | null;
   totalMiles: number;
   netRevenue: number;
@@ -56,7 +58,9 @@ export const computeTruckMetrics = (
   truckFuel: FuelEntry[],
   services: MaintenanceService[],
   now: Date,
-  homeDays: string[] = [], // "YYYY-MM-DD" home marks, for the week breakdown
+  homeDays: string[] = [], // explicit per-diem "home" marks ("YYYY-MM-DD")
+  travelDays: string[] = [], // per-diem "full"/"half" (on-the-road) marks
+  assetNote = 0, // monthly note for this rig (truck + trailer) — folds into cost-to-run
 ): TruckMetrics => {
   // Earned freight — delivered AND paid — matches the truck's net revenue elsewhere.
   const earned = truckLoads.filter(
@@ -91,9 +95,12 @@ export const computeTruckMetrics = (
   const windowStart =
     [inServiceDay, firstPickup].filter((d): d is string => !!d).sort().at(-1) ??
     null;
+  // Half-open [windowStart, now) — 0 on the very first day (windowStart === today),
+  // which keeps the per-day loop below summing exactly to windowDays. Floor at 0,
+  // not 1, so a same-day/future window doesn't claim a phantom day the loop can't fill.
   const windowDays = windowStart
     ? Math.max(
-        1,
+        0,
         Math.round(
           (Date.parse(`${nowDay}T00:00:00Z`) -
             Date.parse(`${windowStart}T00:00:00Z`)) /
@@ -102,24 +109,46 @@ export const computeTruckMetrics = (
       )
     : 0;
 
+  // Categorize every window day. The per-diem default is HOME (an unmarked day
+  // means you were home), so home = explicit "home" mark OR unmarked, unless you
+  // were under a load. "full"/"half" (travel) days you weren't loaded are idle
+  // (out, not earning). An explicit home mark wins over a load's date envelope.
   const underLoadSet = underLoadDaySet(truckLoads, windowStart, nowDay);
-  // An explicit "home" mark wins over a load's pickup→delivery envelope: if you
-  // said you were home that day, you weren't hauling — even if a multi-day load's
-  // span technically covers it. So home days are removed from under-load, not the
-  // other way around. Home still counts against utilization (costs accrue) — this
-  // only labels why the truck wasn't earning.
-  const homeSet = new Set(
-    homeDays.filter((d) => (!windowStart || d >= windowStart) && d <= nowDay),
-  );
-  const underLoadDays = [...underLoadSet].filter((d) => !homeSet.has(d)).length;
-  const homeDayCount = homeSet.size;
+  const homeSet = new Set(homeDays);
+  const travelSet = new Set(travelDays);
+  let underLoadDays = 0;
+  let homeDayCount = 0;
+  let idleDays = 0;
+  if (windowStart) {
+    // [windowStart, now) — windowDays days, so the three counts sum to windowDays.
+    const cur = new Date(`${windowStart}T00:00:00Z`);
+    const end = new Date(`${nowDay}T00:00:00Z`);
+    while (cur < end) {
+      const k = cur.toISOString().slice(0, 10);
+      if (homeSet.has(k)) homeDayCount++;
+      else if (underLoadSet.has(k)) underLoadDays++;
+      else if (travelSet.has(k)) idleDays++;
+      else homeDayCount++; // unmarked → home
+      cur.setUTCDate(cur.getUTCDate() + 1);
+    }
+  }
   const utilization =
     windowDays > 0 ? Math.min(1, underLoadDays / windowDays) : null;
-  const idleDays = Math.max(0, windowDays - underLoadDays - homeDayCount);
 
   const monthsInService = inService
     ? Math.max(1, (now.getTime() - inService.getTime()) / (30.44 * DAY))
     : null;
+  const milesPerMonth = monthsInService ? totalMiles / monthsInService : null;
+
+  // All-in cost to run: fuel + maintenance (spend ÷ miles driven) plus the rig's own
+  // note spread over the miles it runs a month. The note is a per-mile rate on a
+  // different time base than fuel/maint, but each piece is a valid $/mi, so they add.
+  const notePerMile =
+    milesPerMonth && milesPerMonth > 0 && assetNote > 0 ? assetNote / milesPerMonth : null;
+  const operatingPerMile =
+    totalMiles > 0 ? (fuelSpend + maintSpend) / totalMiles : null;
+  const costToRunPerMile =
+    operatingPerMile != null ? operatingPerMile + (notePerMile ?? 0) : null;
 
   return {
     utilization,
@@ -131,10 +160,11 @@ export const computeTruckMetrics = (
     bestTank: fs.bestMpg,
     fuelPerMile: fs.costPerMile,
     revPerMile: totalMiles > 0 ? netRevenue / totalMiles : null,
-    costToRunPerMile: totalMiles > 0 ? (fuelSpend + maintSpend) / totalMiles : null,
+    costToRunPerMile,
     fuelSpend,
     maintSpend,
-    milesPerMonth: monthsInService ? totalMiles / monthsInService : null,
+    notePerMile,
+    milesPerMonth,
     totalMiles,
     netRevenue,
     loads: delivered.length,

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1377,20 +1377,24 @@ const GuidePage = () => {
 
           <Metric
             title="Cost to run per mile — what the truck costs you"
-            answers="The truck's own operating cost per mile — fuel plus maintenance. The truck note isn't here; it lives on the payoff tracker, so it's never double-counted."
+            answers="What the rig costs per mile, all-in: fuel, maintenance, and its note. The truck page carries the truck note, the trailer page the trailer note, and the Fleet dashboard rolls both into the whole rig."
             sources={[{ label: "Garage", to: "/garage" }]}
           >
             <div className="flex items-center gap-2 flex-wrap mb-3">
-              <ChainBox top="$0.58" bottom="fuel / mi" />
+              <ChainBox top="$0.28" bottom="fuel / mi" />
               <span className="text-muted-text">+</span>
-              <ChainBox top="$0.14" bottom="maintenance / mi" />
+              <ChainBox top="$0.12" bottom="maintenance / mi" />
+              <span className="text-muted-text">+</span>
+              <ChainBox top="$0.50" bottom="note / mi" />
               <span className="text-muted-text">=</span>
-              <ChainBox top="$0.72" bottom="cost to run / mi" />
+              <ChainBox top="$0.90" bottom="cost to run / mi" />
             </div>
-            <Formula>(fuel spend + maintenance spend) ÷ miles driven</Formula>
+            <Formula>(fuel + maintenance) ÷ miles driven + note ÷ miles per month</Formula>
             <Why>
-              The real cost of keeping this truck rolling, kept separate from
-              financing.
+              The real cost of keeping the rig rolling — the note included, so the
+              number reflects what actually leaves your pocket each mile. The same
+              payment also shows on the payoff tracker, but as balance paid down, not
+              a per-mile cost.
             </Why>
           </Metric>
 

--- a/frontend/src/pages/TrailerDetailPage.tsx
+++ b/frontend/src/pages/TrailerDetailPage.tsx
@@ -109,6 +109,18 @@ const TrailerDetailPage = () => {
       isPayoffTracked(o),
   );
 
+  // The trailer's monthly note — folded into cost-to-run (all-in). Active, non-draw,
+  // trailer-scoped, mirroring the truck page.
+  const trailerNote = obligations
+    .filter(
+      (o) =>
+        o.active &&
+        !o.is_draw &&
+        o.asset_type === "trailer" &&
+        (o.asset_id === id || o.asset_id == null),
+    )
+    .reduce((s, o) => s + (Number(o.amount) || 0), 0);
+
   // Latest hub reading, derived from the app: stored + newest trailer service.
   const hub = useMemo(() => {
     if (!trailer) return 0;
@@ -174,7 +186,7 @@ const TrailerDetailPage = () => {
     );
 
   const now = new Date();
-  const metrics = computeTrailerMetrics(trailer, trailerLoads, services, now);
+  const metrics = computeTrailerMetrics(trailer, trailerLoads, services, now, trailerNote);
   const trailerMedals = earnedMedals(
     computeTrailerMedals({
       hubMiles: hub,
@@ -309,7 +321,7 @@ const TrailerDetailPage = () => {
           <Kpi
             value={metrics.costToRunPerMile != null ? `$${metrics.costToRunPerMile.toFixed(2)}` : "—"}
             label="COST TO RUN / MI"
-            sub="maintenance only"
+            sub={metrics.notePerMile != null ? "maintenance + note" : "maintenance only"}
           />
           <Kpi value={metrics.milesPerMonth != null ? num(metrics.milesPerMonth) : "—"} label="MI / MONTH" />
         </div>

--- a/frontend/src/pages/TruckDetailPage.tsx
+++ b/frontend/src/pages/TruckDetailPage.tsx
@@ -10,7 +10,7 @@ import {
   getMaintenanceServices,
 } from "@/services/maintenanceService";
 import { getFuelEntries } from "@/services/fuelService";
-import { getHomeDays } from "@/services/perDiemService";
+import { getPerDiemDays } from "@/services/perDiemService";
 import { useLoads } from "@/hooks/useLoads";
 import {
   computeDue,
@@ -92,6 +92,7 @@ const TruckDetailPage = () => {
   const [obligations, setObligations] = useState<Obligation[]>([]);
   const [trips, setTrips] = useState<Trip[]>([]);
   const [homeDays, setHomeDays] = useState<string[]>([]);
+  const [travelDays, setTravelDays] = useState<string[]>([]);
   const [editing, setEditing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -116,8 +117,17 @@ const TruckDetailPage = () => {
     getTrips()
       .then(setTrips)
       .catch(() => {});
-    getHomeDays()
-      .then(setHomeDays)
+    // Per-diem drives the day split: explicit "home" marks plus "full"/"half"
+    // (on-the-road) days; unmarked days default to home inside computeTruckMetrics.
+    const year = new Date().getUTCFullYear();
+    Promise.all([getPerDiemDays(year), getPerDiemDays(year - 1).catch(() => [])])
+      .then(([a, b]) => {
+        const days = [...a, ...b];
+        setHomeDays(days.filter((d) => d.status === "home").map((d) => d.day));
+        setTravelDays(
+          days.filter((d) => d.status === "full" || d.status === "half").map((d) => d.day),
+        );
+      })
       .catch(() => {});
   }, [id]);
 
@@ -128,6 +138,18 @@ const TruckDetailPage = () => {
       (o.asset_id === id || o.asset_id == null) &&
       isPayoffTracked(o),
   );
+
+  // The truck's monthly note — folded into cost-to-run (all-in). Active, non-draw,
+  // truck-scoped; a personal loan (no asset) isn't a cost of running the rig.
+  const truckNote = obligations
+    .filter(
+      (o) =>
+        o.active &&
+        !o.is_draw &&
+        o.asset_type === "truck" &&
+        (o.asset_id === id || o.asset_id == null),
+    )
+    .reduce((s, o) => s + (Number(o.amount) || 0), 0);
 
   const truckLoads = useMemo(
     () => loads.filter((l) => l.truck_id === id),
@@ -212,7 +234,7 @@ const TruckDetailPage = () => {
   const revenue = earnedLoads.reduce((s, l) => s + loadRevenue(l), 0);
   const now = new Date();
   const truckFuel = fuelEntries.filter((f) => f.truck_id === id);
-  const metrics = computeTruckMetrics(truck, truckLoads, truckFuel, services, now, homeDays);
+  const metrics = computeTruckMetrics(truck, truckLoads, truckFuel, services, now, homeDays, travelDays, truckNote);
   const truckMedals = earnedMedals(
     computeTruckMedals({
       odometer,
@@ -340,7 +362,7 @@ const TruckDetailPage = () => {
           <Kpi
             value={metrics.costToRunPerMile != null ? `$${metrics.costToRunPerMile.toFixed(2)}` : "—"}
             label="COST TO RUN / MI"
-            sub="fuel + maintenance"
+            sub={metrics.notePerMile != null ? "fuel + maint + note" : "fuel + maintenance"}
           />
           <Kpi value={metrics.milesPerMonth != null ? num(metrics.milesPerMonth) : "—"} label="MI / MONTH" />
         </div>


### PR DESCRIPTION
## What & why

Two metric fixes Jason flagged, plus two bugs an adversarial pre-merge review caught.

### Home time / heatmap — unmarked = home
Unmarked per-diem days now classify as **home** (the per-diem calendar's own default), not blank/idle, unless the truck was under a load. Fixes the near-empty "Year in Days" heatmap (was ~1 home dot; now reflects the real ~53 home days) and the utilization day-split (under-load / home / idle). Verified against prod data (unit 580991): **151 under load · 53 home · 10 idle**.

### Cost to run — all-in, everywhere
`cost to run / mi` is now **fuel + maintenance + the asset's monthly note** (note ÷ miles-per-month), attributed per asset and consistent across every surface:
- **Truck page:** fuel + maint + truck note → **$0.84/mi**
- **Trailer page:** maint + trailer note → **$0.07/mi**
- **Dashboard (the rig):** both notes → **$0.90/mi**

Reconciles: rig $0.90 − truck $0.84 = $0.06 = the trailer note. Guide rewritten to match; the same payment still appears on the payoff tracker as balance-paid-down (not double-counted in any single total).

### Bugs caught in review (fixed here)
- **Timezone (major):** `lastHomeDay` + `fleetHeatmap` anchored "today" to **UTC** while per-diem marks and `hometimeStatus` use the operator's **local** day. On a US evening the UTC date is already tomorrow — an unmarked day that falsely read as **"home today."** Both now anchor to the local calendar day. Regression test added (`TZ=America/Chicago`, evening instant).
- **Invariant (minor):** `windowDays` floored to 1 on a same-day/degenerate window while the day loop ran zero iterations, so the 3-way split summed to 0 ≠ 1. Floor is now 0; test added.
- **React key:** duplicate-key error in the Fleet compliance chips / road-ready dues (Jason's data has two "Landstar 120" + two "Maintenance Report" items).

### Follow-up (tracked separately, not in this PR)
The Fleet day-split fetches only 2 years of per-diem but classifies the full utilization window, so trucks with >2yr history could mislabel old idle days as home. Latent (doesn't fire on current data; ~2028 for this truck). Spawned as its own task.

## Verification
- `npx vitest run` → **484 passed** (incl. new TZ + window-invariant regression tests)
- `npm run build` → clean (tsc + vite)
- Visually verified on prod data: dashboard Fleet tab, Truck detail, Trailer detail