### PR TITLE
feat(market): rate playbook — per-tier moves off your rungs + FRED trend (v1.180.0)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.179.0",
+  "version": "1.180.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/market/MarketPlaybookCard.tsx
+++ b/frontend/src/components/market/MarketPlaybookCard.tsx
@@ -1,0 +1,125 @@
+import type { MarketPlaybook, TierPlay } from "@/lib/metrics/marketPlaybook";
+import { rpm as fmtRpm } from "@/lib/format";
+
+const ACTION_COLOR: Record<TierPlay["action"], string> = {
+  raise: "#5dcaa5",
+  hold: "#f5b03a",
+  protect: "#f5b03a",
+  "cut-costs": "#e24b4a",
+};
+
+const RUNG_COLOR: Record<string, string> = {
+  strong: "#5dcaa5",
+  target: "#f5b03a",
+  floor: "#8494ab",
+  breakEven: "#e24b4a",
+  you: "#f5b03a",
+};
+
+const RUNG_TAG: Record<string, string> = {
+  floor: "don't chase below",
+  breakEven: "lose money below",
+};
+
+// The ordered ladder for one tier: rungs + your-rate marker, sorted high → low,
+// so you see where you sit rather than decode a floating percentage.
+const TierColumn = ({ play }: { play: TierPlay }) => {
+  // Degraded whenever there are no rungs — no rate read OR no cost basis. The
+  // engine sets `why` to the honest cause; render it, not a lone marker row.
+  if (play.rungs.length === 0 || play.yourRate == null) {
+    return (
+      <div className="p-4">
+        <div className="text-[11px] uppercase tracking-[.10em] text-faint font-condensed mb-1">
+          {play.label}
+        </div>
+        <p className="text-[13px] text-dim">{play.why}</p>
+      </div>
+    );
+  }
+
+  const rows = [
+    ...play.rungs.map((r) => ({ key: r.key, label: r.label, rate: r.rate, you: false })),
+    { key: "you", label: "You're booking", rate: play.yourRate, you: true },
+  ].sort((a, b) => b.rate - a.rate);
+
+  return (
+    <div className="p-4">
+      <div className="text-[11px] uppercase tracking-[.10em] text-faint font-condensed mb-2">
+        {play.label}
+      </div>
+
+      <div className="font-condensed text-[19px] font-semibold leading-tight" style={{ color: ACTION_COLOR[play.action] }}>
+        {play.headline}
+      </div>
+      <p className="text-[12.5px] text-dim mt-1 mb-3 leading-snug">{play.why}</p>
+
+      <div className="flex flex-col gap-1">
+        {rows.map((r) => (
+          <div
+            key={r.key}
+            className="flex items-center justify-between rounded-[7px] px-2.5 py-1.5"
+            style={
+              r.you
+                ? { background: "rgba(232,148,10,.13)", border: "1px solid rgba(232,148,10,.36)" }
+                : undefined
+            }
+          >
+            <span className="text-[12.5px]" style={{ color: RUNG_COLOR[r.key], fontWeight: r.you ? 600 : 400 }}>
+              {r.label}
+              {RUNG_TAG[r.key] && (
+                <span className="text-[9.5px] uppercase tracking-[.06em] text-faint ml-1.5">
+                  {RUNG_TAG[r.key]}
+                </span>
+              )}
+            </span>
+            <span className="font-condensed text-[16px]" style={{ color: r.you ? "#f5b03a" : "#e6ecf7", fontWeight: r.you ? 600 : 400 }}>
+              {fmtRpm(r.rate)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const TREND_META: Record<string, { arrow: string; word: string; color: string; bg: string; border: string }> = {
+  firming: { arrow: "▲", word: "Firming", color: "#5dcaa5", bg: "rgba(93,202,165,.10)", border: "rgba(93,202,165,.32)" },
+  softening: { arrow: "▼", word: "Softening", color: "#f5b03a", bg: "rgba(232,148,10,.10)", border: "rgba(232,148,10,.32)" },
+  flat: { arrow: "▬", word: "Steady", color: "#8494ab", bg: "rgba(132,148,171,.10)", border: "rgba(132,148,171,.28)" },
+};
+// No FRED reading yet — a distinct, honest badge (never a definite "Steady").
+const NO_INDEX_META = { arrow: "—", word: "No index read", color: "#5a6880", bg: "rgba(90,104,123,.10)", border: "rgba(90,104,123,.26)" };
+
+const readLine = (pb: MarketPlaybook): string => {
+  const pct = pb.pctChange != null ? `${Math.round(Math.abs(pb.pctChange) * 100)}% / 3 mo` : "";
+  if (pb.direction === "firming")
+    return `The freight index is firming (+${pct}) and your rates tend to lag it — here's how far to push per tier.`;
+  if (pb.direction === "softening")
+    return `The freight index has turned down (−${pct}) and your rates usually follow — here's the move per tier.`;
+  if (pb.direction === "flat")
+    return `The freight index is steady — here's where you sit against your rungs per tier.`;
+  return `Not enough index history yet — showing where you sit against your rungs.`;
+};
+
+export const MarketPlaybookCard = ({ playbook }: { playbook: MarketPlaybook }) => {
+  const t = playbook.direction ? (TREND_META[playbook.direction] ?? TREND_META.flat) : NO_INDEX_META;
+  return (
+    <div className="ds2-board overflow-hidden">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-hairline">
+        <span className="font-condensed text-[18px] font-semibold text-ink">Market playbook</span>
+        <span
+          className="ml-auto flex items-center gap-1.5 text-[12.5px] rounded-lg px-2.5 py-1"
+          style={{ color: t.color, background: t.bg, border: `1px solid ${t.border}` }}
+        >
+          <span>{t.arrow}</span> {t.word}
+        </span>
+      </div>
+      <div className="px-4 py-3 border-b border-hairline text-[13.5px] text-dim">{readLine(playbook)}</div>
+      <div className="grid grid-cols-1 md:grid-cols-2 md:divide-x divide-hairline">
+        {playbook.tiers.map((play) => (
+          <TierColumn key={play.key} play={play} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/lib/metrics/marketPlaybook.test.ts
+++ b/frontend/src/lib/metrics/marketPlaybook.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import type { RateLadder } from "./rateTargets";
+import { buildTierPlay } from "./marketPlaybook";
+
+// break-even 4.34, floor 4.75, target 5.60, strong 6.50 (gross $/driven mile).
+const LADDER: RateLadder = { walkAway: 4.34, minimum: 4.75, target: 5.6, strong: 6.5 };
+const play = (rate: number | null, dir: "firming" | "flat" | "softening" | null) =>
+  buildTierPlay("standard", "Standard", LADDER, rate, dir);
+
+describe("buildTierPlay — firming market", () => {
+  it("raises toward strong when below it", () => {
+    const p = play(5.2, "firming");
+    expect(p.action).toBe("raise");
+    expect(p.recommendedRate).toBe(6.5);
+    expect(p.movePct).toBeCloseTo(0.25, 2);
+    expect(p.headline).toBe("Raise +25%");
+  });
+
+  it("says push the ceiling when already at/above strong", () => {
+    const p = play(6.6, "firming");
+    expect(p.action).toBe("raise");
+    expect(p.headline).toMatch(/ceiling/i);
+    expect(p.movePct).toBeNull();
+  });
+});
+
+describe("buildTierPlay — softening market", () => {
+  it("protects the floor with room shown when above it", () => {
+    const p = play(5.2, "softening");
+    expect(p.action).toBe("protect");
+    expect(p.headline).toMatch(/9% cushion to floor/);
+    expect(p.recommendedRate).toBeNull();
+  });
+
+  it("holds the line when already at/below floor (still above break-even)", () => {
+    const p = play(4.6, "softening");
+    expect(p.action).toBe("protect");
+    expect(p.headline).toMatch(/floor/i);
+  });
+});
+
+describe("buildTierPlay — below break-even beats direction", () => {
+  it("cut-costs when under break-even, whatever the market's doing", () => {
+    for (const dir of ["firming", "flat", "softening"] as const) {
+      const p = play(4.2, dir);
+      expect(p.action).toBe("cut-costs");
+      expect(p.headline).toBe("Cut costs");
+      expect(p.underwaterPerMile).toBeCloseTo(0.14, 5);
+    }
+  });
+});
+
+describe("buildTierPlay — flat market", () => {
+  it("nudges up to target when under it", () => {
+    const p = play(5.2, "flat");
+    expect(p.action).toBe("raise");
+    expect(p.recommendedRate).toBe(5.6);
+    expect(p.headline).toMatch(/\+8%/);
+  });
+
+  it("holds at/above target", () => {
+    const p = play(5.8, "flat");
+    expect(p.action).toBe("hold");
+    expect(p.headline).toBe("Hold");
+  });
+});
+
+describe("buildTierPlay — no index reading (null direction)", () => {
+  it("holds to your targets without fabricating a market call", () => {
+    const p = play(5.2, null);
+    expect(p.action).toBe("hold");
+    expect(p.headline).toBe("Hold to your targets");
+    expect(p.movePct).toBeNull();
+    expect(p.recommendedRate).toBeNull();
+    expect(p.rungs).toHaveLength(4);
+  });
+
+  it("still says cut-costs when underwater even with no index", () => {
+    const p = play(4.2, null);
+    expect(p.action).toBe("cut-costs");
+  });
+});
+
+describe("buildTierPlay — degraded causes are named honestly", () => {
+  it("reports no rate read when there are no loads", () => {
+    const p = play(null, "flat");
+    expect(p.rungs).toEqual([]);
+    expect(p.why).toMatch(/loads in range/i);
+  });
+
+  it("reports missing cost basis (not rate history) when the ladder is null but a rate exists", () => {
+    const noLadder = { walkAway: null, minimum: null, target: null, strong: null };
+    const p = buildTierPlay("standard", "Standard", noLadder, 5.2, "flat");
+    expect(p.rungs).toEqual([]);
+    expect(p.yourRate).toBe(5.2);
+    expect(p.why).toMatch(/cost basis/i);
+  });
+});
+
+describe("buildTierPlay — rungs + guards", () => {
+  it("computes signed deltas to each rung from your rate", () => {
+    const p = play(5.2, "flat");
+    const strong = p.rungs.find((r) => r.key === "strong")!;
+    const be = p.rungs.find((r) => r.key === "breakEven")!;
+    expect(strong.deltaPct).toBeCloseTo((6.5 - 5.2) / 5.2, 4);
+    expect(be.deltaPct).toBeCloseTo((4.34 - 5.2) / 5.2, 4);
+  });
+
+  it("degrades to an empty hold when rate history is missing", () => {
+    const p = play(null, "softening");
+    expect(p.action).toBe("hold");
+    expect(p.rungs).toEqual([]);
+    expect(p.headline).toBe("—");
+  });
+});

--- a/frontend/src/lib/metrics/marketPlaybook.ts
+++ b/frontend/src/lib/metrics/marketPlaybook.ts
@@ -1,0 +1,201 @@
+import type { RateLadder } from "./rateTargets";
+import type { MarketDirection } from "./marketSignal";
+import { windowRates, median, type RatePoint } from "./marketAnalytics";
+
+// The market playbook, per rate tier. Given the market's DIRECTION (from the FRED
+// freight index) and where your recent rate sits against your OWN rungs, it gives
+// the single move to make. There is no external per-mile "market rate" feed —
+// your read is your recent median rate + the index's direction, and your rungs
+// (break-even / floor / target / strong) are the guardrails. Everything is on the
+// same gross-$/driven-mile basis as the barometer and scatter, so nothing is
+// compared across bases. Rate math only — the cost-cut planner is separate.
+
+export type PlaybookAction = "raise" | "hold" | "protect" | "cut-costs";
+
+export interface Rung {
+  key: "strong" | "target" | "floor" | "breakEven";
+  label: string;
+  rate: number; // gross $/driven mile
+  deltaPct: number; // signed % move from your current rate to reach this rung
+}
+
+export interface TierPlay {
+  key: "standard" | "specialized";
+  label: string;
+  yourRate: number | null; // your recent median (gross $/driven mile)
+  rungs: Rung[]; // strong → target → floor → break-even (high to low)
+  action: PlaybookAction;
+  headline: string; // the one clear call, e.g. "Raise +23%"
+  movePct: number | null; // the recommended move (signed); null when hold/protect
+  recommendedRate: number | null; // the rate to aim for
+  why: string;
+  underwaterPerMile: number | null; // action "cut-costs": $/mi below break-even
+}
+
+const signed = (x: number): string => `${x >= 0 ? "+" : ""}${Math.round(x * 100)}%`;
+const absPct = (x: number): string => `${Math.round(Math.abs(x) * 100)}%`;
+const usd = (x: number): string => `$${x.toFixed(2)}`;
+const pctMove = (from: number, to: number): number => (from > 0 ? (to - from) / from : 0);
+
+// One tier's play. Pure: rungs + your recent rate + the index direction in, a
+// single recommendation out.
+export const buildTierPlay = (
+  key: "standard" | "specialized",
+  label: string,
+  ladder: RateLadder,
+  yourRate: number | null,
+  direction: MarketDirection | null,
+): TierPlay => {
+  const be = ladder.walkAway;
+  const floor = ladder.minimum;
+  const target = ladder.target;
+  const strong = ladder.strong;
+
+  const base: TierPlay = {
+    key,
+    label,
+    yourRate,
+    rungs: [],
+    action: "hold",
+    headline: "—",
+    movePct: null,
+    recommendedRate: null,
+    why: "Not enough data for this tier yet.",
+    underwaterPerMile: null,
+  };
+  // Two distinct degraded causes — name each honestly instead of blaming
+  // "rate history" for both. The card shows `why` whenever rungs is empty.
+  if (yourRate == null || yourRate <= 0) {
+    return { ...base, why: `No delivered ${label.toLowerCase()} loads in range yet to read a rate.` };
+  }
+  if (be == null || floor == null || target == null || strong == null) {
+    return {
+      ...base,
+      why: `You've got a rate read (${usd(yourRate)}), but no cost basis yet — add a P&L month so your rungs can be placed.`,
+    };
+  }
+
+  const rungs: Rung[] = [
+    { key: "strong", label: "Strong", rate: strong, deltaPct: pctMove(yourRate, strong) },
+    { key: "target", label: "Target", rate: target, deltaPct: pctMove(yourRate, target) },
+    { key: "floor", label: "Floor", rate: floor, deltaPct: pctMove(yourRate, floor) },
+    { key: "breakEven", label: "Break-even", rate: be, deltaPct: pctMove(yourRate, be) },
+  ];
+  const withRungs = { ...base, rungs };
+
+  // Below break-even beats every direction — you're losing money on every mile.
+  if (yourRate < be) {
+    return {
+      ...withRungs,
+      action: "cut-costs",
+      headline: "Cut costs",
+      why: `You're booking below break-even (${usd(be)}). Holding rate means sitting; booking means losing money — cut costs or take home time, don't chase the load.`,
+      underwaterPerMile: be - yourRate,
+    };
+  }
+
+  // No index reading (FRED down, or the transient state before the async fetch
+  // resolves): don't fabricate a market call. Show where you sit, hold to your
+  // own targets. Below-break-even was already handled above and still wins.
+  if (direction == null) {
+    return {
+      ...withRungs,
+      action: "hold",
+      headline: "Hold to your targets",
+      why: `No freight-index read to lean on right now. Here's where your rate sits against your rungs — book to your own targets (${usd(target)}+), don't chase a market you can't see.`,
+    };
+  }
+
+  if (direction === "firming") {
+    if (yourRate >= strong) {
+      return {
+        ...withRungs,
+        action: "raise",
+        headline: "Push the ceiling",
+        why: `The market's firming and you're already at your strong rung (${usd(strong)}). Raise the ceiling — quote higher and hold firm. This is when a hot market pays.`,
+        recommendedRate: strong,
+      };
+    }
+    const move = pctMove(yourRate, strong);
+    return {
+      ...withRungs,
+      action: "raise",
+      headline: `Raise ${signed(move)}`,
+      why: `The market's firming — push toward your strong rung (${usd(strong)}). Sitting at ${usd(yourRate)} leaves room on the table.`,
+      movePct: move,
+      recommendedRate: strong,
+    };
+  }
+
+  if (direction === "softening") {
+    if (yourRate <= floor) {
+      return {
+        ...withRungs,
+        action: "protect",
+        headline: "At your floor — hold the line",
+        why: `You're already at your floor (${usd(floor)}). Don't chase lower — break-even is ${usd(be)}. If it drops further, cut costs or sit it out.`,
+        recommendedRate: floor,
+      };
+    }
+    const roomToFloor = pctMove(yourRate, floor); // negative
+    return {
+      ...withRungs,
+      action: "protect",
+      headline: `Hold — ${absPct(roomToFloor)} cushion to floor`,
+      why: `The market's softening. Hold as high as you can; you've got ${absPct(roomToFloor)} of cushion down to your floor (${usd(floor)}) before the edge — don't chase below it.`,
+    };
+  }
+
+  // Flat market.
+  if (yourRate < target) {
+    const move = pctMove(yourRate, target);
+    return {
+      ...withRungs,
+      action: "raise",
+      headline: `Room to push ${signed(move)}`,
+      why: `Steady market and you're under target (${usd(target)}). Room to push ${signed(move)} without fighting the cycle.`,
+      movePct: move,
+      recommendedRate: target,
+    };
+  }
+  return {
+    ...withRungs,
+    action: "hold",
+    headline: "Hold",
+    why: `Steady market and you're at or above target (${usd(target)}). Hold your rate.`,
+  };
+};
+
+export interface MarketPlaybook {
+  direction: MarketDirection | null;
+  pctChange: number | null; // the index's move over the trend window
+  tiers: TierPlay[]; // [standard, specialized]
+}
+
+// The whole playbook: your recent median rate per tier (gross $/driven mile,
+// same basis as the ladders) + the index direction → a play per tier. Standard =
+// the "standard" bucket; Specialized folds in specialized + hazmat.
+export const buildMarketPlaybook = (
+  points: RatePoint[],
+  stdLadder: RateLadder,
+  specLadder: RateLadder,
+  trend: { direction: MarketDirection; pctChange: number } | null,
+  now: Date,
+  windowDays = 90,
+): MarketPlaybook => {
+  const stdRate = median(
+    windowRates(points.filter((p) => p.bucket === "standard"), now, windowDays),
+  );
+  const specRate = median(
+    windowRates(points.filter((p) => p.bucket !== "standard"), now, windowDays),
+  );
+  const dir = trend?.direction ?? null;
+  return {
+    direction: dir,
+    pctChange: trend?.pctChange ?? null,
+    tiers: [
+      buildTierPlay("standard", "Standard flatbed", stdLadder, stdRate, dir),
+      buildTierPlay("specialized", "Specialized / oversize", specLadder, specRate, dir),
+    ],
+  };
+};

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -950,6 +950,42 @@ const GuidePage = () => {
           </Metric>
 
           <Metric
+            title="Market playbook — the move to make"
+            answers="Reads which way the freight index is turning and where your recent rate sits against your own rungs, then gives one clear call per tier — raise, hold, protect, or cut costs."
+            sources={[{ label: "Market", to: "/market" }]}
+          >
+            <Why>
+              There's no national oversize spot price to book against, so the
+              playbook doesn't invent one. It reads two things you already trust:
+              which way the{" "}
+              <span className="text-light">FRED freight index</span> is pointing
+              (firming, steady, or softening) and where your own{" "}
+              <span className="text-light">recent median rate</span> sits against
+              your rungs — break-even, floor, target, strong. From those it gives
+              one move per tier instead of a wall of numbers.
+            </Why>
+            <Why>
+              Firming and you're under your strong rung →{" "}
+              <span className="text-light">Raise</span>, with the percent to get
+              there. Steady and under target → room to push. Softening →{" "}
+              <span className="text-light">Hold and protect your floor</span>,
+              showing how much cushion you've got before the edge. And if a tier
+              has slipped below break-even it stops being a rate question —{" "}
+              <span className="text-light">Cut costs</span>, because booking there
+              loses money on every mile.
+            </Why>
+            <Why>
+              Each tier lists its rungs high to low with a{" "}
+              <span className="text-light">You're booking</span> marker dropped in
+              where your rate lands, so the call is something you can see, not
+              decode. Standard flatbed and specialized / oversize each get their
+              own read off their own ladder. It rides the top of the Market page,
+              and — like the barometer and gauge — everything is your gross rate
+              per driven mile, so nothing's compared across bases.
+            </Why>
+          </Metric>
+
+          <Metric
             title="Market suggestions — the right market on load entry"
             answers="As you enter a load, the market field suggests the market you've used before for that shipper/receiver or city — so the same place never gets tagged two different ways."
             sources={[{ label: "Loads", to: "/loads" }]}

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -23,6 +23,8 @@ import {
   type RatePoint,
 } from "@/lib/metrics/marketAnalytics";
 import { marketTrend, youVsMarket } from "@/lib/metrics/marketSignal";
+import { buildMarketPlaybook } from "@/lib/metrics/marketPlaybook";
+import { MarketPlaybookCard } from "@/components/market/MarketPlaybookCard";
 import { rpm } from "@/lib/format";
 
 const MACRO = "#4f8cd6"; // FRED PPI overlay line — the house chart blue
@@ -251,6 +253,11 @@ const MarketPage = () => {
     [points, targets.bookingLadder, targets.specLadder, now, trend],
   );
 
+  const playbook = useMemo(
+    () => buildMarketPlaybook(points, targets.bookingLadder, targets.specLadder, trend, now),
+    [points, targets.bookingLadder, targets.specLadder, trend, now],
+  );
+
   const toneColor =
     gauge.tone === "hot" ? "#4ade80" : gauge.tone === "soft" ? "#f87171" : "#e0a020";
 
@@ -307,6 +314,11 @@ const MarketPage = () => {
           <span className="font-condensed font-medium text-[15px] text-dim">
             the freight market, and where you stand in it
           </span>
+        </div>
+
+        {/* the playbook — the one clear move per tier, given the trend */}
+        <div className="mt-4">
+          <MarketPlaybookCard playbook={playbook} />
         </div>
 
         {/* the verdict */}


### PR DESCRIPTION
## What

A **Market playbook** card at the top of `/market`. When the market turns — softening or firming — it stops at "hold or lower" no longer: it gives **one clear call per tier**, keyed to your own rungs, with the percentage move spelled out.

- Reads the **FRED freight-index direction** (firming / steady / softening) + where your **recent median rate** sits against your **own rungs** (break-even / floor / target / strong).
- Prints one move per tier: **Raise +%**, **Room to push +%**, **Hold**, **Hold — % cushion to floor**, or **Cut costs** (when a tier slips under break-even).
- Shows an **ordered ladder** high→low with a **"You're booking"** marker where your rate lands.
- **Standard flatbed** and **specialized / oversize** each read off their own ladder.
- Bidirectional: soft-market protection *and* strong-market "you're pricing too cheap, raise."

## Basis / honesty

- No external per-mile market feed exists (SONAR/FDW shelved). The read is **your own recent median + the index direction**; your rungs are the guardrails.
- Everything is **gross $/driven mile** — same basis as the barometer and tier gauge (`bookingLadder`/`specLadder` from `useRateTargets`), so nothing is compared across bases.
- Degraded states are honest: no FRED read → neutral **"No index read"** badge + "hold to your targets" (never a fabricated push); a rate with no cost basis → "add a P&L month" (not "no rate history").

## Verification

- Pure engine, **13 unit tests**; full suite **613 pass**; strict production build clean.
- Verified against the real app code path on live dev data and standalone renders of the actual component (soft / firm / underwater / no-index / no-basis).
- Adversarial multi-agent review: 2 confirmed findings (both degraded-state contradictions) fixed and re-verified.
- Guide updated ("Market playbook — the move to make").

## Follow-up

Phase B — the intelligent cost-cut planner (overspend-vs-baseline + necessity tiers, balanced to the gap) + per-category cuttability override — lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)