### PR TITLE
feat(agents): Direct vs Spot customer buckets + Foreman priority (v1.179.0)

### DIFF
--- a/backend/db/migrations/058_agent_class.sql
+++ b/backend/db/migrations/058_agent_class.sql
@@ -1,0 +1,11 @@
+-- 058_agent_class.sql
+-- Manual override for an agent's relationship bucket. NULL = auto (derived from
+-- loads: a shipper OR receiver hit 2+ times through the agent = direct customer,
+-- else spot market). 'direct' / 'spot' pin the owner's call when the data can't
+-- see it yet. Idempotent.
+
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS agent_class text;
+
+ALTER TABLE agents DROP CONSTRAINT IF EXISTS agents_agent_class_check;
+ALTER TABLE agents ADD CONSTRAINT agents_agent_class_check
+  CHECK (agent_class IN ('direct', 'spot'));

--- a/backend/src/services/agentServices.js
+++ b/backend/src/services/agentServices.js
@@ -21,6 +21,7 @@ export async function getAgents(user_id) {
             preferred_contact,
             agents.rating AS rating,
             agents.notes AS notes,
+            agents.agent_class AS agent_class,
             agents.created_at AS created_at,
             agents.updated_at AS updated_at
         FROM
@@ -53,6 +54,7 @@ export async function getAgent(user_id, agent_id) {
             agents.preferred_contact AS preferred_contact,
             agents.rating AS rating,
             agents.notes AS notes,
+            agents.agent_class AS agent_class,
             agents.created_at AS created_at,
             agents.updated_at AS updated_at
         FROM
@@ -170,6 +172,7 @@ export async function createAgent(user_id, data) {
     "preferred_contact",
     "rating",
     "notes",
+    "agent_class",
   ];
 
   for (const field in data) {
@@ -228,6 +231,7 @@ export async function patchAgent(user_id, agent_id, data) {
     "preferred_contact",
     "rating",
     "notes",
+    "agent_class",
   ];
 
   // Throw error if data contains invalid field(s)

--- a/backend/src/utils/validation/agentValidation.js
+++ b/backend/src/utils/validation/agentValidation.js
@@ -117,6 +117,13 @@ const rules = {
       errors.push("notes cannot be blank");
     }
   },
+  // null clears the override back to auto (data-derived); otherwise a pin.
+  agent_class: (value, errors) => {
+    if (value === null || value === undefined) return;
+    if (value !== "direct" && value !== "spot") {
+      errors.push("agent_class must be 'direct', 'spot', or null");
+    }
+  },
 };
 
 // ---- CREATE AGENT VALIDATION ----

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.178.0",
+  "version": "1.179.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/agents/AgentCard.tsx
+++ b/frontend/src/components/agents/AgentCard.tsx
@@ -6,7 +6,7 @@ import type {
   AgentStat,
   LiveStanding,
 } from "@/lib/metrics/agentLeaderboard";
-import type { AgentScorecard } from "@/lib/metrics/agentScorecard";
+import { effectiveAgentClass, type AgentScorecard } from "@/lib/metrics/agentScorecard";
 import { agentPrestige } from "@/lib/metrics/agentLeaderboard";
 import { RatingMedallion } from "./RatingMedallion";
 import { PRESTIGE_META } from "./PrestigeBadge";
@@ -46,6 +46,7 @@ export const AgentCard = ({
   live,
   card,
   carrierName,
+  onSetClass,
 }: {
   agent: Agent;
   stats?: AgentStat;
@@ -53,6 +54,8 @@ export const AgentCard = ({
   live?: LiveStanding | null;
   card?: AgentScorecard;
   carrierName?: string;
+  // Set/clear the relationship-bucket override (null = back to auto).
+  onSetClass?: (value: "direct" | "spot" | null) => void;
 }) => {
   const tier = agentPrestige(honors);
   const blurb = live ? liveBlurb(live) : null;
@@ -61,6 +64,8 @@ export const AgentCard = ({
   const goto = card ? TIER_META[card.tier] : null;
   const dwell = card ? dwellStatus(card) : null;
   const flag = card ? flagText(card) : null;
+  const cls = effectiveAgentClass(agent, card);
+  const direct = cls.bucket === "direct";
 
   return (
     <Link
@@ -118,6 +123,52 @@ export const AgentCard = ({
           >
             {goto.label}
           </span>
+        )}
+      </div>
+
+      {/* relationship bucket + override */}
+      <div className="flex items-center justify-between gap-2 mt-2">
+        <span
+          className="text-[10px] font-bold px-2 py-0.5 rounded-md shrink-0"
+          style={
+            direct
+              ? { color: "#5dcaa5", background: "rgba(93,202,165,.12)", border: "1px solid rgba(93,202,165,.40)" }
+              : { color: "#8494ab", background: "rgba(132,148,171,.08)", border: "1px solid rgba(132,148,171,.28)" }
+          }
+          title={cls.source === "pinned" ? "Pinned by you" : "Auto — from a repeat shipper or receiver"}
+        >
+          {direct ? "Direct" : "Spot"}
+          <span className="ml-1 font-normal opacity-70">
+            {cls.source === "pinned" ? "pinned" : "auto"}
+          </span>
+        </span>
+        {onSetClass && (
+          <div className="flex rounded-md overflow-hidden border ds2-cell-rule text-[9px] font-semibold uppercase tracking-wide">
+            {([["Auto", null], ["Direct", "direct"], ["Spot", "spot"]] as const).map(
+              ([lbl, val]) => {
+                const active = (agent.agent_class ?? null) === val;
+                return (
+                  <button
+                    key={lbl}
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onSetClass(val);
+                    }}
+                    className="px-1.5 py-[3px] transition-colors"
+                    style={
+                      active
+                        ? { color: "#5dcaa5", background: "rgba(93,202,165,.13)" }
+                        : { color: "#5a6880" }
+                    }
+                  >
+                    {lbl}
+                  </button>
+                );
+              },
+            )}
+          </div>
         )}
       </div>
 

--- a/frontend/src/components/foreman/WhoToCallTab.tsx
+++ b/frontend/src/components/foreman/WhoToCallTab.tsx
@@ -58,6 +58,16 @@ const TopCall = ({ r }: { r: AgentRanking }) => (
           NEW
         </span>
       )}
+      <span
+        className="font-condensed text-[11px] font-semibold px-2 py-0.5 rounded"
+        style={
+          r.bucket === "direct"
+            ? { color: "#5dcaa5", background: "rgba(93,202,165,.13)" }
+            : { color: "#8494ab", background: "rgba(132,148,171,.10)" }
+        }
+      >
+        {r.bucket === "direct" ? "DIRECT" : "SPOT"}
+      </span>
     </div>
 
     <Link
@@ -124,6 +134,46 @@ const AgentRow = ({ r, rank }: { r: AgentRanking; rank: number }) => (
   </div>
 );
 
+// A labeled tier of rows (Direct customers / Spot market). Hidden when empty.
+const RankGroup = ({
+  label,
+  hint,
+  rows,
+  startRank,
+  tone,
+}: {
+  label: string;
+  hint: string;
+  rows: AgentRanking[];
+  startRank: number;
+  tone: "direct" | "spot";
+}) => {
+  if (rows.length === 0) return null;
+  return (
+    <div className="ds2-board mt-3">
+      <div className="flex items-center gap-2 px-3.5 pt-3 pb-1">
+        <span
+          className="text-[12px] font-bold uppercase tracking-[.09em]"
+          style={{ color: tone === "direct" ? "#5dcaa5" : "#8494ab" }}
+        >
+          {label}
+        </span>
+        <span className="text-[11px] text-faint">{hint}</span>
+      </div>
+      <div className="grid gap-3 px-3.5 pt-1 pb-1.5" style={{ gridTemplateColumns: "20px 1.4fr 80px 72px 92px" }}>
+        <span />
+        <span className="text-[11px] uppercase tracking-widest text-faint font-condensed">Agent</span>
+        <span className="text-[11px] uppercase tracking-widest text-faint font-condensed text-right">Away</span>
+        <span className="text-[11px] uppercase tracking-widest text-faint font-condensed text-right">$/mi</span>
+        <span className="text-[11px] uppercase tracking-widest text-faint font-condensed text-right">History</span>
+      </div>
+      {rows.map((r, i) => (
+        <AgentRow key={r.agentId} r={r} rank={startRank + i} />
+      ))}
+    </div>
+  );
+};
+
 const FOCUS_TABS: { value: LoadTypeFocus; label: string }[] = [
   { value: "any", label: "Any" },
   { value: "standard flatbed", label: "Flatbed" },
@@ -167,6 +217,8 @@ export const WhoToCallTab = () => {
     return <Empty msg="No committed or delivered loads yet — add a load and the Foreman will tell you who to call." />;
 
   const [top, ...rest] = board.rankings;
+  const restDirect = rest.filter((r) => r.bucket === "direct");
+  const restSpot = rest.filter((r) => r.bucket === "spot");
   const anchorHint =
     board.anchor.source === "committed" ? "after your booked load delivers" : "empty here now";
 
@@ -209,21 +261,9 @@ export const WhoToCallTab = () => {
           {/* top call */}
           {top && <TopCall r={top} />}
 
-          {/* the rest */}
-          {rest.length > 0 && (
-            <div className="ds2-board mt-3">
-              <div className="grid gap-3 px-3.5 pt-2.5 pb-1.5" style={{ gridTemplateColumns: "20px 1.4fr 80px 72px 92px" }}>
-                <span />
-                <span className="text-[11px] uppercase tracking-widest text-faint font-condensed">Agent</span>
-                <span className="text-[11px] uppercase tracking-widest text-faint font-condensed text-right">Away</span>
-                <span className="text-[11px] uppercase tracking-widest text-faint font-condensed text-right">$/mi</span>
-                <span className="text-[11px] uppercase tracking-widest text-faint font-condensed text-right">History</span>
-              </div>
-              {rest.map((r, i) => (
-                <AgentRow key={r.agentId} r={r} rank={i + 2} />
-              ))}
-            </div>
-          )}
+          {/* remaining agents, bucketed — direct always above spot */}
+          <RankGroup label="Direct customers" hint="your own — call first" rows={restDirect} startRank={2} tone="direct" />
+          <RankGroup label="Spot market" hint="only if nothing direct fits" rows={restSpot} startRank={2 + restDirect.length} tone="spot" />
 
           {/* footer */}
           <div className="flex flex-wrap items-center justify-between gap-3 mt-3 px-1">

--- a/frontend/src/lib/metrics/agentScorecard.test.ts
+++ b/frontend/src/lib/metrics/agentScorecard.test.ts
@@ -67,6 +67,13 @@ describe("agent bucket (direct vs spot)", () => {
     expect(c.repeatCustomers).toEqual([]);
   });
 
+  it("one load with the same shipper AND receiver name is NOT a repeat", () => {
+    // A plant-to-plant move (Nucor -> Nucor) must not flip a single load to direct.
+    const c = cardFor([load({ shipper_name: "Nucor", receiver_name: "Nucor" })]);
+    expect(c.autoClass).toBe("spot");
+    expect(c.repeatCustomers).toEqual([]);
+  });
+
   it("ignores cancelled loads for the repeat count", () => {
     const c = cardFor([
       load({ shipper_name: "Acme", receiver_name: "R1" }),

--- a/frontend/src/lib/metrics/agentScorecard.test.ts
+++ b/frontend/src/lib/metrics/agentScorecard.test.ts
@@ -4,6 +4,7 @@ import type { Agent } from "@/types/agent";
 import {
   classifySpecialty,
   buildAgentScorecards,
+  effectiveAgentClass,
   agentRosterAnalytics,
   concentrationAnalytics,
   agentMomentum,
@@ -27,6 +28,63 @@ const load = (over: Partial<Load>): Load =>
 
 const agent = (id: string, rating: number | null): Agent =>
   ({ agent_id: id, rating, first_name: id, last_name: "X", broker_name: "B" }) as Agent;
+
+describe("agent bucket (direct vs spot)", () => {
+  const cardFor = (loads: Load[]) =>
+    buildAgentScorecards([agent("a", null)], loads).get("a")!;
+
+  it("direct when the same SHIPPER repeats", () => {
+    const c = cardFor([
+      load({ shipper_name: "Acme", receiver_name: "R1" }),
+      load({ shipper_name: "Acme", receiver_name: "R2" }),
+    ]);
+    expect(c.autoClass).toBe("direct");
+    expect(c.repeatCustomers.find((r) => r.facility === "Acme")?.count).toBe(2);
+  });
+
+  it("direct when the same RECEIVER repeats (different shippers)", () => {
+    const c = cardFor([
+      load({ shipper_name: "S1", receiver_name: "Gulf" }),
+      load({ shipper_name: "S2", receiver_name: "Gulf" }),
+    ]);
+    expect(c.autoClass).toBe("direct");
+  });
+
+  it("direct on a recurring round-trip lane (facility on both sides)", () => {
+    const c = cardFor([
+      load({ shipper_name: "Touchstone", receiver_name: "Fujifilm" }),
+      load({ shipper_name: "Fujifilm", receiver_name: "Touchstone" }),
+    ]);
+    expect(c.autoClass).toBe("direct");
+  });
+
+  it("spot when every facility is a one-off", () => {
+    const c = cardFor([
+      load({ shipper_name: "S1", receiver_name: "R1" }),
+      load({ shipper_name: "S2", receiver_name: "R2" }),
+    ]);
+    expect(c.autoClass).toBe("spot");
+    expect(c.repeatCustomers).toEqual([]);
+  });
+
+  it("ignores cancelled loads for the repeat count", () => {
+    const c = cardFor([
+      load({ shipper_name: "Acme", receiver_name: "R1" }),
+      load({ shipper_name: "Acme", receiver_name: "R2", load_status: "cancelled" }),
+    ]);
+    expect(c.autoClass).toBe("spot");
+  });
+
+  it("effectiveAgentClass: a pin overrides the auto class", () => {
+    const c = cardFor([
+      load({ shipper_name: "Acme", receiver_name: "R1" }),
+      load({ shipper_name: "Acme", receiver_name: "R2" }),
+    ]); // auto = direct
+    const pinned = { ...agent("a", null), agent_class: "spot" as const };
+    expect(effectiveAgentClass(pinned, c)).toEqual({ bucket: "spot", source: "pinned" });
+    expect(effectiveAgentClass(agent("a", null), c)).toEqual({ bucket: "direct", source: "auto" });
+  });
+});
 
 describe("classifySpecialty", () => {
   it("labels oversize when oversize/heavy-haul is the majority (2+)", () => {

--- a/frontend/src/lib/metrics/agentScorecard.ts
+++ b/frontend/src/lib/metrics/agentScorecard.ts
@@ -49,6 +49,14 @@ export type Trend = "up" | "down" | "flat";
 export type GoToTier = "call-first" | "solid" | "watch" | "cold" | "thin";
 export type RatingFlag = "under" | "over"; // your star rating disagrees with the data
 
+// Relationship bucket. An agent you've hit the same shipper OR receiver 2+ times
+// through is a direct customer (their own account); otherwise spot market.
+export type AgentClass = "direct" | "spot";
+export interface RepeatCustomer {
+  facility: string; // original-cased shipper/receiver name
+  count: number; // loads touching it (either role)
+}
+
 export interface AgentScorecard {
   agentId: string;
   loadCount: number; // delivered
@@ -61,6 +69,8 @@ export interface AgentScorecard {
   collectedLoads: number; // detentionCollected
   collectRate: number | null; // collected ÷ (owed + collected), null if none confirmed
   specialty: SpecialtyMix;
+  autoClass: AgentClass; // data-derived; overridden by agent.agent_class when pinned
+  repeatCustomers: RepeatCustomer[]; // facilities seen 2+ times, count desc
   tier: GoToTier;
   ratingFlag: RatingFlag | null;
 }
@@ -114,6 +124,25 @@ const rawScorecard = (
   const collectedLoads = delivered.filter((l) => detentionCollected(l)).length;
   const confirmed = moneyLostLoads + collectedLoads;
 
+  // Relationship bucket: a shipper OR receiver hit 2+ times through this agent is
+  // their own customer. Counts non-cancelled loads (a booked repeat still counts).
+  const facCount = new Map<string, { display: string; count: number }>();
+  for (const l of loads) {
+    if (l.load_status === "cancelled") continue;
+    for (const nm of [l.shipper_name, l.receiver_name]) {
+      const raw = String(nm ?? "").trim();
+      if (!raw) continue;
+      const key = raw.toUpperCase();
+      const cur = facCount.get(key);
+      if (cur) cur.count += 1;
+      else facCount.set(key, { display: raw, count: 1 });
+    }
+  }
+  const repeatCustomers = [...facCount.values()]
+    .filter((v) => v.count >= 2)
+    .map((v) => ({ facility: v.display, count: v.count }))
+    .sort((a, b) => b.count - a.count);
+
   return {
     agentId,
     loadCount: delivered.length,
@@ -126,6 +155,8 @@ const rawScorecard = (
     collectedLoads,
     collectRate: confirmed > 0 ? collectedLoads / confirmed : null,
     specialty: classifySpecialty(delivered),
+    autoClass: repeatCustomers.length > 0 ? "direct" : "spot",
+    repeatCustomers,
   };
 };
 
@@ -218,6 +249,18 @@ export const buildAgentScorecards = (
     });
   }
   return out;
+};
+
+// The effective bucket for an agent: the owner's pin wins; otherwise the
+// data-derived class from the scorecard.
+export const effectiveAgentClass = (
+  agent: Agent,
+  card: AgentScorecard | undefined,
+): { bucket: AgentClass; source: "pinned" | "auto" } => {
+  if (agent.agent_class === "direct" || agent.agent_class === "spot") {
+    return { bucket: agent.agent_class, source: "pinned" };
+  }
+  return { bucket: card?.autoClass ?? "spot", source: "auto" };
 };
 
 // ---- roster-level analytics for the KPI row ----

--- a/frontend/src/lib/metrics/agentScorecard.ts
+++ b/frontend/src/lib/metrics/agentScorecard.ts
@@ -129,10 +129,13 @@ const rawScorecard = (
   const facCount = new Map<string, { display: string; count: number }>();
   for (const l of loads) {
     if (l.load_status === "cancelled") continue;
+    const seenThisLoad = new Set<string>();
     for (const nm of [l.shipper_name, l.receiver_name]) {
       const raw = String(nm ?? "").trim();
       if (!raw) continue;
       const key = raw.toUpperCase();
+      if (seenThisLoad.has(key)) continue; // one load can't make a facility a repeat
+      seenThisLoad.add(key);
       const cur = facCount.get(key);
       if (cur) cur.count += 1;
       else facCount.set(key, { display: raw, count: 1 });

--- a/frontend/src/lib/metrics/foreman.test.ts
+++ b/frontend/src/lib/metrics/foreman.test.ts
@@ -214,6 +214,26 @@ describe("buildForemanBoard — ranking", () => {
   });
 });
 
+describe("buildForemanBoard — direct customers rank above spot", () => {
+  it("a far direct agent (repeat shipper) outranks a closer spot agent", () => {
+    seq = 0;
+    const agents = [mkAgent("dir", "Direct"), mkAgent("spt", "Spot")];
+    const loads: Load[] = [
+      // spot's booked load sets the anchor (Macedonia OH); spot is close (Akron).
+      mkLoad({ agent_id: "spt", load_status: "booked", origin_city: "Akron", origin_state: "OH", destination_city: "Macedonia", destination_state: "OH", pickup_date: "2026-08-17", delivery_date: "2026-08-19" }),
+      mkLoad({ agent_id: "spt", shipper_name: "OneOff", origin_city: "Akron", origin_state: "OH", delivery_date: "2026-08-03" }),
+      // direct: same shipper twice, but FAR (Columbus ~122 mi).
+      mkLoad({ agent_id: "dir", shipper_name: "Acme", origin_city: "Columbus", origin_state: "OH", delivery_date: "2026-08-01" }),
+      mkLoad({ agent_id: "dir", shipper_name: "Acme", origin_city: "Columbus", origin_state: "OH", delivery_date: "2026-08-05" }),
+    ];
+    const board = buildForemanBoard(loads, agents, COORDS, { now: NOW });
+    const ids = board.rankings.map((r) => r.agentId);
+    expect(ids.indexOf("dir")).toBeLessThan(ids.indexOf("spt"));
+    expect(board.rankings.find((r) => r.agentId === "dir")?.bucket).toBe("direct");
+    expect(board.rankings.find((r) => r.agentId === "spt")?.bucket).toBe("spot");
+  });
+});
+
 describe("buildForemanBoard — rate benchmark (per-type median, loaded basis)", () => {
   it("benchmarks each agent against your realized median gross/loaded for that type", () => {
     const { agents, loads } = buildWorld();

--- a/frontend/src/lib/metrics/foreman.ts
+++ b/frontend/src/lib/metrics/foreman.ts
@@ -18,8 +18,10 @@ import { loadRevenue } from "./loads"; // GROSS per load
 import { median } from "./stats";
 import {
   buildAgentScorecards,
+  effectiveAgentClass,
   MIN_SCORE_LOADS,
   type AgentScorecard,
+  type AgentClass,
   type GoToTier,
 } from "./agentScorecard";
 import { getRegion, getMacro } from "@/lib/constants/states";
@@ -205,6 +207,7 @@ export interface AgentRanking {
   daysSince: number | null;
   dwellLoads: number; // confirmed-billable detention left unpaid
   tier: GoToTier;
+  bucket: AgentClass; // direct customer vs spot — direct always ranks first
   isNew: boolean; // < MIN_SCORE_LOADS delivered → "New · building"
   // scoring
   score: number;
@@ -314,6 +317,7 @@ export const buildForemanBoard = (
   const scorecards = buildAgentScorecards(agents, loads, now);
   const origins = agentOrigins(loads);
   const nameById = new Map(agents.map((a) => [a.agent_id, agentName(a)]));
+  const agentById = new Map(agents.map((a) => [a.agent_id, a]));
 
   // one benchmark cache per type (identical across agents)
   const benchCache = new Map<LoadType, number | null>();
@@ -387,6 +391,7 @@ export const buildForemanBoard = (
       daysSince: card.daysSince,
       dwellLoads: card.moneyLostLoads,
       tier: card.tier,
+      bucket: effectiveAgentClass(agentById.get(agentId)!, card).bucket,
       isNew: card.loadCount < MIN_SCORE_LOADS,
       score: 0,
       why: "",
@@ -410,7 +415,15 @@ export const buildForemanBoard = (
     }
   }
 
-  rankings.sort((a, b) => b.score - a.score || (a.distanceMiles ?? 1e9) - (b.distanceMiles ?? 1e9));
+  // Direct customers always rank above spot agents; the score orders within each
+  // bucket (a closer spot agent never outranks a direct customer).
+  const bucketRank = (b: AgentClass) => (b === "direct" ? 0 : 1);
+  rankings.sort(
+    (a, b) =>
+      bucketRank(a.bucket) - bucketRank(b.bucket) ||
+      b.score - a.score ||
+      (a.distanceMiles ?? 1e9) - (b.distanceMiles ?? 1e9),
+  );
   if (anchor) for (const r of rankings) r.why = whyLine(r, anchor);
 
   return {

--- a/frontend/src/lib/metrics/marketFactor.test.ts
+++ b/frontend/src/lib/metrics/marketFactor.test.ts
@@ -109,6 +109,8 @@ describe("theCall", () => {
     collectedLoads: 0,
     collectRate: null,
     specialty: { tag: "standard", oversizeShare: 0, specialtyShare: 0, oversizeCount: 0 },
+    autoClass: "spot",
+    repeatCustomers: [],
     tier: "solid",
     ratingFlag: null,
   };

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { useAgents } from "@/hooks/useAgents";
 import { useLoads } from "@/hooks/useLoads";
+import { patchAgent } from "@/services/patchAgentService";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { AgentCard } from "@/components/agents/AgentCard";
 import { AgentTable } from "@/components/agents/AgentTable";
@@ -25,8 +26,21 @@ type Filter = "all" | "oversize" | "specialty" | "standard" | "call-first" | "co
 const plural = (n: number) => (n !== 1 ? "s" : "");
 
 const AgentsPage = () => {
-  const { agents, isLoading, error } = useAgents();
+  const [refreshKey, setRefreshKey] = useState(0);
+  const { agents, isLoading, error } = useAgents(refreshKey);
   const { loads, isLoading: loadsLoading } = useLoads(0);
+
+  const setAgentClass = async (
+    agent_id: string,
+    value: "direct" | "spot" | null,
+  ) => {
+    try {
+      await patchAgent(agent_id, { agent_class: value });
+      setRefreshKey((k) => k + 1);
+    } catch {
+      // swallow — the badge just stays put; the owner can retry
+    }
+  };
 
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<Filter>("all");
@@ -215,6 +229,7 @@ const AgentsPage = () => {
               live={standings.get(agent.agent_id)}
               card={card}
               carrierName={carrierName}
+              onSetClass={(value) => setAgentClass(agent.agent_id, value)}
             />
           ))}
         </div>

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -609,6 +609,21 @@ const GuidePage = () => {
             </p>
 
             <p className="text-sm font-condensed mb-1" style={{ color: AMBER_HI }}>
+              Direct customers come first
+            </p>
+            <p className="text-sm text-muted-text mb-3">
+              Agents split into two buckets:{" "}
+              <span className="text-light">Direct</span> customers — an agent you've
+              hit the same shipper or receiver 2+ times through (their own account,
+              worth a relationship) — and <span className="text-light">Spot</span>{" "}
+              market agents (load-board one-offs). Every direct customer ranks above
+              every spot agent: a closer spot agent never outranks a direct
+              customer, but it still shows below for a quick one-off when nothing
+              direct fits. The bucket auto-updates as loads come in; you can pin an
+              agent either way on the Agents page.
+            </p>
+
+            <p className="text-sm font-condensed mb-1" style={{ color: AMBER_HI }}>
               Where you'll be empty next
             </p>
             <p className="text-sm text-muted-text mb-3">

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -9,6 +9,8 @@ export interface Agent {
   preferred_contact: string;
   rating?: number | null;
   notes?: string | null;
+  // Manual relationship-bucket override. null/absent = auto (derived from loads).
+  agent_class?: "direct" | "spot" | null;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/types/agentPatchPayload.ts
+++ b/frontend/src/types/agentPatchPayload.ts
@@ -7,6 +7,7 @@ export interface AgentPatchPayload {
   preferred_contact?: string;
   rating?: number | null;
   notes?: string | null;
+  agent_class?: "direct" | "spot" | null; // null clears the override back to auto
   reason?: string; // only when rating changes
   changed_by?: string; // only when rating changes
 }


### PR DESCRIPTION
## What
Split agents into **Direct customers** (they own the shipper/receiver — worth a relationship) vs **Spot market** (load-board one-offs), and prioritize the direct ones on the Foreman.

- **Auto-class** (`agentScorecard`): an agent you've hit the same shipper **or** receiver 2+ times through = Direct; else Spot. Self-updating as loads come in; `repeatCustomers` surfaced for display. `effectiveAgentClass` = the owner's pin, else the derived class.
- **Manual override** (migration 058): nullable `agents.agent_class` with a CHECK for `direct`/`spot`; `getAgents`/`getAgent` return it, create/patch accept it, `null` clears back to auto. Applied to dev + prod.
- **Agents page:** a Direct/Spot badge (with `auto`/`pinned` source) + an `Auto · Direct · Spot` segmented override on the card.
- **Foreman:** every direct customer ranks above every spot agent (a closer spot agent never outranks a direct customer); two-tier board — "Direct customers" / "Spot market".
- Guide updated.

## Validated on live prod
The heuristic cleanly buckets your roster — **6 direct agents**, with the receiver signal catching a real Touchstone ⇄ Fujifilm round-trip lane the shipper-only view missed.

## Verification
- 599 tests (+6 classification, +1 Foreman direct-first) + strict build + backend syntax — all green.
- Design mockup approved before building the UI. Adversarial review of the wiring in progress before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)