### PR TITLE
Fix: avatar art style to the forge brief (v1.154.2)

### DIFF
--- a/backend/src/services/avatarService.js
+++ b/backend/src/services/avatarService.js
@@ -15,12 +15,16 @@ const ENTITY = {
   trailer: { table: "trailers", idCol: "trailer_id" },
 };
 
-// Locked house style: comic-illustration, steel-blue + amber, dark depot,
-// clean front 3/4 (the truck-0 / driver-0 look Jason signed off on).
+// Locked house style — re-briefed to the Forge world (2026-08-09), matching
+// lib/trophies/style.ts so avatars and trophy art read as one set: grounded
+// premium render, machined steel + amber, no comic. Per-kind constraints below
+// are battle-tested against real generation failures — change the style, not them.
 const STYLE =
-  "comic book digital illustration, cel shaded, bold clean line art, " +
-  "dark steel-blue and amber color palette, dark industrial background, " +
-  "cinematic rim lighting";
+  "premium cinematic character render, grounded and realistic, dark " +
+  "machined-steel industrial depot setting, brushed gunmetal and warm amber " +
+  "palette, glowing amber rim lighting, dramatic workshop light, adult and " +
+  "iconic — no comic style, no cel shading, no halftone, no cartoon, no " +
+  "illustration outlines";
 
 const buildPrompt = (kind, row, variant) => {
   if (kind === "truck") {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.154.1",
+  "version": "1.154.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.154.1",
+      "version": "1.154.2",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@react-three/drei": "^10.7.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.154.1",
+  "version": "1.154.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
The four avatar generators (driver, dispatcher, truck, trailer) still carried the comic/cel-shade style. The shared STYLE constant is now the forge brief — grounded premium render, machined-steel depot, gunmetal + amber, explicit no-comic negatives — matching the trophy/hall brief so all generated art reads as one set.

Every per-kind constraint is untouched: the trailer's "NO truck, NO cab" negatives, the truck's 45° grille and marker lights, the dispatcher's headset-and-load-board framing — those solved real generation failures and still apply.

Regenerating existing avatars is Jason's call, same generate-and-approve flow. Backend prompt strings only; tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)