### PR TITLE
feat(loads): market recommender — Phase 2 seeded hubs + regional (v1.178.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.177.2",
+  "version": "1.178.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/LoadForm.tsx
+++ b/frontend/src/components/LoadForm.tsx
@@ -539,8 +539,10 @@ const LoadForm = ({
     newMarket: Market,
     fieldName: "origin_market_id" | "destination_market_id",
   ) => {
-    setMarketList([...marketList, newMarket]);
-    setFormData({ ...formData, [fieldName]: newMarket.market_id });
+    // Functional updates: handleRecCreate awaits a POST first, so reading
+    // marketList/formData from the closure would clobber edits made in-flight.
+    setMarketList((prev) => [...prev, newMarket]);
+    setFormData((prev) => ({ ...prev, [fieldName]: newMarket.market_id }));
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/components/LoadForm.tsx
+++ b/frontend/src/components/LoadForm.tsx
@@ -28,6 +28,12 @@ import { facilityLabel } from "@/lib/facilityMatch";
 import { toInches, toFeetInches, isOverWidth, formatInches } from "@/lib/dimensions";
 import { useCityCoords } from "@/hooks/useCityCoords";
 import {
+  getCityCoords,
+  warmCityCoords,
+  type CityCoordRow,
+} from "@/services/cityCoordsService";
+import { cityKey, type CoordMap } from "@/lib/metrics/foreman";
+import {
   recommendMarket,
   type MarketRecommendation,
 } from "@/lib/metrics/marketRecommender";
@@ -238,11 +244,56 @@ const LoadForm = ({
   const [agentList, setAgentList] = useState<Agent[]>(agents);
   const [marketList, setMarketList] = useState<Market[]>(markets);
 
-  // --- Market recommender (Phase 1: climb your own history) ----------------
-  // `loads` is a stable reference (useLoads array, or NO_LOADS on the edit form),
-  // so useCityCoords settles after one fetch. New cities are geocoded server-side
-  // on load save (loadRoutes), so no form-time warm is needed here.
-  const coords = useCityCoords(loads);
+  // --- Market recommender -----------------------------------------------------
+  // History cities are already geocoded. Tiers 5-6 (nearest hub / regional) need
+  // the coordinate of the entered city — which for a BRAND-NEW city isn't cached
+  // yet — so warm it on entry (debounced, not per keystroke) and merge the
+  // freshly-verified coordinate in a moment later.
+  const historyCoords = useCityCoords(loads);
+  const [enteredCoords, setEnteredCoords] = useState<CoordMap>(new Map());
+  useEffect(() => {
+    const cities = [
+      { city: formData.origin_city, state: formData.origin_state },
+      { city: formData.destination_city, state: formData.destination_state },
+    ].filter((c) => c.city && c.state);
+    if (!cities.length) return;
+    let active = true;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const merge = (rows: CityCoordRow[]) =>
+      setEnteredCoords((prev) => {
+        const m = new Map(prev);
+        for (const r of rows) m.set(cityKey(r.city_norm, r.state), { lat: r.lat, lng: r.lng });
+        return m;
+      });
+    timers.push(
+      setTimeout(() => {
+        if (!active) return;
+        warmCityCoords(cities).then((rows) => {
+          if (!active) return;
+          if (rows.length) merge(rows);
+          timers.push(
+            setTimeout(() => {
+              getCityCoords().then((r) => active && merge(r));
+            }, 2500),
+          );
+        });
+      }, 600),
+    );
+    return () => {
+      active = false;
+      timers.forEach(clearTimeout);
+    };
+  }, [
+    formData.origin_city,
+    formData.origin_state,
+    formData.destination_city,
+    formData.destination_state,
+  ]);
+  const coords = useMemo(() => {
+    const m = new Map(historyCoords);
+    for (const [k, v] of enteredCoords) m.set(k, v);
+    return m;
+  }, [historyCoords, enteredCoords]);
 
   const originRec = useMemo(
     () =>
@@ -286,25 +337,62 @@ const LoadForm = ({
     ],
   );
 
-  // A one-tap suggestion chip under a market select. Hidden when there's no
-  // recommendation or it already matches what's chosen.
+  // Create a not-yet-existing recommended market (tiers 5-6), then select it. The
+  // name is already canonical; createMarket's guard (v1.176.0) normalizes anyway.
+  const handleRecCreate = async (
+    rec: MarketRecommendation,
+    field: "origin_market_id" | "destination_market_id",
+  ) => {
+    try {
+      const created = await createMarket({ market_name: rec.market_name, notes: null });
+      handleMarketCreated(created, field);
+      onMarketCreated();
+    } catch {
+      // Rare race (already created) — a re-render resolves it to a plain "Use".
+    }
+  };
+
+  // A one-tap suggestion chip under a market select. "Use" (amber) selects a
+  // market you already have; "Create & use" (teal) mints a new hub/regional
+  // market first. Hidden when there's no rec or it already matches the selection.
   const renderMarketRec = (
     rec: MarketRecommendation | null,
     field: "origin_market_id" | "destination_market_id",
   ) => {
     if (!rec || rec.market_id === formData[field]) return null;
+    const create = rec.isNew;
     return (
       <button
         type="button"
-        onClick={() => setFormData((f) => ({ ...f, [field]: rec.market_id }))}
-        className="mt-1.5 w-full flex items-center gap-2 rounded-[8px] border border-amber/40 bg-amber/[.06] px-2.5 py-1.5 text-left transition-colors hover:bg-amber/[.12]"
-        title={`Use ${rec.market_name} — ${rec.reason}`}
+        onClick={() =>
+          create
+            ? handleRecCreate(rec, field)
+            : setFormData((f) => ({ ...f, [field]: rec.market_id! }))
+        }
+        className="mt-1.5 w-full flex items-center gap-2 rounded-[8px] border px-2.5 py-1.5 text-left transition-colors"
+        style={
+          create
+            ? { borderColor: "rgba(93,202,165,.42)", background: "rgba(93,202,165,.08)" }
+            : { borderColor: "rgba(232,148,10,.40)", background: "rgba(232,148,10,.06)" }
+        }
+        title={`${create ? "Create & use" : "Use"} ${rec.market_name} — ${rec.reason}`}
       >
-        <span className="shrink-0 text-[10.5px] font-condensed font-semibold uppercase tracking-[.09em] text-amber">
-          Use
+        <span
+          className="shrink-0 text-[10.5px] font-condensed font-semibold uppercase tracking-[.09em]"
+          style={{ color: create ? "#5dcaa5" : "#f5b03a" }}
+        >
+          {create ? "+ Create & use" : "Use"}
         </span>
         <span className="text-[13px] text-ink font-medium truncate">
           {rec.market_name}
+          {create && (
+            <span
+              className="ml-1.5 text-[9.5px] uppercase tracking-[.08em] rounded-[5px] px-1.5 py-px"
+              style={{ color: "#5dcaa5", border: "1px solid rgba(93,202,165,.45)" }}
+            >
+              new
+            </span>
+          )}
         </span>
         <span className="ml-auto shrink-0 text-[11px] text-dim">{rec.reason}</span>
       </button>

--- a/frontend/src/lib/metrics/freightHubs.ts
+++ b/frontend/src/lib/metrics/freightHubs.ts
@@ -1,0 +1,215 @@
+import type { CityCoord } from "./foreman";
+import { haversineMiles } from "./foreman";
+
+// Seeded national freight hubs — the cities a Landstar agent would reference
+// (ports, rail/intermodal, distribution clusters, border crossings, steel /
+// project-cargo origins). Powers the recommender's tier-5 "nearest hub" rung:
+// a load in a new city near one of these suggests "[Hub] Market".
+export interface FreightHub {
+  city: string;
+  state: string; // 2-letter USPS
+  lat: number;
+  lng: number;
+  kind:
+    | "port"
+    | "rail-intermodal"
+    | "distribution"
+    | "manufacturing"
+    | "border"
+    | "metro";
+}
+
+export const FREIGHT_HUBS: FreightHub[] = [
+  { city: "Chicago", state: "IL", lat: 41.8781, lng: -87.6298, kind: "rail-intermodal" },
+  { city: "Atlanta", state: "GA", lat: 33.749, lng: -84.388, kind: "distribution" },
+  { city: "Dallas", state: "TX", lat: 32.7767, lng: -96.797, kind: "metro" },
+  { city: "Los Angeles", state: "CA", lat: 34.0522, lng: -118.2437, kind: "port" },
+  { city: "Houston", state: "TX", lat: 29.7604, lng: -95.3698, kind: "port" },
+  { city: "Memphis", state: "TN", lat: 35.1495, lng: -90.049, kind: "rail-intermodal" },
+  { city: "Kansas City", state: "MO", lat: 39.0997, lng: -94.5786, kind: "rail-intermodal" },
+  { city: "Laredo", state: "TX", lat: 27.5306, lng: -99.4803, kind: "border" },
+  { city: "Joliet", state: "IL", lat: 41.525, lng: -88.0817, kind: "rail-intermodal" },
+  { city: "Fort Worth", state: "TX", lat: 32.7555, lng: -97.3308, kind: "rail-intermodal" },
+  { city: "Ontario", state: "CA", lat: 34.0633, lng: -117.6509, kind: "distribution" },
+  { city: "Elizabeth", state: "NJ", lat: 40.664, lng: -74.2107, kind: "port" },
+  { city: "Savannah", state: "GA", lat: 32.0809, lng: -81.0912, kind: "port" },
+  { city: "Columbus", state: "OH", lat: 39.9612, lng: -82.9988, kind: "distribution" },
+  { city: "Charlotte", state: "NC", lat: 35.2271, lng: -80.8431, kind: "rail-intermodal" },
+  { city: "Indianapolis", state: "IN", lat: 39.7684, lng: -86.1581, kind: "distribution" },
+  { city: "Harrisburg", state: "PA", lat: 40.2732, lng: -76.8867, kind: "distribution" },
+  { city: "Allentown", state: "PA", lat: 40.6084, lng: -75.4902, kind: "distribution" },
+  { city: "Louisville", state: "KY", lat: 38.2527, lng: -85.7585, kind: "distribution" },
+  { city: "Nashville", state: "TN", lat: 36.1627, lng: -86.7816, kind: "distribution" },
+  { city: "Phoenix", state: "AZ", lat: 33.4484, lng: -112.074, kind: "distribution" },
+  { city: "Detroit", state: "MI", lat: 42.3314, lng: -83.0458, kind: "manufacturing" },
+  { city: "Salt Lake City", state: "UT", lat: 40.7608, lng: -111.891, kind: "rail-intermodal" },
+  { city: "Baltimore", state: "MD", lat: 39.2904, lng: -76.6122, kind: "port" },
+  { city: "Norfolk", state: "VA", lat: 36.8508, lng: -76.2859, kind: "port" },
+  { city: "Charleston", state: "SC", lat: 32.7765, lng: -79.9311, kind: "port" },
+  { city: "Jacksonville", state: "FL", lat: 30.3322, lng: -81.6557, kind: "port" },
+  { city: "Miami", state: "FL", lat: 25.7617, lng: -80.1918, kind: "port" },
+  { city: "Seattle", state: "WA", lat: 47.6062, lng: -122.3321, kind: "port" },
+  { city: "Oakland", state: "CA", lat: 37.8044, lng: -122.2712, kind: "port" },
+  { city: "Denver", state: "CO", lat: 39.7392, lng: -104.9903, kind: "metro" },
+  { city: "Philadelphia", state: "PA", lat: 39.9526, lng: -75.1652, kind: "port" },
+  { city: "Pittsburgh", state: "PA", lat: 40.4406, lng: -79.9959, kind: "manufacturing" },
+  { city: "Cleveland", state: "OH", lat: 41.4993, lng: -81.6944, kind: "manufacturing" },
+  { city: "Cincinnati", state: "OH", lat: 39.1031, lng: -84.512, kind: "distribution" },
+  { city: "St. Louis", state: "MO", lat: 38.627, lng: -90.1994, kind: "rail-intermodal" },
+  { city: "Minneapolis", state: "MN", lat: 44.9778, lng: -93.265, kind: "distribution" },
+  { city: "Milwaukee", state: "WI", lat: 43.0389, lng: -87.9065, kind: "manufacturing" },
+  { city: "San Antonio", state: "TX", lat: 29.4241, lng: -98.4936, kind: "metro" },
+  { city: "Austin", state: "TX", lat: 30.2672, lng: -97.7431, kind: "manufacturing" },
+  { city: "El Paso", state: "TX", lat: 31.7619, lng: -106.485, kind: "border" },
+  { city: "Oklahoma City", state: "OK", lat: 35.4676, lng: -97.5164, kind: "distribution" },
+  { city: "Tulsa", state: "OK", lat: 36.154, lng: -95.9928, kind: "manufacturing" },
+  { city: "Little Rock", state: "AR", lat: 34.7465, lng: -92.2896, kind: "distribution" },
+  { city: "Bentonville", state: "AR", lat: 36.3729, lng: -94.2088, kind: "distribution" },
+  { city: "New Orleans", state: "LA", lat: 29.9511, lng: -90.0715, kind: "port" },
+  { city: "Baton Rouge", state: "LA", lat: 30.4515, lng: -91.1871, kind: "manufacturing" },
+  { city: "Birmingham", state: "AL", lat: 33.5186, lng: -86.8104, kind: "manufacturing" },
+  { city: "Mobile", state: "AL", lat: 30.6954, lng: -88.0399, kind: "port" },
+  { city: "Knoxville", state: "TN", lat: 35.9606, lng: -83.9207, kind: "distribution" },
+  { city: "Chattanooga", state: "TN", lat: 35.0456, lng: -85.3097, kind: "manufacturing" },
+  { city: "Greensboro", state: "NC", lat: 36.0726, lng: -79.792, kind: "distribution" },
+  { city: "Spartanburg", state: "SC", lat: 34.9496, lng: -81.932, kind: "manufacturing" },
+  { city: "Tampa", state: "FL", lat: 27.9506, lng: -82.4572, kind: "port" },
+  { city: "Orlando", state: "FL", lat: 28.5383, lng: -81.3792, kind: "distribution" },
+  { city: "Richmond", state: "VA", lat: 37.5407, lng: -77.436, kind: "distribution" },
+  { city: "Gary", state: "IN", lat: 41.5934, lng: -87.3464, kind: "manufacturing" },
+  { city: "Toledo", state: "OH", lat: 41.6528, lng: -83.5379, kind: "manufacturing" },
+  { city: "Boston", state: "MA", lat: 42.3601, lng: -71.0589, kind: "metro" },
+  { city: "Stockton", state: "CA", lat: 37.9577, lng: -121.2908, kind: "rail-intermodal" },
+  { city: "Fresno", state: "CA", lat: 36.7378, lng: -119.7871, kind: "distribution" },
+  { city: "Las Vegas", state: "NV", lat: 36.1699, lng: -115.1398, kind: "distribution" },
+  { city: "Reno", state: "NV", lat: 39.5296, lng: -119.8138, kind: "distribution" },
+  { city: "Portland", state: "OR", lat: 45.5152, lng: -122.6784, kind: "port" },
+  { city: "Tacoma", state: "WA", lat: 47.2529, lng: -122.4443, kind: "port" },
+  { city: "Omaha", state: "NE", lat: 41.2565, lng: -95.9345, kind: "rail-intermodal" },
+  { city: "Des Moines", state: "IA", lat: 41.5868, lng: -93.625, kind: "distribution" },
+  { city: "Corpus Christi", state: "TX", lat: 27.8006, lng: -97.3964, kind: "port" },
+  { city: "Beaumont", state: "TX", lat: 30.0802, lng: -94.1266, kind: "port" },
+  { city: "Midland", state: "TX", lat: 31.9974, lng: -102.0779, kind: "manufacturing" },
+  { city: "Lake Charles", state: "LA", lat: 30.2266, lng: -93.2174, kind: "manufacturing" },
+  { city: "Shreveport", state: "LA", lat: 32.5252, lng: -93.7502, kind: "distribution" },
+  { city: "Huntsville", state: "AL", lat: 34.7304, lng: -86.5861, kind: "manufacturing" },
+  { city: "Albuquerque", state: "NM", lat: 35.0844, lng: -106.6504, kind: "distribution" },
+  { city: "Wichita", state: "KS", lat: 37.6872, lng: -97.3301, kind: "manufacturing" },
+  { city: "Buffalo", state: "NY", lat: 42.8864, lng: -78.8784, kind: "border" },
+  { city: "Syracuse", state: "NY", lat: 43.0481, lng: -76.1474, kind: "rail-intermodal" },
+  { city: "Albany", state: "NY", lat: 42.6526, lng: -73.7562, kind: "port" },
+  { city: "Scranton", state: "PA", lat: 41.409, lng: -75.6624, kind: "distribution" },
+  { city: "Carlisle", state: "PA", lat: 40.2015, lng: -77.1889, kind: "distribution" },
+  { city: "Hartford", state: "CT", lat: 41.7658, lng: -72.6734, kind: "distribution" },
+  { city: "New York", state: "NY", lat: 40.7128, lng: -74.006, kind: "metro" },
+  { city: "Washington", state: "DC", lat: 38.9072, lng: -77.0369, kind: "metro" },
+  { city: "Portland", state: "ME", lat: 43.6591, lng: -70.2568, kind: "port" },
+  { city: "Jackson", state: "MS", lat: 32.2988, lng: -90.1848, kind: "metro" },
+  { city: "Sacramento", state: "CA", lat: 38.5816, lng: -121.4944, kind: "metro" },
+  { city: "San Diego", state: "CA", lat: 32.7157, lng: -117.1611, kind: "metro" },
+  { city: "Tucson", state: "AZ", lat: 32.2226, lng: -110.9747, kind: "manufacturing" },
+  { city: "Nogales", state: "AZ", lat: 31.3404, lng: -110.9343, kind: "border" },
+  { city: "Duluth", state: "MN", lat: 46.7867, lng: -92.1005, kind: "port" },
+  { city: "Boise", state: "ID", lat: 43.615, lng: -116.2023, kind: "metro" },
+  { city: "Billings", state: "MT", lat: 45.7833, lng: -108.5007, kind: "metro" },
+  { city: "Cheyenne", state: "WY", lat: 41.14, lng: -104.8202, kind: "rail-intermodal" },
+  { city: "Fargo", state: "ND", lat: 46.8772, lng: -96.7898, kind: "distribution" },
+  { city: "Sioux Falls", state: "SD", lat: 43.546, lng: -96.7313, kind: "distribution" },
+];
+
+// Full state names for the regional fallback market name ("[Direction] [State]
+// Market" uses the full name, e.g. "Eastern Kentucky Market").
+export const STATE_NAMES: Record<string, string> = {
+  AL: "Alabama", AK: "Alaska", AZ: "Arizona", AR: "Arkansas", CA: "California",
+  CO: "Colorado", CT: "Connecticut", DE: "Delaware", DC: "Washington DC",
+  FL: "Florida", GA: "Georgia", HI: "Hawaii", ID: "Idaho", IL: "Illinois",
+  IN: "Indiana", IA: "Iowa", KS: "Kansas", KY: "Kentucky", LA: "Louisiana",
+  ME: "Maine", MD: "Maryland", MA: "Massachusetts", MI: "Michigan",
+  MN: "Minnesota", MS: "Mississippi", MO: "Missouri", MT: "Montana",
+  NE: "Nebraska", NV: "Nevada", NH: "New Hampshire", NJ: "New Jersey",
+  NM: "New Mexico", NY: "New York", NC: "North Carolina", ND: "North Dakota",
+  OH: "Ohio", OK: "Oklahoma", OR: "Oregon", PA: "Pennsylvania",
+  RI: "Rhode Island", SC: "South Carolina", SD: "South Dakota",
+  TN: "Tennessee", TX: "Texas", UT: "Utah", VT: "Vermont", VA: "Virginia",
+  WA: "Washington", WV: "West Virginia", WI: "Wisconsin", WY: "Wyoming",
+};
+
+// Approximate geographic center of each state — used only to decide which part
+// of the state a city sits in for the regional fallback name. Precision isn't
+// critical: the fallback is rare and always editable.
+export const STATE_CENTERS: Record<string, CityCoord> = {
+  AL: { lat: 32.8, lng: -86.8 }, AZ: { lat: 34.3, lng: -111.7 },
+  AR: { lat: 34.8, lng: -92.4 }, CA: { lat: 37.2, lng: -119.5 },
+  CO: { lat: 39.0, lng: -105.5 }, CT: { lat: 41.6, lng: -72.7 },
+  DE: { lat: 39.0, lng: -75.5 }, FL: { lat: 28.6, lng: -82.4 },
+  GA: { lat: 32.6, lng: -83.4 }, ID: { lat: 44.4, lng: -114.6 },
+  IL: { lat: 40.0, lng: -89.2 }, IN: { lat: 39.9, lng: -86.3 },
+  IA: { lat: 42.0, lng: -93.5 }, KS: { lat: 38.5, lng: -98.4 },
+  KY: { lat: 37.5, lng: -85.3 }, LA: { lat: 31.1, lng: -92.0 },
+  ME: { lat: 45.4, lng: -69.2 }, MD: { lat: 39.0, lng: -76.8 },
+  MA: { lat: 42.3, lng: -71.8 }, MI: { lat: 44.3, lng: -85.4 },
+  MN: { lat: 46.3, lng: -94.3 }, MS: { lat: 32.7, lng: -89.7 },
+  MO: { lat: 38.4, lng: -92.5 }, MT: { lat: 47.0, lng: -109.6 },
+  NE: { lat: 41.5, lng: -99.8 }, NV: { lat: 39.3, lng: -116.6 },
+  NH: { lat: 43.7, lng: -71.6 }, NJ: { lat: 40.2, lng: -74.7 },
+  NM: { lat: 34.4, lng: -106.1 }, NY: { lat: 42.9, lng: -75.5 },
+  NC: { lat: 35.5, lng: -79.4 }, ND: { lat: 47.5, lng: -100.5 },
+  OH: { lat: 40.3, lng: -82.8 }, OK: { lat: 35.6, lng: -97.5 },
+  OR: { lat: 44.0, lng: -120.6 }, PA: { lat: 40.9, lng: -77.8 },
+  RI: { lat: 41.7, lng: -71.6 }, SC: { lat: 33.9, lng: -80.9 },
+  SD: { lat: 44.4, lng: -100.2 }, TN: { lat: 35.9, lng: -86.4 },
+  TX: { lat: 31.5, lng: -99.3 }, UT: { lat: 39.3, lng: -111.7 },
+  VT: { lat: 44.1, lng: -72.7 }, VA: { lat: 37.5, lng: -78.9 },
+  WA: { lat: 47.4, lng: -120.5 }, WV: { lat: 38.6, lng: -80.6 },
+  WI: { lat: 44.6, lng: -89.9 }, WY: { lat: 43.0, lng: -107.6 },
+};
+
+export const MARKET_RADIUS_MI = 75;
+
+// Nearest seeded hub to a coordinate, within the market radius. Null if none.
+export const nearestHub = (
+  here: CityCoord,
+): { hub: FreightHub; distanceMi: number } | null => {
+  let best: { hub: FreightHub; distanceMi: number } | null = null;
+  for (const hub of FREIGHT_HUBS) {
+    const d = haversineMiles(here, { lat: hub.lat, lng: hub.lng });
+    if (d > MARKET_RADIUS_MI) continue;
+    if (!best || d < best.distanceMi) best = { hub, distanceMi: d };
+  }
+  return best;
+};
+
+export type Direction =
+  | "Northern"
+  | "Southern"
+  | "Eastern"
+  | "Western"
+  | "Central";
+
+// Which part of its state a city sits in, from the offset to the state center.
+const CENTRAL_DEG = 0.7; // ~48 mi N/S; a rough "near the middle" band
+export const regionalDirection = (
+  here: CityCoord,
+  state: string,
+): Direction | null => {
+  const center = STATE_CENTERS[String(state).trim().toUpperCase()];
+  if (!center) return null;
+  const dLat = here.lat - center.lat; // + = north
+  const dLng = here.lng - center.lng; // + = east
+  if (Math.abs(dLat) < CENTRAL_DEG && Math.abs(dLng) < CENTRAL_DEG) return "Central";
+  if (Math.abs(dLat) >= Math.abs(dLng)) return dLat > 0 ? "Northern" : "Southern";
+  return dLng > 0 ? "Eastern" : "Western";
+};
+
+// The regional fallback market name for a city with no hub within 75 mi:
+// "[Direction] [State] Market" (e.g. "Western Texas Market"). Null if the state
+// is unknown.
+export const regionalMarketName = (
+  here: CityCoord,
+  state: string,
+): string | null => {
+  const dir = regionalDirection(here, state);
+  const name = STATE_NAMES[String(state).trim().toUpperCase()];
+  if (!dir || !name) return null;
+  return `${dir} ${name} Market`;
+};

--- a/frontend/src/lib/metrics/freightHubs.ts
+++ b/frontend/src/lib/metrics/freightHubs.ts
@@ -196,8 +196,11 @@ export const regionalDirection = (
   if (!center) return null;
   const dLat = here.lat - center.lat; // + = north
   const dLng = here.lng - center.lng; // + = east
-  if (Math.abs(dLat) < CENTRAL_DEG && Math.abs(dLng) < CENTRAL_DEG) return "Central";
-  if (Math.abs(dLat) >= Math.abs(dLng)) return dLat > 0 ? "Northern" : "Southern";
+  // A degree of longitude covers less ground than a degree of latitude away from
+  // the equator; scale it so the N/S-vs-E/W pick compares real distances.
+  const dLngMi = dLng * Math.cos((center.lat * Math.PI) / 180);
+  if (Math.abs(dLat) < CENTRAL_DEG && Math.abs(dLngMi) < CENTRAL_DEG) return "Central";
+  if (Math.abs(dLat) >= Math.abs(dLngMi)) return dLat > 0 ? "Northern" : "Southern";
   return dLng > 0 ? "Eastern" : "Western";
 };
 

--- a/frontend/src/lib/metrics/marketRecommender.test.ts
+++ b/frontend/src/lib/metrics/marketRecommender.test.ts
@@ -51,12 +51,16 @@ const mkLoad = (o: Partial<Load>): Load => ({
   ...o,
 });
 
-// Milner GA ~44 mi S of Atlanta; Chattanooga ~106 mi N (out of range).
+// Milner GA ~44 mi S of Atlanta; Chattanooga ~106 mi N (out of history range,
+// but itself a seeded hub). Bartlett TN sits by the Memphis hub; Ely NV is
+// remote (no hub within 75 mi).
 const COORDS: CoordMap = new Map([
   [cityKey("Atlanta", "GA"), { lat: 33.749, lng: -84.388 }],
   [cityKey("Milner", "GA"), { lat: 33.117, lng: -84.196 }],
   [cityKey("Dallas", "TX"), { lat: 32.7767, lng: -96.797 }],
   [cityKey("Chattanooga", "TN"), { lat: 35.0456, lng: -85.3097 }],
+  [cityKey("Bartlett", "TN"), { lat: 35.2045, lng: -89.8739 }],
+  [cityKey("Ely", "NV"), { lat: 39.2472, lng: -114.8886 }],
 ]);
 
 const base = { loads: [] as Load[], markets: MARKETS, coords: COORDS };
@@ -180,16 +184,53 @@ describe("recommendMarket — tier 4 (nearest mapped city ≤75 mi)", () => {
     expect(rec?.reason).toMatch(/Nearest mapped city · Atlanta, GA/);
   });
 
-  it("returns null when the nearest mapped city is beyond 75 mi", () => {
+  it("falls past tier 4 to the seeded hub when history is beyond 75 mi", () => {
     const loads = [mkLoad({ origin_city: "Atlanta", origin_state: "GA", origin_market_id: "m-atl" })];
-    // Chattanooga is ~106 mi from Atlanta -> out of range; no other signal.
+    // Chattanooga is ~106 mi from the Atlanta history (no tier 4) but IS a seeded hub.
     const rec = recommendMarket({ ...base, loads, role: "origin", city: "Chattanooga", state: "TN" });
-    expect(rec).toBeNull();
+    expect(rec?.tier).toBe(5);
+    expect(rec?.market_name).toBe("Chattanooga Market");
+    expect(rec?.isNew).toBe(true);
   });
 
-  it("returns null for tier 3 when the entered city has no coords", () => {
+  it("returns null when the entered city has no coords and nothing else hits", () => {
     const loads = [mkLoad({ origin_city: "Atlanta", origin_state: "GA", origin_market_id: "m-atl" })];
     const rec = recommendMarket({ ...base, loads, role: "origin", city: "Nowhereville", state: "GA" });
+    expect(rec).toBeNull();
+  });
+});
+
+describe("recommendMarket — tier 5 (nearest seeded freight hub ≤75 mi)", () => {
+  it("suggests the hub's existing market for a new city near a hub (use)", () => {
+    // Milner GA is ~44 mi from the Atlanta hub, and "Atlanta Market" exists.
+    const rec = recommendMarket({ ...base, loads: [], role: "origin", city: "Milner", state: "GA" });
+    expect(rec?.tier).toBe(5);
+    expect(rec?.market_id).toBe("m-atl");
+    expect(rec?.isNew).toBe(false);
+    expect(rec?.market_name).toBe("Atlanta Market");
+    expect(rec?.reason).toMatch(/Nearest hub · Atlanta/);
+  });
+
+  it("flags isNew when the nearest hub's market doesn't exist yet (create)", () => {
+    // Bartlett TN sits by the Memphis hub, but there's no Memphis Market here.
+    const rec = recommendMarket({ ...base, loads: [], role: "origin", city: "Bartlett", state: "TN" });
+    expect(rec?.tier).toBe(5);
+    expect(rec?.market_id).toBeNull();
+    expect(rec?.isNew).toBe(true);
+    expect(rec?.market_name).toBe("Memphis Market");
+  });
+});
+
+describe("recommendMarket — tier 6 (regional fallback)", () => {
+  it("names the market by direction within the state when no hub is near", () => {
+    const rec = recommendMarket({ ...base, loads: [], role: "origin", city: "Ely", state: "NV" });
+    expect(rec?.tier).toBe(6);
+    expect(rec?.isNew).toBe(true);
+    expect(rec?.market_name).toMatch(/Nevada Market$/);
+  });
+
+  it("does not fire without coords (can't place the city)", () => {
+    const rec = recommendMarket({ ...base, loads: [], role: "origin", city: "Ghosttown", state: "NV" });
     expect(rec).toBeNull();
   });
 });

--- a/frontend/src/lib/metrics/marketRecommender.ts
+++ b/frontend/src/lib/metrics/marketRecommender.ts
@@ -1,27 +1,32 @@
 import type { Load } from "@/types/load";
 import type { Market } from "@/types/market";
 import { cityKey, haversineMiles, type CoordMap } from "./foreman";
+import { nearestHub, regionalMarketName } from "./freightHubs";
 
 // A stop's market is defined by its LOCATION: all freight within this radius of a
 // freight hub belongs to that hub's market (docs/business-rules/001).
 export const MARKET_RADIUS_MI = 75;
 
-// Phase 1 climbs your OWN history + existing markets. Higher tier = weaker
-// signal. First hit wins.
+// The confidence ladder — higher tier = weaker signal, first hit wins.
 //   1 = same shipper/receiver seen before -> reuse its market
 //   2 = same city seen before             -> reuse its market
 //   3 = typed city IS an existing market  -> the hub itself (e.g. "Atlanta")
-//   4 = a mapped city within 75 mi        -> reuse the nearest one's market
-// (The canonical seeded-hub + regional fallback are Phase 2.)
-export type MarketRecTier = 1 | 2 | 3 | 4;
+//   4 = a mapped history city within 75mi -> reuse the nearest one's market
+//   5 = a seeded freight hub within 75mi  -> "[Hub] Market" (create if new)
+//   6 = no hub within 75mi                -> "[Direction] [State] Market" (create if new)
+// Tiers 1-4 always resolve to an existing market; 5-6 may need creating (isNew).
+export type MarketRecTier = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface MarketRecommendation {
   tier: MarketRecTier;
-  market_id: string;
+  // The existing market to use, or null when the market must be created (isNew).
+  market_id: string | null;
   market_name: string;
+  // True when market_id is null and the chip should CREATE the market first.
+  isNew: boolean;
   // Short human reason for the chip, e.g. "Same shipper · 3 past loads".
   reason: string;
-  // Present only on tier 3 (straight-line miles to the mapped city).
+  // Straight-line miles, on the proximity tiers (4 and 5).
   distanceMi?: number;
 }
 
@@ -149,6 +154,7 @@ export const recommendMarket = (params: {
         tier: 1,
         market_id: dom.market_id,
         market_name: nameById.get(dom.market_id)!,
+        isNew: false,
         reason: `Same ${label} · ${dom.count} past ${plural(dom.count)}`,
       };
     }
@@ -167,6 +173,7 @@ export const recommendMarket = (params: {
         tier: 2,
         market_id: dom.market_id,
         market_name: nameById.get(dom.market_id)!,
+        isNew: false,
         reason: `Same city · ${dom.count} past ${plural(dom.count)}`,
       };
     }
@@ -186,6 +193,7 @@ export const recommendMarket = (params: {
         tier: 3,
         market_id: hub.market_id,
         market_name: hub.market_name,
+        isNew: false,
         reason: "Matches this city's market",
       };
     }
@@ -235,8 +243,45 @@ export const recommendMarket = (params: {
         tier: 4,
         market_id: nearest.market_id,
         market_name: nearest.market_name,
+        isNew: false,
         reason: `Nearest mapped city · ${nearest.city}, ${nearest.state} (~${Math.round(nearest.distanceMi)} mi)`,
         distanceMi: nearest.distanceMi,
+      };
+    }
+  }
+
+  // --- Tier 5: nearest seeded freight hub within 75 mi ----------------------
+  // A brand-new city with no history: suggest the market of the nearest major
+  // freight hub. The hub's market may already exist (use it) or not (create it).
+  if (here) {
+    const near = nearestHub(here);
+    if (near) {
+      const name = `${near.hub.city} Market`;
+      const id = idByName.get(norm(name)) ?? null;
+      return {
+        tier: 5,
+        market_id: id,
+        market_name: name,
+        isNew: id === null,
+        reason: `Nearest hub · ${near.hub.city} (~${Math.round(near.distanceMi)} mi)`,
+        distanceMi: near.distanceMi,
+      };
+    }
+  }
+
+  // --- Tier 6: regional fallback (no hub within 75 mi) ----------------------
+  // Genuinely remote: name the market by the part of the state it sits in,
+  // "[Direction] [State] Market" (e.g. "Western Texas Market").
+  if (here && hasHere) {
+    const name = regionalMarketName(here, String(state ?? ""));
+    if (name) {
+      const id = idByName.get(norm(name)) ?? null;
+      return {
+        tier: 6,
+        market_id: id,
+        market_name: name,
+        isNew: id === null,
+        reason: "Regional · no hub within 75 mi",
       };
     }
   }

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -955,11 +955,18 @@ const GuidePage = () => {
               <span className="text-light">same city</span>, then{" "}
               <span className="text-light">a market named for that city</span>{" "}
               (type "Atlanta" and it offers your Atlanta Market, even though your
-              loads run from the towns around it), and finally the{" "}
+              loads run from the towns around it), then the{" "}
               <span className="text-light">nearest city you've already mapped</span>{" "}
-              within 75 miles. Tap <span className="text-light">Use</span> to
-              accept it; it's a suggestion, never an auto-fill, so the call stays
-              yours.
+              within 75 miles, then the{" "}
+              <span className="text-light">nearest major freight hub</span> within
+              75 miles, and — for a genuinely remote spot — a{" "}
+              <span className="text-light">regional name</span> like "Western Texas
+              Market." Tap <span className="text-light">Use</span> to accept a
+              market you already have; when the pick is a hub or region you haven't
+              logged yet, the chip reads{" "}
+              <span className="text-light">Create &amp; use</span> and mints that
+              market (canonically named) for you. Either way it's a suggestion,
+              never an auto-fill — the call stays yours.
             </Why>
           </Metric>
 


### PR DESCRIPTION
## What
Extends the recommender past your own history to cover cities/regions you haven't hauled yet.

- **Tier 5 — nearest seeded freight hub ≤75 mi** → `"[Hub] Market"`. 95 curated national hubs (`freightHubs.ts`, with coords) — ports, rail/intermodal, distribution clusters, border crossings, steel/project origins.
- **Tier 6 — regional fallback** → `"[Direction] [State] Market"` (e.g. "Western Texas Market") when no hub is within 75 mi. Direction from the city's position within its state.
- Both may reference a market you don't have yet, so the recommendation carries `isNew` + nullable `market_id`. The chip renders **"Create & use"** (teal) for those — minting the canonical market (via the v1.176.0 name guard) then selecting it — vs the amber **"Use"** for a market you already have.
- **Warm-on-select coords:** a brand-new city isn't geocoded yet, and tiers 5-6 need its coordinate, so LoadForm warms it on entry (debounced) and merges the freshly-verified coord in a moment later.
- Guide updated with the full ladder + Create & use.

## Design
Mockup approved by the owner before writing the chip UI.

## Verification
- 25 engine unit tests (added tier 5/6, regional-direction, name-fallback, create cases) + full 592-test suite + strict build all green.
- Adversarial review of the Phase 2 wiring in progress before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)