### PR TITLE
feat(foreman): The Foreman — who to call from where you'll be empty next (v1.172.0)

### DIFF
--- a/backend/db/migrations/056_city_coords.sql
+++ b/backend/db/migrations/056_city_coords.sql
@@ -1,0 +1,29 @@
+-- Persistent geocode cache for city centers, powering straight-line distance on
+-- the Foreman page (who to call from where you'll be empty next). A city center
+-- doesn't move, so this is a write-once reference table: geocode a (city, state)
+-- via HERE ONCE, validate it, store it, and never call the API for that city
+-- again. It is GLOBAL, not per-user (a city's coordinate is the same for everyone),
+-- so there's no user_id — RLS is still enabled per the house rule, walling it off
+-- from the public PostgREST API; the backend connects as the postgres owner and
+-- bypasses RLS.
+--
+-- status = 'verified' (lat/lng trustworthy — HERE's returned state matched, it
+-- resolved to a locality inside US bounds, and cleared the confidence floor) or
+-- 'failed' (couldn't be trusted — we store the miss so we don't re-hit HERE every
+-- render; lat/lng stay NULL and the Foreman falls back to region-level for it).
+-- lat/lng are double precision so they serialize as JSON numbers, not strings.
+CREATE TABLE IF NOT EXISTS city_coords (
+  city_norm      text NOT NULL,                 -- trimmed + UPPERCASED city
+  state          text NOT NULL,                 -- 2-letter UPPERCASED state
+  lat            double precision,              -- NULL when status = 'failed'
+  lng            double precision,              -- NULL when status = 'failed'
+  label          text,                          -- HERE's matched label (audit trail)
+  query_score    real,                          -- HERE scoring.queryScore (0–1)
+  status         text NOT NULL DEFAULT 'verified'
+                   CHECK (status IN ('verified', 'failed')),
+  failure_reason text,                          -- why a 'failed' row didn't verify
+  geocoded_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (city_norm, state)
+);
+
+ALTER TABLE city_coords ENABLE ROW LEVEL SECURITY;

--- a/backend/src/routes/cityCoordsRoutes.js
+++ b/backend/src/routes/cityCoordsRoutes.js
@@ -1,0 +1,47 @@
+import express from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import {
+  getVerifiedCoords,
+  ensureManyCityCoords,
+} from "../services/cityCoordsService.js";
+
+const router = express.Router();
+router.use(requireAuth);
+
+// ---- ALL VERIFIED CITY COORDINATES ----
+// The lookup the Foreman distances against. Small reference table (one row per
+// distinct booked city), returned whole; the client keys it by "CITY,ST".
+router.get("/", async (req, res) => {
+  try {
+    const coords = await getVerifiedCoords();
+    return res.status(200).json({ message: "City coordinates", coords });
+  } catch (err) {
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+// ---- WARM THE CACHE ----
+// The client posts the cities on its current board; we geocode any missing ones
+// in the BACKGROUND (never blocking the response) so the next render is precise,
+// and return what's already verified now. A city center is write-once, so this is
+// a no-op after the first pass. Body: { cities: [{ city, state }, …] }.
+router.post("/ensure", async (req, res) => {
+  try {
+    const places = Array.isArray(req.body?.cities) ? req.body.cities : [];
+    // Fire-and-forget: don't await the geocoding, and swallow its errors so a
+    // HERE hiccup never surfaces as a request failure.
+    ensureManyCityCoords(places).catch(() => {});
+    const coords = await getVerifiedCoords();
+    return res.status(202).json({ message: "Warming city coordinates", coords });
+  } catch (err) {
+    return res.status(500).json({
+      error: "Internal Server Error",
+      message: err.message,
+    });
+  }
+});
+
+export default router;

--- a/backend/src/routes/loadRoutes.js
+++ b/backend/src/routes/loadRoutes.js
@@ -7,9 +7,20 @@ import {
   patchLoad,
   deleteLoad,
 } from "../services/loadServices.js";
+import { ensureCityCoords } from "../services/cityCoordsService.js";
 
 const router = express.Router();
 router.use(requireAuth);
+
+// Fire-and-forget: make sure this load's origin/destination have persisted
+// coordinates for the Foreman's distance math. Runs in the background AFTER the
+// row is saved, so it never blocks (or fails) the create/patch — a HERE hiccup
+// just means the city gets geocoded on the next attempt.
+const warmLoadCities = (load) => {
+  if (!load) return;
+  ensureCityCoords(load.origin_city, load.origin_state).catch(() => {});
+  ensureCityCoords(load.destination_city, load.destination_state).catch(() => {});
+};
 
 // ---- GET ALL LOADS ----
 router.get("/", async (req, res) => {
@@ -70,6 +81,7 @@ router.post("/", async (req, res) => {
     const data = req.body;
 
     const load = await createLoad(user_id, data, req.user.self_id);
+    warmLoadCities(load);
 
     return res.status(201).json({
       message: "Load created successfully",
@@ -99,6 +111,7 @@ router.patch("/:load_id", async (req, res) => {
     const data = req.body;
 
     const load = await patchLoad(user_id, load_id, data);
+    warmLoadCities(load);
 
     return res.status(200).json({
       message: "Load updated successfully",

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -31,6 +31,7 @@ import accessorialRateRouter from "./routes/accessorialRateRoutes.js";
 import routingRouter from "./routes/routingRoutes.js";
 import freightIndexRouter from "./routes/freightIndexRoutes.js";
 import vendorRouter from "./routes/vendorRoutes.js";
+import cityCoordsRouter from "./routes/cityCoordsRoutes.js";
 
 const app = express();
 
@@ -83,6 +84,7 @@ app.use("/accessorial-rates", accessorialRateRouter);
 app.use("/routing", routingRouter);
 app.use("/freight-index", freightIndexRouter);
 app.use("/vendors", vendorRouter);
+app.use("/city-coords", cityCoordsRouter);
 
 app.get("/", (req, res) => {
   res.send("Home Page");

--- a/backend/src/services/cityCoordsService.js
+++ b/backend/src/services/cityCoordsService.js
@@ -1,0 +1,85 @@
+import { db } from "../../db/pool.js";
+import { geocodeDetailed, validateGeocodeResult } from "./hereProvider.js";
+
+// The persistent city-coordinate cache behind the Foreman's straight-line
+// distances. Geocode a (city, state) via HERE ONCE, validate it, store it, and
+// never call the API for that city again. Normalization matches the migration
+// (trim + uppercase) and the in-process geoCache key in hereProvider.
+const norm = (s) => String(s ?? "").trim().toUpperCase();
+
+// Every verified coordinate, as a flat list the frontend distances against. One
+// row per distinct city ever booked (small), so we return the whole table.
+export async function getVerifiedCoords() {
+  const { rows } = await db.query(
+    `SELECT city_norm, state, lat, lng FROM city_coords WHERE status = 'verified'`,
+  );
+  return rows; // [{ city_norm, state, lat, lng }]
+}
+
+// Resolve one (city, state) into the cache. Idempotent: a row that already exists
+// — verified OR failed — is left alone (a city center doesn't move, and a genuine
+// bad match won't spontaneously fix itself, so we never re-hit HERE for it). A
+// TRANSIENT miss (no API key, network error, or the API matched nothing) persists
+// NOTHING, so a later attempt can still succeed. Returns { lat, lng } | null.
+export async function ensureCityCoords(city, state) {
+  const c = norm(city);
+  const s = norm(state);
+  if (!c || !s) return null;
+
+  const existing = await db.query(
+    `SELECT lat, lng, status FROM city_coords WHERE city_norm = $1 AND state = $2`,
+    [c, s],
+  );
+  if (existing.rowCount > 0) {
+    const row = existing.rows[0];
+    return row.status === "verified" ? { lat: row.lat, lng: row.lng } : null;
+  }
+
+  let detail;
+  try {
+    detail = await geocodeDetailed(city, state);
+  } catch {
+    return null; // transient (HTTP / network) — leave absent so we retry later
+  }
+  if (detail == null) return null; // unconfigured / blank — don't persist a failure
+
+  const v = validateGeocodeResult(s, detail);
+  if (v.ok) {
+    await db.query(
+      `INSERT INTO city_coords (city_norm, state, lat, lng, label, query_score, status)
+       VALUES ($1, $2, $3, $4, $5, $6, 'verified')
+       ON CONFLICT (city_norm, state) DO NOTHING`,
+      [c, s, v.coords.lat, v.coords.lng, v.label ?? null, v.queryScore ?? null],
+    );
+    return { lat: v.coords.lat, lng: v.coords.lng };
+  }
+
+  // A real, trustworthy negative (wrong state / out of bounds / low score / the
+  // API found nothing): record the miss so we don't waste a call on it again.
+  await db.query(
+    `INSERT INTO city_coords (city_norm, state, status, failure_reason)
+     VALUES ($1, $2, 'failed', $3)
+     ON CONFLICT (city_norm, state) DO NOTHING`,
+    [c, s, v.reason ?? "unknown"],
+  );
+  return null;
+}
+
+// Warm the cache for many places, de-duped and SEQUENTIAL — keeps HERE calls
+// gentle (no 50-at-once burst against the rate limit). Returns how many resolved.
+// Meant to run fire-and-forget in the background off a page load.
+export async function ensureManyCityCoords(places) {
+  const seen = new Set();
+  let resolved = 0;
+  for (const p of places ?? []) {
+    const c = norm(p?.city);
+    const s = norm(p?.state);
+    if (!c || !s) continue;
+    const key = `${c},${s}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const r = await ensureCityCoords(p.city, p.state);
+    if (r) resolved++;
+  }
+  return resolved;
+}

--- a/backend/src/services/hereProvider.js
+++ b/backend/src/services/hereProvider.js
@@ -63,6 +63,84 @@ export const geocode = async (city, state) => {
   return coords;
 };
 
+// ---- detailed geocode + validation (for the persistent city_coords cache) ----
+// The plain geocode above returns just { lat, lng } and is fine for the live map.
+// The Foreman STORES coordinates, so it needs enough context to TRUST one before
+// persisting it — the state HERE actually matched, whether it's a US result, and
+// HERE's own confidence — so a wrong point never silently poisons a ranking.
+
+// US bounding box (continental + AK + HI + PR): generous, but enough to reject an
+// obviously-wrong hit like a same-named foreign city.
+export const US_BOUNDS = { minLat: 15, maxLat: 72, minLng: -170, maxLng: -64 };
+
+// HERE geocode item → the fields we need to trust a coordinate. `found:false` when
+// nothing usable came back (the API answered but matched nothing).
+export const parseGeocodeDetailed = (json) => {
+  const item = json?.items?.[0];
+  const pos = item?.position;
+  if (!item || !pos || typeof pos.lat !== "number" || typeof pos.lng !== "number")
+    return { found: false };
+  return {
+    found: true,
+    lat: pos.lat,
+    lng: pos.lng,
+    stateCode: item.address?.stateCode ?? null,
+    countryCode: item.address?.countryCode ?? null,
+    resultType: item.resultType ?? null,
+    queryScore:
+      typeof item.scoring?.queryScore === "number" ? item.scoring.queryScore : null,
+    label: item.address?.label ?? item.title ?? null,
+  };
+};
+
+// Is a detailed result trustworthy enough to STORE? We keep a coordinate only when
+// HERE agrees on the state, it's a US result, it sits inside US bounds, and it
+// clears the confidence floor. Anything else → don't store a number, fall back to
+// region-level. Pure + unit-tested (no key needed).
+// → { ok:true, coords, label, queryScore } | { ok:false, reason }
+export const validateGeocodeResult = (state, d, minScore = 0.8) => {
+  if (!d || d.found === false) return { ok: false, reason: "no_match" };
+  const st = String(state ?? "").trim().toUpperCase();
+  if (d.countryCode && d.countryCode !== "USA")
+    return { ok: false, reason: `country_${d.countryCode}` };
+  if (!d.stateCode || d.stateCode.toUpperCase() !== st)
+    return { ok: false, reason: `state_mismatch_${d.stateCode ?? "none"}` };
+  if (
+    d.lat < US_BOUNDS.minLat ||
+    d.lat > US_BOUNDS.maxLat ||
+    d.lng < US_BOUNDS.minLng ||
+    d.lng > US_BOUNDS.maxLng
+  )
+    return { ok: false, reason: "out_of_bounds" };
+  // Fail closed: a missing OR low confidence score is not trustworthy enough to
+  // STORE (city_coords is write-once), so we fall back to region-level instead.
+  if (d.queryScore == null) return { ok: false, reason: "no_score" };
+  if (d.queryScore < minScore)
+    return { ok: false, reason: `low_score_${d.queryScore.toFixed(2)}` };
+  return {
+    ok: true,
+    coords: { lat: d.lat, lng: d.lng },
+    label: d.label,
+    queryScore: d.queryScore,
+  };
+};
+
+// city/state → detailed geocode. Returns null when unconfigured/blank (a SKIP —
+// the caller must NOT persist a failure, so a later attempt with a key can still
+// succeed); throws on HTTP error (transient); otherwise the parsed detail
+// ({ found:true, … } | { found:false }).
+export const geocodeDetailed = async (city, state) => {
+  if (!hasKey() || !city || !state) return null;
+  const params = new URLSearchParams({
+    q: `${city.trim()}, ${state.trim()}, USA`,
+    apiKey: process.env.HERE_API_KEY,
+    limit: "1",
+  });
+  const res = await fetch(`${GEOCODE_URL}?${params}`);
+  if (!res.ok) throw new Error(`HERE geocode failed (${res.status})`);
+  return parseGeocodeDetailed(await res.json());
+};
+
 // Apply the load's dims to a routing request — HERE wants centimeters + kg.
 // Turns on PHYSICAL restrictions (the oversize reroute around low bridges,
 // narrow roads, weight limits) and, for tolls, the correct vehicle toll class.

--- a/backend/src/services/hereProvider.test.js
+++ b/backend/src/services/hereProvider.test.js
@@ -5,6 +5,8 @@ import {
   inchesToCm,
   poundsToKg,
   parseGeocode,
+  parseGeocodeDetailed,
+  validateGeocodeResult,
   parseRouteMeters,
   parseRouteTolls,
   parseCitySuggestions,
@@ -37,6 +39,96 @@ describe("parseGeocode", () => {
     assert.equal(parseGeocode({ items: [] }), null);
     assert.equal(parseGeocode({}), null);
     assert.equal(parseGeocode({ items: [{ position: { lat: "x", lng: 1 } }] }), null);
+  });
+});
+
+describe("parseGeocodeDetailed", () => {
+  const hit = {
+    items: [
+      {
+        title: "Macedonia, OH, United States",
+        resultType: "locality",
+        address: { label: "Macedonia, OH, United States", countryCode: "USA", stateCode: "OH" },
+        position: { lat: 41.31, lng: -81.5 },
+        scoring: { queryScore: 0.99 },
+      },
+    ],
+  };
+
+  test("pulls the trust fields from the top hit", () => {
+    assert.deepEqual(parseGeocodeDetailed(hit), {
+      found: true,
+      lat: 41.31,
+      lng: -81.5,
+      stateCode: "OH",
+      countryCode: "USA",
+      resultType: "locality",
+      queryScore: 0.99,
+      label: "Macedonia, OH, United States",
+    });
+  });
+
+  test("found:false when nothing usable came back", () => {
+    assert.deepEqual(parseGeocodeDetailed({ items: [] }), { found: false });
+    assert.deepEqual(parseGeocodeDetailed({}), { found: false });
+    assert.deepEqual(
+      parseGeocodeDetailed({ items: [{ position: { lat: "x", lng: 1 } }] }),
+      { found: false },
+    );
+  });
+});
+
+describe("validateGeocodeResult", () => {
+  const good = {
+    found: true,
+    lat: 41.31,
+    lng: -81.5,
+    stateCode: "OH",
+    countryCode: "USA",
+    resultType: "locality",
+    queryScore: 0.99,
+    label: "Macedonia, OH",
+  };
+
+  test("accepts a US, state-matched, in-bounds, high-confidence hit", () => {
+    const v = validateGeocodeResult("oh", good);
+    assert.equal(v.ok, true);
+    assert.deepEqual(v.coords, { lat: 41.31, lng: -81.5 });
+  });
+
+  test("rejects a state mismatch (the classic wrong-Springfield guard)", () => {
+    const v = validateGeocodeResult("IL", { ...good, stateCode: "MO" });
+    assert.equal(v.ok, false);
+    assert.match(v.reason, /state_mismatch/);
+  });
+
+  test("rejects a non-US result", () => {
+    const v = validateGeocodeResult("OH", { ...good, countryCode: "CAN" });
+    assert.equal(v.ok, false);
+    assert.match(v.reason, /country/);
+  });
+
+  test("rejects a point outside US bounds", () => {
+    const v = validateGeocodeResult("OH", { ...good, lat: 4.6, lng: -74.1 }); // Bogotá
+    assert.equal(v.ok, false);
+    assert.equal(v.reason, "out_of_bounds");
+  });
+
+  test("rejects a low-confidence match", () => {
+    const v = validateGeocodeResult("OH", { ...good, queryScore: 0.55 });
+    assert.equal(v.ok, false);
+    assert.match(v.reason, /low_score/);
+  });
+
+  test("no_match when the API found nothing", () => {
+    assert.equal(validateGeocodeResult("OH", { found: false }).ok, false);
+    assert.equal(validateGeocodeResult("OH", null).reason, "no_match");
+  });
+
+  test("fails closed when HERE returned no confidence score", () => {
+    const v = validateGeocodeResult("OH", { ...good, queryScore: null });
+    assert.equal(v.ok, false);
+    assert.equal(v.reason, "no_score");
   });
 });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.171.3",
+  "version": "1.172.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import DashboardPage from "@/pages/DashboardPage";
 import LoadsPage from "@/pages/LoadsPage";
 import TripsPage from "@/pages/TripsPage";
 import ScoreLoadPage from "@/pages/ScoreLoadPage";
+import ForemanPage from "@/pages/ForemanPage";
 import GaragePage from "@/pages/GaragePage";
 import ExpensesPage from "@/pages/ExpensesPage";
 import MarketPage from "@/pages/MarketPage";
@@ -57,6 +58,7 @@ const App = () => {
           <Route path="/loads/:load_id" element={<LoadDetailPage />} />
           <Route path="/trips" element={<TripsPage />} />
           <Route path="/score" element={<ScoreLoadPage />} />
+          <Route path="/foreman" element={<ForemanPage />} />
           <Route
             path="/lanes"
             element={

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -4,6 +4,7 @@ import {
   ChevronRight,
   LayoutDashboard,
   Target,
+  Phone,
   Package,
   Truck,
   Wallet,
@@ -47,6 +48,7 @@ const isGroup = (e: Entry): e is Group => "children" in e;
 const nav: Entry[] = [
   { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { to: "/score", label: "Score a Load", icon: Target },
+  { to: "/foreman", label: "The Foreman", icon: Phone },
   {
     label: "Freight",
     icon: Package,

--- a/frontend/src/components/foreman/WhoToCallTab.tsx
+++ b/frontend/src/components/foreman/WhoToCallTab.tsx
@@ -1,0 +1,244 @@
+import { useState, useMemo } from "react";
+import { Link } from "react-router-dom";
+import { useLoads } from "@/hooks/useLoads";
+import { useAgents } from "@/hooks/useAgents";
+import { useCityCoords } from "@/hooks/useCityCoords";
+import { SegmentedTabs } from "@/components/ui/SegmentedTabs";
+import { ForgedPlate, Well } from "@/components/ui/ForgedPlate";
+import {
+  buildForemanBoard,
+  distanceLabel,
+  TYPE_LABELS,
+  type AgentRanking,
+  type ForemanMode,
+  type LoadTypeFocus,
+} from "@/lib/metrics/foreman";
+
+const money2 = (n: number) => `$${n.toFixed(2)}`;
+
+// The rate benchmark line: how the agent's $/mi compares to your realized median
+// for the load type they're judged on.
+const RateNote = ({ r }: { r: AgentRanking }) => {
+  if (r.rpm == null)
+    return <span className="text-faint">no {TYPE_LABELS[r.loadType].toLowerCase()} loads yet</span>;
+  if (r.rateDelta == null || r.benchmark == null) return null;
+  const up = r.rateDelta >= 0;
+  return (
+    <span style={{ color: up ? "#5dcaa5" : "#8494ab" }}>
+      {up ? "+" : "−"}
+      {money2(Math.abs(r.rateDelta)).slice(1)} vs your {TYPE_LABELS[r.loadType].toLowerCase()} avg
+    </span>
+  );
+};
+
+const historySub = (r: AgentRanking) => {
+  if (r.daysSince == null) return "no delivered loads yet";
+  const dwell = r.dwellLoads > 0 ? "detention owed" : "low dwell";
+  return `last ${r.daysSince}d ago · ${dwell}`;
+};
+
+const originSub = (r: AgentRanking) => {
+  if (!r.nearestOrigin) return "";
+  const verb = r.regionFallback ? "sources out of" : "loads out of";
+  return `${verb} ${r.nearestOrigin.city}, ${r.nearestOrigin.state}`;
+};
+
+// ---- the one forged plate: the top call ----
+const TopCall = ({ r }: { r: AgentRanking }) => (
+  <ForgedPlate chamfer tilt className="p-4 sm:p-5">
+    <div className="flex items-center gap-2 mb-2">
+      <span className="font-forge text-[12px] tracking-wider px-2.5 py-1 rounded-md bg-amber text-canvas font-bold">
+        {"★"} TOP CALL
+      </span>
+      <span className="font-condensed text-[12px] font-semibold px-2 py-0.5 rounded-md bg-well text-hot">
+        {TYPE_LABELS[r.loadType]}
+      </span>
+      {r.isNew && (
+        <span className="font-condensed text-[11px] font-semibold px-2 py-0.5 rounded" style={{ color: "#5dcaa5", background: "rgba(53,160,140,.13)" }}>
+          NEW
+        </span>
+      )}
+    </div>
+
+    <Link
+      to={`/agents/${r.agentId}`}
+      className="font-display text-[26px] text-amber leading-none hover:text-hot transition-colors"
+    >
+      {r.agentName}
+    </Link>
+
+    <div className="grid grid-cols-3 gap-3 mt-4 mb-3">
+      <div>
+        <p className="text-[11px] uppercase tracking-widest text-faint font-condensed">Proximity</p>
+        <p className="font-display text-[24px] text-ink leading-none mt-1">{distanceLabel(r)}</p>
+        <p className="text-[12px] text-dim mt-1">{originSub(r)}</p>
+      </div>
+      <div>
+        <p className="text-[11px] uppercase tracking-widest text-faint font-condensed">Rate</p>
+        <p className="font-display text-[24px] text-ink leading-none mt-1">
+          {r.rpm != null ? money2(r.rpm) : "—"}
+          {r.rpm != null && <span className="font-condensed text-[13px] text-dim"> /mi gross</span>}
+        </p>
+        <p className="text-[12px] mt-1"><RateNote r={r} /></p>
+      </div>
+      <div>
+        <p className="text-[11px] uppercase tracking-widest text-faint font-condensed">History</p>
+        <p className="font-display text-[24px] text-ink leading-none mt-1">
+          {r.loadCount} load{r.loadCount === 1 ? "" : "s"}
+        </p>
+        <p className="text-[12px] text-dim mt-1">{historySub(r)}</p>
+      </div>
+    </div>
+
+    <Well className="px-3 py-2.5 flex items-center gap-3">
+      <span className="text-[11px] uppercase tracking-widest text-amber font-condensed shrink-0">Why</span>
+      <span className="text-[13.5px] text-ink/90">{r.why}</span>
+    </Well>
+  </ForgedPlate>
+);
+
+// ---- flat reading rows: #2..N ----
+const AgentRow = ({ r, rank }: { r: AgentRanking; rank: number }) => (
+  <div className="grid items-center gap-3 px-3.5 py-3 border-t border-hairline-lo" style={{ gridTemplateColumns: "20px 1.4fr 80px 72px 92px" }}>
+    <span className="font-display text-[17px] text-faint">{rank}</span>
+    <div className="min-w-0">
+      <Link to={`/agents/${r.agentId}`} className="font-condensed text-[15px] text-amber hover:text-hot transition-colors">
+        {r.agentName}
+      </Link>
+      <div className="text-[11.5px] truncate">
+        {r.isNew ? (
+          <span className="font-condensed font-semibold uppercase tracking-wide" style={{ color: "#5dcaa5" }}>
+            New {"·"} building
+          </span>
+        ) : (
+          <span className="text-dim">{originSub(r)}</span>
+        )}
+      </div>
+    </div>
+    <span className="font-display text-[17px] text-ink text-right">{distanceLabel(r)}</span>
+    <span className="font-display text-[17px] text-right" >{r.rpm != null ? money2(r.rpm) : <span className="text-faint">{"—"}</span>}</span>
+    <span className="font-condensed text-[13px] text-dim text-right">
+      {r.loadCount} load{r.loadCount === 1 ? "" : "s"}
+      {r.daysSince != null ? ` · ${r.daysSince}d` : ""}
+    </span>
+  </div>
+);
+
+const FOCUS_TABS: { value: LoadTypeFocus; label: string }[] = [
+  { value: "any", label: "Any" },
+  { value: "standard flatbed", label: "Flatbed" },
+  { value: "oversize", label: "Oversize" },
+  { value: "hazmat", label: "Hazmat" },
+  { value: "heavy haul", label: "Heavy" },
+];
+const MODE_TABS: { value: ForemanMode; label: string }[] = [
+  { value: "balanced", label: "Balanced" },
+  { value: "closest", label: "Closest" },
+  { value: "best-rate", label: "Best rate" },
+];
+
+const Loading = () => (
+  <div className="space-y-3">
+    <div className="ds2-board h-14 animate-pulse" />
+    <div className="ds2-forged h-40 animate-pulse" />
+    <div className="ds2-board h-52 animate-pulse" />
+  </div>
+);
+
+const Empty = ({ msg }: { msg: string }) => (
+  <div className="ds2-board p-8 text-center text-dim">{msg}</div>
+);
+
+export const WhoToCallTab = () => {
+  const { loads, isLoading: loadsLoading } = useLoads(0);
+  const { agents, isLoading: agentsLoading } = useAgents();
+  const coords = useCityCoords(loads);
+
+  const [focus, setFocus] = useState<LoadTypeFocus>("any");
+  const [mode, setMode] = useState<ForemanMode>("balanced");
+
+  const board = useMemo(
+    () => buildForemanBoard(loads, agents, coords, { focus, mode }),
+    [loads, agents, coords, focus, mode],
+  );
+
+  if (loadsLoading || agentsLoading) return <Loading />;
+  if (!board.anchor)
+    return <Empty msg="No committed or delivered loads yet — add a load and the Foreman will tell you who to call." />;
+
+  const [top, ...rest] = board.rankings;
+  const anchorHint =
+    board.anchor.source === "committed" ? "after your booked load delivers" : "empty here now";
+
+  return (
+    <div>
+      {/* controls */}
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mb-4">
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] uppercase tracking-widest text-faint font-condensed">Looking for</span>
+          <SegmentedTabs size="sm" tabs={FOCUS_TABS} value={focus} onChange={setFocus} ariaLabel="Load type focus" />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] uppercase tracking-widest text-faint font-condensed">Rank by</span>
+          <SegmentedTabs size="sm" tabs={MODE_TABS} value={mode} onChange={setMode} ariaLabel="Rank by" />
+        </div>
+      </div>
+
+      {/* anchor */}
+      <div className="ds2-board flex items-center gap-3 px-4 py-3 mb-4">
+        <span className="text-amber text-[15px]">{"◉"}</span>
+        <div className="flex-1 min-w-0">
+          <p className="text-[11px] uppercase tracking-widest text-faint font-condensed">Empty next</p>
+          <p className="font-condensed text-[18px] font-semibold text-ink leading-tight">
+            {board.anchor.city}, {board.anchor.state}
+            <span className="text-dim font-normal text-[12px] ml-2">{anchorHint}</span>
+          </p>
+        </div>
+      </div>
+
+      {board.rankings.length === 0 ? (
+        <Empty
+          msg={
+            focus === "any"
+              ? "No agents to rank yet — book a load and they'll show up here."
+              : `You haven't booked ${TYPE_LABELS[focus].toLowerCase()} freight yet — switch to "Any" to see everyone.`
+          }
+        />
+      ) : (
+        <>
+          {/* top call */}
+          {top && <TopCall r={top} />}
+
+          {/* the rest */}
+          {rest.length > 0 && (
+            <div className="ds2-board mt-3">
+              <div className="grid gap-3 px-3.5 pt-2.5 pb-1.5" style={{ gridTemplateColumns: "20px 1.4fr 80px 72px 92px" }}>
+                <span />
+                <span className="text-[11px] uppercase tracking-widest text-faint font-condensed">Agent</span>
+                <span className="text-[11px] uppercase tracking-widest text-faint font-condensed text-right">Away</span>
+                <span className="text-[11px] uppercase tracking-widest text-faint font-condensed text-right">$/mi</span>
+                <span className="text-[11px] uppercase tracking-widest text-faint font-condensed text-right">History</span>
+              </div>
+              {rest.map((r, i) => (
+                <AgentRow key={r.agentId} r={r} rank={i + 2} />
+              ))}
+            </div>
+          )}
+
+          {/* footer */}
+          <div className="flex flex-wrap items-center justify-between gap-3 mt-3 px-1">
+            <p className="text-[11.5px] text-faint max-w-xl">
+              Ranked on straight-line distance to where you'll be empty, your gross $/mi within load type,
+              and your history — a call list from who you've booked, not a live load feed.
+              {board.coverage.withCoords < board.coverage.total &&
+                " Distances sharpen to real miles as new cities finish geocoding."}
+            </p>
+            <Link to="/guide" className="font-condensed text-[12.5px] text-dim hover:text-ink whitespace-nowrap">
+              How it's ranked {"→"}
+            </Link>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useCityCoords.ts
+++ b/frontend/src/hooks/useCityCoords.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from "react";
+import type { Load } from "@/types/load";
+import { getCityCoords, warmCityCoords, type CityCoordRow } from "@/services/cityCoordsService";
+import { cityKey, type CoordMap } from "@/lib/metrics/foreman";
+
+const toMap = (rows: CityCoordRow[]): CoordMap => {
+  const m: CoordMap = new Map();
+  for (const r of rows) m.set(cityKey(r.city_norm, r.state), { lat: r.lat, lng: r.lng });
+  return m;
+};
+
+// The trusted city-coordinate lookup for the Foreman. Fetches what's already
+// verified (fast), then warms the cache for every city on the current board and
+// refetches once so a first-ever visit sharpens from region-level to real miles
+// within a few seconds — all in the background, no user involvement.
+export const useCityCoords = (loads: Load[]): CoordMap => {
+  const [map, setMap] = useState<CoordMap>(new Map());
+
+  useEffect(() => {
+    let active = true;
+    getCityCoords().then((rows) => active && setMap(toMap(rows)));
+
+    if (!loads.length) return () => { active = false; };
+
+    // distinct cities on the board (origins + destinations)
+    const seen = new Set<string>();
+    const cities: { city: string; state: string }[] = [];
+    for (const l of loads) {
+      for (const [c, s] of [
+        [l.origin_city, l.origin_state],
+        [l.destination_city, l.destination_state],
+      ] as const) {
+        const k = cityKey(c, s);
+        if (c && s && !seen.has(k)) {
+          seen.add(k);
+          cities.push({ city: c, state: s });
+        }
+      }
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    warmCityCoords(cities).then(() => {
+      // ensure returns immediately while it geocodes in the background — give it a
+      // moment, then pick up any newly-verified coordinates.
+      timer = setTimeout(() => {
+        getCityCoords().then((rows) => active && setMap(toMap(rows)));
+      }, 5000);
+    });
+
+    return () => {
+      active = false;
+      if (timer) clearTimeout(timer);
+    };
+  }, [loads]);
+
+  return map;
+};

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -14,6 +14,7 @@ import { isDispatcher } from "@/lib/roles";
 // both roles share (like /lanes) are full-bleed for everyone.
 const FULL_BLEED_PREFIXES = [
   { prefix: "/dashboard", ownerOnly: false }, // both boards carry their own trigger now
+  { prefix: "/foreman", ownerOnly: false },
   { prefix: "/lanes", ownerOnly: false },
   { prefix: "/trophy-room", ownerOnly: false },
   { prefix: "/trips", ownerOnly: false },

--- a/frontend/src/lib/metrics/foreman.test.ts
+++ b/frontend/src/lib/metrics/foreman.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { Agent } from "@/types/agent";
+import {
+  buildForemanBoard,
+  emptyNextAnchor,
+  haversineMiles,
+  cityKey,
+  type CoordMap,
+} from "./foreman";
+
+// ---- fixtures ----
+let seq = 0;
+const mkLoad = (o: Partial<Load>): Load => ({
+  load_id: `L${seq++}`,
+  load_number: "N",
+  load_type: "standard flatbed",
+  load_status: "delivered",
+  broker_id: "b1",
+  broker: "B",
+  agent_id: "a1",
+  agent: "Agent",
+  agent_email: null,
+  pickup_date: "2026-07-01",
+  origin_market_id: "m1",
+  origin_city: "Akron",
+  origin_state: "OH",
+  origin_market: "Akron",
+  destination_market_id: "m2",
+  destination_city: "Dallas",
+  destination_state: "TX",
+  delivery_market: "Dallas",
+  deadhead_miles: 0,
+  loaded_miles: 1000,
+  linehaul: "5800",
+  fuel_surcharge: "200",
+  total_accessorials: "0",
+  commodity: null,
+  payment_status: "paid",
+  created_at: "2026-07-01",
+  updated_at: "2026-07-01",
+  ...o,
+});
+
+const mkAgent = (id: string, first: string): Agent => ({
+  agent_id: id,
+  broker_id: "b1",
+  broker_name: "B",
+  first_name: first,
+  last_name: "Co",
+  preferred_contact: "phone",
+  created_at: "2026-01-01",
+  updated_at: "2026-01-01",
+});
+
+// NE Ohio geography (real-ish centroids) — anchor is Macedonia, OH.
+const COORDS: CoordMap = new Map([
+  [cityKey("Macedonia", "OH"), { lat: 41.31, lng: -81.5 }],
+  [cityKey("Akron", "OH"), { lat: 41.08, lng: -81.52 }], // ~16 mi
+  [cityKey("Youngstown", "OH"), { lat: 41.1, lng: -80.65 }], // ~46 mi
+  [cityKey("Columbus", "OH"), { lat: 39.96, lng: -82.99 }], // ~122 mi
+  [cityKey("Pittsburgh", "PA"), { lat: 40.44, lng: -79.99 }], // ~99 mi
+]);
+
+const NOW = new Date("2026-08-13T12:00:00Z");
+
+// A1 Summit: 5 delivered standard out of Akron, rpm 6.0 — deepest tie, closest.
+// A2 Buckeye: 1 delivered oversize out of Columbus, rpm 8.0 — thin, far, top rate.
+// A3 GreatLakes: 2 delivered standard out of Youngstown, rpm 5.5.
+// A4 Keystone: 1 delivered standard out of Pittsburgh, rpm 5.0 — thin.
+// Plus a BOOKED load (Akron → Macedonia) that sets the empty-next anchor.
+const buildWorld = () => {
+  seq = 0;
+  const agents = [
+    mkAgent("a1", "Summit"),
+    mkAgent("a2", "Buckeye"),
+    mkAgent("a3", "GreatLakes"),
+    mkAgent("a4", "Keystone"),
+  ];
+  const loads: Load[] = [
+    mkLoad({
+      agent_id: "a1",
+      load_status: "booked",
+      origin_city: "Akron",
+      origin_state: "OH",
+      destination_city: "Macedonia",
+      destination_state: "OH",
+      pickup_date: "2026-08-17",
+      delivery_date: "2026-08-19",
+    }),
+  ];
+  for (let i = 0; i < 5; i++)
+    loads.push(
+      mkLoad({
+        agent_id: "a1",
+        origin_city: "Akron",
+        origin_state: "OH",
+        linehaul: "5800",
+        fuel_surcharge: "200", // gross 6000 / 1000 = 6.0
+        delivery_date: i === 0 ? "2026-08-08" : `2026-0${5 + (i % 3)}-10`,
+      }),
+    );
+  loads.push(
+    mkLoad({
+      agent_id: "a2",
+      load_type: "oversize",
+      origin_city: "Columbus",
+      origin_state: "OH",
+      loaded_miles: 800,
+      linehaul: "6200",
+      fuel_surcharge: "200", // gross 6400 / 800 = 8.0
+      delivery_date: "2026-07-15",
+    }),
+  );
+  for (let i = 0; i < 2; i++)
+    loads.push(
+      mkLoad({
+        agent_id: "a3",
+        origin_city: "Youngstown",
+        origin_state: "OH",
+        linehaul: "5300",
+        fuel_surcharge: "200", // gross 5500 / 1000 = 5.5
+        delivery_date: "2026-07-20",
+      }),
+    );
+  loads.push(
+    mkLoad({
+      agent_id: "a4",
+      origin_city: "Pittsburgh",
+      origin_state: "PA",
+      linehaul: "4800",
+      fuel_surcharge: "200", // gross 5000 / 1000 = 5.0
+      delivery_date: "2026-06-20",
+    }),
+  );
+  return { agents, loads };
+};
+
+describe("haversineMiles", () => {
+  it("Akron → Macedonia is ~16 mi", () => {
+    const d = haversineMiles(COORDS.get(cityKey("Macedonia", "OH"))!, COORDS.get(cityKey("Akron", "OH"))!);
+    expect(d).toBeGreaterThan(13);
+    expect(d).toBeLessThan(19);
+  });
+  it("is zero for the same point", () => {
+    const p = { lat: 41.31, lng: -81.5 };
+    expect(haversineMiles(p, p)).toBeCloseTo(0, 6);
+  });
+});
+
+describe("emptyNextAnchor", () => {
+  it("follows the committed chain to the furthest-out booked/in-transit destination", () => {
+    const { loads } = buildWorld();
+    const a = emptyNextAnchor(loads);
+    expect(a).toEqual({ city: "Macedonia", state: "OH", source: "committed" });
+  });
+
+  it("falls back to the last delivered destination when nothing is committed", () => {
+    const loads = [
+      mkLoad({ load_status: "delivered", destination_city: "Reno", destination_state: "NV", delivery_date: "2026-08-01" }),
+      mkLoad({ load_status: "delivered", destination_city: "Ogden", destination_state: "UT", delivery_date: "2026-08-05" }),
+    ];
+    expect(emptyNextAnchor(loads)).toEqual({ city: "Ogden", state: "UT", source: "last-delivered" });
+  });
+
+  it("returns null with no usable loads", () => {
+    expect(emptyNextAnchor([])).toBeNull();
+  });
+});
+
+describe("buildForemanBoard — ranking", () => {
+  it("balanced favors the deepest tie near the drop over a farther, thinner, higher-rate agent", () => {
+    const { agents, loads } = buildWorld();
+    const board = buildForemanBoard(loads, agents, COORDS, { mode: "balanced", now: NOW });
+    expect(board.anchor).toEqual({ city: "Macedonia", state: "OH", source: "committed" });
+    expect(board.rankings[0].agentId).toBe("a1"); // Summit: 5 loads, ~16 mi
+    // Buckeye (a2) pays most but is 1 load + far → not the top call in balanced.
+    const a2Rank = board.rankings.findIndex((r) => r.agentId === "a2");
+    expect(a2Rank).toBeGreaterThan(0);
+  });
+
+  it("best-rate surfaces the highest raw $/mi agent", () => {
+    const { agents, loads } = buildWorld();
+    const board = buildForemanBoard(loads, agents, COORDS, { mode: "best-rate", now: NOW });
+    expect(board.rankings[0].agentId).toBe("a2"); // rpm 8.0
+    expect(board.rankings[0].rpm).toBeCloseTo(8.0, 5);
+  });
+
+  it("closest surfaces the nearest origin", () => {
+    const { agents, loads } = buildWorld();
+    const board = buildForemanBoard(loads, agents, COORDS, { mode: "closest", now: NOW });
+    expect(board.rankings[0].agentId).toBe("a1"); // Akron ~16 mi
+    expect(board.rankings[0].distanceMiles).toBeLessThan(19);
+  });
+
+  it("computes straight-line distance to each agent's nearest origin", () => {
+    const { agents, loads } = buildWorld();
+    const board = buildForemanBoard(loads, agents, COORDS, { now: NOW });
+    const byId = Object.fromEntries(board.rankings.map((r) => [r.agentId, r]));
+    expect(byId.a1.distanceMiles!).toBeLessThan(19); // Akron
+    expect(byId.a2.distanceMiles!).toBeGreaterThan(110); // Columbus ~122
+    expect(byId.a4.distanceMiles!).toBeGreaterThan(85); // Pittsburgh ~99
+    expect(board.coverage).toEqual({ withCoords: 4, total: 4 });
+  });
+
+  it("flags thin agents (< 2 delivered) as New", () => {
+    const { agents, loads } = buildWorld();
+    const board = buildForemanBoard(loads, agents, COORDS, { now: NOW });
+    const byId = Object.fromEntries(board.rankings.map((r) => [r.agentId, r]));
+    expect(byId.a1.isNew).toBe(false); // 5
+    expect(byId.a3.isNew).toBe(false); // 2
+    expect(byId.a2.isNew).toBe(true); // 1
+    expect(byId.a4.isNew).toBe(true); // 1
+  });
+});
+
+describe("buildForemanBoard — rate benchmark (per-type median, loaded basis)", () => {
+  it("benchmarks each agent against your realized median gross/loaded for that type", () => {
+    const { agents, loads } = buildWorld();
+    const board = buildForemanBoard(loads, agents, COORDS, { now: NOW });
+    const byId = Object.fromEntries(board.rankings.map((r) => [r.agentId, r]));
+    // your standard loads: 5×6.0, 2×5.5, 1×5.0 → median 6.0; a1 pays 6.0 → delta ~0
+    expect(byId.a1.loadType).toBe("standard flatbed");
+    expect(byId.a1.benchmark).toBeCloseTo(6.0, 5);
+    expect(byId.a1.rateDelta).toBeCloseTo(0, 5);
+    // a2 judged on oversize; the only oversize load is its own 8.0 → median 8.0
+    expect(byId.a2.loadType).toBe("oversize");
+    expect(byId.a2.benchmark).toBeCloseTo(8.0, 5);
+    expect(byId.a2.rpm).toBeCloseTo(8.0, 5);
+  });
+});
+
+describe("buildForemanBoard — membership", () => {
+  it("filters to agents who bring that type, judged on it", () => {
+    const { agents, loads } = buildWorld();
+    const board = buildForemanBoard(loads, agents, COORDS, { focus: "oversize", now: NOW });
+    expect(board.rankings).toHaveLength(1);
+    expect(board.rankings[0].agentId).toBe("a2");
+    expect(board.rankings[0].loadType).toBe("oversize");
+  });
+
+  it("excludes roster agents you've never booked", () => {
+    const { agents, loads } = buildWorld();
+    const stranger = mkAgent("a9", "Stranger"); // on the roster, zero loads
+    const board = buildForemanBoard(loads, [...agents, stranger], COORDS, { now: NOW });
+    expect(board.rankings.find((r) => r.agentId === "a9")).toBeUndefined();
+  });
+
+  it("excludes an agent whose only load is cancelled", () => {
+    const { agents, loads } = buildWorld();
+    const cancelledOnly = mkAgent("a8", "Ghost");
+    loads.push(mkLoad({ agent_id: "a8", load_status: "cancelled", origin_city: "Akron", origin_state: "OH" }));
+    const board = buildForemanBoard(loads, [...agents, cancelledOnly], COORDS, { now: NOW });
+    expect(board.rankings.find((r) => r.agentId === "a8")).toBeUndefined();
+  });
+
+  it("returns no rankings for a focus type you've never hauled", () => {
+    const { agents, loads } = buildWorld(); // no heavy-haul loads
+    const board = buildForemanBoard(loads, agents, COORDS, { focus: "heavy haul", now: NOW });
+    expect(board.rankings).toHaveLength(0);
+    expect(board.anchor).not.toBeNull();
+  });
+});
+
+describe("buildForemanBoard — region fallback (no coords)", () => {
+  it("still ranks by region + relationship, marking region fallback", () => {
+    const { agents, loads } = buildWorld();
+    const board = buildForemanBoard(loads, agents, new Map(), { mode: "balanced", now: NOW });
+    expect(board.anchorResolved).toBe(false);
+    expect(board.coverage.withCoords).toBe(0);
+    for (const r of board.rankings) {
+      expect(r.distanceMiles).toBeNull();
+      expect(r.regionFallback).toBe(true);
+    }
+    // relationship still carries balanced → Summit (5 loads, same region) on top
+    expect(board.rankings[0].agentId).toBe("a1");
+    // origin still surfaced for the label even without coordinates
+    expect(board.rankings[0].nearestOrigin).not.toBeNull();
+  });
+});

--- a/frontend/src/lib/metrics/foreman.ts
+++ b/frontend/src/lib/metrics/foreman.ts
@@ -1,0 +1,433 @@
+// The Foreman — "who to call from where you'll be empty next." Ranks the agents
+// you've booked by three axes, all on the SAME basis the Agents page uses:
+//   • Proximity  — straight-line miles from your empty-next point to the agent's
+//                  NEAREST recurring origin (not their average — the question is
+//                  "can they load me near here").
+//   • Rate       — the agent's gross $/LOADED mile FOR A LOAD TYPE, measured
+//                  against your own target/average for that type (loaded basis,
+//                  so an agent is never dinged for a deadhead they didn't cause).
+//   • History    — loads together, recency, and dwell (money left sitting).
+//
+// It is a call list from who you've booked, ranked by history + fit — NOT a live
+// load feed. Everything is GROSS (agents are a market-value lens), matching
+// agentScorecard. Distances come from the persisted city_coords cache; a city we
+// can't trust a coordinate for falls back to region-level, never a fake number.
+import type { Load } from "@/types/load";
+import type { Agent } from "@/types/agent";
+import { loadRevenue } from "./loads"; // GROSS per load
+import { median } from "./stats";
+import {
+  buildAgentScorecards,
+  MIN_SCORE_LOADS,
+  type AgentScorecard,
+  type GoToTier,
+} from "./agentScorecard";
+import { getRegion, getMacro } from "@/lib/constants/states";
+
+// ---- load types ----
+export const LOAD_TYPES = [
+  "standard flatbed",
+  "oversize",
+  "hazmat",
+  "heavy haul",
+] as const;
+export type LoadType = (typeof LOAD_TYPES)[number];
+export type LoadTypeFocus = "any" | LoadType;
+const STANDARD_TYPE: LoadType = "standard flatbed";
+// Specialized = anything non-standard → the Specialized tier set (oversize /
+// hazmat / heavy haul), matching lib/constants/targets.
+export const isSpecialized = (type: string): boolean => type !== STANDARD_TYPE;
+
+export type ForemanMode = "balanced" | "closest" | "best-rate";
+
+// ---- geo ----
+export interface CityCoord {
+  lat: number;
+  lng: number;
+}
+export type CoordMap = Map<string, CityCoord>; // key = cityKey(city, state)
+
+export const cityKey = (city?: string | null, state?: string | null): string =>
+  `${String(city ?? "").trim().toUpperCase()},${String(state ?? "").trim().toUpperCase()}`;
+
+const R_MILES = 3958.7613;
+const toRad = (d: number) => (d * Math.PI) / 180;
+
+// Great-circle (straight-line) distance in miles between two coordinates. Plenty
+// precise for RANKING agents by proximity — we're ordering, not billing miles.
+export const haversineMiles = (a: CityCoord, b: CityCoord): number => {
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const la1 = toRad(a.lat);
+  const la2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(la1) * Math.cos(la2) * Math.sin(dLng / 2) ** 2;
+  return 2 * R_MILES * Math.asin(Math.min(1, Math.sqrt(h)));
+};
+
+// ---- anchor: where you'll be empty next ----
+export interface Anchor {
+  city: string;
+  state: string;
+  source: "committed" | "last-delivered";
+}
+
+const COMMITTED = new Set(["booked", "in_transit"]);
+const refDay = (l: Load): string => l.delivery_date ?? l.pickup_date ?? "";
+
+// Your empty-next point = the destination of the furthest-out load you're already
+// committed to (booked or in-transit) — you're covered until it drops. With
+// nothing committed, you're already empty at your last delivery. null when there's
+// no usable load at all.
+export const emptyNextAnchor = (loads: Load[]): Anchor | null => {
+  const committed = loads.filter(
+    (l) => COMMITTED.has(l.load_status) && l.destination_city && l.destination_state,
+  );
+  if (committed.length) {
+    const f = committed.reduce((best, l) => (refDay(l) > refDay(best) ? l : best));
+    return { city: f.destination_city, state: f.destination_state, source: "committed" };
+  }
+  const delivered = loads.filter(
+    (l) =>
+      l.load_status === "delivered" &&
+      l.destination_city &&
+      l.destination_state &&
+      l.delivery_date,
+  );
+  if (delivered.length) {
+    const latest = delivered.reduce((best, l) =>
+      (l.delivery_date as string) > (best.delivery_date as string) ? l : best,
+    );
+    return {
+      city: latest.destination_city,
+      state: latest.destination_state,
+      source: "last-delivered",
+    };
+  }
+  return null;
+};
+
+// ---- per-agent helpers ----
+type Place = { city: string; state: string };
+
+// Every origin an agent has loaded you from (non-cancelled), so we can find the
+// one closest to where you'll be empty.
+const agentOrigins = (loads: Load[]): Map<string, Place[]> => {
+  const m = new Map<string, Place[]>();
+  for (const l of loads) {
+    if (l.load_status === "cancelled" || !l.agent_id || !l.origin_city || !l.origin_state)
+      continue;
+    const arr = m.get(l.agent_id) ?? [];
+    arr.push({ city: l.origin_city, state: l.origin_state });
+    m.set(l.agent_id, arr);
+  }
+  return m;
+};
+
+const loadRpm = (l: Load): number | null => {
+  const miles = Number(l.loaded_miles);
+  if (!(miles > 0)) return null;
+  return loadRevenue(l) / miles; // GROSS ÷ loaded mile
+};
+
+// An agent's typical gross $/loaded mile for ONE load type (delivered loads only).
+const agentTypeRpm = (loads: Load[], type: LoadType): number | null => {
+  const rpms = loads
+    .filter((l) => l.load_status === "delivered" && l.load_type === type)
+    .map(loadRpm)
+    .filter((r): r is number => r != null);
+  return rpms.length ? median(rpms) : null;
+};
+
+const agentTypeCount = (loads: Load[], type: LoadType): number =>
+  loads.filter((l) => l.load_status === "delivered" && l.load_type === type).length;
+
+// The type an agent brings you most (for focus = "any").
+const dominantType = (loads: Load[]): LoadType => {
+  let best: LoadType = STANDARD_TYPE;
+  let bestN = -1;
+  for (const t of LOAD_TYPES) {
+    const n = agentTypeCount(loads, t);
+    if (n > bestN) {
+      bestN = n;
+      best = t;
+    }
+  }
+  return best;
+};
+
+// ---- rate benchmark ----
+// Your per-type rate yardstick = your OWN realized median gross $/loaded mile for
+// that load type. So an agent reads against what you actually get for oversize vs
+// flatbed vs hazmat — the honest "my average rate per mile with the load type."
+// The real data shows this swings hard by type (flatbed ~$5, oversize ~$8.7), so
+// a per-type yardstick is the whole point; a single blended average would make
+// every flatbed agent look terrible next to your oversize rates. (A tier-markup
+// TARGET was considered, but it hangs off a type-agnostic break-even and would
+// saturate for specialized freight — every oversize agent reads far "over target"
+// — so it can't tell strong oversize agents from weak ones. The median can.)
+const typeBenchmark = (type: LoadType, allLoads: Load[]): number | null => {
+  const mine = allLoads
+    .filter((l) => l.load_status === "delivered" && l.load_type === type)
+    .map(loadRpm)
+    .filter((r): r is number => r != null);
+  return mine.length ? median(mine) : null;
+};
+
+// ---- scoring ----
+// Balanced weights RELATIONSHIP as heavily as proximity (Jason's steer: he's
+// building ties, not shopping the board), with rate a notch below. Exported so
+// the Guide can state them and tests can pin them.
+export const FOREMAN_WEIGHTS = { proximity: 0.35, rate: 0.3, relationship: 0.35 };
+const FADE_MILES = 500; // proximity score reaches 0 by here
+const REL_FULL_LOADS = 5; // loads together for a full relationship base
+const RECENCY_DAYS = 90; // recency fades to 0 by here
+
+const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
+
+// ---- output ----
+export interface AgentRanking {
+  agentId: string;
+  agentName: string;
+  // proximity
+  nearestOrigin: Place | null;
+  distanceMiles: number | null; // straight-line; null when no trusted coord
+  regionFallback: boolean; // true → ranked by region, not miles
+  // rate (for the judged type)
+  loadType: LoadType; // the type this agent is judged on
+  rpm: number | null; // gross ÷ loaded mile for that type
+  benchmark: number | null; // your realized median gross/loaded for this type
+  rateDelta: number | null; // rpm − benchmark
+  typeLoadCount: number; // delivered loads of the judged type
+  // history
+  loadCount: number; // total delivered with this agent
+  daysSince: number | null;
+  dwellLoads: number; // confirmed-billable detention left unpaid
+  tier: GoToTier;
+  isNew: boolean; // < MIN_SCORE_LOADS delivered → "New · building"
+  // scoring
+  score: number;
+  why: string;
+}
+
+export interface ForemanBoard {
+  anchor: Anchor | null;
+  anchorResolved: boolean; // did the anchor city have a trusted coordinate?
+  focus: LoadTypeFocus;
+  mode: ForemanMode;
+  benchmark: number | null; // the focus type's median (when focus ≠ any)
+  rankings: AgentRanking[]; // best first
+  coverage: { withCoords: number; total: number }; // how many agents got real miles
+}
+
+// Region proximity as a fallback ordering when a coordinate is missing: same
+// freight region as the anchor is closest, then same macro, then elsewhere.
+const regionRank = (anchorState: string, originState: string): number => {
+  if (getRegion(anchorState) === getRegion(originState)) return 0;
+  if (getMacro(anchorState) === getMacro(originState)) return 1;
+  return 2;
+};
+
+// Real-miles agents sit in the [0.3, 1.0] band; region-fallback agents (no
+// trusted coordinate) sit strictly BELOW it — so a KNOWN distance always beats an
+// unknown one, even a far known origin over a same-region guess. Within each band,
+// closer ranks higher.
+const proximityScore = (r: AgentRanking, anchorState: string): number => {
+  if (r.distanceMiles != null) return 0.3 + 0.7 * clamp01(1 - r.distanceMiles / FADE_MILES);
+  if (!r.nearestOrigin) return 0;
+  const rank = regionRank(anchorState, r.nearestOrigin.state);
+  return rank === 0 ? 0.2 : rank === 1 ? 0.12 : 0.05;
+};
+
+const rateScore = (r: AgentRanking): number => {
+  if (r.rpm == null) return 0.35; // unknown rate → mild neutral
+  if (r.benchmark == null || r.benchmark <= 0) return 0.5;
+  return clamp01(0.5 + (r.rpm - r.benchmark) / r.benchmark); // at benchmark = 0.5
+};
+
+const relationshipScore = (r: AgentRanking): number => {
+  const depth = clamp01(r.loadCount / REL_FULL_LOADS);
+  const recency =
+    r.daysSince == null ? 0.3 : clamp01(1 - r.daysSince / RECENCY_DAYS);
+  const dwellPenalty = r.dwellLoads > 0 ? 0.15 : 0;
+  return clamp01(depth * 0.6 + recency * 0.4 - dwellPenalty);
+};
+
+// Short, human labels for a load type (the stencil-free operational voice).
+export const TYPE_LABELS: Record<LoadType, string> = {
+  "standard flatbed": "Flatbed",
+  oversize: "Oversize",
+  hazmat: "Hazmat",
+  "heavy haul": "Heavy haul",
+};
+
+export const distanceLabel = (r: AgentRanking): string => {
+  if (r.distanceMiles != null) return `~${Math.round(r.distanceMiles)} mi`;
+  if (r.nearestOrigin) return `${getRegion(r.nearestOrigin.state)} region`;
+  return "—";
+};
+
+const whyLine = (r: AgentRanking, anchor: Anchor): string => {
+  const bits: string[] = [];
+  const where = r.nearestOrigin ? `${r.nearestOrigin.city}, ${r.nearestOrigin.state}` : "";
+  if (r.isNew) {
+    bits.push(`New tie — ${r.loadCount} load${r.loadCount === 1 ? "" : "s"} so far`);
+    if (r.distanceMiles != null) bits.push(`${distanceLabel(r)} from your drop`);
+    else if (where) bits.push(`sources out of ${where}`);
+    bits.push("a relationship worth building");
+    return capitalize(bits.join(", ")) + ".";
+  }
+  bits.push(`Your ${r.loadCount >= REL_FULL_LOADS ? "deepest" : "strongest"} tie near ${anchor.city}`);
+  bits.push(`${r.loadCount} loads`);
+  if (r.distanceMiles != null) bits.push(`${distanceLabel(r)} from your drop`);
+  if (r.rateDelta != null)
+    bits.push(
+      r.rateDelta >= 0
+        ? "pays at or above your usual for the type"
+        : "pays a touch under your usual for the type",
+    );
+  return bits.join(", ") + ".";
+};
+
+const capitalize = (s: string) => (s ? s[0].toUpperCase() + s.slice(1) : s);
+
+// Build the ranked call list. `loads` and `agents` are your full sets; `coords`
+// is the trusted city_coords lookup.
+export const buildForemanBoard = (
+  loads: Load[],
+  agents: Agent[],
+  coords: CoordMap,
+  opts: {
+    focus?: LoadTypeFocus;
+    mode?: ForemanMode;
+    now?: Date;
+  } = {},
+): ForemanBoard => {
+  const focus = opts.focus ?? "any";
+  const mode = opts.mode ?? "balanced";
+  const now = opts.now ?? new Date();
+
+  const anchor = emptyNextAnchor(loads);
+  const anchorCoord = anchor ? coords.get(cityKey(anchor.city, anchor.state)) ?? null : null;
+
+  const scorecards = buildAgentScorecards(agents, loads, now);
+  const origins = agentOrigins(loads);
+  const nameById = new Map(agents.map((a) => [a.agent_id, agentName(a)]));
+
+  // one benchmark cache per type (identical across agents)
+  const benchCache = new Map<LoadType, number | null>();
+  const benchFor = (t: LoadType): number | null => {
+    if (benchCache.has(t)) return benchCache.get(t) ?? null;
+    const b = typeBenchmark(t, loads);
+    benchCache.set(t, b);
+    return b;
+  };
+
+  let withCoords = 0;
+  const rankings: AgentRanking[] = [];
+
+  for (const [agentId, card] of scorecards) {
+    // Non-cancelled loads only: a roster agent with no loads — or only cancelled
+    // ones — is not on your call list (this is a call list from your history).
+    const agentLoads = loads.filter(
+      (l) => l.agent_id === agentId && l.load_status !== "cancelled",
+    );
+    if (agentLoads.length === 0) continue;
+
+    // The type this agent is judged on, and whether they qualify under a focus.
+    let judgedType: LoadType;
+    if (focus === "any") {
+      judgedType = dominantType(agentLoads);
+    } else {
+      if (agentTypeCount(agentLoads, focus) === 0) continue; // no such freight from them
+      judgedType = focus;
+    }
+
+    // nearest origin with a trusted coordinate → straight-line miles
+    const myOrigins = origins.get(agentId) ?? [];
+    let nearestOrigin: Place | null = null;
+    let distanceMiles: number | null = null;
+    if (anchorCoord) {
+      for (const o of myOrigins) {
+        const c = coords.get(cityKey(o.city, o.state));
+        if (!c) continue;
+        const d = haversineMiles(anchorCoord, c);
+        if (distanceMiles == null || d < distanceMiles) {
+          distanceMiles = d;
+          nearestOrigin = o;
+        }
+      }
+    }
+    const regionFallback = distanceMiles == null;
+    // For the label/region fallback, still surface an origin even without coords:
+    // the one in the closest region to the anchor.
+    if (!nearestOrigin && myOrigins.length && anchor) {
+      nearestOrigin = [...myOrigins].sort(
+        (a, b) => regionRank(anchor.state, a.state) - regionRank(anchor.state, b.state),
+      )[0];
+    }
+    if (distanceMiles != null) withCoords++;
+
+    const bench = benchFor(judgedType);
+    const rpm = agentTypeRpm(agentLoads, judgedType);
+
+    const r: AgentRanking = {
+      agentId,
+      agentName: nameById.get(agentId) ?? "Agent",
+      nearestOrigin,
+      distanceMiles,
+      regionFallback,
+      loadType: judgedType,
+      rpm,
+      benchmark: bench,
+      rateDelta: rpm != null && bench != null ? rpm - bench : null,
+      typeLoadCount: agentTypeCount(agentLoads, judgedType),
+      loadCount: card.loadCount,
+      daysSince: card.daysSince,
+      dwellLoads: card.moneyLostLoads,
+      tier: card.tier,
+      isNew: card.loadCount < MIN_SCORE_LOADS,
+      score: 0,
+      why: "",
+    };
+    rankings.push(r);
+  }
+
+  // score for the active mode
+  const anchorState = anchor?.state ?? "";
+  for (const r of rankings) {
+    if (mode === "closest") {
+      r.score = proximityScore(r, anchorState);
+    } else if (mode === "best-rate") {
+      // Raw highest-paying first (what "best rate" reads as); unknown rate last.
+      r.score = r.rpm ?? -1;
+    } else {
+      r.score =
+        FOREMAN_WEIGHTS.proximity * proximityScore(r, anchorState) +
+        FOREMAN_WEIGHTS.rate * rateScore(r) +
+        FOREMAN_WEIGHTS.relationship * relationshipScore(r);
+    }
+  }
+
+  rankings.sort((a, b) => b.score - a.score || (a.distanceMiles ?? 1e9) - (b.distanceMiles ?? 1e9));
+  if (anchor) for (const r of rankings) r.why = whyLine(r, anchor);
+
+  return {
+    anchor,
+    anchorResolved: anchorCoord != null,
+    focus,
+    mode,
+    benchmark: focus === "any" ? null : benchFor(focus),
+    rankings,
+    coverage: { withCoords, total: rankings.length },
+  };
+};
+
+// Agent display name — first + last, as the roster shows it.
+function agentName(a: Agent): string {
+  return `${a.first_name ?? ""} ${a.last_name ?? ""}`.trim() || "Agent";
+}
+
+// Re-export for consumers that want the shared scorecard shape alongside.
+export type { AgentScorecard };

--- a/frontend/src/pages/ForemanPage.tsx
+++ b/frontend/src/pages/ForemanPage.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { SegmentedTabs } from "@/components/ui/SegmentedTabs";
+import { WhoToCallTab } from "@/components/foreman/WhoToCallTab";
+
+// The Foreman — a tabbed smart-dispatch hub. v1 ships the "Who to Call" tab (rank
+// the agents to call from where you'll be empty next); more spark tools slot in
+// as sibling tabs over time.
+type ForemanTab = "who-to-call";
+
+export default function ForemanPage() {
+  const [tab, setTab] = useState<ForemanTab>("who-to-call");
+
+  return (
+    <div className="p-4 sm:p-6 max-w-5xl mx-auto">
+      <div className="flex items-center gap-3">
+        <SidebarTrigger />
+        <div>
+          <p className="text-[11px] uppercase tracking-widest text-amber font-condensed leading-none">
+            Dispatch
+          </p>
+          <h1 className="font-display text-[32px] text-ink leading-none mt-1">THE FOREMAN</h1>
+        </div>
+      </div>
+      <p className="text-dim text-[13px] mt-2 mb-4">
+        Who to call from where you'll be empty next — and the ties worth building.
+      </p>
+
+      <div className="flex items-center gap-3 mb-5">
+        <SegmentedTabs
+          tabs={[{ value: "who-to-call", label: "Who to Call" }]}
+          value={tab}
+          onChange={setTab}
+          ariaLabel="Foreman sections"
+        />
+        <span className="text-[11px] text-faint font-condensed">more tools coming</span>
+      </div>
+
+      {tab === "who-to-call" && <WhoToCallTab />}
+    </div>
+  );
+}

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -326,6 +326,10 @@ const NAV: { group: string; items: string[] }[] = [
     items: ["The tabbed dashboard — five views of your operation"],
   },
   {
+    group: "The Foreman",
+    items: ["The Foreman — who to call from where you'll be empty next"],
+  },
+  {
     group: "The money",
     items: [
       "Your net revenue — what you actually keep",
@@ -582,6 +586,88 @@ const GuidePage = () => {
                 and a day-by-day heatmap of earning vs. home vs. idle.
               </TabLine>
             </div>
+          </Section>
+
+          <h2
+            id={slug("The Foreman")}
+            className="font-condensed text-2xl mb-3 mt-8 scroll-mt-6"
+            style={{ color: AMBER_HI }}
+          >
+            The Foreman
+          </h2>
+
+          <Section title="The Foreman — who to call from where you'll be empty next">
+            <p className="text-sm text-muted-text mb-3">
+              The Foreman turns "who do we usually call around here?" into a ranked
+              call list. It looks at where you'll be{" "}
+              <span className="text-light">empty next</span>, then ranks the agents
+              you've booked by how well each one fits your next load. It is a call
+              list built from your own history —{" "}
+              <span className="text-light">not a live load feed</span>: it can't know
+              who has freight posted today, only who's your best bet to call from
+              here.
+            </p>
+
+            <p className="text-sm font-condensed mb-1" style={{ color: AMBER_HI }}>
+              Where you'll be empty next
+            </p>
+            <p className="text-sm text-muted-text mb-3">
+              The anchor is the destination of the furthest-out load you're already
+              committed to (booked or in-transit) — you're covered until it drops.
+              With nothing committed, you're already empty at your last delivery.
+            </p>
+
+            <p className="text-sm font-condensed mb-1" style={{ color: AMBER_HI }}>
+              The three axes
+            </p>
+            <ul className="text-sm text-muted-text mb-3 space-y-1.5 list-disc pl-5">
+              <li>
+                <span className="text-light">Proximity</span> — straight-line miles
+                from your empty-next point to the{" "}
+                <span className="text-light">nearest</span> origin that agent has
+                loaded you from (their closest origin, not their average — the
+                question is "can they load me near here").
+              </li>
+              <li>
+                <span className="text-light">Rate</span> — the agent's gross dollars
+                per <span className="text-light">loaded</span> mile for a load type,
+                measured against your own <span className="text-light">realized median
+                rate for that type</span> (your flatbed rate runs far under your
+                oversize rate, so the yardstick has to be per-type). Loaded-mile, the
+                same basis as the Agents page, so an agent is never dinged for a
+                deadhead they didn't cause.
+              </li>
+              <li>
+                <span className="text-light">History</span> — loads you've run
+                together, how recently, and dwell (money left sitting in unpaid
+                detention).
+              </li>
+            </ul>
+
+            <p className="text-sm font-condensed mb-1" style={{ color: AMBER_HI }}>
+              Rank by
+            </p>
+            <p className="text-sm text-muted-text mb-3">
+              <span className="text-light">Balanced</span> blends all three, weighting
+              your relationship as heavily as proximity — you're building ties, not
+              just chasing the closest freight.{" "}
+              <span className="text-light">Closest</span> sorts by distance alone;{" "}
+              <span className="text-light">Best rate</span> by the highest raw $/mi.
+              The <span className="text-light">Looking for</span> selector narrows to a
+              load type and benchmarks each agent against your median rate for that type.
+            </p>
+            <Formula>
+              Balanced score = 0.35 × proximity + 0.30 × rate + 0.35 × relationship
+            </Formula>
+
+            <p className="text-sm text-muted-text mt-3">
+              An agent you've run once shows as{" "}
+              <span style={{ color: "#5dcaa5" }}>New · building</span> — not a
+              low-confidence reject, but a relationship worth deepening. Distances are
+              straight-line estimates (shown with a ~) and sharpen to real miles as the
+              app geocodes each city quietly in the background; a city it can't place
+              yet falls back to region-level rather than a fake number.
+            </p>
           </Section>
 
           <h2

--- a/frontend/src/services/cityCoordsService.ts
+++ b/frontend/src/services/cityCoordsService.ts
@@ -1,0 +1,34 @@
+import api from "./api";
+
+// A verified city center from the persistent cache (city_norm already normalized).
+export interface CityCoordRow {
+  city_norm: string;
+  state: string;
+  lat: number;
+  lng: number;
+}
+
+// Every verified coordinate. Non-fatal on failure — the Foreman just falls back
+// to region-level ordering when the map is empty.
+export const getCityCoords = async (): Promise<CityCoordRow[]> => {
+  try {
+    const response = await api.get("/city-coords");
+    return response.data.coords ?? [];
+  } catch {
+    return [];
+  }
+};
+
+// Warm the cache for the cities on the current board. Fire-and-forget: the server
+// geocodes any missing ones in the background, so this returns fast and the next
+// fetch is precise. Failures are swallowed (distances just stay region-level).
+export const warmCityCoords = async (
+  cities: { city: string; state: string }[],
+): Promise<CityCoordRow[]> => {
+  try {
+    const response = await api.post("/city-coords/ensure", { cities });
+    return response.data.coords ?? [];
+  } catch {
+    return [];
+  }
+};


### PR DESCRIPTION
A new **tabbed smart-dispatch page**. v1 ships the **Who to Call** tab: a ranked call list of the agents you've booked, from where you'll be **empty next**. It's a call list from your own history — not a live load feed.

## Ranking (GROSS $ / LOADED mile — the Agents-page basis)
- **Proximity** — straight-line miles from your empty-next point to the agent's *nearest* recurring origin. "Empty next" = destination of the furthest-out committed (booked/in-transit) load; else your last delivery.
- **Rate** — the agent's gross $/loaded mile *for a load type*, vs your **own realized median** for that type. Your real data: flatbed ~$4.95, oversize ~$8.67 — so the yardstick has to be per-type. A **Looking for** selector (Any / Flatbed / Oversize / Hazmat / Heavy haul) narrows and re-benchmarks.
- **History** — loads together, recency, dwell. **Balanced** weights relationship as heavily as proximity (building ties); **Closest** / **Best rate** re-sort. Single-load agents read *"New · building."*

## Geo — persisted, validated, background
- New `city_coords` cache (migration `056`, **RLS on**): geocode each city **once** via HERE, **validate** (state-match + US bounds + confidence ≥ 0.8, **fail-closed** on a missing score), store, never re-hit. Transient misses persist nothing (retryable); genuine bad matches persist `failed` → region fallback. Warmed in the background on load-write and on the board — never blocks the user. **Distance is local haversine — zero API calls at view time.**

## Forge fidelity
One forged plate (the top call); stencil reserved for its badge; operational data in display/condensed. Agent names link to `/agents/:id`. Guide section added. Available to dispatchers.

## Verification
- **553 frontend + 43 backend tests** — the ranking engine on the real Macedonia scenario, per-type median, never-booked + cancelled-only guards, region fallback, geocode validation.
- Strict production build clean.
- **5-dimension adversarial review** (money-basis / ranking-edges / backend / frontend-runtime / conventions) → 4 real issues found and fixed; a follow-up zero-defect re-review of the refactored money math.
- Ranking inputs cross-checked against **prod** data. Migration applied to **prod first**.

Note: not live-rendered in a browser (the dev DB uses the owner's own credentials, which I don't have) — runtime safety was validated by the re-review instead, and it's visible on prod immediately on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)