### PR TITLE
Fix: TopAgents font sweep S13 missed (v1.155.1)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.155.0",
+  "version": "1.155.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.155.0",
+      "version": "1.155.1",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@react-three/drei": "^10.7.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.155.0",
+  "version": "1.155.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/TopAgents.tsx
+++ b/frontend/src/components/dashboard/TopAgents.tsx
@@ -25,7 +25,7 @@ const MEDAL = [
 const Rank = ({ i }: { i: number }) =>
   i < 3 ? (
     <span
-      className="font-comic shrink-0 flex items-center justify-center text-[15px]"
+      className="font-forge font-bold shrink-0 flex items-center justify-center text-[15px]"
       style={{
         width: 26,
         height: 26,
@@ -39,7 +39,7 @@ const Rank = ({ i }: { i: number }) =>
     </span>
   ) : (
     <span
-      className="font-comic shrink-0 text-center text-dim text-[15px]"
+      className="font-forge font-bold shrink-0 text-center text-dim text-[15px]"
       style={{ width: 26 }}
     >
       {i + 1}
@@ -69,7 +69,7 @@ export const TopAgents = ({ agents, honors, standings }: Props) => (
 
     <div className="relative flex items-center gap-2 mb-2.5">
       <Trophy size={17} style={{ color: "var(--color-amber-hi)" }} />
-      <span className="font-comic text-xl" style={{ color: "var(--color-amber-hi)" }}>
+      <span className="font-forge font-bold text-xl" style={{ color: "var(--color-amber-hi)" }}>
         TOP AGENTS
       </span>
       <span className="flex-1" />
@@ -101,7 +101,7 @@ export const TopAgents = ({ agents, honors, standings }: Props) => (
               <span className="flex-1 min-w-0">
                 {first ? (
                   <span
-                    className="font-comic block truncate leading-none text-[17px]"
+                    className="font-forge font-bold block truncate leading-none text-[17px]"
                     style={{ color: "var(--color-amber-hi)" }}
                   >
                     {agent.agent}
@@ -123,7 +123,7 @@ export const TopAgents = ({ agents, honors, standings }: Props) => (
               {!first && onBoard && <Pulse />}
               <span className="text-right shrink-0">
                 <span
-                  className="font-comic block leading-none"
+                  className="font-forge font-bold block leading-none"
                   style={{
                     fontSize: first ? 19 : 15,
                     color: first ? "var(--color-amber-hi)" : i < 3 ? "#e8eef7" : "#9daabb",


### PR DESCRIPTION
S13's pre-ship grep flagged TopAgents (5 font-comic uses) and the ship chain ran anyway — with Bangers gone from the bundle those spans were silently unstyled on both boards. Swept to the forge voice; repo now greps zero font-comic uses (GrindMeter's remaining hit is a historical comment). Tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)