### PR TITLE
feat(loads): fix booked-by wipe on edit + show the booker's name (v1.175.0)

### DIFF
--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -4,6 +4,7 @@ import {
   createDispatcher,
   listAccountUsers,
   getTeamMember,
+  updateMyDisplayName,
 } from "../services/userServices.js";
 
 const router = express.Router();
@@ -21,6 +22,21 @@ router.get("/", requireAuth, async (req, res) => {
   try {
     const team = await listAccountUsers(req.user.account_id);
     return res.status(200).json({ team });
+  } catch (err) {
+    return res
+      .status(500)
+      .json({ error: "Internal Server Error", message: err.message });
+  }
+});
+
+// ---- UPDATE my own display name ---- any signed-in member sets their own name.
+// (Distinct method+path from GET /:id, so no route collision.)
+router.patch("/me", requireAuth, async (req, res) => {
+  try {
+    const raw = req.body?.display_name;
+    const name = typeof raw === "string" && raw.trim() ? raw.trim() : null;
+    const user = await updateMyDisplayName(req.user.self_id, name);
+    return res.status(200).json({ user });
   } catch (err) {
     return res
       .status(500)

--- a/backend/src/services/loadServices.js
+++ b/backend/src/services/loadServices.js
@@ -204,6 +204,11 @@ export async function getLoad(user_id, load_id) {
             l.driver_id,
             l.trailer_id,
             l.booked_by,
+            COALESCE(
+              bu.display_name,
+              NULLIF(TRIM(COALESCE(bp.first_name, '') || ' ' || COALESCE(bp.last_name, '')), ''),
+              bu.email
+            ) AS booked_by_name,
             trk.unit_number AS truck_unit,
             drv.first_name || ' ' || drv.last_name AS driver_name,
             trl.unit_number AS trailer_unit,
@@ -226,6 +231,10 @@ export async function getLoad(user_id, load_id) {
         ON l.trailer_id = trl.trailer_id
         LEFT JOIN settlement_schedules AS ss
         ON ss.user_id = l.user_id
+        LEFT JOIN users AS bu
+        ON bu.user_id = l.booked_by
+        LEFT JOIN profiles AS bp
+        ON bp.user_id = l.booked_by
         WHERE l.user_id = $1
         AND load_id = $2;
     `;

--- a/backend/src/services/userServices.js
+++ b/backend/src/services/userServices.js
@@ -104,13 +104,30 @@ export async function createDispatcher(accountId, { email, password, display_nam
 // ---- LIST an account's team ---- (owner + its dispatchers; safe fields only)
 export async function listAccountUsers(accountId) {
   const result = await db.query(
-    `SELECT user_id, email, role, display_name, avatar_url, created_at
-       FROM users
-      WHERE user_id = $1 OR parent_user_id = $1
-      ORDER BY (user_id = $1) DESC, created_at`,
+    `SELECT u.user_id, u.email, u.role,
+            COALESCE(
+              u.display_name,
+              NULLIF(TRIM(COALESCE(p.first_name, '') || ' ' || COALESCE(p.last_name, '')), '')
+            ) AS display_name,
+            u.avatar_url, u.created_at
+       FROM users u
+       LEFT JOIN profiles p ON p.user_id = u.user_id
+      WHERE u.user_id = $1 OR u.parent_user_id = $1
+      ORDER BY (u.user_id = $1) DESC, u.created_at`,
     [accountId],
   );
   return result.rows;
+}
+
+// ---- UPDATE my own display name ---- any member may set their own name (the
+// owner has no profile row, so their name lives here alongside dispatchers').
+export async function updateMyDisplayName(userId, displayName) {
+  const result = await db.query(
+    `UPDATE users SET display_name = $1 WHERE user_id = $2
+       RETURNING user_id, email, role, display_name`,
+    [displayName, userId],
+  );
+  return result.rows[0] ?? null;
 }
 
 // ---- FETCH one account member ---- (for a team member's dispatcher page).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.174.0",
+  "version": "1.175.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/LoadDetailPage.tsx
+++ b/frontend/src/pages/LoadDetailPage.tsx
@@ -414,6 +414,7 @@ export const LoadDetailPage = () => {
                 truck_id: load.truck_id ?? null,
                 driver_id: load.driver_id ?? null,
                 trailer_id: load.trailer_id ?? null,
+                booked_by: load.booked_by ?? null,
               }}
               brokers={brokers}
               agents={agents}
@@ -499,6 +500,7 @@ export const LoadDetailPage = () => {
           </div>
           <p className="text-dim text-sm mt-1">
             {load.broker} · {load.agent} · {capitalize(load.load_type)}
+            {load.booked_by_name ? ` · booked by ${load.booked_by_name}` : ""}
           </p>
         </div>
         <div className="flex gap-2 shrink-0">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,6 +3,7 @@ import {
   getSettlementSchedule,
   updateSettlementSchedule,
 } from "@/services/settlementScheduleService";
+import { getTeam, updateMyName } from "@/services/teamService";
 import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { AccessorialRatesCard } from "@/components/settings/AccessorialRatesCard";
@@ -133,6 +134,7 @@ const SettingsPage = () => {
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [sfx, setSfx] = useState(sfxEnabled());
+  const [displayName, setDisplayName] = useState("");
 
   // Real break-even for the tier previews + weekly-target preview (cost-based,
   // so it's independent of the tier values being edited).
@@ -170,6 +172,16 @@ const SettingsPage = () => {
         setMarginGoal(pct(s.margin_goal));
       })
       .catch(() => setErr("Couldn't load your settlement schedule."));
+  }, []);
+
+  useEffect(() => {
+    const selfId = localStorage.getItem("user_id");
+    getTeam()
+      .then((t) => {
+        const me = t.find((m) => m.user_id === selfId);
+        if (me) setDisplayName(me.display_name ?? "");
+      })
+      .catch(() => {});
   }, []);
 
   const set = (k: keyof Pcts) => (v: number) => {
@@ -210,6 +222,7 @@ const SettingsPage = () => {
         rate_tier_spec_strong: specTiers.strong / 100,
         margin_goal: marginGoal / 100,
       });
+      await updateMyName(displayName.trim());
       setMsg("Saved. Your revenue and targets now use this split.");
     } catch (e) {
       setErr(
@@ -268,6 +281,26 @@ const SettingsPage = () => {
           </span>
           <span className="text-sm text-light">{sfx ? "On" : "Off"}</span>
         </button>
+      </Panel>
+
+      <Panel className="mt-6 max-w-[680px] p-5">
+        <h2 className="text-lg font-medium text-light">Your name</h2>
+        <p className="text-sm text-muted-text mt-1">
+          Shown as the booker on loads you book (instead of your email), and
+          anywhere the app credits you.
+        </p>
+        <label className="block mt-4 max-w-xs">
+          <input
+            type="text"
+            placeholder="e.g. Jason Delgado"
+            value={displayName}
+            onChange={(e) => {
+              setMsg(null);
+              setDisplayName(e.target.value);
+            }}
+            className="w-full mt-1 bg-steel rounded px-2 py-1.5 text-light text-sm block"
+          />
+        </label>
       </Panel>
 
       <Panel className="mt-6 max-w-[680px] p-5">

--- a/frontend/src/services/teamService.ts
+++ b/frontend/src/services/teamService.ts
@@ -22,6 +22,12 @@ export const getUser = async (id: string): Promise<TeamMember> => {
   return res.data.user;
 };
 
+// Set your OWN display name (owner or dispatcher). Shown as the booker on loads
+// and anywhere the app credits you, in place of your email.
+export const updateMyName = async (display_name: string): Promise<void> => {
+  await api.patch("/users/me", { display_name });
+};
+
 export const createDispatcher = async (data: {
   email: string;
   password: string;

--- a/frontend/src/types/load.ts
+++ b/frontend/src/types/load.ts
@@ -69,6 +69,9 @@ export interface Load {
   // The user (self_id) who booked this load — powers the dispatcher card's
   // per-person credit. Defaults to the creator; editable to reassign credit.
   booked_by?: string | null;
+  // The booker's resolved display name (users.display_name, else profile
+  // first+last, else email), joined on the single-load fetch (getLoad). Read-only.
+  booked_by_name?: string | null;
   // Joined labels, present on the single-load fetch (getLoad) only.
   truck_unit?: string | null;
   driver_name?: string | null;


### PR DESCRIPTION
Editing a load silently **erased** its "Booked by" — the edit form omitted `booked_by`, so it loaded blank and the save wrote null back (also corrupting the per-person dispatcher stats). The booker also showed as a raw **email**.

## Fixes
- **Persist:** `LoadDetailPage` carries `load.booked_by` into the edit form's `initialData`, so a plain edit preserves the booker (even when the picker is hidden on a solo account).
- **Name:** `getLoad` joins the booker → `booked_by_name = COALESCE(display_name, profile first+last, email)`; the detail page shows "· booked by {name}". The team picker falls back to the profile name too.
- **Settings "Your name":** the owner has **no `profiles` row** (and `profiles.first/last` + `carrier_type` are `NOT NULL`, so it can't be created from a name field). So the name lives in **`users.display_name`** — nullable, exactly how dispatchers' names are stored. New `PATCH /users/me` self-update. Once set, you show as your name everywhere instead of email.

No migration (columns exist).

## Verification
- 567 frontend + 43 backend tests; strict build.
- Both SQL joins checked against **real prod data** (Brandie resolves to "Brandie").
- **Adversarially reviewed** — the review caught my first attempt (the profiles path would break Settings Save with "Profile not found" / a NOT NULL 500); this is the corrected `display_name` approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)