### PR TITLE
feat(scorer): destination/repositioning factor + the call — Phase 2 (v1.174.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.173.1",
+  "version": "1.174.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/marketFactor.test.ts
+++ b/frontend/src/lib/metrics/marketFactor.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import type { Load } from "@/types/load";
+import type { AgentScorecard } from "./agentScorecard";
+import { cityKey, type CoordMap } from "./foreman";
+import { outboundStrength, destinationFactor, theCall } from "./marketFactor";
+
+let seq = 0;
+const mk = (originCity: string, originState: string, rpm: number, agent: string): Load =>
+  ({
+    load_id: `L${seq++}`,
+    load_number: "N",
+    load_type: "standard flatbed",
+    load_status: "delivered",
+    broker_id: "b",
+    broker: "B",
+    agent_id: agent,
+    agent: "A",
+    agent_email: null,
+    pickup_date: "2026-07-01",
+    origin_market_id: "m",
+    origin_city: originCity,
+    origin_state: originState,
+    origin_market: originCity,
+    destination_market_id: "m2",
+    destination_city: "Somewhere",
+    destination_state: "XX",
+    delivery_market: "Somewhere",
+    deadhead_miles: 0,
+    loaded_miles: 1000,
+    linehaul: String(rpm * 1000), // gross = rpm × 1000 loaded → gross/loaded = rpm
+    fuel_surcharge: "0",
+    total_accessorials: "0",
+    commodity: null,
+    payment_status: "paid",
+    delivery_date: "2026-07-05",
+    created_at: "",
+    updated_at: "",
+  }) as Load;
+
+// PA strong (4 loads @ $8, 2 agents), AL fair (4 @ $5.8), TX soft (3 @ $4.2),
+// MS thin (1 load). Overall outbound median works out to 5.8.
+const world = (): Load[] => {
+  seq = 0;
+  return [
+    mk("Bellefonte", "PA", 8.0, "a1"),
+    mk("Bellefonte", "PA", 8.0, "a2"),
+    mk("Reading", "PA", 8.0, "a1"),
+    mk("Reading", "PA", 8.0, "a2"),
+    mk("Dothan", "AL", 5.8, "a3"),
+    mk("Dothan", "AL", 5.8, "a4"),
+    mk("Mobile", "AL", 5.8, "a3"),
+    mk("Mobile", "AL", 5.8, "a4"),
+    mk("Laredo", "TX", 4.2, "a5"),
+    mk("Laredo", "TX", 4.2, "a5"),
+    mk("Dallas", "TX", 4.2, "a6"),
+    mk("Iuka", "MS", 7.0, "a7"),
+  ];
+};
+
+const COORDS: CoordMap = new Map([
+  [cityKey("Houston", "TX"), { lat: 29.76, lng: -95.37 }],
+  [cityKey("Bellefonte", "PA"), { lat: 40.91, lng: -77.78 }],
+  [cityKey("Reading", "PA"), { lat: 40.34, lng: -75.93 }],
+]);
+
+describe("outboundStrength", () => {
+  it("grades each origin market by your own outbound rate + volume", () => {
+    const s = outboundStrength(world());
+    expect(s.get("PA")).toMatchObject({ grade: "strong", loadsOut: 4, medianRpm: 8.0, agents: 2 });
+    expect(s.get("AL")).toMatchObject({ grade: "fair", loadsOut: 4, medianRpm: 5.8 });
+    expect(s.get("TX")).toMatchObject({ grade: "soft", loadsOut: 3, medianRpm: 4.2 });
+    expect(s.get("MS")).toMatchObject({ grade: "thin", loadsOut: 1 }); // a single load → thin
+  });
+});
+
+describe("destinationFactor", () => {
+  it("flags a soft delivery market + names your strong markets + nearest strong freight", () => {
+    const d = destinationFactor(world(), { city: "Houston", state: "TX" }, COORDS);
+    expect(d.market?.grade).toBe("soft");
+    expect(d.strongMarkets.map((m) => m.state)).toEqual(["PA"]);
+    // Houston → Reading, PA (~1300 mi) is the nearest strong origin with a coord
+    expect(d.nearestStrong?.state).toBe("PA");
+    expect(d.nearestStrong!.miles).toBeGreaterThan(1100);
+  });
+
+  it("returns a null market for a state you've never loaded out of", () => {
+    const d = destinationFactor(world(), { city: "Miami", state: "FL" }, COORDS);
+    expect(d.market).toBeNull();
+    expect(d.strongMarkets.length).toBe(1);
+  });
+
+  it("omits nearest-strong when the delivery city has no trusted coordinate", () => {
+    const d = destinationFactor(world(), { city: "Nowhere", state: "TX" }, new Map());
+    expect(d.market?.grade).toBe("soft");
+    expect(d.nearestStrong).toBeNull();
+  });
+});
+
+describe("theCall", () => {
+  const keeper: AgentScorecard = {
+    agentId: "a1",
+    loadCount: 6,
+    revenue: 0,
+    medianRpm: 8,
+    trend: null,
+    lastWorked: null,
+    daysSince: 10,
+    moneyLostLoads: 0,
+    collectedLoads: 0,
+    collectRate: null,
+    specialty: { tag: "standard", oversizeShare: 0, specialtyShare: 0, oversizeCount: 0 },
+    tier: "solid",
+    ratingFlag: null,
+  };
+  const softDest = destinationFactor(world(), { city: "Houston", state: "TX" }, COORDS);
+  const strongDest = destinationFactor(world(), { city: "Reading", state: "PA" }, COORDS);
+
+  it("null when there's no verdict", () => {
+    expect(theCall(null, softDest, keeper, false)).toBeNull();
+  });
+
+  it("a marginal load into a soft market with a keeper leans on the relationship", () => {
+    const c = theCall("meh", softDest, keeper, false)!;
+    expect(c.tone).toBe("caution");
+    expect(c.text).toMatch(/keeper/i);
+    expect(c.text).toMatch(/SOLID/);
+  });
+
+  it("a good load into a strong market says take it", () => {
+    const c = theCall("take", strongDest, null, false)!;
+    expect(c.tone).toBe("good");
+    expect(c.text).toMatch(/strong outbound market/i);
+    expect(c.text).toMatch(/take it/i);
+  });
+
+  it("a money-loser says pass", () => {
+    const c = theCall("pass", softDest, null, false)!;
+    expect(c.tone).toBe("bad");
+    expect(c.text).toMatch(/loses money/i);
+  });
+
+  it("a good load into a soft market says take-but-reposition", () => {
+    const c = theCall("take", softDest, null, false)!;
+    expect(c.tone).toBe("caution");
+    expect(c.text).toMatch(/reposition/i);
+  });
+});

--- a/frontend/src/lib/metrics/marketFactor.ts
+++ b/frontend/src/lib/metrics/marketFactor.ts
@@ -1,0 +1,196 @@
+// The destination / repositioning factor for the Load Scorer: "where does this
+// load leave me?" A load can pay fine yet strand you in a market you can't get a
+// good load OUT of. This grades the delivery market by YOUR OWN outbound history —
+// how well freight out of there has paid you, how much of it there's been, and how
+// many agents source it — so a soft market reads as a reposition cost at booking
+// time, not a surprise later. Everything is GROSS (market value, like agents/lanes).
+import type { Load } from "@/types/load";
+import type { Verdict } from "./loadScore";
+import { loadRevenue } from "./loads"; // GROSS per load
+import { median } from "./stats";
+import { haversineMiles, cityKey, type CoordMap } from "./foreman";
+import type { AgentScorecard } from "./agentScorecard";
+
+const up = (s?: string | null): string => String(s ?? "").trim().toUpperCase();
+const loadedRpm = (l: Load): number | null => {
+  const miles = Number(l.loaded_miles);
+  return miles > 0 ? loadRevenue(l) / miles : null;
+};
+
+// Below this many loads OUT of a market, we can't judge it — "thin," not graded.
+// Set to 2 so a single load is thin but a 2-load market still surfaces its signal
+// (the UI always shows the load count, so the thinness stays visible/honest). It
+// firms up as more loads log. STRONG still needs real volume (STRONG_MIN_LOADS).
+export const THIN_OUT = 2;
+const STRONG_MULT = 1.05; // pays ≥5% over your overall norm → strong
+const SOFT_MULT = 0.85; // pays ≤15% under → soft
+const STRONG_MIN_LOADS = 4; // …and enough volume to be reliable
+
+export type MarketGrade = "strong" | "fair" | "soft" | "thin";
+
+export interface OutboundMarket {
+  state: string;
+  loadsOut: number; // delivered loads that ORIGINATED here
+  medianRpm: number | null; // gross ÷ loaded mile, out of here
+  agents: number; // distinct agents sourcing here
+  grade: MarketGrade;
+}
+
+// Your outbound strength per origin state, from delivered loads. Grade is relative
+// to your OWN overall outbound rate, so it means "good/soft FOR ME," not a market
+// absolute.
+export const outboundStrength = (loads: Load[]): Map<string, OutboundMarket> => {
+  const delivered = loads.filter((l) => l.load_status === "delivered");
+  const overall = median(
+    delivered.map(loadedRpm).filter((r): r is number => r != null),
+  );
+
+  const byState = new Map<string, Load[]>();
+  for (const l of delivered) {
+    const s = up(l.origin_state);
+    if (!s) continue;
+    (byState.get(s) ?? byState.set(s, []).get(s)!).push(l);
+  }
+
+  const out = new Map<string, OutboundMarket>();
+  for (const [state, ls] of byState) {
+    const rpms = ls.map(loadedRpm).filter((r): r is number => r != null);
+    const medianRpm = rpms.length ? median(rpms) : null;
+    const agents = new Set(ls.map((l) => l.agent_id).filter(Boolean)).size;
+    const loadsOut = ls.length;
+
+    let grade: MarketGrade;
+    if (loadsOut < THIN_OUT || medianRpm == null || overall == null) {
+      grade = "thin";
+    } else if (medianRpm >= overall * STRONG_MULT && loadsOut >= STRONG_MIN_LOADS) {
+      grade = "strong";
+    } else if (medianRpm <= overall * SOFT_MULT) {
+      grade = "soft";
+    } else {
+      grade = "fair";
+    }
+    out.set(state, { state, loadsOut, medianRpm, agents, grade });
+  }
+  return out;
+};
+
+export interface NearestStrong {
+  city: string;
+  state: string;
+  miles: number;
+}
+
+export interface DestinationFactor {
+  state: string;
+  market: OutboundMarket | null; // the delivery state's outbound (null = never loaded out of here)
+  strongMarkets: OutboundMarket[]; // your strongest outbound markets, for contrast
+  nearestStrong: NearestStrong | null; // nearest strong-market origin you've actually loaded from
+}
+
+const byRateThenVolume = (a: OutboundMarket, b: OutboundMarket): number =>
+  (b.medianRpm ?? 0) - (a.medianRpm ?? 0) || b.loadsOut - a.loadsOut;
+
+// The delivery market's grade, your strong markets for contrast, and — when we
+// have a trusted coordinate for the delivery city — the nearest strong-market
+// origin you've actually loaded from, so "this strands you" comes with a distance.
+export const destinationFactor = (
+  loads: Load[],
+  delivery: { city: string; state: string },
+  coords: CoordMap,
+): DestinationFactor => {
+  const strengths = outboundStrength(loads);
+  const state = up(delivery.state);
+  const market = strengths.get(state) ?? null;
+  const strongMarkets = [...strengths.values()]
+    .filter((m) => m.grade === "strong")
+    .sort(byRateThenVolume);
+
+  let nearestStrong: NearestStrong | null = null;
+  const deliveryCoord = coords.get(cityKey(delivery.city, delivery.state));
+  if (deliveryCoord && strongMarkets.length) {
+    const strongStates = new Set(strongMarkets.map((m) => m.state));
+    const seen = new Set<string>();
+    for (const l of loads) {
+      if (l.load_status !== "delivered" || !strongStates.has(up(l.origin_state))) continue;
+      const key = cityKey(l.origin_city, l.origin_state);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const c = coords.get(key);
+      if (!c) continue;
+      const miles = haversineMiles(deliveryCoord, c);
+      if (!nearestStrong || miles < nearestStrong.miles)
+        nearestStrong = { city: l.origin_city, state: l.origin_state, miles };
+    }
+  }
+
+  return { state, market, strongMarkets: strongMarkets.slice(0, 3), nearestStrong };
+};
+
+// ---- the synthesized recommendation ----
+export type CallTone = "good" | "caution" | "bad";
+export interface TheCall {
+  tone: CallTone;
+  text: string;
+}
+
+const isKeeper = (a: AgentScorecard | null | undefined): boolean =>
+  !!a && a.loadCount >= 3 && a.moneyLostLoads === 0;
+
+// Weigh the rate verdict, the destination market, and the agent into one honest
+// bottom-line. The rate verdict leads (it's the money); the destination and agent
+// tip a marginal load or add a caution — they never rescue a money-loser on their
+// own.
+export const theCall = (
+  verdict: Verdict | null,
+  dest: DestinationFactor | null,
+  agent: AgentScorecard | null | undefined,
+  _isNewAgent: boolean,
+): TheCall | null => {
+  if (!verdict) return null;
+  const grade = dest?.market?.grade ?? null;
+  const keeper = isKeeper(agent);
+  const dist = dest?.nearestStrong
+    ? ` (nearest strong freight ~${Math.round(dest.nearestStrong.miles)} mi)`
+    : "";
+
+  if (verdict === "pass") {
+    return {
+      tone: "bad",
+      text: `Loses money after the deadhead — pass unless ${keeper ? "the relationship" : "a strong backhaul"} makes it strategic.`,
+    };
+  }
+
+  const clears = verdict === "steal" ? "Clears your strong tier" : "Clears your target";
+
+  if (verdict === "take" || verdict === "steal") {
+    if (grade === "soft")
+      return {
+        tone: "caution",
+        text: `${clears}, but it strands you in a soft outbound market${dist}. Take it and plan your reposition${keeper ? ", or lean on the agent for the backhaul" : ""}.`,
+      };
+    if (grade === "strong")
+      return {
+        tone: "good",
+        text: `Good load — ${clears.toLowerCase()} and drops you into a strong outbound market${keeper ? ", from a keeper agent" : ""}. Take it.`,
+      };
+    return { tone: "good", text: `${clears}. Take it.` };
+  }
+
+  // meh — the deadhead dragged it; the destination + agent decide if it's worth it
+  if (grade === "strong")
+    return {
+      tone: "caution",
+      text: "Only fair on rate — the deadhead's the drag — but it sets you up in a strong market. Worth it; counter toward SOLID.",
+    };
+  if (keeper)
+    return {
+      tone: "caution",
+      text: "Only fair on rate, but the agent's a keeper. Counter toward SOLID — the relationship's worth it.",
+    };
+  if (grade === "soft")
+    return {
+      tone: "caution",
+      text: `Only fair on rate, and it strands you in a soft market${dist}. Counter up hard, or let it go.`,
+    };
+  return { tone: "caution", text: "Only fair on rate. Counter up, or let it go." };
+};

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -825,6 +825,22 @@ const GuidePage = () => {
               until you actually run a load with them.
             </Why>
             <Why>
+              It also scores the <span className="text-light">destination</span> — where
+              the load leaves you — off your own outbound history: how well freight OUT
+              of that market has paid you, how much of it there's been, and how many
+              agents source it, graded{" "}
+              <span style={{ color: "#5dcaa5" }}>STRONG</span> /{" "}
+              <span className="text-light">FAIR</span> /{" "}
+              <span style={{ color: "#e8940a" }}>SOFT</span> / thin against your overall
+              norm. So a fair-paying load that drops you somewhere you can't reload reads
+              as a <span className="text-light">reposition cost</span>, with your strong
+              markets named for contrast and — when the city's geocoded — the distance to
+              your nearest strong freight. A line up top, <span className="text-light">the
+              call</span>, weighs the rate, the destination, and the agent into one
+              honest recommendation. Thin markets are flagged, not guessed; it sharpens
+              as you log loads.
+            </Why>
+            <Why>
               Miles come from truck routing (HERE), not a straight line — the
               deadhead starts from your{" "}
               <span className="text-light">last-known location</span> (your last

--- a/frontend/src/pages/ScoreLoadPage.tsx
+++ b/frontend/src/pages/ScoreLoadPage.tsx
@@ -6,6 +6,12 @@ import { useRateTargets } from "@/hooks/useRateTargets";
 import { scoreLoad, counterRates, VERDICT_META } from "@/lib/metrics/loadScore";
 import { buildAgentScorecards } from "@/lib/metrics/agentScorecard";
 import { emptyNextAnchor } from "@/lib/metrics/foreman";
+import { useCityCoords } from "@/hooks/useCityCoords";
+import {
+  destinationFactor,
+  theCall,
+  type MarketGrade,
+} from "@/lib/metrics/marketFactor";
 import { playSfx } from "@/lib/sfx";
 import { RATE_TIERS, type RateTiers } from "@/lib/constants/targets";
 import { getLoadMiles, type Place } from "@/services/routingService";
@@ -31,6 +37,14 @@ const markerPct = (
   if (pct < tiers.strong)
     return 50 + ((pct - tiers.target) / (tiers.strong - tiers.target)) * 25; // SOLID
   return 75 + Math.min(1, (pct - tiers.strong) / 0.4) * 25; // PRIME
+};
+
+// Destination market grade → forge stencil badge.
+const GRADE_META: Record<MarketGrade, { label: string; color: string }> = {
+  strong: { label: "STRONG", color: "#5dcaa5" },
+  fair: { label: "FAIR", color: "#8494ab" },
+  soft: { label: "SOFT", color: "#e8940a" },
+  thin: { label: "THIN", color: "#5a6880" },
 };
 
 // ---- forge inputs ----
@@ -229,6 +243,7 @@ const ScoreLoadPage = () => {
     () => buildAgentScorecards(agents ?? [], loads ?? [], now),
     [agents, loads, now],
   );
+  const coords = useCityCoords(loads ?? []);
 
   const [rate, setRate] = useState("");
   const [truckNow, setTruckNow] = useState<Place>({ city: "", state: "" });
@@ -353,6 +368,12 @@ const ScoreLoadPage = () => {
     !agent && agentQuery.trim().length >= 2 && matchAgents(agents ?? [], agentQuery).length === 0;
   const agentCard = agent ? scorecards.get(agent.agent_id) : undefined;
 
+  const destFactor = useMemo(
+    () => destinationFactor(loads ?? [], delivery, coords),
+    [loads, delivery.city, delivery.state, coords],
+  );
+  const call = theCall(score.verdict, destFactor, agentCard, isNewAgent);
+
   const routeNote = routing
     ? "routing…"
     : routeErr
@@ -397,6 +418,19 @@ const ScoreLoadPage = () => {
               </span>
             </div>
           </div>
+
+          {/* the call — verdict + destination + agent, weighed */}
+          {call && (
+            <div
+              className="ds2-board p-3.5 mb-3"
+              style={{
+                borderLeft: `3px solid ${call.tone === "good" ? "#5dcaa5" : call.tone === "bad" ? "#e24b4a" : "#e8940a"}`,
+              }}
+            >
+              <Lbl accent>The call</Lbl>
+              <p className="text-[14.5px] text-ink font-medium">{call.text}</p>
+            </div>
+          )}
 
           {/* verdict hero */}
           <ForgedPlate chamfer className="p-4 sm:p-5">
@@ -452,7 +486,7 @@ const ScoreLoadPage = () => {
           </ForgedPlate>
 
           {/* factor grid — full width */}
-          <div className="grid grid-cols-1 md:grid-cols-[1.3fr_1fr_1fr] gap-3 mt-3">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3 mt-3">
             <div className="ds2-board p-4">
               <Lbl>Freight vs deadhead</Lbl>
               <div className="grid grid-cols-2 gap-2.5 mt-2 mb-2.5">
@@ -478,6 +512,59 @@ const ScoreLoadPage = () => {
               </p>
               {toll != null && (
                 <p className="text-[11.5px] text-faint mt-2">Est. tolls ≈ {money(toll)} · bill as accessorial (Landstar pays 100%)</p>
+              )}
+            </div>
+
+            {/* destination — where it leaves you */}
+            <div className="ds2-board p-4">
+              <div className="flex items-center justify-between gap-2">
+                <Lbl>Destination · where it leaves you</Lbl>
+                <span
+                  className="font-forge text-[16px] tracking-wide"
+                  style={{ color: destFactor.market ? GRADE_META[destFactor.market.grade].color : "#5a6880" }}
+                >
+                  {destFactor.market ? GRADE_META[destFactor.market.grade].label : "UNPROVEN"}
+                </span>
+              </div>
+              <div className="font-condensed text-[15px] font-semibold text-ink mt-1">
+                {delivery.city}, {delivery.state}
+              </div>
+              {destFactor.market ? (
+                <Well className="px-3 py-2 mt-2">
+                  <div className="text-[11.5px] text-dim">
+                    Your {destFactor.state} outbound:{" "}
+                    <span style={{ color: GRADE_META[destFactor.market.grade].color }}>
+                      {destFactor.market.loadsOut} load{destFactor.market.loadsOut === 1 ? "" : "s"}
+                      {destFactor.market.medianRpm != null ? ` · ${fmtRpm(destFactor.market.medianRpm)}/loaded` : ""}
+                    </span>{" "}
+                    · {destFactor.market.agents} agent{destFactor.market.agents === 1 ? "" : "s"}
+                  </div>
+                </Well>
+              ) : (
+                <div className="text-[11.5px] text-dim mt-2">
+                  No outbound history from {destFactor.state || "here"} yet — unproven for you.
+                </div>
+              )}
+              {destFactor.strongMarkets.length > 0 && (
+                <>
+                  <div className="text-[11px] text-faint mt-2.5">Your strong outbound:</div>
+                  <div className="flex gap-1.5 flex-wrap mt-1">
+                    {destFactor.strongMarkets.map((m) => (
+                      <span
+                        key={m.state}
+                        className="font-condensed text-[11.5px] px-2 py-0.5 rounded"
+                        style={{ background: "rgba(53,160,140,.12)", color: "#5dcaa5" }}
+                      >
+                        {m.state} {fmtRpm(m.medianRpm)} · {m.loadsOut}
+                      </span>
+                    ))}
+                  </div>
+                </>
+              )}
+              {destFactor.nearestStrong && (
+                <p className="text-[11.5px] text-dim mt-2.5">
+                  Nearest strong freight ~{Math.round(destFactor.nearestStrong.miles)} mi ({destFactor.nearestStrong.city}, {destFactor.nearestStrong.state})
+                </p>
               )}
             </div>
 


### PR DESCRIPTION
The piece that targets the repositioning habit: the Scorer now scores **where a load leaves you**, not just what it pays.

## What changed
- **`marketFactor.ts` (new).** `outboundStrength` grades each origin market by *your own* outbound history — gross $/loaded median + volume + agent depth per state, relative to your overall norm → **STRONG / FAIR / SOFT / thin**. A fair-paying load that strands you in a market you can't reload out of reads as a reposition cost. Graded at **≥2 loads** so a thin market still surfaces its signal (the load count is always shown); STRONG still needs real volume (≥4). Your strong markets are named for contrast, and — when the delivery city is geocoded — the haversine distance to your nearest strong-market origin (reuses `city_coords` from The Foreman).
- **`theCall`.** One line up top weighing the rate verdict + destination grade + agent (keeper = 3+ loads, no dwell) into an honest recommendation. The rate verdict **leads** — a money-loser can't be talked into a take by a good market or agent.
- Wired into the full-width result view: a tone-colored **"the call"** banner over the 4-up factor grid (freight-vs-deadhead · destination · agent · counter).

## Verification
- **567 tests** (9 for the market engine — grades, nearest-strong, the call).
- Strict build clean.
- Grade thresholds checked against **real prod data** (overall outbound median $6.36 → PA/NC/OH strong, TX soft).
- Adversarial review — no defects; one consistency guard folded in.

Completes the Load Scorer rework (Phase 1 was v1.173.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)