### PR TITLE
fix(market): window the ladder distribution to the trailing 90 days (v1.180.2)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.180.1",
+  "version": "1.180.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/metrics/marketAnalytics.ts
+++ b/frontend/src/lib/metrics/marketAnalytics.ts
@@ -80,18 +80,24 @@ export const percentileOf = (xs: number[], value: number): number | null => {
   return xs.filter((x) => x <= value).length / xs.length;
 };
 
-// Rates from the trailing `days` window ending at `now` (inclusive of today).
-export const windowRates = (
+// Points from the trailing `days` window ending at `now` (inclusive of today).
+// The one place we define "recent" — everything windowed shares this so the rate,
+// the gauge, and the distribution all read the same slice of time.
+export const windowPoints = (
   points: RatePoint[],
   now: Date,
   days = 90,
-): number[] => {
+): RatePoint[] => {
   const today = now.toISOString().slice(0, 10);
   const cut = new Date(now.getTime() - days * 86400000)
     .toISOString()
     .slice(0, 10);
-  return points.filter((p) => p.date > cut && p.date <= today).map((p) => p.rate);
+  return points.filter((p) => p.date > cut && p.date <= today);
 };
+
+// Rates from the trailing `days` window ending at `now` (inclusive of today).
+export const windowRates = (points: RatePoint[], now: Date, days = 90): number[] =>
+  windowPoints(points, now, days).map((p) => p.rate);
 
 export interface TierGaugeRow {
   label: string;

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -20,6 +20,7 @@ import {
   ratePoints,
   monthlyMedianRate,
   tierGauge,
+  windowPoints,
   type RatePoint,
 } from "@/lib/metrics/marketAnalytics";
 import { marketTrend, youVsMarket } from "@/lib/metrics/marketSignal";
@@ -295,28 +296,31 @@ const MarketPage = () => {
   const yvmColor =
     yvm?.verdict === "beating" ? "#4ade80" : yvm?.verdict === "lagging" ? "#f0b86a" : "#c9d3e0";
 
-  // The ladder as a distribution — where the year's loads actually landed,
-  // in the banded ladder's zones. Same zone colors, same walk-away.
+  // The ladder as a distribution — where your RECENT loads landed, in the banded
+  // ladder's zones. Windowed to the same trailing 90 days as the rate and gauge,
+  // so old loads (booked against an older, lower ladder) don't pile into "below
+  // the floor" against today's break-even. Same zone colors, same walk-away.
   const zones = (() => {
     const L = targets.bookingLadder;
     if (L.walkAway == null || L.minimum == null || L.target == null) return null;
+    const wp = windowPoints(points, now, 90);
     const buckets = { below: 0, floor: 0, mid: 0, past: 0 };
-    for (const pt of points) {
+    for (const pt of wp) {
       if (pt.rate < L.walkAway) buckets.below++;
       else if (pt.rate < L.minimum) buckets.floor++;
       else if (pt.rate < L.target) buckets.mid++;
       else buckets.past++;
     }
-    const stdBelow = points.filter(
+    const stdBelow = wp.filter(
       (pt) => pt.bucket === "standard" && pt.rate < (L.walkAway as number),
     ).length;
-    const stdTotal = points.filter((pt) => pt.bucket === "standard").length;
-    const specBelow = points.filter(
+    const stdTotal = wp.filter((pt) => pt.bucket === "standard").length;
+    const specBelow = wp.filter(
       (pt) => pt.bucket !== "standard" && pt.rate < (L.walkAway as number),
     ).length;
-    const specTotal = points.filter((pt) => pt.bucket !== "standard").length;
+    const specTotal = wp.filter((pt) => pt.bucket !== "standard").length;
     const max = Math.max(1, buckets.below, buckets.floor, buckets.mid, buckets.past);
-    return { ...buckets, max, stdBelow, stdTotal, specBelow, specTotal };
+    return { ...buckets, max, stdBelow, stdTotal, specBelow, specTotal, total: wp.length };
   })();
 
   const lastMedian = monthly.length > 0 ? monthly[monthly.length - 1].median : null;
@@ -567,7 +571,7 @@ const MarketPage = () => {
                     Where your loads land · the ladder as a distribution
                   </span>
                   <span className="font-condensed text-[12px] text-faint">
-                    · {points.length} measurable loads · zone colors = the banded ladder's
+                    · {zones.total} loads · last 90 days · zone colors = the banded ladder's
                   </span>
                 </div>
                 {[
@@ -595,7 +599,7 @@ const MarketPage = () => {
                       <i className="block h-full" style={{ width: `${(z.v / zones.max) * 100}%`, background: z.bg }} />
                     </span>
                     <span className="w-[120px] text-right text-[13px] text-dim tabular-nums">
-                      {z.v} load{z.v === 1 ? "" : "s"} · {Math.round((z.v / Math.max(1, points.length)) * 100)}%
+                      {z.v} load{z.v === 1 ? "" : "s"} · {Math.round((z.v / Math.max(1, zones.total)) * 100)}%
                     </span>
                   </div>
                 ))}


### PR DESCRIPTION
## What

The Market page's "where your loads land" distribution histogram was the one place still binning **all** delivered loads against **today's** ladder. Because rates rose through the year (specialized $3.68 → $7.87 Q1→Q3), loads booked earlier piled into "below the floor" against the current, higher break-even — exactly the whole-year blur the rest of the page avoids.

## Fix

- Histogram now uses the same **trailing 90-day** window as the rate and tier gauge.
- New shared `windowPoints()` helper in `marketAnalytics.ts`; `windowRates()` now derives from it (behavior unchanged, tests green).
- Header reads "N loads · last 90 days"; zone percentages use the windowed total.

Came out of a seasonality audit — confirmed every rate/break-even number is already a rolling quarter (90 days / 3 complete months), never a 12-month average; this was the lone exception.

614 tests pass · strict build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)