### PR TITLE
fix(money): correct four audited gross/net + pace defects (v1.171.1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.171.0",
+  "version": "1.171.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/PulseTab.tsx
+++ b/frontend/src/components/dashboard/PulseTab.tsx
@@ -12,6 +12,7 @@ import {
   getUpcomingLoads,
 } from "@/lib/metrics/dashboard";
 import { loadRevenue } from "@/lib/metrics/loads";
+import { loadRevenue as loadNet } from "@/lib/metrics/rateTargets";
 import { getQuarterPace } from "@/lib/metrics/quarterPace";
 import { agentStops, scoreStops } from "@/lib/metrics/stopScore";
 import { projectWeek } from "@/lib/metrics/weekProjection";
@@ -130,7 +131,9 @@ export const PulseTab = ({
   const pace = useMemo(() => getQuarterPace(loads, now), [loads, now]);
 
   // Landing on the next weekly settlement: delivered, POD in, not yet paid.
-  // Timing, not receivables — the carrier clears it every settlement day.
+  // Timing, not receivables — the carrier clears it every settlement day. This is
+  // the money that ACTUALLY lands, so it's NET (Landstar's deposit after its cut),
+  // not the gross customer rate.
   const pipelineLoads = useMemo(
     () =>
       loads.filter(
@@ -139,7 +142,7 @@ export const PulseTab = ({
     [loads],
   );
   const pipeline = useMemo(
-    () => pipelineLoads.reduce((s, l) => s + loadRevenue(l), 0),
+    () => pipelineLoads.reduce((s, l) => s + loadNet(l), 0),
     [pipelineLoads],
   );
   const settleDate =

--- a/frontend/src/lib/metrics/lanes.test.ts
+++ b/frontend/src/lib/metrics/lanes.test.ts
@@ -350,17 +350,20 @@ describe("getWindowTotals", () => {
 describe("getOriginStateRollup", () => {
   it("ranks repeats by volume then rate, counts singles, crowns the best rate", () => {
     const r = getOriginStateRollup([
-      makeLoad({ origin_state: "AL", linehaul: "1000", loaded_miles: 500 }),
-      makeLoad({ origin_state: "AL", linehaul: "1000", loaded_miles: 500 }),
-      makeLoad({ origin_state: "AL", linehaul: "1000", loaded_miles: 500 }),
+      // AL carries a fuel surcharge, so its blended rate is GROSS-based ($1,500/load
+      // ÷ 500mi = $3/mi), not linehaul-only ($2/mi) — guards the gross accumulation.
+      makeLoad({ origin_state: "AL", linehaul: "1000", fuel_surcharge: "500", loaded_miles: 500 }),
+      makeLoad({ origin_state: "AL", linehaul: "1000", fuel_surcharge: "500", loaded_miles: 500 }),
+      makeLoad({ origin_state: "AL", linehaul: "1000", fuel_surcharge: "500", loaded_miles: 500 }),
       makeLoad({ origin_state: "SC", linehaul: "3000", loaded_miles: 250 }),
       makeLoad({ origin_state: "SC", linehaul: "3000", loaded_miles: 250 }),
       makeLoad({ origin_state: "NV", linehaul: "900", loaded_miles: 300 }),
     ]);
     expect(r.rows.map((x) => x.state)).toEqual(["AL", "SC"]);
     expect(r.rows[0].name).toBe("Alabama");
+    expect(r.rows[0].blendedRpm).toBeCloseTo(3, 5); // GROSS, not linehaul-only ($2)
     expect(r.singles).toBe(1);
-    // SC blends $12/mi vs AL $2/mi — best is rate, not volume.
+    // SC blends $12/mi vs AL's gross $3/mi — best is rate, not volume.
     expect(r.best?.state).toBe("SC");
   });
 

--- a/frontend/src/lib/metrics/lanes.ts
+++ b/frontend/src/lib/metrics/lanes.ts
@@ -499,13 +499,19 @@ export interface OriginStateRollup {
 }
 
 export const getOriginStateRollup = (loads: Load[]): OriginStateRollup => {
-  const acc = new Map<string, { n: number; lh: number; mi: number }>();
+  const acc = new Map<string, { n: number; gross: number; mi: number }>();
   for (const l of loads) {
     const st = l.origin_state;
     if (!st) continue;
-    const a = acc.get(st) ?? { n: 0, lh: 0, mi: 0 };
+    const a = acc.get(st) ?? { n: 0, gross: 0, mi: 0 };
     a.n += 1;
-    a.lh += Number(l.linehaul) || 0;
+    // GROSS (linehaul + FSC + accessorials), to match every other $/mi on the Lanes
+    // page — linehaul-only understated oversize origins most (their tarp/permit
+    // accessorials are the biggest slice).
+    a.gross +=
+      (Number(l.linehaul) || 0) +
+      (Number(l.fuel_surcharge) || 0) +
+      (Number(l.total_accessorials) || 0);
     a.mi += Number(l.loaded_miles) || 0;
     acc.set(st, a);
   }
@@ -513,7 +519,7 @@ export const getOriginStateRollup = (loads: Load[]): OriginStateRollup => {
     state,
     name: getStateName(state) ?? state,
     loadCount: a.n,
-    blendedRpm: a.mi > 0 ? a.lh / a.mi : null,
+    blendedRpm: a.mi > 0 ? a.gross / a.mi : null,
   }));
   const rows = all
     .filter((r) => r.loadCount >= 2)

--- a/frontend/src/lib/metrics/monthCoverage.ts
+++ b/frontend/src/lib/metrics/monthCoverage.ts
@@ -1,7 +1,8 @@
 import type { Load } from "@/types/load";
 import type { ExpensePeriod } from "@/types/expense";
-import { loadRevenue } from "./loads";
-import { getCostBasis } from "./rateTargets";
+// NET loadRevenue (post-carrier-cut) — the MTD estimate must be the money-kept
+// basis the P&L income line uses and the true-cost threshold is measured on.
+import { getCostBasis, loadRevenue } from "./rateTargets";
 
 // THE month metric (Jason, 2026-08-10): "one load will cover my notes — what I
 // really need to track is covering my monthly expense threshold, and whether I

--- a/frontend/src/lib/metrics/trailerMetrics.ts
+++ b/frontend/src/lib/metrics/trailerMetrics.ts
@@ -65,10 +65,21 @@ export const computeTrailerMetrics = (
   ).size;
   const utilization =
     weeksInService && weeksInService > 0 ? Math.min(1, activeWeeks / weeksInService) : null;
-  const monthsInService = inService
-    ? Math.max(1, (now.getTime() - inService.getTime()) / (30.44 * DAY))
-    : null;
-  const milesPerMonth = monthsInService ? totalMiles / monthsInService : null;
+  // Pace over the OPERATING window (later of in-service and first earned load → now),
+  // NOT raw calendar time since in-service — see truckMetrics. Dead pre-tracking
+  // months must not dilute miles/month, which drives note-per-mile → cost-to-run.
+  const nowDay = now.toISOString().slice(0, 10);
+  const inServiceDay = trailer.in_service_date ? trailer.in_service_date.slice(0, 10) : null;
+  const firstEarned = earnedLoads
+    .filter((l) => l.pickup_date)
+    .map((l) => l.pickup_date.slice(0, 10))
+    .sort()[0];
+  const windowStart =
+    [inServiceDay, firstEarned].filter((d): d is string => !!d).sort().at(-1) ?? null;
+  const windowMonths = windowStart
+    ? Math.max(0, (Date.parse(`${nowDay}T00:00:00Z`) - Date.parse(`${windowStart}T00:00:00Z`)) / DAY) / 30.44
+    : 0;
+  const milesPerMonth = windowMonths > 0 ? totalMiles / windowMonths : null;
 
   // All-in: maintenance ÷ miles plus the trailer's own note spread over its monthly
   // miles. Mirrors the truck's cost-to-run so the label means the same thing.

--- a/frontend/src/lib/metrics/truckMetrics.test.ts
+++ b/frontend/src/lib/metrics/truckMetrics.test.ts
@@ -105,6 +105,22 @@ describe("computeTruckMetrics — all-in cost to run (note)", () => {
   });
 });
 
+describe("computeTruckMetrics — miles/month uses the operating window", () => {
+  it("does NOT dilute the pace with dead pre-first-load calendar time", () => {
+    // In service 8 months before `now`, but the first (and only) load is ~4 weeks
+    // back. Pace must reflect the operating window (first load → now), not the raw
+    // 8-month in-service span, or note-per-mile → cost-to-run inflates ~10x.
+    const truck = { in_service_date: "2025-06-01", current_odometer: 0 } as Truck;
+    const m = run(truck, [load("2026-01-05", "2026-01-07")], [], [], 1000);
+    expect(m.windowDays).toBe(27); // 2026-01-05 → 2026-02-01
+    // 500 mi ÷ (27 / 30.44) mo ≈ 564 mi/mo — NOT 500 ÷ 8mo ≈ 62 (the diluted bug).
+    expect(m.milesPerMonth).toBeCloseTo(500 / (27 / 30.44), 1);
+    expect(m.milesPerMonth!).toBeGreaterThan(400);
+    // note/mi rides on the correct pace: 1000 ÷ ~564, not 1000 ÷ ~62.
+    expect(m.notePerMile!).toBeLessThan(2);
+  });
+});
+
 describe("computeTruckMetrics — loads hauled vs earned", () => {
   const truck = { in_service_date: "2026-01-01", current_odometer: 0 } as Truck;
   const unpaid = (pickup: string, delivery: string): Load =>

--- a/frontend/src/lib/metrics/truckMetrics.ts
+++ b/frontend/src/lib/metrics/truckMetrics.ts
@@ -81,9 +81,6 @@ export const computeTruckMetrics = (
   // before you were running loads don't read as "idle" — they're unmeasured, not
   // wasted. Days basis (not weeks) so intensity shows: a light week and a heavy one
   // no longer look identical.
-  const inService = truck.in_service_date
-    ? new Date(truck.in_service_date.slice(0, 10) + "T00:00:00Z")
-    : null;
   const nowDay = now.toISOString().slice(0, 10);
   const inServiceDay = truck.in_service_date
     ? truck.in_service_date.slice(0, 10)
@@ -135,10 +132,12 @@ export const computeTruckMetrics = (
   const utilization =
     windowDays > 0 ? Math.min(1, underLoadDays / windowDays) : null;
 
-  const monthsInService = inService
-    ? Math.max(1, (now.getTime() - inService.getTime()) / (30.44 * DAY))
-    : null;
-  const milesPerMonth = monthsInService ? totalMiles / monthsInService : null;
+  // Pace over the OPERATING window (windowStart→now — the same span utilization uses),
+  // NOT raw calendar time since the in-service date. Months the truck logged nothing
+  // (before dash tracking began, or before its first load) must not dilute the pace:
+  // that understates miles/month and inflates note-per-mile → cost-to-run.
+  const windowMonths = windowDays / 30.44;
+  const milesPerMonth = windowMonths > 0 ? totalMiles / windowMonths : null;
 
   // All-in cost to run: fuel + maintenance (spend ÷ miles driven) plus the rig's own
   // note spread over the miles it runs a month. The note is a per-mile rate on a

--- a/frontend/src/pages/LoadsPage.tsx
+++ b/frontend/src/pages/LoadsPage.tsx
@@ -221,9 +221,12 @@ const LoadsPage = () => {
     );
 
   const view = [...inTransit, ...rest];
-  const viewNet = view.reduce((sum, l) => sum + loadRevenue(l), 0);
+  // GROSS booked revenue — loadRevenue here is the loads.ts version (linehaul + FSC
+  // + accessorials, the full customer rate), so this line is labeled "gross," and
+  // the $/mi below is a gross rate per loaded mile.
+  const viewGross = view.reduce((sum, l) => sum + loadRevenue(l), 0);
   const viewMiles = view.reduce((sum, l) => sum + (Number(l.loaded_miles) || 0), 0);
-  const viewRpm = viewMiles > 0 ? viewNet / viewMiles : null;
+  const viewRpm = viewMiles > 0 ? viewGross / viewMiles : null;
 
   return (
     <div className="min-h-screen text-ink font-body">
@@ -274,7 +277,7 @@ const LoadsPage = () => {
           {view.length} load{plural(view.length)}
         </span>
         <span className="text-[12px] text-faint">in this view ·</span>
-        <b className="font-condensed font-semibold text-ink tabular-nums">{money(viewNet)} net</b>
+        <b className="font-condensed font-semibold text-ink tabular-nums">{money(viewGross)} gross</b>
         {viewRpm != null && (
           <>
             <span className="text-[12px] text-faint">·</span>


### PR DESCRIPTION
Corrections from the money-math audit (recovered from the Fable session, then finished + adversarially verified in a follow-up). Four confirmed wrong-number defects, each checked against prod, plus the primary label fix.

## Fixes
- **miles/month → operating window** (`truckMetrics.ts`, `trailerMetrics.ts`): paced over the operating window (first load → now) instead of raw in-service calendar time. Dead pre-tracking months were diluting the pace ~2× — truck 580991: **3,574 → 7,018 mi/mo** (verified on prod: 50,031 earned miles ÷ 217-day window). That inflated note-per-mile, so the all-in **cost-to-run corrects $0.90 → ~$0.66/mi**. Regression test added.
- **Pulse "Next settlement · landing" → NET** (`PulseTab.tsx`): now sums Landstar's actual net deposit, not the gross customer rate — **$6,068 → $4,519** on the current pipeline load.
- **Lanes "best origin" → GROSS** (`lanes.ts` `getOriginStateRollup`): ranks/rates on linehaul + FSC + accessorials like every other $/mi on the page; linehaul-only understated oversize origins most. Test hardened with an FSC-bearing fixture so a revert is caught.
- **Month coverage MTD → NET** (`monthCoverage.ts`): the estimate now uses the net helper, matching the P&L income and the true-cost threshold it races (was gross vs a net threshold).
- **LoadsPage footer** (`LoadsPage.tsx`): summed gross but was labeled "net" → renamed `viewGross`, relabeled "gross" (the audit's primary label-vs-value finding).

## Verification
- `npx vitest run` → **536 passed** (incl. the new miles/month regression + hardened lanes test)
- `npm run build` → clean
- Fix A confirmed against prod SQL; B/C/D deltas confirmed by the audit's prod-checked verifiers
- **Pre-merge adversarial review**: all four verified correct, no regressions

Full audit (confirmed + the label-convention items awaiting a ruling + minors) is in `MONEY_MATH_AUDIT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)