### PR TITLE
fix(recap/awards): gross basis for hauled / best-week / avg-rpm (v1.171.2)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.171.1",
+  "version": "1.171.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/awards.ts
+++ b/frontend/src/lib/metrics/awards.ts
@@ -15,7 +15,7 @@ import {
   personalBests,
 } from "./playerCard";
 import { resolvePeriod, loadsInRange, type RecapScope } from "./recap";
-import { loadRevenue } from "./rateTargets";
+import { loadRevenue, loadGross } from "./rateTargets";
 import { computePatches } from "@/lib/awards/patches";
 import { computeMedals } from "@/lib/awards/medals";
 import type { TrophyDef } from "@/lib/trophies/catalog";
@@ -72,7 +72,7 @@ export const earnedAwards = (i: AwardInputs): Award[] => {
     if (subsumed) continue;
     const inR = loadsInRange(i.loads, r);
     if (inR.length === 0) continue;
-    const gross = inR.reduce((s, l) => s + loadRevenue(l), 0);
+    const gross = inR.reduce((s, l) => s + loadGross(l), 0); // GROSS — "hauled" = freight moved
     out.push({
       id: `recap:${scope}:${r.label}`,
       tier: "recap",

--- a/frontend/src/lib/metrics/playerCard.ts
+++ b/frontend/src/lib/metrics/playerCard.ts
@@ -7,7 +7,11 @@ import type { Trip } from "@/types/trip";
 import type { ExpensePeriod } from "@/types/expense";
 import type { FuelEntry } from "@/types/fuelEntry";
 import { deadheadPctOver } from "./deadhead";
-import { loadRevenue, type RateLadder } from "./rateTargets";
+// GROSS revenue — avgRpm (booking rate), bestLane, and the best-week/biggest-load
+// records are market value (Jason's ruling). The net figures (netRevenue, netProfit,
+// trueNet) are derived from the P&L `income`, not from loadRevenue.
+import { loadRevenue } from "./loads";
+import { type RateLadder } from "./rateTargets";
 import { resolvePeriod } from "./recap";
 import { mileMilestone } from "./mileClub";
 import { fuelStats } from "./fuelEconomy";

--- a/frontend/src/lib/metrics/recap.test.ts
+++ b/frontend/src/lib/metrics/recap.test.ts
@@ -57,7 +57,9 @@ describe("latestRecapWithData", () => {
 
 describe("computeRecap", () => {
   const loads = [
-    L({ load_id: "a", delivery_date: "2026-05-12", linehaul: "3200", loaded_miles: 1000, origin_state: "TX", destination_state: "GA", origin_market: "Dallas", delivery_market: "Atlanta" }),
+    // FSC + a below-gross net_revenue so gross (3500) ≠ net (2555) — pins the recap
+    // to GROSS (Jason's ruling): a revert to the net helper would read 2555 here.
+    L({ load_id: "a", delivery_date: "2026-05-12", linehaul: "3200", fuel_surcharge: "300", net_revenue: "2555", loaded_miles: 1000, origin_state: "TX", destination_state: "GA", origin_market: "Dallas", delivery_market: "Atlanta" }),
     L({ load_id: "b", delivery_date: "2026-06-15", linehaul: "2600", loaded_miles: 800, origin_state: "TX", destination_state: "TN", origin_market: "Houston", delivery_market: "Memphis" }),
     L({ load_id: "c", delivery_date: "2025-12-30", linehaul: "9999", loaded_miles: 500, origin_state: "CA", destination_state: "NV", origin_market: "LA", delivery_market: "Vegas" }), // prior year — excluded
   ];
@@ -68,19 +70,19 @@ describe("computeRecap", () => {
 
   it("aggregates the year's highlights", () => {
     const r = computeRecap(loads, [] as FuelEntry[], periods, 0, rangeFor("year", 2026, 0), "year", NOW);
-    expect(r.gross).toBe(5800);
+    expect(r.gross).toBe(6100); // GROSS: a(3200+300) + b(2600); net would be 5155
     expect(r.loadedMiles).toBe(1800);
     expect(r.totalMiles).toBe(1800); // no odometers → falls back to loaded miles
     expect(r.states).toBe(3); // TX, GA, TN — prior-year CA/NV excluded
     expect(r.loads).toBe(2);
-    expect(r.biggestLoad).toBe(3200);
+    expect(r.biggestLoad).toBe(3500); // load a gross (linehaul + FSC), not its net
     expect(r.longestHaul).toBe(1000);
-    expect(r.avgRpm).toBeCloseTo(5800 / 1800, 3);
+    expect(r.avgRpm).toBeCloseTo(6100 / 1800, 3);
     expect(r.topLane).toBe("Dallas → Atlanta");
     expect(r.topAgent).toBe("Redwood");
     // 12 months for a year, with only May + Jun carrying gross
     expect(r.monthlyGross).toHaveLength(12);
-    expect(r.monthlyGross[4]).toEqual({ label: "May", gross: 3200 });
+    expect(r.monthlyGross[4]).toEqual({ label: "May", gross: 3500 });
     expect(r.monthlyGross[5]).toEqual({ label: "Jun", gross: 2600 });
   });
 

--- a/frontend/src/lib/metrics/recap.ts
+++ b/frontend/src/lib/metrics/recap.ts
@@ -3,9 +3,12 @@
 import type { Load } from "@/types/load";
 import type { FuelEntry } from "@/types/fuelEntry";
 import type { ExpensePeriod } from "@/types/expense";
+// GROSS revenue — the recap's hauled/lane/agent/monthly/RPM figures are market value
+// (freight moved), per Jason's ruling; the net figures come from the P&L (`periods`).
+import { loadRevenue } from "./loads";
 import {
-  loadRevenue,
-  getWeekBookedGross,
+  getWeekGrossEarned,
+  getWeekEarnedGross,
   getGrossTargets,
   getCostBasis,
   payWeekRange,
@@ -207,9 +210,15 @@ export const computeRecap = (
   const firstWeek = payWeekRange(range.start, PAY_WEEK_START_DOW).start.getTime();
   for (let t = firstWeek; t < range.end.getTime(); t += WEEK_MS) {
     if (t < range.start.getTime()) continue; // skip the partial leading week
-    const wg = getWeekBookedGross(loads, new Date(t), new Date(t + WEEK_MS));
-    if (bestWeek == null || wg > bestWeek) bestWeek = wg;
-    statuses.push(classify(wg, targets));
+    const ws = new Date(t);
+    const we = new Date(t + WEEK_MS);
+    // Best week = most GROSS freight hauled, DELIVERED-only (Jason's ruling) — the
+    // same getWeekGrossEarned the dashboard uses, so the record is one number.
+    const grossWeek = getWeekGrossEarned(loads, ws, we);
+    if (bestWeek == null || grossWeek > bestWeek) bestWeek = grossWeek;
+    // Streak = weeks that beat the (net-basis) target, delivered-only — not committed
+    // (a booked-then-cancelled load must not extend a record).
+    statuses.push(classify(getWeekEarnedGross(loads, ws, we), targets));
   }
 
   // Gross per month across the range (1 for a month, 3 for a quarter, 12 for a


### PR DESCRIPTION
Part 2 of the money-math audit — the label-vs-value rulings. Owner ruled **gross** on all three: the recap/award/player-card celebratory figures were computing NET (they imported `loadRevenue` from `rateTargets`) under gross-implying labels.

## Fixes
- **Recap "HAULED" tile** + monthly-gross strip + top-lane/agent + biggest-load + avgRpm → **gross** (`recap.ts` imports `loadRevenue` from `./loads`). 2026 "hauled" **~$166k (net) → ~$219k (gross freight moved)**. The recap's net figures (netProfit, best/hardest month) come from the P&L, unaffected.
- **Award "$X hauled"** → **gross** (`loadGross`); `cumulativeNet` stays net.
- **Player-card Avg RPM** + bestLane + best-week + biggest-load records → **gross** (`playerCard.ts` imports `loadRevenue` from `./loads`); netRevenue/netProfit/trueNet derive from the P&L income, unaffected. The `avgRpm` doc comment ("gross ÷ loaded mile") is now actually true.
- **Recap best-week** now **gross, delivered-only** (`getWeekGrossEarned` — the same helper the dashboard uses, so it's one number everywhere), and the streak counts **delivered-only** (`getWeekEarnedGross`), not committed booked/in-transit freight.

## Verification
- `npx vitest run` → **536 passed**; `recap.test.ts` hardened (load carries an FSC + a below-gross `net_revenue`) so a revert to the net helper fails the test.
- `npm run build` → clean
- Prod SQL confirmed the ~$166k→~$219k hauled delta
- **Pre-merge adversarial review**: clean — every call site verified gross, no net figure wrongly flipped

Closes **Part 2** of `MONEY_MATH_AUDIT.md`; only the minors/latent backlog remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)