### PR TITLE
fix(loads): recommend the market when you type a hub city (v1.177.1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.177.0",
+  "version": "1.177.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/marketRecommender.test.ts
+++ b/frontend/src/lib/metrics/marketRecommender.test.ts
@@ -129,11 +129,36 @@ describe("recommendMarket — tier 2 (same city)", () => {
   });
 });
 
-describe("recommendMarket — tier 3 (nearest mapped city ≤75 mi)", () => {
+describe("recommendMarket — tier 3 (typed city is an existing market/hub)", () => {
+  it("matches the hub city to its market with no load history there", () => {
+    // The real Atlanta case: history lives in a suburb, so tiers 1-2 miss, but
+    // "Atlanta" IS a market.
+    const loads = [mkLoad({ origin_city: "Milner", origin_state: "GA", origin_market_id: "m-atl" })];
+    const rec = recommendMarket({ ...base, loads, role: "origin", city: "Atlanta", state: "GA" });
+    expect(rec?.tier).toBe(3);
+    expect(rec?.market_id).toBe("m-atl");
+    expect(rec?.reason).toMatch(/market/i);
+  });
+
+  it("fires from the city alone, before a state is entered", () => {
+    const rec = recommendMarket({ ...base, loads: [], role: "origin", city: "Dallas", state: "" });
+    expect(rec?.tier).toBe(3);
+    expect(rec?.market_id).toBe("m-dal");
+  });
+
+  it("same-city history (tier 2) still wins over the hub match", () => {
+    const loads = [mkLoad({ origin_city: "Atlanta", origin_state: "GA", origin_market_id: "m-chi" })];
+    const rec = recommendMarket({ ...base, loads, role: "origin", city: "Atlanta", state: "GA" });
+    expect(rec?.tier).toBe(2);
+    expect(rec?.market_id).toBe("m-chi");
+  });
+});
+
+describe("recommendMarket — tier 4 (nearest mapped city ≤75 mi)", () => {
   it("recommends a mapped city's market when within radius", () => {
     const loads = [mkLoad({ origin_city: "Atlanta", origin_state: "GA", origin_market_id: "m-atl" })];
     const rec = recommendMarket({ ...base, loads, role: "origin", city: "Milner", state: "GA" });
-    expect(rec?.tier).toBe(3);
+    expect(rec?.tier).toBe(4);
     expect(rec?.market_id).toBe("m-atl");
     expect(rec?.distanceMi).toBeGreaterThan(0);
     expect(rec?.distanceMi).toBeLessThan(75);
@@ -181,13 +206,16 @@ describe("recommendMarket — precedence & edge cases", () => {
   });
 
   it("skips a market_id that no longer exists in the market list", () => {
-    const loads = [mkLoad({ origin_city: "Atlanta", origin_state: "GA", origin_market_id: "m-deleted" })];
-    const rec = recommendMarket({ ...base, loads, role: "origin", city: "Atlanta", state: "GA" });
+    // Etowah is not a market name and not geocoded, so only tier-2 could fire —
+    // and it must skip the dangling market_id, leaving nothing.
+    const loads = [mkLoad({ origin_city: "Etowah", origin_state: "GA", origin_market_id: "m-deleted" })];
+    const rec = recommendMarket({ ...base, loads, role: "origin", city: "Etowah", state: "GA" });
     expect(rec).toBeNull();
   });
 
-  it("returns null with no history", () => {
-    expect(recommendMarket({ ...base, loads: [], role: "origin", facilityName: "X", city: "Atlanta", state: "GA" })).toBeNull();
+  it("returns null with no history and no matching market/hub", () => {
+    // Nowhereville is not a market and not in the coord map -> nothing to offer.
+    expect(recommendMarket({ ...base, loads: [], role: "origin", facilityName: "X", city: "Nowhereville", state: "GA" })).toBeNull();
   });
 
   it("returns null when nothing is entered", () => {

--- a/frontend/src/lib/metrics/marketRecommender.ts
+++ b/frontend/src/lib/metrics/marketRecommender.ts
@@ -6,13 +6,14 @@ import { cityKey, haversineMiles, type CoordMap } from "./foreman";
 // freight hub belongs to that hub's market (docs/business-rules/001).
 export const MARKET_RADIUS_MI = 75;
 
-// Phase 1 climbs your OWN history — the confidence ladder's first three rungs.
-// Higher tier = weaker signal. First hit wins.
+// Phase 1 climbs your OWN history + existing markets. Higher tier = weaker
+// signal. First hit wins.
 //   1 = same shipper/receiver seen before -> reuse its market
 //   2 = same city seen before             -> reuse its market
-//   3 = a mapped city within 75 mi        -> reuse the nearest one's market
-// (Rungs 4-5, the canonical seeded-hub + regional fallback, are Phase 2.)
-export type MarketRecTier = 1 | 2 | 3;
+//   3 = typed city IS an existing market  -> the hub itself (e.g. "Atlanta")
+//   4 = a mapped city within 75 mi        -> reuse the nearest one's market
+// (The canonical seeded-hub + regional fallback are Phase 2.)
+export type MarketRecTier = 1 | 2 | 3 | 4;
 
 export interface MarketRecommendation {
   tier: MarketRecTier;
@@ -27,6 +28,11 @@ export interface MarketRecommendation {
 export type MarketRole = "origin" | "destination";
 
 const norm = (s?: string | null): string => String(s ?? "").trim().toUpperCase();
+
+// "Atlanta Market" -> "Atlanta" (also handles the regional "[Direction] [State]
+// Market" form, which just won't match a plain city).
+const stripMarketSuffix = (name: string): string =>
+  name.replace(/\s+market\s*$/i, "").trim();
 
 interface StopRef {
   city: string;
@@ -156,7 +162,26 @@ export const recommendMarket = (params: {
     }
   }
 
-  // --- Tier 3: nearest mapped city within 75 mi ------------------------------
+  // --- Tier 3: the typed city IS one of your markets (the hub) --------------
+  // Load history lives in the SUBURBS, but a market is named for its hub. When
+  // someone types the hub itself ("Atlanta"), there's no load AT Atlanta — match
+  // it straight to the existing "Atlanta Market".
+  const cityN = norm(city);
+  if (cityN) {
+    const hub = markets.find(
+      (m) => norm(stripMarketSuffix(m.market_name)) === cityN,
+    );
+    if (hub) {
+      return {
+        tier: 3,
+        market_id: hub.market_id,
+        market_name: hub.market_name,
+        reason: "Matches this city's market",
+      };
+    }
+  }
+
+  // --- Tier 4: nearest mapped city within 75 mi ------------------------------
   const here = hasHere ? coords.get(hereKey) : undefined;
   if (here) {
     // Group history by distinct city, each carrying its own dominant market.
@@ -197,7 +222,7 @@ export const recommendMarket = (params: {
 
     if (nearest) {
       return {
-        tier: 3,
+        tier: 4,
         market_id: nearest.market_id,
         market_name: nearest.market_name,
         reason: `Nearest mapped city · ${nearest.city}, ${nearest.state} (~${Math.round(nearest.distanceMi)} mi)`,

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -952,7 +952,10 @@ const GuidePage = () => {
               <span className="text-light">same shipper or receiver</span> you've
               hauled before — matched to the state, so a national plant with sites
               in two states picks the right one — then the{" "}
-              <span className="text-light">same city</span>, then the{" "}
+              <span className="text-light">same city</span>, then{" "}
+              <span className="text-light">a market named for that city</span>{" "}
+              (type "Atlanta" and it offers your Atlanta Market, even though your
+              loads run from the towns around it), and finally the{" "}
               <span className="text-light">nearest city you've already mapped</span>{" "}
               within 75 miles. Tap <span className="text-light">Use</span> to
               accept it; it's a suggestion, never an auto-fill, so the call stays


### PR DESCRIPTION
## What
Phase 1's history ladder missed the most intuitive case: typing the **hub city** itself. Load history lives in the suburbs (a load's origin_city is "Milner", not "Atlanta"), but markets are named for the hub — so typing "Atlanta" (0 loads at that exact city) surfaced nothing.

Adds a tier that matches the typed city against an existing market's name (`"Atlanta"` → `"Atlanta Market"`), placed **after** same-city history and **before** the nearest-mapped-city fallback. Fires from the city alone, before a state is entered. Covers every hub you have a market for.

Verified against prod: 0 loads at city "Atlanta" despite "Atlanta Market" having loads — the exact gap this closes.

## Verification
- 20 engine unit tests (added hub-match + precedence cases) + full 587-test suite + strict build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)