### PR TITLE
Fix: three trophy art subjects (v1.154.1)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.154.0",
+  "version": "1.154.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.154.0",
+      "version": "1.154.1",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@react-three/drei": "^10.7.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.154.0",
+  "version": "1.154.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/trophies/catalog.ts
+++ b/frontend/src/lib/trophies/catalog.ts
@@ -50,7 +50,7 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     kind: "manual",
     blurb: "The trailer, paid off.",
     promptIdea:
-      "a massive golden padlock bursting open with a broken shackle, resting on a flatbed trailer in warm light",
+      "a heavy-duty steel flatbed semi-trailer built for a Class 8 truck — long drop-deck with wooden deck boards, tandem axles with dual wheels, winch tracks and chain tie-downs along the rail, fifth-wheel kingpin plate visible — a massive golden padlock bursting open with a broken shackle standing on the deck, warm amber light, no truck attached, no small utility trailer",
   },
   {
     key: "second-driver",
@@ -95,7 +95,7 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     kind: "auto",
     blurb: "$1,000,000 gross hauled.",
     promptIdea:
-      "a towering golden mountain of stacked freight crates and cargo on a flatbed, gleaming like treasure",
+      "an oversize mountain of gleaming solid-gold ingots strapped down on a flatbed semi-trailer like a permitted heavy-haul load — heavy chains, ratchet binders and edge protectors over the gold, red oversize-load flags on the corners, low camera angle so the load towers like a monument",
   },
   {
     key: "highway-legend",
@@ -103,6 +103,7 @@ export const TROPHY_CATALOG: TrophyDef[] = [
     form: "cup",
     kind: "capstone",
     blurb: "The capstone — own authority, truck free-and-clear, and the million miles.",
-    promptIdea: "a chromed-out legend rig in golden-hour light, a halo of road behind it",
+    promptIdea:
+      "a fully custom long-nose American show semi truck in the style of a Peterbilt 389 or Kenworth W900 — long square hood, tall dual chrome exhaust stacks, full chrome front bumper and grille, drop visor, rows of glowing amber marker lights (chicken lights) outlining the cab, visor, and fenders, custom paint, show-truck stance at night in golden light with a halo of highway behind it — a semi tractor only, no motorcycle, no car",
   },
 ];


### PR DESCRIPTION
Jason's regen feedback, prompt-crafted so the model can't miss:

- **Trailer Paid Off** — the trailer is now unmistakably Class 8 flatbed iron: drop-deck, wooden boards, tandem duals, winch tracks, kingpin plate — with explicit negatives against utility trailers. The bursting padlock stays as the "paid off" read.
- **One Million Hauled** — reimagined trucking-native: a mountain of gold ingots secured like a permitted heavy-haul load — chains, binders, edge protectors, oversize flags — shot low so it towers.
- **Highway Legend** — spelled out to kill the motorcycle: long-nose show semi in the style of a Peterbilt 389 / Kenworth W900, long square hood, dual chrome stacks, drop visor, rows of glowing chicken lights, night golden-hour, with "semi tractor only, no motorcycle, no car" negatives.

Regen + approve in the Studio when ready. Tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)