### PR TITLE
feat(market): intelligent cost-cut planner + Settings cut-tiers override (v1.181.0)

### DIFF
--- a/backend/db/migrations/059_cuttability.sql
+++ b/backend/db/migrations/059_cuttability.sql
@@ -1,0 +1,13 @@
+-- 059_cuttability.sql
+-- Per-category cost-cut tier override for the Market page's cut planner.
+-- NULL = the planner auto-classifies the tier from the category name; a value
+-- pins it. Lives on expense_category_defaults (already keyed per user+category).
+-- RLS is already enabled on that table (042); adding a column inherits it.
+
+DO $$ BEGIN
+  CREATE TYPE cut_tier AS ENUM
+    ('off_limits', 'essential', 'discretionary', 'deferrable', 'efficiency', 'last_resort');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE expense_category_defaults
+  ADD COLUMN IF NOT EXISTS cuttability cut_tier;

--- a/backend/src/routes/expenseRoutes.js
+++ b/backend/src/routes/expenseRoutes.js
@@ -6,6 +6,8 @@ import {
   getExpensePeriod,
   getExpenseCategoryRollup,
   getCategoryDefaults,
+  getCutTierData,
+  setCuttability,
   addExpenseLine,
   patchExpenseLine,
   deleteExpenseLine,
@@ -31,6 +33,27 @@ router.get("/defaults", async (req, res) => {
   try {
     const defaults = await getCategoryDefaults(req.user.user_id);
     return res.status(200).json({ defaults });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+// ---- CUT-PLANNER TIER DATA ---- (before "/:period_id" so it isn't matched as one)
+router.get("/cut-tiers", async (req, res) => {
+  try {
+    const categories = await getCutTierData(req.user.user_id);
+    return res.status(200).json({ categories });
+  } catch (err) {
+    return handleError(res, err);
+  }
+});
+
+// ---- SET A CATEGORY'S CUT TIER OVERRIDE (null = auto) ----
+router.put("/cuttability", async (req, res) => {
+  try {
+    const { category, cuttability } = req.body ?? {};
+    await setCuttability(req.user.user_id, category, cuttability ?? null);
+    return res.status(200).json({ ok: true });
   } catch (err) {
     return handleError(res, err);
   }

--- a/backend/src/services/expenseServices.js
+++ b/backend/src/services/expenseServices.js
@@ -183,10 +183,111 @@ export async function getExpenseCategoryRollup(user_id, year) {
 export async function getCategoryDefaults(user_id) {
   if (!user_id) throw new ValidationError("Missing user_id");
   const result = await db.query(
-    `SELECT category, type FROM expense_category_defaults WHERE user_id = $1`,
+    `SELECT category, type, cuttability FROM expense_category_defaults WHERE user_id = $1`,
     [user_id],
   );
   return result.rows;
+}
+
+// The cost-cut tiers the planner + Settings recognize. NULL cuttability = auto.
+export const CUT_TIERS = [
+  "off_limits",
+  "essential",
+  "discretionary",
+  "deferrable",
+  "efficiency",
+  "last_resort",
+];
+
+const monthKey = (v) =>
+  (v instanceof Date ? v.toISOString() : String(v)).slice(0, 10);
+
+// Per-category cost picture for the Market cut planner: the latest month's spend
+// (current) + the trailing monthly average (baseline, over the up-to-6 months
+// before it, treating absent months as $0) + the saved type/cuttability. The
+// planner tiers each category; this just supplies the dollars and the override.
+export async function getCutTierData(user_id) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  const { rows } = await db.query(
+    `SELECT l.category, l.section, p.period_month, SUM(l.amount)::float8 AS amt
+       FROM expense_lines l
+       JOIN expense_periods p ON p.period_id = l.period_id
+      WHERE l.user_id = $1
+      GROUP BY l.category, l.section, p.period_month`,
+    [user_id],
+  );
+  if (rows.length === 0) return [];
+
+  const { rows: defs } = await db.query(
+    `SELECT category, type, cuttability FROM expense_category_defaults WHERE user_id = $1`,
+    [user_id],
+  );
+  const defByCat = new Map(defs.map((d) => [d.category, d]));
+
+  const maxMonth = rows.reduce(
+    (mx, r) => (monthKey(r.period_month) > mx ? monthKey(r.period_month) : mx),
+    "0000-00-00",
+  );
+  const md = new Date(maxMonth);
+  const baseCutoff = new Date(
+    Date.UTC(md.getUTCFullYear(), md.getUTCMonth() - 6, 1),
+  )
+    .toISOString()
+    .slice(0, 10);
+
+  const byCat = new Map();
+  for (const r of rows) {
+    const m = monthKey(r.period_month);
+    const e =
+      byCat.get(r.category) ??
+      { category: r.category, section: r.section, current: 0, baseSum: 0, baseMonths: new Set() };
+    e.section = r.section;
+    if (m === maxMonth) e.current += r.amt;
+    else if (m >= baseCutoff && m < maxMonth) {
+      e.baseSum += r.amt;
+      e.baseMonths.add(m); // PER-CATEGORY: a category new this month has none
+    }
+    byCat.set(r.category, e);
+  }
+
+  return [...byCat.values()]
+    .map((e) => {
+      const def = defByCat.get(e.category);
+      const n = e.baseMonths.size;
+      return {
+        category: e.category,
+        section: e.section,
+        type: def?.type ?? null,
+        cuttability: def?.cuttability ?? null,
+        current: Math.round(e.current),
+        // No baseline history for THIS category → baseline = current, so a brand-new
+        // (or lumpy quarterly) cost isn't mislabeled as "overspend" and cut first.
+        baseline: n > 0 ? Math.round(e.baseSum / n) : Math.round(e.current),
+      };
+    })
+    .sort((a, b) => b.baseline - a.baseline);
+}
+
+// Pin (or clear, with null) a category's cost-cut tier. Upserts onto the
+// per-user default row, inventing a type only if the category has none yet.
+export async function setCuttability(user_id, category, cuttability) {
+  if (!user_id) throw new ValidationError("Missing user_id");
+  if (!category || typeof category !== "string")
+    throw new ValidationError("category is required");
+  if (cuttability != null && !CUT_TIERS.includes(cuttability))
+    throw new ValidationError("invalid cuttability tier");
+  await db.query(
+    `INSERT INTO expense_category_defaults (user_id, category, type, cuttability)
+     VALUES ($1::uuid, $2::varchar,
+       COALESCE(
+         (SELECT type FROM expense_category_defaults WHERE user_id = $1::uuid AND category = $2::varchar),
+         'variable'::expense_type
+       ),
+       $3::cut_tier)
+     ON CONFLICT (user_id, category)
+       DO UPDATE SET cuttability = EXCLUDED.cuttability, updated_at = NOW()`,
+    [user_id, category, cuttability],
+  );
 }
 
 // ---- ADD A LINE ----

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.180.2",
+  "version": "1.181.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/market/CutPanel.tsx
+++ b/frontend/src/components/market/CutPanel.tsx
@@ -1,0 +1,99 @@
+import { consolidateLevers, type CutPlan, type CutTier } from "@/lib/metrics/cutPlanner";
+import { money } from "@/lib/format";
+
+const TIER_COLOR: Record<CutTier, string> = {
+  off_limits: "#5a6880",
+  essential: "#8494ab",
+  discretionary: "#5dcaa5",
+  deferrable: "#f5b03a",
+  efficiency: "#e8940a",
+  last_resort: "#e24b4a",
+};
+const TIER_LABEL: Record<CutTier, string> = {
+  off_limits: "off-limits",
+  essential: "essential",
+  discretionary: "discretionary",
+  deferrable: "deferrable",
+  efficiency: "efficiency",
+  last_resort: "your pay",
+};
+
+const rgba = (hex: string, a: number) => {
+  const n = parseInt(hex.slice(1), 16);
+  return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+};
+
+// The cut plan, shown under the Market playbook ONLY when the whole operation is
+// under break-even. Every lever is one of the owner's real categories.
+export const CutPanel = ({ plan }: { plan: CutPlan }) => {
+  const lines = consolidateLevers(plan.levers);
+  if (lines.length === 0 && plan.gapNeeded <= 0) return null;
+
+  return (
+    <div className="ds2-board overflow-hidden mt-3" style={{ background: "#090d15" }}>
+      <div className="px-4 pt-3 pb-2.5 border-b border-hairline">
+        <div className="text-[11.5px] font-bold uppercase tracking-[.07em]" style={{ color: "#e24b4a" }}>
+          A cut plan from your books — to get back to break-even
+        </div>
+        <p className="text-[12.5px] text-dim mt-1 leading-snug">
+          You need about <span className="text-ink font-semibold">{money(plan.gapNeeded)}/mo</span>. Cheapest,
+          least-painful first — pulled from <span className="text-ink">your</span> spend, balanced to hit the number
+          (never a canned list).
+        </p>
+      </div>
+
+      <div className="px-4">
+        {lines.map((l) => (
+          <div
+            key={l.category}
+            className="grid grid-cols-[1fr_auto] items-baseline gap-x-3.5 py-2.5 border-t border-hairline/60 first:border-t-0"
+          >
+            <div>
+              <span className="text-[13.5px] text-ink">{l.category}</span>
+              <span
+                className="ml-2 text-[9.5px] uppercase tracking-[.05em] font-bold rounded px-1.5 py-px"
+                style={{ color: TIER_COLOR[l.tier], background: rgba(TIER_COLOR[l.tier], 0.11), border: `1px solid ${rgba(TIER_COLOR[l.tier], 0.3)}` }}
+              >
+                {TIER_LABEL[l.tier]}
+              </span>
+              <div className="text-[11px] text-faint mt-0.5">{l.reason}</div>
+            </div>
+            <div className="font-condensed text-[16px]" style={{ color: l.tier === "last_resort" ? "#e24b4a" : "#5dcaa5" }}>
+              −{money(l.amount)}
+            </div>
+          </div>
+        ))}
+
+        <div className="grid grid-cols-[1fr_auto] gap-x-3.5 pt-2.5 pb-1 mt-1 border-t border-hairline">
+          <div className="font-condensed font-bold text-[14px]" style={{ color: plan.reachesGap ? "#5dcaa5" : "#f5b03a" }}>
+            {plan.reachesGap ? "Plan total — closes the gap" : "Plan total — as far as safe cuts reach"}
+          </div>
+          <div className="font-condensed font-bold text-[17px]" style={{ color: plan.reachesGap ? "#5dcaa5" : "#f5b03a" }}>
+            −{money(plan.planTotal)}
+          </div>
+        </div>
+      </div>
+
+      <div className="px-4 pb-3.5 pt-2">
+        {!plan.reachesGap && (
+          <p className="text-[12px] mt-1 mb-2 leading-snug" style={{ color: "#f5b03a" }}>
+            Even after every safe cut you're about <span className="font-semibold">{money(plan.shortfall)}/mo</span> short —
+            that last stretch has to come from rate or home time, not more cost-cutting.
+          </p>
+        )}
+        <p className="text-[11px] text-faint leading-relaxed">
+          {plan.offLimits.length > 0 && (
+            <>
+              <span style={{ color: "#5a6880" }}>🔒 Off-limits (never cut):</span>{" "}
+              {plan.offLimits.slice(0, 8).join(" · ")}
+              {plan.offLimits.length > 8 ? ` +${plan.offLimits.length - 8} more` : ""}.{" "}
+            </>
+          )}
+          <span className="text-dim">Your pay is last</span> — the plan only reaches for it when nothing else closes the
+          gap, and says so plainly. Set how each category is treated in{" "}
+          <span className="text-dim">Settings → Cost-cut tiers</span>.
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/settings/CutTiersCard.tsx
+++ b/frontend/src/components/settings/CutTiersCard.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from "react";
+import { Panel } from "@/components/ui/Panel";
+import { money } from "@/lib/format";
+import {
+  getCutTierData,
+  setCuttability,
+  type CutTierRow,
+} from "@/services/expensesService";
+import { classifyCutTier, type CutTier } from "@/lib/metrics/cutPlanner";
+
+const TIERS: { key: CutTier; label: string; color: string; blurb: string }[] = [
+  { key: "off_limits", label: "Off-limits", color: "#5a6880", blurb: "never cut" },
+  { key: "essential", label: "Essential", color: "#8494ab", blurb: "trim overspend only" },
+  { key: "discretionary", label: "Discretionary", color: "#5dcaa5", blurb: "pare into it" },
+  { key: "deferrable", label: "Deferrable", color: "#f5b03a", blurb: "defer a portion" },
+  { key: "efficiency", label: "Efficiency", color: "#e8940a", blurb: "small slice" },
+  { key: "last_resort", label: "Last resort", color: "#e24b4a", blurb: "your pay" },
+];
+const COLOR = Object.fromEntries(TIERS.map((t) => [t.key, t.color])) as Record<CutTier, string>;
+const LABEL = Object.fromEntries(TIERS.map((t) => [t.key, t.label])) as Record<CutTier, string>;
+
+const errText = (e: unknown): string =>
+  (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+  "Something went wrong — try again.";
+
+export const CutTiersCard = () => {
+  const [rows, setRows] = useState<CutTierRow[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const load = () =>
+    getCutTierData()
+      .then(setRows)
+      .catch(() => setErr("Couldn't load your categories."));
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  // Optimistic: reflect the change immediately, roll back on failure.
+  const change = async (category: string, next: CutTier | null) => {
+    setErr(null);
+    const prevTier = rows?.find((r) => r.category === category)?.cuttability ?? null;
+    setRows((rs) =>
+      rs ? rs.map((r) => (r.category === category ? { ...r, cuttability: next } : r)) : rs,
+    );
+    try {
+      await setCuttability(category, next);
+    } catch (e) {
+      setErr(errText(e));
+      // Revert ONLY this category, so an overlapping successful edit isn't clobbered.
+      setRows((rs) =>
+        rs ? rs.map((r) => (r.category === category ? { ...r, cuttability: prevTier } : r)) : rs,
+      );
+    }
+  };
+
+  return (
+    <Panel className="mt-6 max-w-[680px] p-5">
+      <h2 className="text-lg font-medium text-light">Cost-cut tiers</h2>
+      <p className="text-sm text-muted-text mt-1">
+        When a soft market forces a cut, the Market playbook protects what it must and trims what
+        it can. Each category is auto-sorted from its name — change any, and your choice sticks.
+        This is the only place the plan's judgment lives.
+      </p>
+
+      <div className="flex flex-wrap gap-x-3 gap-y-1.5 mt-3">
+        {TIERS.map((t) => (
+          <span key={t.key} className="inline-flex items-center gap-1.5 text-[11px] text-muted-text">
+            <span className="inline-block h-2 w-2 rounded-full" style={{ background: t.color }} />
+            <span className="text-light">{t.label}</span> {t.blurb}
+          </span>
+        ))}
+      </div>
+
+      {err && (
+        <p className="text-sm text-red-400 mt-3">
+          {err}{" "}
+          <button type="button" onClick={load} className="underline hover:text-red-300">
+            retry
+          </button>
+        </p>
+      )}
+
+      {rows == null ? (
+        !err && <p className="text-sm text-muted-text mt-4">Loading your categories…</p>
+      ) : rows.length === 0 ? (
+        <p className="text-sm text-muted-text mt-4">
+          No expense categories yet — they'll appear here once you've saved a P&amp;L month.
+        </p>
+      ) : (
+        <div className="mt-4 divide-y divide-white/5">
+          {rows.map((r) => {
+            const auto = classifyCutTier(r.category);
+            const effective = r.cuttability ?? auto;
+            const overridden = r.cuttability != null;
+            return (
+              <div key={r.category} className="grid grid-cols-[1fr_auto_auto] items-center gap-3 py-2.5">
+                <div className="min-w-0">
+                  <span className="text-sm text-light">{r.category}</span>
+                  {overridden && (
+                    <button
+                      type="button"
+                      onClick={() => change(r.category, null)}
+                      className="ml-2 text-[10.5px] uppercase tracking-wide text-amber-400 hover:underline"
+                      title={`Reset to auto (${LABEL[auto]})`}
+                    >
+                      edited · reset
+                    </button>
+                  )}
+                </div>
+                <span className="text-xs text-muted-text tabular-nums whitespace-nowrap">
+                  {money(r.baseline)}/mo
+                </span>
+                <div className="relative">
+                  <span
+                    className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 h-2 w-2 rounded-full"
+                    style={{ background: COLOR[effective] }}
+                  />
+                  <select
+                    value={effective}
+                    aria-label={`Cost-cut tier for ${r.category}`}
+                    onChange={(e) => change(r.category, e.target.value as CutTier)}
+                    className="appearance-none bg-steel rounded-lg pl-6 pr-7 py-1.5 text-light text-xs w-[168px] cursor-pointer"
+                  >
+                    {TIERS.map((t) => (
+                      <option key={t.key} value={t.key}>
+                        {t.label}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-text text-[10px]">
+                    ▾
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Panel>
+  );
+};

--- a/frontend/src/lib/metrics/cutPlanner.test.ts
+++ b/frontend/src/lib/metrics/cutPlanner.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyCutTier,
+  resolveCutTier,
+  buildCutPlan,
+  toCutCategories,
+  consolidateLevers,
+  type CutCategory,
+} from "./cutPlanner";
+
+describe("classifyCutTier — Jason's real QuickBooks categories", () => {
+  const cases: [string, string][] = [
+    ["Insurance", "off_limits"],
+    ["Interest Expense - Trailer Loan", "off_limits"],
+    ["Loan Guarantor Fee - Deborah Delgado", "off_limits"],
+    ["PrePass & Tolls", "off_limits"],
+    ["Taxes paid", "off_limits"],
+    ["Trailer Plates", "off_limits"],
+    ["Permits - Truck", "off_limits"],
+    ["EOBR Airtime", "off_limits"],
+    ["NTP Warranty", "off_limits"], // Jason: fixed contract, can't touch
+    ["Max Weight", "off_limits"],
+    ["Utilities", "essential"],
+    ["Legal & accounting services", "essential"],
+    ["Commissions & fees", "essential"],
+    ["Fuel", "efficiency"],
+    ["Repairs & maintenance", "deferrable"],
+    ["Payroll expenses", "last_resort"],
+    ["Employee benefits", "last_resort"],
+    ["Supplies", "discretionary"],
+    ["Office expenses", "discretionary"],
+    ["General business expenses", "discretionary"],
+    ["Travel", "discretionary"],
+    ["Rental Expense - Computer", "discretionary"],
+  ];
+  for (const [cat, tier] of cases) {
+    it(`${cat} → ${tier}`, () => {
+      expect(classifyCutTier(cat)).toBe(tier);
+    });
+  }
+});
+
+describe("classifyCutTier — no over-match on lookalike names", () => {
+  const cases: [string, string][] = [
+    ["Taxi", "discretionary"], // not 'tax' → off_limits
+    ["Template printing", "discretionary"], // not 'plate'
+    ["Sewage disposal", "discretionary"], // not 'wage' → last_resort
+    ["Release fee", "discretionary"], // not 'lease'
+  ];
+  for (const [cat, tier] of cases) {
+    it(`${cat} → ${tier}`, () => {
+      expect(classifyCutTier(cat)).toBe(tier);
+    });
+  }
+});
+
+describe("resolveCutTier", () => {
+  it("uses the manual override when present", () => {
+    expect(resolveCutTier("Supplies", "off_limits")).toBe("off_limits");
+  });
+  it("falls back to auto-classification when no override", () => {
+    expect(resolveCutTier("Supplies", null)).toBe("discretionary");
+    expect(resolveCutTier("Supplies")).toBe("discretionary");
+  });
+});
+
+// A representative slice of Jason's book (~monthly).
+const BOOK: CutCategory[] = [
+  { category: "Insurance", current: 785, baseline: 785, tier: "off_limits" },
+  { category: "Repairs & maintenance", current: 1952, baseline: 1952, tier: "deferrable" },
+  { category: "Fuel", current: 5509, baseline: 5509, tier: "efficiency" },
+  { category: "Utilities", current: 543, baseline: 433, tier: "essential" }, // $110 over
+  { category: "Supplies", current: 352, baseline: 352, tier: "discretionary" },
+  { category: "Office expenses", current: 280, baseline: 280, tier: "discretionary" },
+  { category: "Payroll expenses", current: 6000, baseline: 6000, tier: "last_resort" },
+];
+
+describe("buildCutPlan — ordering & balance", () => {
+  it("takes overspend first, then discretionary, before deferrable/efficiency/pay", () => {
+    const plan = buildCutPlan(BOOK, 500);
+    expect(plan.reachesGap).toBe(true);
+    // First lever is the utilities overspend ($110), then discretionary trims.
+    expect(plan.levers[0].kind).toBe("overspend");
+    expect(plan.levers[0].category).toBe("Utilities");
+    // The gap (500) is small — it should never reach payroll or off-limits.
+    expect(plan.lastResortUsed).toBe(false);
+    expect(plan.levers.some((l) => l.category === "Payroll expenses")).toBe(false);
+    expect(plan.levers.some((l) => l.category === "Insurance")).toBe(false);
+    expect(plan.planTotal).toBeCloseTo(500, 0);
+  });
+
+  it("never lists an off-limits category and always reports them", () => {
+    const plan = buildCutPlan(BOOK, 500);
+    expect(plan.offLimits).toContain("Insurance");
+    expect(plan.levers.every((l) => l.tier !== "off_limits")).toBe(true);
+  });
+
+  it("reaches into deferrable/efficiency before pay for a bigger gap", () => {
+    const plan = buildCutPlan(BOOK, 1500);
+    expect(plan.reachesGap).toBe(true);
+    expect(plan.lastResortUsed).toBe(false);
+    const tiers = plan.levers.map((l) => l.tier);
+    // discretionary levers come before deferrable, which comes before efficiency.
+    const firstDeferrable = tiers.indexOf("deferrable");
+    const lastDiscretionary = tiers.lastIndexOf("discretionary");
+    if (firstDeferrable >= 0 && lastDiscretionary >= 0)
+      expect(lastDiscretionary).toBeLessThan(firstDeferrable);
+  });
+
+  it("uses your pay only as a last resort, and flags it", () => {
+    const plan = buildCutPlan(BOOK, 4000); // more than the painless pool
+    expect(plan.lastResortUsed).toBe(true);
+    const payLever = plan.levers.find((l) => l.category === "Payroll expenses");
+    expect(payLever?.kind).toBe("last_resort");
+    // pay is last in the list
+    expect(plan.levers[plan.levers.length - 1].category).toBe("Payroll expenses");
+  });
+
+  it("at last resort, pulls a pay spike back (overspend + base slice), not just the base", () => {
+    const cats: CutCategory[] = [
+      { category: "Payroll expenses", current: 9554, baseline: 4839, tier: "last_resort" },
+    ];
+    // avail = (9554−4839) + 4839*0.5 ≈ 7135, so a $6k gap is reachable from pay alone.
+    const plan = buildCutPlan(cats, 6000);
+    expect(plan.reachesGap).toBe(true);
+    expect(plan.planTotal).toBeCloseTo(6000, 0);
+  });
+
+  it("is honest when the gap can't be closed even with everything", () => {
+    const plan = buildCutPlan(BOOK, 100000);
+    expect(plan.reachesGap).toBe(false);
+    expect(plan.shortfall).toBeGreaterThan(0);
+  });
+
+  it("stops exactly at the gap — the running total never overshoots", () => {
+    const plan = buildCutPlan(BOOK, 300);
+    expect(plan.planTotal).toBeCloseTo(300, 0);
+  });
+});
+
+describe("toCutCategories", () => {
+  it("resolves each row's tier, override winning over auto", () => {
+    const cats = toCutCategories([
+      { category: "Fuel", current: 5000, baseline: 5000 },
+      { category: "Supplies", current: 300, baseline: 300, cuttability: "off_limits" },
+    ]);
+    expect(cats[0].tier).toBe("efficiency"); // auto
+    expect(cats[1].tier).toBe("off_limits"); // override beats auto (discretionary)
+  });
+});
+
+describe("consolidateLevers", () => {
+  it("merges a category's overspend + trim into one line, preserving order", () => {
+    // Utilities overspend, then General business overspend + base trim.
+    const cats: CutCategory[] = [
+      { category: "Utilities", current: 543, baseline: 433, tier: "essential" },
+      { category: "General business expenses", current: 297, baseline: 274, tier: "discretionary" },
+    ];
+    const plan = buildCutPlan(cats, 400);
+    const lines = consolidateLevers(plan.levers);
+    const gb = lines.find((l) => l.category === "General business expenses")!;
+    // two levers (overspend $23 + trim) collapse to one line
+    expect(plan.levers.filter((l) => l.category === "General business expenses").length).toBeGreaterThan(1);
+    expect(lines.filter((l) => l.category === "General business expenses").length).toBe(1);
+    expect(gb.reason).toMatch(/overspend \+ pare/i);
+    expect(gb.amount).toBeGreaterThan(23);
+  });
+});

--- a/frontend/src/lib/metrics/cutPlanner.ts
+++ b/frontend/src/lib/metrics/cutPlanner.ts
@@ -1,0 +1,223 @@
+// The intelligent cost-cut planner. When the WHOLE operation is under break-even
+// (see marketPlaybook's businessUnderwater), this builds a plan to close the gap
+// from YOUR OWN books — least-painful first, summing to the dollars needed, and
+// honest when it can't reach without cutting your own pay. It is NOT a canned
+// "fuel / per-diem / maintenance" list: every lever is one of your real expense
+// categories, tiered by how much cutting it would actually hurt.
+
+export type CutTier =
+  | "off_limits" // insurance, debt/interest, permits, taxes, tolls — never cut
+  | "essential" // utilities, legal, commissions — trim OVERSPEND back to normal only
+  | "discretionary" // supplies, office, travel — can pare into the base
+  | "deferrable" // non-safety repairs — defer a portion this month
+  | "efficiency" // fuel — a small routing/idle slice only
+  | "last_resort"; // payroll / your own pay — only if nothing else reaches the gap
+
+// How deep BELOW its own baseline each tier can be cut (fraction of sustained
+// spend). Overspend ABOVE baseline is always fully trimmable regardless of tier —
+// that's just returning to normal. These are the knobs; keep them conservative.
+export const BELOW_BASELINE: Record<CutTier, number> = {
+  off_limits: 0,
+  essential: 0,
+  discretionary: 0.6,
+  deferrable: 0.5,
+  efficiency: 0.05,
+  last_resort: 0.5,
+};
+
+// Least-painful → most. Overspend trim (any tier) always runs before any of these.
+const TIER_ORDER: CutTier[] = ["discretionary", "deferrable", "efficiency", "last_resort"];
+
+// Keyword auto-classification of a QuickBooks-style category name. The manual
+// cuttability override (expense_category_defaults.cuttability) always wins over
+// this — these idiosyncratic names (e.g. "NTP Warranty", "Max Weight") are why
+// the override exists.
+export const classifyCutTier = (category: string): CutTier => {
+  const c = category.toLowerCase();
+  if (
+    /insurance|interest|\bloan|\blease|guarantor|permit|\bplates?\b|\btolls?\b|prepass|\btaxes?\b|eobr|\beld\b|ifta|2290|heavy vehicle|max weight|warranty|\bscales?\b/.test(
+      c,
+    )
+  )
+    return "off_limits";
+  if (/payroll|salary|\bwages?\b|owner|\bdraw\b|benefit/.test(c)) return "last_resort";
+  if (/fuel|diesel/.test(c)) return "efficiency";
+  if (/repair|maintenance|\btire/.test(c)) return "deferrable";
+  if (/utilit|legal|account|commission/.test(c)) return "essential";
+  return "discretionary";
+};
+
+// Resolve a category's tier: the manual override if present, else auto-classify.
+export const resolveCutTier = (category: string, override?: CutTier | null): CutTier =>
+  override ?? classifyCutTier(category);
+
+export interface CutCategory {
+  category: string;
+  current: number; // latest month's spend
+  baseline: number; // trailing average spend
+  tier: CutTier;
+}
+
+export interface CutLever {
+  category: string;
+  tier: CutTier;
+  kind: "overspend" | "trim" | "last_resort";
+  amount: number; // dollars to cut
+  reason: string;
+}
+
+export interface CutPlan {
+  gapNeeded: number;
+  levers: CutLever[];
+  planTotal: number;
+  reachesGap: boolean; // the painless+deferrable+efficiency levers cover the gap
+  shortfall: number; // dollars still short after every available lever
+  lastResortUsed: boolean; // the plan had to touch your own pay
+  offLimits: string[]; // categories the plan will never cut
+}
+
+// Build the planner's category list from the raw cut-tier rows, resolving each
+// tier (manual override if set, else auto-classified from the name).
+export const toCutCategories = (
+  rows: { category: string; current: number; baseline: number; cuttability?: CutTier | null }[],
+): CutCategory[] =>
+  rows.map((r) => ({
+    category: r.category,
+    current: r.current,
+    baseline: r.baseline,
+    tier: resolveCutTier(r.category, r.cuttability ?? null),
+  }));
+
+export interface CutLine {
+  category: string;
+  tier: CutTier;
+  amount: number;
+  reason: string;
+}
+
+// Merge a plan's levers so each category is one line (the overspend trim and the
+// into-the-base cut combined), preserving plan order. All levers for a category
+// share its tier, so the merged line's tier is unambiguous. For the panel.
+export const consolidateLevers = (levers: CutLever[]): CutLine[] => {
+  const order: string[] = [];
+  const byCat = new Map<string, { tier: CutTier; amount: number; kinds: Set<string>; reason: string }>();
+  for (const l of levers) {
+    const e = byCat.get(l.category);
+    if (e) {
+      e.amount += l.amount;
+      e.kinds.add(l.kind);
+    } else {
+      order.push(l.category);
+      byCat.set(l.category, { tier: l.tier, amount: l.amount, kinds: new Set([l.kind]), reason: l.reason });
+    }
+  }
+  return order.map((category) => {
+    const e = byCat.get(category)!;
+    const reason =
+      e.kinds.has("overspend") && (e.kinds.has("trim") || e.kinds.has("last_resort"))
+        ? "trim the overspend + pare into the base"
+        : e.reason;
+    return { category, tier: e.tier, amount: e.amount, reason };
+  });
+};
+
+const usd = (x: number): string => `$${Math.round(x).toLocaleString("en-US")}`;
+
+const reasonFor = (tier: CutTier, months: number): string => {
+  switch (tier) {
+    case "discretionary":
+      return "discretionary overhead — pare back";
+    case "deferrable":
+      return "defer the non-safety portion this month";
+    case "efficiency":
+      return "tighten routing / idle (~5%)";
+    case "last_resort":
+      return "last resort — your own pay";
+    default:
+      return `${months}-mo normal`;
+  }
+};
+
+// Build the plan. Pure: your tiered categories + the monthly gap in, an ordered,
+// gap-balanced plan out. Stops as soon as the running total meets the gap, so the
+// last lever is only cut by what's still needed.
+export const buildCutPlan = (
+  cats: CutCategory[],
+  gapNeeded: number,
+  baselineMonths = 6,
+): CutPlan => {
+  const offLimits = cats.filter((c) => c.tier === "off_limits").map((c) => c.category);
+  const levers: CutLever[] = [];
+  let remaining = Math.max(0, gapNeeded);
+
+  const take = (avail: number): number => {
+    const amt = Math.min(Math.max(0, avail), remaining);
+    remaining -= amt;
+    return amt;
+  };
+
+  // 1) Overspend trim — the safest dollars: any category (except off-limits and
+  //    last-resort pay) running above its own baseline, trimmed back to normal.
+  const overspenders = cats
+    .filter((c) => c.tier !== "off_limits" && c.tier !== "last_resort")
+    .map((c) => ({ c, over: Math.max(0, c.current - c.baseline) }))
+    .filter((x) => x.over > 0.5)
+    .sort((a, b) => b.over - a.over);
+  for (const { c, over } of overspenders) {
+    if (remaining <= 0.5) break;
+    const amount = take(over);
+    if (amount > 0.5)
+      levers.push({
+        category: c.category,
+        tier: c.tier,
+        kind: "overspend",
+        amount,
+        reason: `running ${usd(over)} over your ${baselineMonths}-mo normal — trim to baseline`,
+      });
+  }
+
+  // 2) Below-baseline cuts, tier by tier, least painful first.
+  for (const tier of TIER_ORDER) {
+    if (remaining <= 0.5) break;
+    const frac = BELOW_BASELINE[tier];
+    if (frac <= 0) continue;
+    const inTier = cats
+      .filter((c) => c.tier === tier)
+      .map((c) => ({
+        c,
+        // Other tiers had their overspend trimmed in step 1, so here they only cut
+        // into the baseline. last_resort (pay) was held out of step 1 — so when we
+        // finally reach it, it can pull a pay SPIKE back to normal AND cut a slice
+        // of the baseline, i.e. down to (1 − frac) of normal.
+        avail:
+          tier === "last_resort"
+            ? Math.max(0, c.current - c.baseline) + Math.min(c.current, c.baseline) * frac
+            : Math.min(c.current, c.baseline) * frac,
+      }))
+      .filter((x) => x.avail > 0.5)
+      .sort((a, b) => b.avail - a.avail);
+    for (const { c, avail } of inTier) {
+      if (remaining <= 0.5) break;
+      const amount = take(avail);
+      if (amount > 0.5)
+        levers.push({
+          category: c.category,
+          tier,
+          kind: tier === "last_resort" ? "last_resort" : "trim",
+          amount,
+          reason: reasonFor(tier, baselineMonths),
+        });
+    }
+  }
+
+  const planTotal = levers.reduce((s, l) => s + l.amount, 0);
+  return {
+    gapNeeded,
+    levers,
+    planTotal,
+    reachesGap: remaining <= 0.5,
+    shortfall: Math.max(0, remaining),
+    lastResortUsed: levers.some((l) => l.kind === "last_resort"),
+    offLimits,
+  };
+};

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -984,6 +984,19 @@ const GuidePage = () => {
               rate, is the lever.
             </Why>
             <Why>
+              When the whole operation is under, a <span className="text-light">cut
+              plan</span> appears under the playbook — built from{" "}
+              <span className="text-light">your own books</span>, not a canned list.
+              It closes the monthly gap least-painful first: overspend trimmed back to
+              normal, then discretionary overhead, a deferred slice of non-safety
+              repairs, a small fuel-efficiency slice — and only reaches for your pay as
+              a last resort, saying so plainly when a gap runs deeper than the safe
+              cuts. Insurance, loans and interest, permits, tolls, and taxes are never
+              touched. You set how each category is treated in{" "}
+              <span className="text-light">Settings → Cost-cut tiers</span>; the plan
+              obeys your choices.
+            </Why>
+            <Why>
               Each tier lists its rungs high to low with a{" "}
               <span className="text-light">You're booking</span> marker dropped in
               where your rate lands, so the call is something you can see, not

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -25,7 +25,10 @@ import {
 } from "@/lib/metrics/marketAnalytics";
 import { marketTrend, youVsMarket } from "@/lib/metrics/marketSignal";
 import { buildMarketPlaybook } from "@/lib/metrics/marketPlaybook";
+import { buildCutPlan, toCutCategories } from "@/lib/metrics/cutPlanner";
 import { MarketPlaybookCard } from "@/components/market/MarketPlaybookCard";
+import { CutPanel } from "@/components/market/CutPanel";
+import { getCutTierData, type CutTierRow } from "@/services/expensesService";
 import { rpm } from "@/lib/format";
 
 const MACRO = "#4f8cd6"; // FRED PPI overlay line — the house chart blue
@@ -275,6 +278,29 @@ const MarketPage = () => {
     [points, targets.bookingLadder, targets.specLadder, trend, now, businessUnderwater],
   );
 
+  // Monthly dollars to cut to get the whole operation back to break-even:
+  // cost minus what your booked gross actually covers after the Landstar take.
+  // > 0 exactly when businessUnderwater — the same reconciled basis.
+  const monthlyGap = useMemo(() => {
+    const b = targets.basis;
+    if (b.grossPerTotalMile == null || b.trueMonthlyCost == null || b.months <= 0) return null;
+    const monthlyGross = (b.grossPerTotalMile * b.totalMiles) / b.months;
+    return b.trueMonthlyCost - monthlyGross * targets.linehaulTake;
+  }, [targets.basis, targets.linehaulTake]);
+
+  // Only fetch the cut-tier data when the plan will actually show.
+  const [cutRows, setCutRows] = useState<CutTierRow[]>([]);
+  useEffect(() => {
+    if (!businessUnderwater) return;
+    getCutTierData().then(setCutRows).catch(() => {});
+  }, [businessUnderwater]);
+
+  const cutPlan = useMemo(() => {
+    if (!businessUnderwater || monthlyGap == null || monthlyGap <= 0 || cutRows.length === 0)
+      return null;
+    return buildCutPlan(toCutCategories(cutRows), monthlyGap);
+  }, [businessUnderwater, monthlyGap, cutRows]);
+
   const toneColor =
     gauge.tone === "hot" ? "#4ade80" : gauge.tone === "soft" ? "#f87171" : "#e0a020";
 
@@ -339,6 +365,7 @@ const MarketPage = () => {
         {/* the playbook — the one clear move per tier, given the trend */}
         <div className="mt-4">
           <MarketPlaybookCard playbook={playbook} />
+          {cutPlan && <CutPanel plan={cutPlan} />}
         </div>
 
         {/* the verdict */}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { getTeam, updateMyName } from "@/services/teamService";
 import { useLoads } from "@/hooks/useLoads";
 import { useRateTargets } from "@/hooks/useRateTargets";
 import { AccessorialRatesCard } from "@/components/settings/AccessorialRatesCard";
+import { CutTiersCard } from "@/components/settings/CutTiersCard";
 import { TeamCard } from "@/components/settings/TeamCard";
 import { sfxEnabled, setSfxEnabled, playSfx } from "@/lib/sfx";
 import { Panel } from "@/components/ui/Panel";
@@ -645,6 +646,8 @@ const SettingsPage = () => {
       </Panel>
 
       <AccessorialRatesCard />
+
+      <CutTiersCard />
     </div>
   );
 };

--- a/frontend/src/services/expensesService.ts
+++ b/frontend/src/services/expensesService.ts
@@ -1,5 +1,6 @@
 import api from "./api";
 import { dedupe } from "@/lib/dedupe";
+import type { CutTier } from "@/lib/metrics/cutPlanner";
 import type {
   ExpensePeriod,
   ExpenseLine,
@@ -80,6 +81,33 @@ export const getCategoryDefaults = async (): Promise<
   } catch {
     throw new Error("Unable to fetch category defaults");
   }
+};
+
+// ---- Cost-cut tiers (the Market cut planner + Settings override) ----
+export interface CutTierRow {
+  category: string;
+  section: "cogs" | "expenses";
+  type: ExpenseType | null;
+  cuttability: CutTier | null; // null = auto-classify from the name
+  current: number; // latest month's spend
+  baseline: number; // trailing monthly average
+}
+
+export const getCutTierData = async (): Promise<CutTierRow[]> => {
+  try {
+    const res = await api.get("/expenses/cut-tiers");
+    return (res.data.categories ?? []) as CutTierRow[];
+  } catch {
+    throw new Error("Unable to fetch cut-tier data");
+  }
+};
+
+// Pin a category's tier, or pass null to clear the override (back to auto).
+export const setCuttability = async (
+  category: string,
+  cuttability: CutTier | null,
+): Promise<void> => {
+  await api.put("/expenses/cuttability", { category, cuttability });
 };
 
 export interface SaveExpenseLine {


### PR DESCRIPTION
## What

Phase B of the Market playbook. When your **whole operation** books under break-even (`businessUnderwater`), a **cut plan** appears under the playbook — built from **your own expense categories**, not a canned list — to close the monthly gap.

- **Six necessity tiers**, auto-classified from each category's name and **overridable**: off-limits (insurance, interest, permits, tolls, taxes) · essential (trim overspend only) · discretionary · deferrable (non-safety repairs) · efficiency (fuel, ~5% slice) · last-resort (your pay).
- The plan closes the gap **least-painful first**, stops exactly at the number, and is **honest** — `reachesGap=false` + a stated shortfall when safe cuts can't close it without cutting your pay. Off-limits is never touched; a pay *spike* is only pulled back at the last resort.
- **Settings → Cost-cut tiers** to tune how each category is treated.

## Data

- Migration `059_cuttability` — nullable `cut_tier` enum column on `expense_category_defaults` (**applied to dev + prod**).
- `GET /expenses/cut-tiers` — per-category latest-month spend + trailing (per-category) baseline + override. `PUT /expenses/cuttability` — pin/clear a tier.

## Verification

- Engine: **37 unit tests**. Full suite **651 pass**, strict build clean.
- Backend endpoints round-trip tested on dev (set / verify / clear / reject bad tier).
- CutPanel screenshotted on real prod-derived book (closes-the-gap and honest-shortfall states).
- Gap math uses `useRateTargets`' basis on the **same `linehaulTake` basis** as `businessUnderwater`, so the panel appears exactly when the operation is under break-even.
- **Adversarial review** (4 dimensions → independent verifiers): 5 findings fixed (new-category baseline, classifier over-match, Settings rollback/load-state/a11y), 2 rejected as false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)