### PR TITLE
fix(market): playbook cut-costs is a business-level call, not a single tier (v1.180.1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.180.0",
+  "version": "1.180.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/market/MarketPlaybookCard.tsx
+++ b/frontend/src/components/market/MarketPlaybookCard.tsx
@@ -5,6 +5,7 @@ const ACTION_COLOR: Record<TierPlay["action"], string> = {
   raise: "#5dcaa5",
   hold: "#f5b03a",
   protect: "#f5b03a",
+  "under-floor": "#e8940a", // caution — below cost floor, but not a loss
   "cut-costs": "#e24b4a",
 };
 

--- a/frontend/src/lib/metrics/marketPlaybook.test.ts
+++ b/frontend/src/lib/metrics/marketPlaybook.test.ts
@@ -4,8 +4,11 @@ import { buildTierPlay } from "./marketPlaybook";
 
 // break-even 4.34, floor 4.75, target 5.60, strong 6.50 (gross $/driven mile).
 const LADDER: RateLadder = { walkAway: 4.34, minimum: 4.75, target: 5.6, strong: 6.5 };
-const play = (rate: number | null, dir: "firming" | "flat" | "softening" | null) =>
-  buildTierPlay("standard", "Standard", LADDER, rate, dir);
+const play = (
+  rate: number | null,
+  dir: "firming" | "flat" | "softening" | null,
+  businessUnderwater = false,
+) => buildTierPlay("standard", "Standard", LADDER, rate, dir, businessUnderwater);
 
 describe("buildTierPlay — firming market", () => {
   it("raises toward strong when below it", () => {
@@ -39,10 +42,24 @@ describe("buildTierPlay — softening market", () => {
   });
 });
 
-describe("buildTierPlay — below break-even beats direction", () => {
-  it("cut-costs when under break-even, whatever the market's doing", () => {
-    for (const dir of ["firming", "flat", "softening"] as const) {
-      const p = play(4.2, dir);
+describe("buildTierPlay — a tier under break-even, business still profitable", () => {
+  it("flags 'below cost floor' (subsidized), NOT cut-costs, whatever the market's doing", () => {
+    for (const dir of ["firming", "flat", "softening", null] as const) {
+      const p = play(4.2, dir); // businessUnderwater defaults false
+      expect(p.action).toBe("under-floor");
+      expect(p.headline).toBe("Below your cost floor");
+      expect(p.why).not.toMatch(/cut costs/i);
+      expect(p.why).toMatch(/not losing you money/i); // reassure, don't alarm
+      expect(p.recommendedRate).toBe(4.75); // lift toward the floor
+      expect(p.underwaterPerMile).toBeCloseTo(0.14, 5);
+    }
+  });
+});
+
+describe("buildTierPlay — whole operation under break-even", () => {
+  it("cut-costs when the business itself is underwater, whatever the market's doing", () => {
+    for (const dir of ["firming", "flat", "softening", null] as const) {
+      const p = play(4.2, dir, true);
       expect(p.action).toBe("cut-costs");
       expect(p.headline).toBe("Cut costs");
       expect(p.underwaterPerMile).toBeCloseTo(0.14, 5);
@@ -75,9 +92,9 @@ describe("buildTierPlay — no index reading (null direction)", () => {
     expect(p.rungs).toHaveLength(4);
   });
 
-  it("still says cut-costs when underwater even with no index", () => {
+  it("still flags below-cost-floor when under break-even with no index (business healthy)", () => {
     const p = play(4.2, null);
-    expect(p.action).toBe("cut-costs");
+    expect(p.action).toBe("under-floor");
   });
 });
 

--- a/frontend/src/lib/metrics/marketPlaybook.ts
+++ b/frontend/src/lib/metrics/marketPlaybook.ts
@@ -10,7 +10,11 @@ import { windowRates, median, type RatePoint } from "./marketAnalytics";
 // same gross-$/driven-mile basis as the barometer and scatter, so nothing is
 // compared across bases. Rate math only — the cost-cut planner is separate.
 
-export type PlaybookAction = "raise" | "hold" | "protect" | "cut-costs";
+// "under-floor" = this tier books below your break-even, but the BUSINESS is
+// still profitable (a cheap tier carried by richer freight) — a raise/mix nudge,
+// not the "you're losing money" alarm. "cut-costs" is reserved for when the whole
+// operation is under break-even.
+export type PlaybookAction = "raise" | "hold" | "protect" | "under-floor" | "cut-costs";
 
 export interface Rung {
   key: "strong" | "target" | "floor" | "breakEven";
@@ -45,6 +49,7 @@ export const buildTierPlay = (
   ladder: RateLadder,
   yourRate: number | null,
   direction: MarketDirection | null,
+  businessUnderwater = false,
 ): TierPlay => {
   const be = ladder.walkAway;
   const floor = ladder.minimum;
@@ -83,13 +88,28 @@ export const buildTierPlay = (
   ];
   const withRungs = { ...base, rungs };
 
-  // Below break-even beats every direction — you're losing money on every mile.
+  // Below break-even beats every market direction. But WHAT it means depends on
+  // the whole operation: a single cheap tier under the blended floor (while the
+  // business is profitable) is subsidized freight, not a loss — don't cry "cut
+  // costs." Only when the whole operation is under break-even is cutting costs the
+  // right lever.
   if (yourRate < be) {
+    if (businessUnderwater) {
+      return {
+        ...withRungs,
+        action: "cut-costs",
+        headline: "Cut costs",
+        why: `Your whole operation is booking below break-even (${usd(be)}) — you're losing money on the miles. Cut costs or take home time; don't chase loads at this rate.`,
+        underwaterPerMile: be - yourRate,
+      };
+    }
     return {
       ...withRungs,
-      action: "cut-costs",
-      headline: "Cut costs",
-      why: `You're booking below break-even (${usd(be)}). Holding rate means sitting; booking means losing money — cut costs or take home time, don't chase the load.`,
+      action: "under-floor",
+      headline: "Below your cost floor",
+      why: `Your ${label.toLowerCase()} median (${usd(yourRate)}) runs under your break-even (${usd(be)}) — these loads lean on your better-paying freight, they're not losing you money. Lift this tier toward ${usd(floor)}+ or fill the miles with richer freight; just don't chase them lower.`,
+      movePct: pctMove(yourRate, floor),
+      recommendedRate: floor,
       underwaterPerMile: be - yourRate,
     };
   }
@@ -181,6 +201,10 @@ export const buildMarketPlaybook = (
   specLadder: RateLadder,
   trend: { direction: MarketDirection; pctChange: number } | null,
   now: Date,
+  // Is the WHOLE operation booking below break-even? (blended gross/driven mile <
+  // break-even-to-book). Gates the "cut-costs" verdict; a single cheap tier under
+  // the floor while this is false is subsidized freight, not a loss.
+  businessUnderwater = false,
   windowDays = 90,
 ): MarketPlaybook => {
   const stdRate = median(
@@ -194,8 +218,8 @@ export const buildMarketPlaybook = (
     direction: dir,
     pctChange: trend?.pctChange ?? null,
     tiers: [
-      buildTierPlay("standard", "Standard flatbed", stdLadder, stdRate, dir),
-      buildTierPlay("specialized", "Specialized / oversize", specLadder, specRate, dir),
+      buildTierPlay("standard", "Standard flatbed", stdLadder, stdRate, dir, businessUnderwater),
+      buildTierPlay("specialized", "Specialized / oversize", specLadder, specRate, dir, businessUnderwater),
     ],
   };
 };

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -969,10 +969,19 @@ const GuidePage = () => {
               <span className="text-light">Raise</span>, with the percent to get
               there. Steady and under target → room to push. Softening →{" "}
               <span className="text-light">Hold and protect your floor</span>,
-              showing how much cushion you've got before the edge. And if a tier
-              has slipped below break-even it stops being a rate question —{" "}
-              <span className="text-light">Cut costs</span>, because booking there
-              loses money on every mile.
+              showing how much cushion you've got before the edge.
+            </Why>
+            <Why>
+              A tier can sit <span className="text-light">below your cost floor</span>{" "}
+              (break-even) while the business is still very profitable — your cheap
+              standard freight carried by your oversize work. That's flagged as a
+              nudge to lift that tier or fill the miles with richer freight, not an
+              alarm — it isn't losing you money. The{" "}
+              <span className="text-light">Cut costs</span> call is reserved for
+              when your <span className="text-light">whole operation</span> books
+              below break-even (your blended rate across every load can't cover
+              cost after Landstar's cut) — that's when cutting costs, not chasing
+              rate, is the lever.
             </Why>
             <Why>
               Each tier lists its rungs high to low with a{" "}

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -253,9 +253,25 @@ const MarketPage = () => {
     [points, targets.bookingLadder, targets.specLadder, now, trend],
   );
 
+  // Is the WHOLE operation under break-even? Blended gross/driven mile < the
+  // break-even-to-book (walkAway). This — not a single cheap tier — is what
+  // makes "cut costs" the right call. (grossPerTotalMile ≥ walkAway exactly when
+  // booked gross covers cost after your Landstar take.)
+  const businessUnderwater =
+    targets.basis.grossPerTotalMile != null &&
+    targets.bookingLadder.walkAway != null &&
+    targets.basis.grossPerTotalMile < targets.bookingLadder.walkAway;
   const playbook = useMemo(
-    () => buildMarketPlaybook(points, targets.bookingLadder, targets.specLadder, trend, now),
-    [points, targets.bookingLadder, targets.specLadder, trend, now],
+    () =>
+      buildMarketPlaybook(
+        points,
+        targets.bookingLadder,
+        targets.specLadder,
+        trend,
+        now,
+        businessUnderwater,
+      ),
+    [points, targets.bookingLadder, targets.specLadder, trend, now, businessUnderwater],
   );
 
   const toneColor =


### PR DESCRIPTION
## The bug (found on real prod data)

The playbook's **Cut costs** verdict compared **one tier's median rate** against the **fleet-wide** break-even. For a mixed carrier, the cheap tier (standard flatbed) is subsidized by richer freight (oversize), so it sits below the blended floor **even when the business is very profitable** — and the card cried "cut costs, you're losing money."

Verified on real numbers (last 3 complete months):

| | value |
|---|---|
| Break-even to book (`walkAway`) | **$3.91/mi** |
| Standard median (driven) | $3.49 → under the floor |
| Specialized median | $5.71 → healthy |
| **Blended** gross/driven mile | **$4.76 ≥ $3.91** → business above break-even |
| Monthly margin | 20–43% (goal 26%) |

## The fix

- A tier under break-even **while the business is healthy** → new **"Below your cost floor"** action (amber caution): *"these loads lean on your better-paying freight, they're not losing you money — lift toward the floor or fill the miles with richer freight."* A raise/mix nudge, not an alarm.
- **"Cut costs"** fires only when the **whole operation** is underwater — `businessUnderwater = grossPerTotalMile < walkAway` (blended booked gross can't cover cost after the Landstar take). Threaded through `buildMarketPlaybook` → `buildTierPlay`. This is also Phase B's cut-planner trigger.
- Guide corrected; engine + 2 tests (**614 pass**); strict build clean.
- Rendered against real-derived rungs to confirm: standard → "Below your cost floor", specialized → "Room to push +3%", and the underwater counterfactual still fires cut-costs.

## Follow-up

The **Load Scorer** SCRAP grade and the Market scatter break-even line use the same tier-vs-fleet-floor comparison and likely over-penalize standard loads the same way — auditing next (no changes here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)