### PR TITLE
feat(dashboard): after-notes margin, recency-first agents, quarterly board, fuel fit (v1.139.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.138.2",
+  "version": "1.139.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/FleetTab.tsx
+++ b/frontend/src/components/dashboard/FleetTab.tsx
@@ -141,7 +141,21 @@ export const FleetTab = ({ loads }: { loads: Load[] }) => {
   const uHome = metrics ? (metrics.homeDays / wd) * 100 : 0;
   const uIdle = metrics ? (metrics.idleDays / wd) * 100 : 0;
 
-  const mmin = Math.min(...mpgSeries, 0), mmax = Math.max(...mpgSeries, 1);
+  // Auto-fit the y-axis to the actual tanks (± 0.3 padding) so real variance reads
+  // instead of hugging a zero baseline — with a minimum span so a genuinely steady
+  // week doesn't get blown up into a dramatic zigzag.
+  let mmin = 0;
+  let mmax = 1;
+  if (mpgSeries.length > 0) {
+    mmin = Math.min(...mpgSeries) - 0.3;
+    mmax = Math.max(...mpgSeries) + 0.3;
+    const MIN_SPAN = 1.5;
+    if (mmax - mmin < MIN_SPAN) {
+      const mid = (mmin + mmax) / 2;
+      mmin = mid - MIN_SPAN / 2;
+      mmax = mid + MIN_SPAN / 2;
+    }
+  }
   const mpgPts = mpgSeries
     .map((m, i) => `${8 + (i / Math.max(1, mpgSeries.length - 1)) * 304},${44 - ((m - mmin) / Math.max(0.1, mmax - mmin)) * 34}`)
     .join(" ");

--- a/frontend/src/components/dashboard/MoneyTab.tsx
+++ b/frontend/src/components/dashboard/MoneyTab.tsx
@@ -24,10 +24,22 @@ const Tile = ({ label, value, sub, color }: { label: string; value: string; sub:
   </div>
 );
 
-export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: number | null }) => {
+export const MoneyTab = ({
+  loads,
+  marginGoal,
+  obligationsMonthly,
+}: {
+  loads: Load[];
+  marginGoal: number | null;
+  obligationsMonthly: number; // active, non-draw monthly notes (principal) — interest is already in the P&L
+}) => {
   const { periods, categoriesYTD, loading } = useExpensePeriods();
   const year = new Date().getUTCFullYear();
 
+  // Two margins per month: OPERATING (income − COGS − expenses; interest lives in
+  // those expense lines) and CASH / after-notes (operating minus the monthly note
+  // principal — the money that actually leaves the account). No interest double-
+  // count: the notes carry principal only, interest is already in the P&L.
   const rows = useMemo(
     () =>
       [...periods]
@@ -36,14 +48,24 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
         .map((p) => {
           const income = p.income_total ?? 0;
           const cost = (p.cogs_total ?? 0) + (p.expense_total ?? 0);
-          return { month: p.period_month, income, cost, profit: income - cost, margin: income > 0 ? (income - cost) / income : 0 };
+          const profit = income - cost;
+          return {
+            month: p.period_month,
+            income,
+            cost,
+            profit,
+            margin: income > 0 ? profit / income : 0,
+            cashMargin: income > 0 ? (profit - obligationsMonthly) / income : 0,
+          };
         }),
-    [periods],
+    [periods, obligationsMonthly],
   );
   const ytd = useMemo(() => rows.filter((r) => r.month.startsWith(String(year))), [rows, year]);
   const ytdIncome = ytd.reduce((s, r) => s + r.income, 0);
   const ytdProfit = ytd.reduce((s, r) => s + r.profit, 0);
   const ytdMargin = ytdIncome > 0 ? ytdProfit / ytdIncome : null;
+  // After-notes: subtract the monthly note once per P&L month in the window.
+  const ytdCashMargin = ytdIncome > 0 ? (ytdProfit - obligationsMonthly * ytd.length) / ytdIncome : null;
   const best = ytd.reduce<(typeof ytd)[number] | null>((b, r) => (!b || r.margin > b.margin ? r : b), null);
 
   // "Where it goes" — the year's spending by category (backend rollup), top 6 +
@@ -88,10 +110,16 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
         <Tile label={`Income · ${year}`} value={money(ytdIncome)} sub={`${ytd.length} months · net of carrier cut`} />
         <Tile label="Operating profit" value={money(ytdProfit)} color="#4ade80" sub="income − COGS − expenses" />
         <Tile
-          label="Margin"
-          value={ytdMargin != null ? `${Math.round(ytdMargin * 100)}%` : "—"}
-          color={ytdMargin != null && marginGoal != null ? (ytdMargin >= marginGoal ? "#4ade80" : "#f5a623") : undefined}
-          sub={marginGoal != null ? `${ytdMargin != null && ytdMargin >= marginGoal ? "▲ above" : "vs"} ${Math.round(marginGoal * 100)}% goal` : "operating margin"}
+          label="Margin · after notes"
+          value={ytdCashMargin != null ? `${Math.round(ytdCashMargin * 100)}%` : "—"}
+          color={ytdCashMargin != null && marginGoal != null ? (ytdCashMargin >= marginGoal ? "#4ade80" : "#f5a623") : undefined}
+          sub={
+            marginGoal != null && ytdCashMargin != null
+              ? `${ytdCashMargin >= marginGoal ? "▲ above" : "under"} ${Math.round(marginGoal * 100)}% goal${ytdMargin != null ? ` · ${Math.round(ytdMargin * 100)}% op` : ""}`
+              : ytdMargin != null
+                ? `${Math.round(ytdMargin * 100)}% operating`
+                : "after truck/trailer notes"
+          }
         />
         <Tile label="Best month" value={best ? `${monthShort(best.month)} · ${Math.round(best.margin * 100)}%` : "—"} sub={best ? `${money(best.profit)} profit` : ""} />
       </div>
@@ -131,9 +159,15 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
           </div>
         </div>
 
-        {/* margin trend */}
+        {/* margin trend — operating vs after-notes, against the goal */}
         <div className="rounded-xl p-3" style={C}>
-          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2">Margin trend</h3>
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2 flex justify-between items-center">
+            Margin trend
+            <span className="normal-case tracking-normal font-normal flex gap-2.5 text-[10px]">
+              <span style={{ color: "#f5b03a" }}>● operating</span>
+              <span style={{ color: "#5fd0e0" }}>● after notes</span>
+            </span>
+          </h3>
           <svg viewBox="0 0 320 140" className="w-full">
             {marginGoal != null && (
               <>
@@ -147,11 +181,17 @@ export const MoneyTab = ({ loads, marginGoal }: { loads: Load[]; marginGoal: num
               strokeWidth={2}
               points={rows.map((r, i) => `${8 + (i / Math.max(1, rows.length - 1)) * 304},${120 - Math.max(0, r.margin) * 220}`).join(" ")}
             />
+            <polyline
+              fill="none"
+              stroke="#5fd0e0"
+              strokeWidth={2}
+              points={rows.map((r, i) => `${8 + (i / Math.max(1, rows.length - 1)) * 304},${120 - Math.max(0, r.cashMargin) * 220}`).join(" ")}
+            />
             {rows.map((r, i) => (
-              <circle key={r.month} cx={8 + (i / Math.max(1, rows.length - 1)) * 304} cy={120 - Math.max(0, r.margin) * 220} r={3} fill={r.margin < 0.2 ? "#f87171" : i === rows.length - 1 ? "#4ade80" : "#f5b03a"} />
+              <circle key={r.month} cx={8 + (i / Math.max(1, rows.length - 1)) * 304} cy={120 - Math.max(0, r.cashMargin) * 220} r={2.5} fill={marginGoal != null && r.cashMargin < marginGoal ? "#f5a623" : "#5fd0e0"} />
             ))}
           </svg>
-          <p className="text-[11px] text-muted-text mt-1">Your operating margin, month by month{best ? ` — best was ${monthShort(best.month)} at ${Math.round(best.margin * 100)}%` : ""}.</p>
+          <p className="text-[11px] text-muted-text mt-1">Operating vs after-notes margin (owner's take), month by month{marginGoal != null ? ` — dashed line is your ${Math.round(marginGoal * 100)}% goal` : ""}.</p>
         </div>
       </div>
 

--- a/frontend/src/components/dashboard/agents/AgentsTab.tsx
+++ b/frontend/src/components/dashboard/agents/AgentsTab.tsx
@@ -7,10 +7,14 @@ import {
   buildAgentScorecards,
   agentRosterAnalytics,
   concentrationAnalytics,
-  agentMomentum,
-  MIN_SCORE_LOADS,
 } from "@/lib/metrics/agentScorecard";
-import { currentQuarterStandings, quarterKey } from "@/lib/metrics/agentLeaderboard";
+import {
+  quarterStandings,
+  quarterContenders,
+  currentQuarterKey,
+  lastCompleteQuarterKey,
+  type BoardStanding,
+} from "@/lib/metrics/agentLeaderboard";
 import { SPECIALTY_META, flagText } from "@/components/agents/agentDisplay";
 import { money, rpm as fmtRpm } from "@/lib/format";
 import { AgentScatter, type ScatterPoint } from "./AgentScatter";
@@ -45,24 +49,31 @@ const KpiTile = ({
   </div>
 );
 
-const MomBar = ({ pct }: { pct: number | null }) => {
-  if (pct == null) return <div className="h-4" />;
-  const up = pct >= 0;
-  const w = Math.min(48, Math.abs(pct) * 50);
-  return (
-    <div className="relative h-4 rounded" style={{ background: "#0c1119", border: "1px solid #1c2536" }}>
-      <div className="absolute top-0 bottom-0" style={{ left: "50%", width: 1, background: "#2f3b52" }} />
-      <div
-        className="absolute top-[2px] bottom-[2px]"
-        style={
-          up
-            ? { left: "50%", width: `${w}%`, background: "#2f7d55", borderRadius: "0 3px 3px 0" }
-            : { right: "50%", width: `${w}%`, background: "#8a3b3b", borderRadius: "3px 0 0 3px" }
-        }
-      />
-    </div>
-  );
-};
+const FRESH = (d: number | null): string =>
+  d == null ? "#8b93a3" : d <= 14 ? "#4ade80" : d <= 45 ? "#f5b03a" : "#8b93a3";
+
+const MEDAL = ["#f5b03a", "#c3ccd6", "#c78a3a"]; // gold · silver · bronze
+
+// "2026-Q2" → "Q2 2026"
+const qLabel = (q: string): string => q.split("-").reverse().join(" ");
+
+const BoardRow = ({ s, label }: { s: BoardStanding; label: string }) => (
+  <Link
+    to={`/agents/${s.agentId}`}
+    className="flex items-center gap-2.5 py-1.5 border-t first:border-t-0"
+    style={{ borderColor: "#1a2233" }}
+  >
+    <span
+      className="w-5 h-5 rounded-full flex items-center justify-center text-[11px] font-extrabold flex-none"
+      style={{ background: MEDAL[s.rank - 1] ?? "#5b6577", color: "#0d1119" }}
+    >
+      {s.rank}
+    </span>
+    <span className="flex-1 font-semibold text-light truncate">{label}</span>
+    <span className="text-[10px] text-muted-text whitespace-nowrap">{s.loads} loads</span>
+    <span className="font-bold whitespace-nowrap">{money(s.revenue)}</span>
+  </Link>
+);
 
 const Badge = ({ tag }: { tag: "oversize" | "specialty" }) => {
   const m = SPECIALTY_META[tag];
@@ -86,8 +97,11 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
   );
   const roster = useMemo(() => agentRosterAnalytics(scorecards), [scorecards]);
   const conc = useMemo(() => concentrationAnalytics(loads, now), [loads, now]);
-  const momentum = useMemo(() => agentMomentum(loads, now), [loads, now]);
-  const standings = useMemo(() => currentQuarterStandings(loads, now), [loads, now]);
+  const liveQ = currentQuarterKey(now);
+  const lastQ = lastCompleteQuarterKey(now);
+  const liveBoard = useMemo(() => quarterStandings(loads, liveQ), [loads, liveQ]);
+  const liveContenders = useMemo(() => quarterContenders(loads, liveQ), [loads, liveQ]);
+  const lastBoard = useMemo(() => quarterStandings(loads, lastQ), [loads, lastQ]);
   const byId = useMemo(
     () => new Map((agents ?? []).map((a) => [a.agent_id, a])),
     [agents],
@@ -107,22 +121,24 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
     return a ? `${a.first_name} ${a.last_name}` : "—";
   };
 
-  // momentum: top agents by revenue that have a reading
-  const momRows = useMemo(
+  // "Running with lately" — recent 90-day gross per agent (from the concentration
+  // window), joined to their days-since-last-load. Sorted by recency: who you're
+  // actually working with now, newest at the top. The quiet ones are the "going
+  // cold" card's job, so this stays the active bench.
+  const rev90 = useMemo(
+    () => new Map(conc.shares.map((s) => [s.agentId, s.revenue])),
+    [conc],
+  );
+  const recentRows = useMemo(
     () =>
       rows
-        .filter((r) => r.card.loadCount >= MIN_SCORE_LOADS && momentum.get(r.agent.agent_id) != null)
-        .sort((a, b) => b.card.revenue - a.card.revenue)
+        // Within the 90-day window this card is scoped to (matches the "90d $"
+        // header, and guarantees a real recent-$). Quieter agents are the "going
+        // cold" card's job, so they don't show here as a stale $0 row.
+        .filter((r) => r.card.daysSince != null && r.card.daysSince <= 90)
+        .sort((a, b) => (a.card.daysSince ?? 0) - (b.card.daysSince ?? 0))
         .slice(0, 6),
-    [rows, momentum],
-  );
-
-  const board = useMemo(
-    () =>
-      [...standings.entries()]
-        .sort((a, b) => b[1].revenue - a[1].revenue)
-        .slice(0, 3),
-    [standings],
+    [rows],
   );
 
   const cold = useMemo(
@@ -138,7 +154,6 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
 
   const rateLeader = roster.rateLeader ? byId.get(roster.rateLeader.agentId) : null;
   const coldTop = roster.goingCold ? byId.get(roster.goingCold.agentId) : null;
-  const RANK = ["#f5b03a", "#c3ccd6", "#c78a3a"];
   const topShares = conc.shares.slice(0, 3);
   const elseShare = Math.max(0, 1 - topShares.reduce((s, x) => s + x.share, 0));
 
@@ -147,7 +162,7 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
       <div className="flex items-baseline justify-between">
         <h2 className="text-xl font-condensed text-light">Your agent bench</h2>
         <span className="text-xs text-muted-text">
-          who pays · who volumes · who to call — {quarterKey(now.toISOString())}
+          who pays · who volumes · who to call
         </span>
       </div>
 
@@ -203,62 +218,66 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
         </div>
       </div>
 
-      {/* momentum + live board */}
+      {/* running-lately + quarterly board */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <div className="rounded-xl p-3.5" style={C.card}>
-          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5">
-            Momentum — last 90d vs prior
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5 flex justify-between items-center">
+            Running with lately
+            <span className="normal-case tracking-normal font-normal text-muted-text">last worked · 90d $</span>
           </h3>
-          {momRows.length === 0 ? (
-            <p className="text-xs text-muted-text">Not enough recent history to trend yet.</p>
+          {recentRows.length === 0 ? (
+            <p className="text-xs text-muted-text">No delivered loads in the last 90 days.</p>
           ) : (
-            momRows.map(({ agent, card }) => {
-              const pct = momentum.get(agent.agent_id)!;
-              const up = (pct ?? 0) >= 0;
-              return (
-                <div key={agent.agent_id} className="grid items-center gap-2 py-[3px]" style={{ gridTemplateColumns: "108px 1fr 46px" }}>
-                  <span className="text-[11.5px] truncate">
-                    {agent.first_name.charAt(0)}. {agent.last_name}
-                    {card.specialty.tag !== "standard" && <> <Badge tag={card.specialty.tag} /></>}
-                  </span>
-                  <MomBar pct={pct} />
-                  <span className="text-[11px] font-bold text-right" style={{ color: up ? "#4ade80" : "#f87171" }}>
-                    {up ? "+" : "−"}
-                    {Math.round(Math.abs(pct ?? 0) * 100)}%
-                  </span>
-                </div>
-              );
-            })
+            recentRows.map(({ agent, card }) => (
+              <Link
+                key={agent.agent_id}
+                to={`/agents/${agent.agent_id}`}
+                className="grid items-center gap-2 py-[5px] border-t first:border-t-0"
+                style={{ gridTemplateColumns: "1fr 62px 66px", borderColor: "#1a2233" }}
+              >
+                <span className="text-[12px] truncate flex items-center gap-1.5">
+                  <span className="w-1.5 h-1.5 rounded-full flex-none" style={{ background: FRESH(card.daysSince) }} />
+                  {agent.first_name} {agent.last_name}
+                  {card.specialty.tag !== "standard" && <Badge tag={card.specialty.tag} />}
+                </span>
+                <span className="text-[11px] text-right" style={{ color: FRESH(card.daysSince) }}>
+                  {card.daysSince}d ago
+                </span>
+                <span className="text-[11.5px] font-semibold text-right">{money(rev90.get(agent.agent_id) ?? 0)}</span>
+              </Link>
+            ))
           )}
         </div>
 
         <div className="rounded-xl p-3.5" style={C.card}>
-          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-2.5 flex justify-between">
-            Live board · {quarterKey(now.toISOString())}
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mb-1.5 flex justify-between items-center">
+            <span>This quarter · {qLabel(liveQ)}</span>
             <span className="inline-flex items-center gap-1.5 text-[9.5px]" style={{ color: "#f5a623" }}>
               <span className="w-1.5 h-1.5 rounded-full animate-pulse" style={{ background: "#f5a623" }} />
               LIVE
             </span>
           </h3>
-          {board.length === 0 ? (
-            <p className="text-xs text-muted-text">No delivered loads this quarter yet.</p>
+          {liveBoard.length === 0 ? (
+            <p className="text-[11.5px] text-muted-text">No one's hit 2 loads yet — the board opens at a second load.</p>
           ) : (
-            board.map(([id, s], i) => (
-              <Link
-                key={id}
-                to={`/agents/${id}`}
-                className="flex items-center gap-2.5 py-1.5 border-t first:border-t-0"
-                style={{ borderColor: "#1a2233" }}
-              >
-                <span className="w-5 h-5 rounded-full flex items-center justify-center text-[11px] font-extrabold" style={{ background: RANK[i], color: "#0d1119" }}>
-                  {i + 1}
-                </span>
-                <span className="flex-1 font-semibold text-light truncate">{name(id)}</span>
-                <span className="font-bold">{money(s.revenue)}</span>
-              </Link>
-            ))
+            liveBoard.slice(0, 3).map((s) => <BoardRow key={s.agentId} s={s} label={name(s.agentId)} />)
           )}
-          <p className="text-[10.5px] text-muted-text mt-2">Provisional — the board agents earn medals on, not yet official.</p>
+          {liveContenders.length > 0 && (
+            <p className="text-[10.5px] text-muted-text mt-1.5">
+              One more load to qualify: {liveContenders.slice(0, 3).map((c) => `${byId.get(c.agentId)?.last_name ?? "—"} ${money(c.revenue)}`).join(" · ")}
+            </p>
+          )}
+
+          <h3 className="text-[11px] uppercase tracking-wide text-muted-text font-bold mt-3 pt-2.5 mb-1.5 border-t flex justify-between items-center" style={{ borderColor: "#1a2233" }}>
+            <span>Last quarter · {qLabel(lastQ)}</span>
+            <span className="normal-case tracking-normal font-normal text-[9.5px]">final</span>
+          </h3>
+          {lastBoard.length === 0 ? (
+            <p className="text-[11.5px] text-muted-text">No qualifying agents last quarter.</p>
+          ) : (
+            lastBoard.slice(0, 3).map((s) => <BoardRow key={s.agentId} s={s} label={name(s.agentId)} />)
+          )}
+          <p className="text-[10px] text-muted-text mt-2">Top 3 earners by gross · 2+ loads to qualify · ties break on revenue per load. Formal trophies (each agent's page) use a stricter rule.</p>
         </div>
       </div>
 
@@ -277,6 +296,15 @@ export const AgentsTab = ({ loads }: { loads: Load[] }) => {
                 <div className="h-full flex items-center justify-center text-[9px]" style={{ width: `${elseShare * 100}%`, background: "#2a3347", color: "#9aa4b5" }}>
                   rest
                 </div>
+              </div>
+              <div className="flex flex-wrap gap-x-3.5 gap-y-1 mb-2">
+                {topShares.map((s, i) => (
+                  <Link key={s.agentId} to={`/agents/${s.agentId}`} className="text-[11.5px] flex items-center gap-1.5 hover:underline">
+                    <span className="inline-block w-2 h-2 rounded-sm flex-none" style={{ background: ["#e8940a", "#f5b03a", "#c8890a"][i] }} />
+                    <span className="text-light">{name(s.agentId)}</span>
+                    <span className="text-muted-text">{Math.round(s.share * 100)}%</span>
+                  </Link>
+                ))}
               </div>
               <p className="text-[11px] text-muted-text">
                 Top 3 = <b style={{ color: conc.overSingleCap ? "#f5a623" : "#f5b03a" }}>{Math.round((conc.top3Pct ?? 0) * 100)}%</b> of your recent book.

--- a/frontend/src/hooks/useRateTargets.ts
+++ b/frontend/src/hooks/useRateTargets.ts
@@ -102,6 +102,7 @@ export const useRateTargets = (loads: Load[]) => {
       basis,
       gross, // weekly/daily GROSS revenue targets (break-even + margin goal)
       marginGoal, // target profit margin driving those revenue targets
+      obligationsMonthly, // active, non-draw monthly notes (principal) — for cash margin
       weekBooked, // this week's gross committed (booked + in-transit + delivered)
       weekEarned, // this week's gross earned (delivered only)
       rollingRpm,

--- a/frontend/src/lib/metrics/agentLeaderboard.test.ts
+++ b/frontend/src/lib/metrics/agentLeaderboard.test.ts
@@ -7,6 +7,8 @@ import {
   agentPrestige,
   agentSeasonLog,
   currentQuarterStanding,
+  quarterStandings,
+  lastCompleteQuarterKey,
 } from "./agentLeaderboard";
 
 // Minimal delivered-load factory. Revenue = linehaul (fsc/accessorials 0).
@@ -207,5 +209,53 @@ describe("rosterKpis", () => {
     expect(k.topEarner?.agentId).toBe("A");
     expect(k.topEarner?.revenue).toBe(9000);
     expect(k.activeCount).toBe(2);
+  });
+});
+
+describe("quarterStandings — board rules + tie-break", () => {
+  it("ranks 2+-load agents by gross; single-load agents are off the board", () => {
+    const loads = [
+      mk("A", "2026-05-01", 5000),
+      mk("A", "2026-06-01", 4000), // A: 2 loads, $9k, $4.5k/load
+      mk("B", "2026-05-10", 8000), // B: 1 load — excluded
+      mk("C", "2026-04-15", 3000),
+      mk("C", "2026-05-20", 3000),
+      mk("C", "2026-06-20", 3000), // C: 3 loads, $9k, $3k/load
+    ];
+    const board = quarterStandings(loads, "2026-Q2");
+    const ids = board.map((s) => s.agentId);
+    expect(ids).not.toContain("B"); // single load
+    // A and C tie on $9k gross → revenue-per-load breaks it: A ($4.5k) over C ($3k)
+    expect(ids).toEqual(["A", "C"]);
+    expect(board[0]).toMatchObject({ rank: 1, podium: true, loads: 2 });
+  });
+
+  it("tie on gross AND revenue-per-load falls to the most recent load", () => {
+    const loads = [
+      mk("A", "2026-05-01", 5000),
+      mk("A", "2026-05-02", 5000), // $10k / 2, last 05-02
+      mk("B", "2026-06-29", 5000),
+      mk("B", "2026-06-30", 5000), // $10k / 2, last 06-30 (more recent)
+    ];
+    expect(quarterStandings(loads, "2026-Q2").map((s) => s.agentId)).toEqual(["B", "A"]);
+  });
+
+  it("podium is top 3, board is top 5", () => {
+    const loads: ReturnType<typeof mk>[] = [];
+    ([["A", 6000], ["B", 5000], ["C", 4000], ["D", 3000], ["E", 2000], ["F", 1000]] as [string, number][]).forEach(
+      ([id, rev]) => loads.push(mk(id, "2026-05-01", rev), mk(id, "2026-05-02", rev)),
+    );
+    const board = quarterStandings(loads, "2026-Q2");
+    expect(board.filter((s) => s.podium).map((s) => s.agentId)).toEqual(["A", "B", "C"]);
+    expect(board.filter((s) => s.onBoard).map((s) => s.agentId)).toEqual(["A", "B", "C", "D", "E"]);
+    expect(board[5].onBoard).toBe(false);
+  });
+});
+
+describe("lastCompleteQuarterKey", () => {
+  it("returns the prior complete quarter, crossing the year boundary", () => {
+    expect(lastCompleteQuarterKey(new Date("2026-08-08T12:00:00Z"))).toBe("2026-Q2");
+    expect(lastCompleteQuarterKey(new Date("2026-05-15T12:00:00Z"))).toBe("2026-Q1");
+    expect(lastCompleteQuarterKey(new Date("2026-02-10T12:00:00Z"))).toBe("2025-Q4");
   });
 });

--- a/frontend/src/lib/metrics/agentLeaderboard.ts
+++ b/frontend/src/lib/metrics/agentLeaderboard.ts
@@ -21,9 +21,10 @@ export const quarterKey = (dateStr: string): string => {
 interface QAgg {
   revenue: number;
   loads: number;
+  lastWorked: string; // latest delivery day this quarter ('YYYY-MM-DD')
 }
 
-// Delivered loads → quarter → agent → { revenue, loads }.
+// Delivered loads → quarter → agent → { revenue, loads, lastWorked }.
 const byQuarterAgent = (loads: Load[]): Map<string, Map<string, QAgg>> => {
   const out = new Map<string, Map<string, QAgg>>();
   for (const l of loads) {
@@ -34,18 +35,27 @@ const byQuarterAgent = (loads: Load[]): Map<string, Map<string, QAgg>> => {
       agents = new Map();
       out.set(q, agents);
     }
-    const cur = agents.get(l.agent_id) ?? { revenue: 0, loads: 0 };
+    const cur = agents.get(l.agent_id) ?? { revenue: 0, loads: 0, lastWorked: "" };
     cur.revenue += loadRevenue(l);
     cur.loads += 1;
+    const dd = l.delivery_date.slice(0, 10);
+    if (dd > cur.lastWorked) cur.lastWorked = dd;
     agents.set(l.agent_id, cur);
   }
   return out;
 };
 
-// Revenue desc, then agent_id asc so ties resolve deterministically.
-const rankByRevenue = (entries: [string, QAgg][]): [string, QAgg][] =>
+// Rank by gross revenue, then a stated tie-break cascade (never a coin-flip on id):
+// 1) gross revenue  2) revenue per load — same money in fewer loads = richer freight
+// 3) most recent load — the still-active agent  4) agent_id, only so it's deterministic.
+const revPerLoad = (a: QAgg) => (a.loads > 0 ? a.revenue / a.loads : 0);
+const rankAgents = (entries: [string, QAgg][]): [string, QAgg][] =>
   [...entries].sort(
-    (a, b) => b[1].revenue - a[1].revenue || a[0].localeCompare(b[0]),
+    (a, b) =>
+      b[1].revenue - a[1].revenue ||
+      revPerLoad(b[1]) - revPerLoad(a[1]) ||
+      b[1].lastWorked.localeCompare(a[1].lastWorked) ||
+      a[0].localeCompare(b[0]),
   );
 
 export const computeHonors = (
@@ -66,13 +76,13 @@ export const computeHonors = (
     if (quarter >= currentQ) continue;
     const entries = [...agents.entries()];
     // Board: 2+ loads, top 5 by revenue.
-    const board = rankByRevenue(entries.filter(([, a]) => a.loads >= 2)).slice(
+    const board = rankAgents(entries.filter(([, a]) => a.loads >= 2)).slice(
       0,
       5,
     );
     for (const [agentId] of board) bump(agentId, "board");
     // Podium: 3+ loads, #1 gold, #2 silver.
-    const podium = rankByRevenue(entries.filter(([, a]) => a.loads >= 3));
+    const podium = rankAgents(entries.filter(([, a]) => a.loads >= 3));
     if (podium[0]) bump(podium[0][0], "gold");
     if (podium[1]) bump(podium[1][0], "silver");
   }
@@ -117,8 +127,8 @@ export const agentSeasonLog = (
     const mine = agents.get(agentId);
     if (!mine) continue;
     const entries = [...agents.entries()];
-    const podium = rankByRevenue(entries.filter(([, a]) => a.loads >= 3));
-    const board = rankByRevenue(entries.filter(([, a]) => a.loads >= 2))
+    const podium = rankAgents(entries.filter(([, a]) => a.loads >= 3));
+    const board = rankAgents(entries.filter(([, a]) => a.loads >= 2))
       .slice(0, 5)
       .map(([id]) => id);
     let result: SeasonEntry["result"] = "ran";
@@ -153,8 +163,8 @@ export const currentQuarterStandings = (
   if (!agents) return out;
 
   const entries = [...agents.entries()];
-  const boardRanked = rankByRevenue(entries.filter(([, a]) => a.loads >= 2));
-  const podium = rankByRevenue(entries.filter(([, a]) => a.loads >= 3));
+  const boardRanked = rankAgents(entries.filter(([, a]) => a.loads >= 2));
+  const podium = rankAgents(entries.filter(([, a]) => a.loads >= 3));
 
   for (const [agentId, agg] of entries) {
     const idx = boardRanked.findIndex(([id]) => id === agentId);
@@ -179,6 +189,56 @@ export const currentQuarterStanding = (
   now: Date,
 ): LiveStanding | null =>
   currentQuarterStandings(loads, now).get(agentId) ?? null;
+
+// ---- dashboard quarterly board (live current quarter + last complete quarter) ----
+
+// One agent's finish in a given quarter's board race. Podium = top 3 (the
+// dashboard shows gold/silver/bronze by position), board = top 5. Only 2+-load
+// agents qualify, so a one-off single load doesn't land a medal position.
+export interface BoardStanding {
+  agentId: string;
+  rank: number; // 1-based among 2+-load agents
+  revenue: number;
+  loads: number;
+  podium: boolean; // top 3
+  onBoard: boolean; // top 5
+}
+
+export const quarterStandings = (loads: Load[], quarter: string): BoardStanding[] => {
+  const agents = byQuarterAgent(loads).get(quarter);
+  if (!agents) return [];
+  return rankAgents([...agents.entries()].filter(([, a]) => a.loads >= 2)).map(
+    ([agentId, a], i) => ({
+      agentId,
+      rank: i + 1,
+      revenue: a.revenue,
+      loads: a.loads,
+      podium: i < 3,
+      onBoard: i < 5,
+    }),
+  );
+};
+
+// Agents who ran this quarter but are short of the 2-load board minimum — the
+// "one more load to qualify" contenders, ranked by gross.
+export const quarterContenders = (loads: Load[], quarter: string): BoardStanding[] => {
+  const agents = byQuarterAgent(loads).get(quarter);
+  if (!agents) return [];
+  return rankAgents([...agents.entries()].filter(([, a]) => a.loads < 2)).map(
+    ([agentId, a], i) => ({ agentId, rank: i + 1, revenue: a.revenue, loads: a.loads, podium: false, onBoard: false }),
+  );
+};
+
+export const currentQuarterKey = (now: Date): string => quarterKey(now.toISOString());
+
+// The last COMPLETE calendar quarter — the app's "season" convention, never the
+// in-progress one. Today (2026-08-08, Q3) → "2026-Q2".
+export const lastCompleteQuarterKey = (now: Date): string => {
+  const qStartMonth = Math.floor(now.getUTCMonth() / 3) * 3;
+  // Day 0 of the current quarter's first month = the last day of the prior quarter.
+  const prevQEnd = new Date(Date.UTC(now.getUTCFullYear(), qStartMonth, 0));
+  return quarterKey(prevQEnd.toISOString());
+};
 
 // ---- per-agent card stats ----
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -96,7 +96,7 @@ const OwnerDashboard = () => {
           active === "pulse" ? (
             <PulseTab loads={loads} trips={trips} targets={targets} alerts={alerts} />
           ) : active === "money" ? (
-            <MoneyTab loads={loads} marginGoal={targets.marginGoal ?? null} />
+            <MoneyTab loads={loads} marginGoal={targets.marginGoal ?? null} obligationsMonthly={targets.obligationsMonthly} />
           ) : active === "lanes" ? (
             <LanesTab loads={loads} />
           ) : active === "agents" ? (

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -552,9 +552,12 @@ const GuidePage = () => {
                 rest fold behind a tap.
               </TabLine>
               <TabLine name="Money" q="Am I profitable?">
-                Year-to-date income, operating profit and margin against your goal,
-                the monthly P&amp;L, your margin trend, where the money goes by
-                expense category, and what's delivered but not yet settled.
+                Year-to-date income and two margins — operating, and your
+                after-notes (owner's take) margin, which is the one graded
+                against your goal since it's what's actually left after the truck,
+                trailer, and loan notes. Plus the monthly P&amp;L, the margin
+                trend, where the money goes by category, and what's delivered but
+                not yet settled.
               </TabLine>
               <TabLine name="Lanes" q="Where does my freight run?">
                 The U.S. map shaded by your $/mi (fire marks your best-paying
@@ -563,8 +566,9 @@ const GuidePage = () => {
                 window and how finely the map groups.
               </TabLine>
               <TabLine name="Agents" q="Who should I call?">
-                Your bench plotted by rate × volume, momentum vs the prior 90 days,
-                the live quarter board, revenue concentration (so no one agent owns
+                Your bench plotted by rate × volume, who you're running with lately
+                (by last worked), quarterly standings — this quarter live plus last
+                quarter's top earners — revenue concentration (so no one agent owns
                 too much of your book), and who's going cold.
               </TabLine>
               <TabLine name="Fleet" q="Is my rig ready to roll?">


### PR DESCRIPTION
Dashboard revision Jason reviewed and approved (design-first mockup → build → verified on real prod data).

## Money
- Graded headline margin is now the **after-notes (owner's take)** margin — operating minus the monthly note **principal** (interest is already booked in the P&L, so no double-count) — held against the 26% goal. Operating margin shows alongside. On real data: **21% after-notes** (under goal) vs **29% operating**.
- Margin-trend chart draws both operating (amber) and after-notes (cyan) lines against the goal.

## Agents
- **Momentum → "Running with lately"**: replaced the recent-vs-prior-90d ratio (which ranked a 68-day-stale agent as *hottest*) with a recency-first list — sorted by last worked, within 90 days, showing recent gross + a freshness dot.
- **Leaderboard → two sections**: live current quarter + last **complete** quarter (matches the app's season convention). Rules enforced: 2+ loads to qualify, top 3 = podium. Ties break on a **stated cascade** — gross → revenue-per-load → most-recent load → id — not a coin-flip on database id. Verified live: Mike Sorrentino & Eric Hesketh tied at $8,540 in Q2; Mike takes the higher spot on revenue-per-load. This is a standings view; the **formal trophy ledger keeps its own stricter rule** (Jason's call to keep them separate).
- **Revenue concentration**: agent names as a linked legend under the bar (Canfield 18% · Cleary 9% · Bradford 8%).

## Fleet
- Fuel-economy chart auto-fits its y-axis (± 0.3 padding, 1.5 minimum-span floor) instead of a zero baseline, so the real 6.1–6.5 MPG spread reads as a curve.

## Verification
- `npx vitest run` → **488 passed** (incl. new tie-break + quarter-boundary tests)
- `npm run build` → clean
- Rendered every changed tab against real prod data
- **Pre-merge adversarial review** (4 dimensions, findings verified): 1 confirmed minor finding fixed — the recency card now bounds to the 90-day window so a slow stretch can't surface a stale "$0 · 120d ago" row. A latent margin-snapshot concern was reviewed and correctly refuted (matches app-wide convention, no wrong output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)