### PR TITLE
fix(metrics): money-audit minors backlog — 5 fixes (v1.171.3)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.171.2",
+  "version": "1.171.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/dashboard/PulseTab.tsx
+++ b/frontend/src/components/dashboard/PulseTab.tsx
@@ -433,8 +433,8 @@ export const PulseTab = ({
           }
           sub={
             onTime.onTimePct != null
-              ? `${onTime.gradedStops} timed stops · 90d`
-              : "needs 3+ timed stops"
+              ? `${onTime.gradedStops} graded stops · 90d`
+              : "needs 3+ graded stops"
           }
           tone={
             onTime.onTimePct == null

--- a/frontend/src/components/expenses/ExpenseYtdChart.tsx
+++ b/frontend/src/components/expenses/ExpenseYtdChart.tsx
@@ -76,7 +76,7 @@ export const ExpenseYtdChart = ({
   return (
     <div className="ds2-board p-4 mt-4" style={{ height: 280 }}>
       <p className="text-xs text-faint mb-2">
-        Revenue vs {obligationsTotal > 0 ? "true cost" : "cost"} · year to date
+        Revenue vs {obligationsTotal > 0 ? "true cost" : "cost"} · by month
       </p>
       <ResponsiveContainer width="100%" height="88%">
         <LineChart data={data} margin={{ top: 8, right: 12, bottom: 0, left: 8 }}>

--- a/frontend/src/lib/metrics/lanes.test.ts
+++ b/frontend/src/lib/metrics/lanes.test.ts
@@ -331,14 +331,15 @@ describe("getStateDetail", () => {
 });
 
 describe("getWindowTotals", () => {
-  it("sums linehaul and blends the rate, coercing numeric strings", () => {
+  it("sums linehaul for the dollar total but blends the rate on GROSS", () => {
     const t = getWindowTotals([
-      makeLoad({ linehaul: "1000", loaded_miles: 200 }),
+      makeLoad({ linehaul: "1000", fuel_surcharge: "200", loaded_miles: 200 }),
       makeLoad({ linehaul: "500.50", loaded_miles: 100 }),
     ]);
     expect(t.loads).toBe(2);
-    expect(t.linehaul).toBeCloseTo(1500.5, 5);
-    expect(t.blendedRpm).toBeCloseTo(1500.5 / 300, 5);
+    expect(t.linehaul).toBeCloseTo(1500.5, 5); // dollar total stays linehaul-only
+    // GROSS ÷ miles (incl. the $200 FSC) = 1700.5/300, NOT linehaul-only 1500.5/300
+    expect(t.blendedRpm).toBeCloseTo(1700.5 / 300, 5);
   });
 
   it("blends to null with no miles, and zeros on empty", () => {

--- a/frontend/src/lib/metrics/lanes.ts
+++ b/frontend/src/lib/metrics/lanes.ts
@@ -467,17 +467,15 @@ export const getLanesSummary = (loads: Load[]): LanesSummary => {
 export interface WindowTotals {
   loads: number;
   linehaul: number;
-  blendedRpm: number | null; // linehaul ÷ loaded miles across the set
+  blendedRpm: number | null; // GROSS ÷ loaded miles — matches every other $/mi on the page
 }
 
 export const getWindowTotals = (loads: Load[]): WindowTotals => {
-  let lh = 0;
-  let mi = 0;
-  for (const l of loads) {
-    lh += Number(l.linehaul) || 0;
-    mi += Number(l.loaded_miles) || 0;
-  }
-  return { loads: loads.length, linehaul: lh, blendedRpm: mi > 0 ? lh / mi : null };
+  // The dollar total stays linehaul (settlement-relevant, labeled "linehaul" in the
+  // UI), but the blended $/mi is GROSS — "blended" means gross ÷ miles everywhere
+  // else on the Lanes page, and linehaul-only understated oversize windows most.
+  const linehaul = loads.reduce((sum, l) => sum + (Number(l.linehaul) || 0), 0);
+  return { loads: loads.length, linehaul, blendedRpm: avgRpm(loads) };
 };
 
 // ---- Origin states for the markets board. ----

--- a/frontend/src/lib/metrics/rateTargets.test.ts
+++ b/frontend/src/lib/metrics/rateTargets.test.ts
@@ -114,6 +114,16 @@ describe("getCostBasis", () => {
     expect(b.grossPerTotalMile).toBeCloseTo(3.2, 5);
   });
 
+  it("guards a reversed/equal odometer reading — contributes 0 driven miles, not negative", () => {
+    const periods = [period("2026-06-01", 5000, 5000)]; // one complete month (June)
+    const loads = [
+      load({ delivery_date: "2026-06-10", loaded_miles: 1000, odometer_start: 1000, odometer_end: 3500, linehaul: "5000" }), // 2500 driven
+      load({ delivery_date: "2026-06-20", loaded_miles: 800, odometer_start: 5000, odometer_end: 4000, linehaul: "4000" }), // reversed → 0, not −1000
+    ];
+    const b = getCostBasis(periods, 0, loads, now);
+    expect(b.totalMiles).toBe(2500); // without the guard it would read 1500
+  });
+
   it("skips months with no P&L, keeping cost and miles aligned", () => {
     const periods = [period("2026-05-01", 5000, 5000)]; // only May
     const loads = [

--- a/frontend/src/lib/metrics/rateTargets.ts
+++ b/frontend/src/lib/metrics/rateTargets.ts
@@ -75,7 +75,7 @@ const monthMiles = (loads: Load[], year: number, month: number) => {
     (s, l) =>
       s +
       (l.odometer_end != null && l.odometer_start != null
-        ? Number(l.odometer_end) - Number(l.odometer_start)
+        ? Math.max(0, Number(l.odometer_end) - Number(l.odometer_start)) // guard a reversed/equal reading
         : 0),
     0,
   );

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -48,7 +48,7 @@ const monthMiles = (loads: Load[], periodMonth: string) => {
     (s, l) =>
       s +
       (l.odometer_end != null && l.odometer_start != null
-        ? Number(l.odometer_end) - Number(l.odometer_start)
+        ? Math.max(0, Number(l.odometer_end) - Number(l.odometer_start)) // guard a reversed/equal reading
         : 0),
     0,
   );

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -471,7 +471,9 @@ export const LoadDetailPage = () => {
                 {
                   rate: loadRevenue(load),
                   loadedMiles: Number(load.loaded_miles) || 0,
-                  deadheadMiles: Number(load.deadhead_miles) || 0,
+                  // Odometer is truth: grade a run load on its ACTUAL empty miles,
+                  // falling back to the planning estimate only until the window exists.
+                  deadheadMiles: empty != null && empty >= 0 ? empty : Number(load.deadhead_miles) || 0,
                 },
                 { costPerDrivenMile: basis.costPerTotalMile, payTake: basis.payTake },
               );


### PR DESCRIPTION
From the money-audit minors triage. Five verified fixes; the detention midnight-window fix was **pulled by the pre-merge review** (see below).

## Fixes
- **Reversed-odometer guard** (`rateTargets.ts`, `ExpensesPage.tsx`): `Math.max(0, end-start)` so a backwards/equal reading contributes 0 driven miles, not a negative that would inflate cost-per-total-mile → the booking ladder. Zero change on current data; getCostBasis test added.
- **Lanes "$/mi blended" → gross** (`lanes.ts` `getWindowTotals`): reuses `avgRpm` (gross ÷ loaded) — the last linehaul-only $/mi on the page, now consistent with every sibling and the Guide. Dollar total stays labeled "linehaul." *The Lanes header $/mi goes up*, most on oversize windows. Test hardened (FSC fixture pins gross).
- **LoadDetailPage booked-grade → odometer truth**: grades a run load on its actual odometer empty miles, falling back to the deadhead estimate only until the window exists. Grades get slightly stricter for over-planned deadhead.
- **On-time sub-label** "N timed stops" → **"graded stops"** (`PulseTab.tsx`) — matches the count.
- **Expenses chart** caption "year to date" → **"by month"** (`ExpenseYtdChart.tsx`).

## Pulled by review (deferred)
The detention midnight-window fix mis-charged an early pre-window arrival (21:00 arrival / 01:00 release on a 22:00→02:00 window read **1200 min** instead of **0**). Dormant (0 crossing windows on prod) but wrong — the honest fix needs arrival **dates** (day-blind without them). Also deferred: the dashboard "this month" UTC→local anchor (~8 sites), the driven-mile denominator asymmetry, the `net_revenue` COALESCE fallback, the backend pg date type-parser, and on-time day-blindness.

## Verification
- `npx vitest run` → **537 passed** (incl. new odometer-guard + hardened lanes tests)
- `npm run build` → clean
- **Pre-merge adversarial review**: fixes #2–#5 verified clean; detention (#1) caught as buggy and pulled

🤖 Generated with [Claude Code](https://claude.com/claude-code)