### PR TITLE
feat(dispatch): The Dispatch Forge + dispatcher scorecards that fire (v1.182.0)

### DIFF
--- a/backend/src/services/loadServices.js
+++ b/backend/src/services/loadServices.js
@@ -249,11 +249,12 @@ export async function getLoad(user_id, load_id) {
 }
 
 // ---- CREATE LOAD SERVICE ----
-// A load's booker defaults to the ACCOUNT OWNER (user_id === account_id), not
-// whoever enters it: in this owner-operator shop the owner does the booking and
-// a training dispatcher just logs the loads. The client sends booked_by
-// explicitly (the "Booked by" picker, default = owner) and anyone can reassign
-// it per-load. `self_id` (the logged-in person) is accepted for caller parity.
+// A load's booker defaults to WHOEVER CREATES IT (self_id — the logged-in
+// person), so a dispatcher's bookings are credited to her (and the owner's to
+// him). The client sends booked_by explicitly (the "Booked by" picker) and
+// anyone can reassign it per-load; only if it's absent do we fall back to the
+// creator, then the account owner. This is the attribution the dispatcher
+// scorecards + forge awards are scoped by.
 export async function createLoad(user_id, data, self_id) {
   // Reject missing user_id
   if (!user_id) throw new ValidationError("Missing user_id");
@@ -317,8 +318,8 @@ export async function createLoad(user_id, data, self_id) {
 
   if (errors.length > 0) throw new ValidationError("Validation failed", errors);
 
-  // Booker: explicit override (the "Booked by" picker), else the account owner.
-  const booker = data.booked_by ?? user_id;
+  // Booker: explicit override (the "Booked by" picker), else the creator, else owner.
+  const booker = data.booked_by ?? self_id ?? user_id;
   let fields = ["user_id", "booked_by"];
   let values = [user_id, booker];
   let placeholders = ["$1", "$2"];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.181.0",
+  "version": "1.182.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ import { SwatchesPage } from "@/pages/SwatchesPage";
 import SignupPage from "@/pages/SignupPage";
 import GuidePage from "@/pages/GuidePage";
 import DispatcherPage from "@/pages/DispatcherPage";
+import DispatchForgePage from "@/pages/DispatchForgePage";
 import CompliancePage from "@/pages/CompliancePage";
 import RecapPage from "@/pages/RecapPage";
 import TrophyHallPage from "@/pages/TrophyHallPage";
@@ -89,6 +90,7 @@ const App = () => {
           <Route path="/facilities/:id" element={<FacilityDetailPage />} />
           <Route path="/guide" element={<GuidePage />} />
           <Route path="/dispatcher/:id" element={<DispatcherPage />} />
+          <Route path="/forge" element={<DispatchForgePage />} />
 
           {/* Owner-only — a dispatcher is redirected to /dashboard (see roles.ts) */}
           <Route element={<AdminRoute />}>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -10,6 +10,7 @@ import {
   Wallet,
   ShieldCheck,
   Trophy,
+  Flame,
   BookOpen,
   Volume2,
   VolumeX,
@@ -36,7 +37,7 @@ import { sfxEnabled, setSfxEnabled, playSfx } from "@/lib/sfx";
 // `adminOnly` items are owner-only; a dispatcher's nav filters them out (and the
 // route guard bounces her if she types the URL). Keep these flags in lockstep
 // with ADMIN_ONLY_PREFIXES in lib/roles.
-type Child = { to: string; label: string; adminOnly?: boolean };
+type Child = { to: string; label: string; adminOnly?: boolean; dispatcherOnly?: boolean };
 type Leaf = Child & { icon: LucideIcon };
 type Group = { label: string; icon: LucideIcon; children: Child[] };
 type Entry = Leaf | Group;
@@ -85,21 +86,18 @@ const nav: Entry[] = [
   },
   { to: "/compliance", label: "Compliance", icon: ShieldCheck },
   { to: "/trophy-room", label: "Trophy Room", icon: Trophy, adminOnly: true },
+  { to: "/forge", label: "The Forge", icon: Flame, dispatcherOnly: true },
   { to: "/guide", label: "Guide", icon: BookOpen },
 ];
 
-// A dispatcher sees only the non-adminOnly items; empty groups drop out.
+// A dispatcher sees only the non-adminOnly items; the owner sees everything except
+// the dispatcher-only ones (e.g. The Forge, which is each dispatcher's own room).
+// Empty groups drop out.
 const navFor = (dispatcher: boolean): Entry[] => {
-  if (!dispatcher) return nav;
+  const drop = (c: Child) => (dispatcher ? c.adminOnly : c.dispatcherOnly);
   return nav
-    .map((e) =>
-      isGroup(e)
-        ? { ...e, children: e.children.filter((c) => !c.adminOnly) }
-        : e,
-    )
-    .filter((e) =>
-      isGroup(e) ? e.children.length > 0 : !(e as Leaf).adminOnly,
-    );
+    .map((e) => (isGroup(e) ? { ...e, children: e.children.filter((c) => !drop(c)) } : e))
+    .filter((e) => (isGroup(e) ? e.children.length > 0 : !drop(e as Leaf)));
 };
 
 const AppSidebar = () => {

--- a/frontend/src/components/LoadForm.tsx
+++ b/frontend/src/components/LoadForm.tsx
@@ -401,26 +401,22 @@ const LoadForm = ({
   const [facilityList, setFacilityList] = useState<Facility[]>(facilities);
 
   // Booking credit. Anyone on the account (owner or a dispatcher) can attribute
-  // a load; the picker below defaults to the account owner, since in this shop
-  // the owner does the booking and a training dispatcher just logs the loads.
+  // a load; the picker below defaults to WHOEVER IS CREATING IT, so a dispatcher's
+  // bookings are credited to her and count toward her scorecards + forge awards.
   const selfId = localStorage.getItem("user_id");
   const [team, setTeam] = useState<TeamMember[]>([]);
   useEffect(() => {
     getTeam().then(setTeam).catch(() => {});
   }, []);
-  // New load: once the team loads, default the booker to the account owner
-  // (role "admin"). Edit mode keeps the load's existing booker; a manual pick
-  // wins (we only fill a still-empty booked_by).
+  // New load: default the booker to the logged-in creator (self). Edit mode keeps
+  // the load's existing booker; a manual pick wins (we only fill a still-empty
+  // booked_by). Matches the backend default (createLoad → self_id).
   useEffect(() => {
-    if (initialData) return;
-    // The account owner is the first row — listAccountUsers sorts owner-first.
-    const owner = team[0];
-    if (owner) {
-      setFormData((prev) =>
-        prev.booked_by ? prev : { ...prev, booked_by: owner.user_id },
-      );
-    }
-  }, [team, initialData]);
+    if (initialData || !selfId) return;
+    setFormData((prev) =>
+      prev.booked_by ? prev : { ...prev, booked_by: selfId },
+    );
+  }, [initialData, selfId]);
 
   const [trucks, setTrucks] = useState<Truck[]>([]);
   const [drivers, setDrivers] = useState<Driver[]>([]);

--- a/frontend/src/components/dashboard/GrindMeter.tsx
+++ b/frontend/src/components/dashboard/GrindMeter.tsx
@@ -1,12 +1,14 @@
 import type { CSSProperties } from "react";
 import type { Load } from "@/types/load";
 import { useGrind } from "@/hooks/useGrind";
-import type { WeekStatus } from "@/lib/metrics/grind";
+import type { Grind, WeekStatus } from "@/lib/metrics/grind";
 import { Board } from "@/components/ui/Board";
 
 // Design System v2 / The Forge — the grind streak as HEAT. Target weeks keep
-// the metal hot; the streak is consecutive weeks at temperature. Same engine
-// (useGrind — frozen), new body: the comic flame/Bangers treatment retired.
+// the metal hot; the streak is consecutive weeks at temperature. Two modes: the
+// owner's cost target, and a dispatcher's personal pace (her own typical week).
+type Mode = "owner" | "personal";
+
 const CELL: Record<WeekStatus, { cls: string; style?: CSSProperties }> = {
   target: {
     cls: "",
@@ -20,17 +22,42 @@ const CELL: Record<WeekStatus, { cls: string; style?: CSSProperties }> = {
   home: { cls: "bg-well", style: { boxShadow: "inset 0 1px 3px rgba(0,0,0,.6)" } },
 };
 
-const thisWeekLine = (s: WeekStatus): { text: string; color: string } => {
-  switch (s) {
-    case "target":
-      return { text: "You've beaten your weekly target — nice run.", color: "var(--color-status-positive-text)" };
-    case "breakeven":
-      return { text: "Covering the floor — a bit more freight beats target.", color: "var(--color-amber)" };
-    case "below":
-      return { text: "Below your weekly floor so far.", color: "var(--color-status-negative-text)" };
-    default:
-      return { text: "Nothing delivered yet this week.", color: "var(--color-dim)" };
-  }
+// Copy differs by mode: the owner grades against a cost target; the dispatcher
+// against her own usual week.
+const COPY: Record<Mode, {
+  streak: string;
+  coldHint: string;
+  legendTarget: string;
+  legendMid: string;
+  legendBelow: string;
+  thisWeek: Record<WeekStatus, { text: string; color: string }>;
+}> = {
+  owner: {
+    streak: "on a target-beating streak",
+    coldHint: "beat target this week to light it",
+    legendTarget: "Beat target",
+    legendMid: "Covered break-even",
+    legendBelow: "Below",
+    thisWeek: {
+      target: { text: "You've beaten your weekly target — nice run.", color: "var(--color-status-positive-text)" },
+      breakeven: { text: "Covering the floor — a bit more freight beats target.", color: "var(--color-amber)" },
+      below: { text: "Below your weekly floor so far.", color: "var(--color-status-negative-text)" },
+      home: { text: "Nothing delivered yet this week.", color: "var(--color-dim)" },
+    },
+  },
+  personal: {
+    streak: "on a booking streak",
+    coldHint: "book your usual week to light it",
+    legendTarget: "Hit your pace",
+    legendMid: "Light week",
+    legendBelow: "Slow",
+    thisWeek: {
+      target: { text: "You beat your usual week — nice run.", color: "var(--color-status-positive-text)" },
+      breakeven: { text: "A lighter week — a bit more matches your usual pace.", color: "var(--color-amber)" },
+      below: { text: "Slow start this week.", color: "var(--color-status-negative-text)" },
+      home: { text: "Nothing delivered yet this week.", color: "var(--color-dim)" },
+    },
+  },
 };
 
 const Dot = ({ style, label }: { style?: CSSProperties; label: string }) => (
@@ -43,13 +70,15 @@ const Dot = ({ style, label }: { style?: CSSProperties; label: string }) => (
   </span>
 );
 
-export const GrindMeter = ({ loads }: { loads: Load[] }) => {
-  const grind = useGrind(loads);
+// Presentational — takes a pre-computed grind so a dispatcher's personal-pace
+// grind can flow through without the owner's P&L fetch.
+export const GrindMeterView = ({ grind, mode = "owner" }: { grind: Grind | null; mode?: Mode }) => {
   if (!grind || !grind.hasLadder || grind.weeks.length === 0) return null;
 
+  const c = COPY[mode];
   const { currentStreak, bestStreak, weeks, thisWeek } = grind;
   const cold = currentStreak === 0;
-  const status = thisWeekLine(thisWeek);
+  const status = c.thisWeek[thisWeek];
 
   return (
     <Board className="p-4">
@@ -70,9 +99,7 @@ export const GrindMeter = ({ loads }: { loads: Load[] }) => {
           {cold ? (
             <>
               <span className="font-forge font-bold text-[30px] text-faint">COLD</span>
-              <div className="text-xs text-dim mt-1.5">
-                beat target this week to light it
-              </div>
+              <div className="text-xs text-dim mt-1.5">{c.coldHint}</div>
             </>
           ) : (
             <>
@@ -82,7 +109,7 @@ export const GrindMeter = ({ loads }: { loads: Load[] }) => {
               <span className="font-forge font-semibold text-[15px] ml-1.5 text-dim">
                 {currentStreak === 1 ? "WEEK" : "WEEKS"}
               </span>
-              <div className="text-xs text-dim mt-1">on a target-beating streak</div>
+              <div className="text-xs text-dim mt-1">{c.streak}</div>
             </>
           )}
         </div>
@@ -117,9 +144,9 @@ export const GrindMeter = ({ loads }: { loads: Load[] }) => {
       </div>
 
       <div className="flex gap-x-4 gap-y-1 flex-wrap mt-3">
-        <Dot style={CELL.target.style} label="Beat target" />
-        <Dot style={CELL.breakeven.style} label="Covered break-even" />
-        <Dot style={CELL.below.style} label="Below" />
+        <Dot style={CELL.target.style} label={c.legendTarget} />
+        <Dot style={CELL.breakeven.style} label={c.legendMid} />
+        <Dot style={CELL.below.style} label={c.legendBelow} />
         <Dot style={{ background: "var(--color-well)" }} label="Home" />
       </div>
 
@@ -129,4 +156,10 @@ export const GrindMeter = ({ loads }: { loads: Load[] }) => {
       </div>
     </Board>
   );
+};
+
+// The owner's grind — fetches the P&L target via useGrind, then renders the view.
+export const GrindMeter = ({ loads }: { loads: Load[] }) => {
+  const grind = useGrind(loads);
+  return <GrindMeterView grind={grind} mode="owner" />;
 };

--- a/frontend/src/hooks/useDispatcherAwardPops.ts
+++ b/frontend/src/hooks/useDispatcherAwardPops.ts
@@ -37,23 +37,24 @@ export const useDispatcherAwardPops = (
   input: DispatcherAwardInput | null,
 ): Award[] => {
   const [pops, setPops] = useState<Award[]>([]);
-  const [done, setDone] = useState(false);
+  // Depend on the underlying DATA, not the input object (rebuilt every render).
+  // Recomputing whenever her loads/streak change — rather than once per mount —
+  // is what makes a freshly-earned award actually fire; the per-device seen-store
+  // dedups, so a re-run never re-pops something already celebrated.
+  const loads = input?.loads;
+  const userId = input?.userId;
+  const streak = input?.streak;
+  const freeHours = input?.freeHours;
+  const ladder = input?.ladder;
 
   useEffect(() => {
-    if (!input || input.loads.length === 0 || done) return;
-    setDone(true);
+    if (!input || !loads || loads.length === 0) return;
 
     // Patches + medals (incl. Backhaul Boss) plus the current-period season
     // trophies — all through one seen-store so day-one baselines silently.
     const earned = [
       ...dispatcherEarnedAwards(input),
-      ...dispatcherSeasonAwards(
-        input.loads,
-        input.userId,
-        input.ladder,
-        input.freeHours,
-        new Date(),
-      ),
+      ...dispatcherSeasonAwards(loads, userId!, ladder!, freeHours!, new Date()),
     ];
     const currentIds = earned.map((a) => a.id);
     const store = read();
@@ -67,7 +68,8 @@ export const useDispatcherAwardPops = (
       write({ baselined: true, seen: [...new Set([...store.seen, ...currentIds])] });
       setPops(fresh);
     }
-  }, [input, done]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loads, userId, streak, freeHours, ladder]);
 
   return pops;
 };

--- a/frontend/src/hooks/useGrind.ts
+++ b/frontend/src/hooks/useGrind.ts
@@ -6,7 +6,7 @@ import { getExpensePeriods } from "@/services/expensesService";
 import { getObligations } from "@/services/obligationsService";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
 import type { SettlementSchedule } from "@/types/settlementSchedule";
-import { computeGrind, type Grind } from "@/lib/metrics/grind";
+import { computeGrind, computePersonalGrind, type Grind } from "@/lib/metrics/grind";
 import { monthlyObligationCost } from "@/lib/metrics/rateTargets";
 import { marginGoalFrom } from "@/lib/constants/targets";
 
@@ -29,3 +29,11 @@ export const useGrind = (loads: Load[]): Grind | null => {
     return computeGrind(loads, periods, obligationsMonthly, new Date(), marginGoalFrom(schedule));
   }, [periods, obligations, loads, schedule]);
 };
+
+// A dispatcher's personal-pace grind — graded against her own typical week, so no
+// P&L is needed. Null until she has enough booking history for a bar.
+export const usePersonalGrind = (mine: Load[]): Grind | null =>
+  useMemo(
+    () => (mine.length > 0 ? computePersonalGrind(mine, new Date()) : null),
+    [mine],
+  );

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -25,6 +25,7 @@ const FULL_BLEED_PREFIXES = [
   { prefix: "/facilities", ownerOnly: false },
   { prefix: "/drivers", ownerOnly: false },
   { prefix: "/dispatcher", ownerOnly: false },
+  { prefix: "/forge", ownerOnly: false }, // Dispatch Forge — carries its own trigger
   { prefix: "/trucks", ownerOnly: false },
   { prefix: "/trailers", ownerOnly: false },
   { prefix: "/maintenance", ownerOnly: false },

--- a/frontend/src/lib/awards/dispatcherAwards.ts
+++ b/frontend/src/lib/awards/dispatcherAwards.ts
@@ -10,6 +10,7 @@ import { loadDeadheadPct, loadEmptyMiles } from "@/lib/metrics/deadhead";
 import { onTimeStatus, detentionCollected } from "@/lib/detention";
 import { isSpecializedLoadType } from "@/lib/dimensions";
 import { tiered, type Medal } from "./medals";
+import { howToEarn } from "./dispatcherHowTo";
 import type { Award } from "@/lib/metrics/awards";
 import {
   DEADHEAD_TARGET,
@@ -258,7 +259,7 @@ export const dispatcherEarnedAwards = (input: DispatcherAwardInput): Award[] => 
         id: `medal:${m.key}:${m.tier}`,
         tier: "medal",
         name: `${m.name} ${m.tierLabel}`,
-        detail: m.hint,
+        detail: howToEarn(m.key) || m.hint,
         icon: m.icon,
         medalTier: m.tier,
       });

--- a/frontend/src/lib/awards/dispatcherHowTo.ts
+++ b/frontend/src/lib/awards/dispatcherHowTo.ts
@@ -1,0 +1,32 @@
+// One-line "how to earn" for every dispatcher achievement — the single source of
+// truth, shown on the forge-room card, in the earned-award pop, and in the Guide,
+// so a cryptic name like "Whale" or "Backhaul Boss" is never a mystery. Keyed by
+// the same medal/patch/season keys the award engines use.
+export const DISPATCHER_HOW_TO: Record<string, string> = {
+  // medals (rare feats)
+  "disp-steal": "Book a load the Scorer grades a STEAL",
+  "disp-double-up": "Book a load paying 2× your break-even",
+  "disp-whale": "Book a load grossing $10k or more",
+  "disp-superload": "Book a superload — 16'+ wide/tall, 150'+ long, or 200k lb",
+  "disp-perfect-week": "A week where every load beats your target rate",
+  "disp-grand-slam": "A steal that's on-time both ends, under 10% deadhead",
+  "disp-big-week": "Book 5+ loads in one week",
+  // patches (the grind)
+  "disp-deal-closer": "Every load you book",
+  "disp-rainmaker": "Total gross you've booked",
+  "disp-rate-hawk": "Book a load at or above your target rate",
+  "disp-iron-booker": "Weeks in a row hitting your booking pace",
+  "disp-bounty": "Loads where you collected detention",
+  "disp-right-hand": "Loads booked with a single agent",
+  "disp-clockwork": "Loads on-time at pickup AND delivery",
+  "disp-quick-turn": "Book the next load within a day of delivering",
+  "disp-oversize": "Book oversize loads",
+  "disp-lean": "Loads that ran with low deadhead",
+  "disp-backhaul-boss": "Book a return leg from where you last delivered",
+  // season crowns
+  booking: "Book the most loads this period",
+  rate: "Book the highest average rate this period",
+  perfect: "Deliver every load on-time this period",
+};
+
+export const howToEarn = (key: string): string => DISPATCHER_HOW_TO[key] ?? "";

--- a/frontend/src/lib/metrics/grind.test.ts
+++ b/frontend/src/lib/metrics/grind.test.ts
@@ -3,8 +3,21 @@ import {
   classify,
   currentStreakOf,
   bestStreakOf,
+  computePersonalGrind,
   type WeekStatus,
 } from "./grind";
+import type { Load } from "@/types/load";
+
+// A delivered load worth `gross`, keyed to a delivery week.
+const deliv = (date: string, gross: number) =>
+  ({
+    load_status: "delivered",
+    delivery_date: date,
+    linehaul: gross,
+    fuel_surcharge: 0,
+    total_accessorials: 0,
+    booked_by: "u1",
+  } as unknown as Load);
 
 const targets = {
   weeklyBreakEven: 5447,
@@ -43,5 +56,59 @@ describe("bestStreakOf", () => {
     expect(bestStreakOf(["target", "target", "below", "target", "target", "target"])).toBe(3);
     expect(bestStreakOf(["target", "home", "target"])).toBe(2);
     expect(bestStreakOf(["below", "breakeven", "home"])).toBe(0);
+  });
+});
+
+describe("computePersonalGrind — graded against her own typical week", () => {
+  it("streaks the weeks at/above 75% of her typical, a slow week breaks it", () => {
+    // typical (median of active) = 9000 → bar 6750, floor 3600.
+    const loads = [
+      deliv("2026-01-01", 10000),
+      deliv("2026-01-08", 10000),
+      deliv("2026-01-15", 10000),
+      deliv("2026-01-22", 2000), // below floor → breaks the streak
+      deliv("2026-01-29", 9000),
+      deliv("2026-02-05", 9000),
+      deliv("2026-02-12", 9000),
+      deliv("2026-02-19", 8000),
+    ];
+    const g = computePersonalGrind(loads, new Date("2026-03-04T12:00:00Z"));
+    expect(g.hasLadder).toBe(true);
+    expect(g.currentStreak).toBe(4); // the four weeks after the slow one
+    expect(g.bestStreak).toBe(4);
+    expect(g.thisWeek).toBe("home"); // nothing delivered in the current week
+  });
+
+  it("needs a few active weeks before a bar is meaningful", () => {
+    const g = computePersonalGrind(
+      [deliv("2026-02-05", 9000), deliv("2026-02-12", 9000)],
+      new Date("2026-03-04T12:00:00Z"),
+    );
+    expect(g.hasLadder).toBe(false); // < 3 active weeks
+    expect(g.currentStreak).toBe(0);
+  });
+
+  it("degrades cleanly with no delivered freight", () => {
+    const g = computePersonalGrind([], new Date("2026-03-04T12:00:00Z"));
+    expect(g.hasLadder).toBe(false);
+    expect(g.weeks).toEqual([]);
+  });
+
+  it("reads 'typical' from the trailing quarter, not all-time (seasonal)", () => {
+    // Old huge weeks (outside the 13-week window) must NOT set the bar. If they
+    // did, the bar would be ~15000 and her recent $6k weeks would read 'below'
+    // (streak 0). Windowed, the bar is 4500 and the recent weeks streak.
+    const loads = [
+      deliv("2025-12-03", 20000),
+      deliv("2025-12-10", 20000),
+      deliv("2025-12-17", 20000),
+      deliv("2025-12-24", 20000),
+      deliv("2026-05-13", 6000),
+      deliv("2026-05-20", 6000),
+      deliv("2026-05-27", 6000),
+    ];
+    const g = computePersonalGrind(loads, new Date("2026-06-03T12:00:00Z"));
+    expect(g.hasLadder).toBe(true);
+    expect(g.currentStreak).toBeGreaterThanOrEqual(3); // recent weeks count as target
   });
 });

--- a/frontend/src/lib/metrics/grind.ts
+++ b/frontend/src/lib/metrics/grind.ts
@@ -73,22 +73,23 @@ export const bestStreakOf = (statuses: WeekStatus[]): number => {
   return best;
 };
 
-export const computeGrind = (
-  loads: Load[],
-  periods: ExpensePeriod[],
-  obligationsMonthly: number,
-  now: Date,
-  marginGoal: number = MARGIN_GOAL,
-  weeksToShow = 14,
-): Grind => {
-  const basis = getCostBasis(periods, obligationsMonthly, loads, now);
-  const targets = getGrossTargets(
-    basis.trueMonthlyCost,
-    marginGoal,
-    WORKING_DAYS_PER_MONTH,
-  );
-  const hasLadder = targets.weeklyTarget != null;
+const medianOf = (xs: number[]): number | null => {
+  if (xs.length === 0) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
 
+// The shared core: grade every pay-week from the earliest delivery to now against
+// a target set, and roll up the streaks. Both grinds — the owner's cost target and
+// a dispatcher's personal pace — flow through here so they render identically.
+const grindFrom = (
+  loads: Load[],
+  targets: GrossTargets,
+  now: Date,
+  weeksToShow: number,
+  hasLadder: boolean,
+): Grind => {
   const current = payWeekRange(now, PAY_WEEK_START_DOW);
   const thisWeekGross = getWeekEarnedGross(loads, current.start, current.end);
   const thisWeek: WeekStatus = hasLadder ? classify(thisWeekGross, targets) : "home";
@@ -126,4 +127,70 @@ export const computeGrind = (
     thisWeekGross,
     hasLadder,
   };
+};
+
+export const computeGrind = (
+  loads: Load[],
+  periods: ExpensePeriod[],
+  obligationsMonthly: number,
+  now: Date,
+  marginGoal: number = MARGIN_GOAL,
+  weeksToShow = 14,
+): Grind => {
+  const basis = getCostBasis(periods, obligationsMonthly, loads, now);
+  const targets = getGrossTargets(
+    basis.trueMonthlyCost,
+    marginGoal,
+    WORKING_DAYS_PER_MONTH,
+  );
+  return grindFrom(loads, targets, now, weeksToShow, targets.weeklyTarget != null);
+};
+
+// A dispatcher's grind, graded against HER OWN typical week instead of the shop's
+// cost target — so the streak is winnable and genuinely hers. "Typical" is the
+// median of her active (non-zero) weekly booked gross over the trailing quarter,
+// so the bar tracks the current season, not an all-time average. A week at ≥ 75%
+// of that keeps the streak hot; an off week (nothing delivered) stays neutral.
+export const PERSONAL_SOLID = 0.75; // ≥ this share of a typical week = a "target" week
+export const PERSONAL_FLOOR = 0.4; // below this share = a "below" week
+const TYPICAL_WINDOW_WEEKS = 13; // ~ a quarter — the seasonal window for "typical"
+const MIN_ACTIVE_WEEKS = 3; // need a few weeks before a personal bar is meaningful
+
+export const computePersonalGrind = (
+  mine: Load[],
+  now: Date,
+  weeksToShow = 14,
+): Grind => {
+  const empty: Grind = {
+    weeks: [], currentStreak: 0, bestStreak: 0, thisWeek: "home", thisWeekGross: 0, hasLadder: false,
+  };
+  const delivered = mine.filter((l) => l.load_status === "delivered" && l.delivery_date);
+  if (delivered.length === 0) return empty;
+
+  let earliest = delivered[0].delivery_date!;
+  for (const l of delivered)
+    if (l.delivery_date! < earliest) earliest = l.delivery_date!;
+  const firstStart = payWeekRange(
+    new Date(earliest.slice(0, 10) + "T00:00:00Z"),
+    PAY_WEEK_START_DOW,
+  ).start;
+  const current = payWeekRange(now, PAY_WEEK_START_DOW);
+
+  // Her active weekly grosses over the trailing quarter → the seasonal "typical".
+  const windowStart = current.start.getTime() - TYPICAL_WINDOW_WEEKS * WEEK_MS;
+  const active: number[] = [];
+  for (let t = firstStart.getTime(); t < current.start.getTime(); t += WEEK_MS) {
+    if (t < windowStart) continue;
+    const g = getWeekEarnedGross(mine, new Date(t), new Date(t + WEEK_MS));
+    if (g > 0) active.push(g);
+  }
+  const typical = medianOf(active);
+  const hasLadder = typical != null && typical > 0 && active.length >= MIN_ACTIVE_WEEKS;
+  const targets: GrossTargets = {
+    weeklyBreakEven: typical != null ? typical * PERSONAL_FLOOR : null,
+    weeklyTarget: typical != null ? typical * PERSONAL_SOLID : null,
+    dailyBreakEven: null,
+    dailyTarget: null,
+  };
+  return grindFrom(mine, targets, now, weeksToShow, hasLadder);
 };

--- a/frontend/src/pages/DispatchDashboard.tsx
+++ b/frontend/src/pages/DispatchDashboard.tsx
@@ -7,12 +7,12 @@ import { useRateTargets } from "@/hooks/useRateTargets";
 import { useMaintenanceAlerts } from "@/hooks/useMaintenanceAlerts";
 import { useComplianceAlerts } from "@/hooks/useComplianceAlerts";
 import { useDispatcherAwardPops } from "@/hooks/useDispatcherAwardPops";
-import { useGrind } from "@/hooks/useGrind";
+import { usePersonalGrind } from "@/hooks/useGrind";
 import { AwardPopHost } from "@/components/celebrations/AwardPopHost";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { AlertBanners } from "@/components/dashboard/AlertBanners";
-import { GrindMeter } from "@/components/dashboard/GrindMeter";
+import { GrindMeterView } from "@/components/dashboard/GrindMeter";
 import { TopAgents } from "@/components/dashboard/TopAgents";
 import { DispatchLoadsTable } from "@/components/dashboard/DispatchLoadsTable";
 import { DispatchAgentsTable } from "@/components/dashboard/DispatchAgentsTable";
@@ -32,6 +32,7 @@ import {
   currentQuarterStandings,
 } from "@/lib/metrics/agentLeaderboard";
 import { getDispatcherCard } from "@/lib/metrics/dispatcherCard";
+import { getWeekGrossCommitted, getWeekGrossEarned } from "@/lib/metrics/rateTargets";
 import { getSettlementSchedule } from "@/services/settlementScheduleService";
 import { DEADHEAD_TARGET } from "@/lib/constants/targets";
 import { money, rpm as fmtRpm } from "@/lib/format";
@@ -61,8 +62,19 @@ const DispatchDashboard = () => {
   const { trips, isLoading: tripsLoading, error: tripsError } = useTrips(0);
   const targets = useRateTargets(loads);
   const alerts = [...useMaintenanceAlerts(loads), ...useComplianceAlerts()];
-  const grind = useGrind(loads);
   const now = useMemo(() => new Date(), []);
+
+  // Her board counts only the loads SHE booked (the shared agent race below stays
+  // account-wide). Attribution is booked_by === her own id.
+  const selfId = localStorage.getItem("user_id") ?? "";
+  const mine = useMemo(
+    () => (selfId ? loads.filter((l) => l.booked_by === selfId) : []),
+    [loads, selfId],
+  );
+  // Her personal-pace streak: graded against her OWN typical week (median of her
+  // recent weekly booked gross), so it's winnable and genuinely hers — not the
+  // shop's cost target. Feeds the HEAT meter + the Iron Booker patch.
+  const grind = usePersonalGrind(mine);
 
   // Free-time setting drives what counts as detention (same source as Loads).
   const [freeHours, setFreeHours] = useState(3);
@@ -75,7 +87,6 @@ const DispatchDashboard = () => {
   // Her achievements pop the same way the driver's do — computed from her own
   // bookings, celebrated on her board. Gated on the rate ladder being ready so
   // the day-one baseline is built from complete data.
-  const selfId = localStorage.getItem("user_id") ?? "";
   const awardInput =
     selfId && targets.bookingLadder.walkAway != null
       ? {
@@ -88,6 +99,10 @@ const DispatchDashboard = () => {
           },
           freeHours,
           streak: grind?.bestStreak ?? 0,
+          // Grade "steal"/"grand slam" on the same tiers her forge page uses, so
+          // the two surfaces never disagree on a medal.
+          tiers: targets.tiers,
+          specTiers: targets.specTiers,
         }
       : null;
   const pops = useDispatcherAwardPops(awardInput);
@@ -130,11 +145,11 @@ const DispatchDashboard = () => {
       </div>
     );
 
-  const bookedCount = loads.filter((l) => l.load_status === "booked").length;
-  const inTransitCount = loads.filter(
+  const bookedCount = mine.filter((l) => l.load_status === "booked").length;
+  const inTransitCount = mine.filter(
     (l) => l.load_status === "in_transit",
   ).length;
-  const loadsMonthly = getLoadsMonthly(loads);
+  const loadsMonthly = getLoadsMonthly(mine);
   const loadsDeltaPct =
     loadsMonthly.lastMonth > 0
       ? Math.round(
@@ -143,7 +158,10 @@ const DispatchDashboard = () => {
             100,
         )
       : null;
-  const detention = getDetentionOwed(loads, freeHours);
+  const detention = getDetentionOwed(mine, freeHours);
+  // Deadhead is truck physics — trips carry no booker, so pairing HER loads with
+  // fleet trips would mis-charge fleet empty miles against her loaded miles. Keep
+  // it account-wide (the rig's real deadhead), which is what the tile means.
   const deadhead = getDeadheadTrend(loads, trips, now);
   // Leaner than the 90-day baseline (or the target when there's no baseline yet)
   // reads green; drifting above it reads red so she catches it early.
@@ -158,9 +176,16 @@ const DispatchDashboard = () => {
   const agentHonors = computeHonors(loads, now);
   const agentStandings = currentQuarterStandings(loads, now);
 
-  // Her chase surface — the ladder she books against and the week she's filling.
-  const earned = targets.weekEarned ?? 0;
-  const committed = targets.weekBooked ?? 0;
+  // Her chase surface — the shop's booking floor + weekly target (account cost),
+  // but the week she's actually filling is HER bookings (earned + committed).
+  const earned =
+    targets.weekStart && targets.weekEnd
+      ? getWeekGrossEarned(mine, targets.weekStart, targets.weekEnd)
+      : 0;
+  const committed =
+    targets.weekStart && targets.weekEnd
+      ? getWeekGrossCommitted(mine, targets.weekStart, targets.weekEnd)
+      : 0;
   const weeklyTarget: number | null = targets.gross?.weeklyTarget ?? null;
   const weeklyFloor: number | null = targets.gross?.weeklyBreakEven ?? null;
   const dailyTarget: number | null = targets.gross?.dailyTarget ?? null;
@@ -311,7 +336,7 @@ const DispatchDashboard = () => {
             <ForgedPlate chamfer tilt className="p-5">
               <div className="flex items-baseline justify-between flex-wrap gap-2">
                 <span className="ds2-label">
-                  Booking floor &amp; week pace · gross — your numbers
+                  Booking floor &amp; your week pace · gross
                 </span>
                 {cur != null && (
                   <span className="font-condensed font-semibold text-[15px] text-amber-hi tabular-nums">
@@ -413,7 +438,7 @@ const DispatchDashboard = () => {
                 )}
               </div>
             </ForgedPlate>
-            <GrindMeter loads={loads} />
+            <GrindMeterView grind={grind} mode="personal" />
           </div>
 
           {/* The workhorses — searchable, paginated loads + agents */}

--- a/frontend/src/pages/DispatchForgePage.tsx
+++ b/frontend/src/pages/DispatchForgePage.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useMemo, useState } from "react";
+import { useLoads } from "@/hooks/useLoads";
+import { useRateTargets } from "@/hooks/useRateTargets";
+import { usePersonalGrind } from "@/hooks/useGrind";
+import { useDispatcherAwardPops } from "@/hooks/useDispatcherAwardPops";
+import { getUser, type TeamMember } from "@/services/teamService";
+import { getSettlementSchedule } from "@/services/settlementScheduleService";
+import { getDispatcherCard } from "@/lib/metrics/dispatcherCard";
+import {
+  dispatcherMedals,
+  dispatcherPatches,
+  type DispatcherAwardInput,
+  type GrindPatch,
+} from "@/lib/awards/dispatcherAwards";
+import { currentSeason, type SeasonTrophy } from "@/lib/metrics/dispatcherSeason";
+import { howToEarn } from "@/lib/awards/dispatcherHowTo";
+import type { Medal } from "@/lib/awards/medals";
+import { AwardPopHost } from "@/components/celebrations/AwardPopHost";
+import { EntityAvatar } from "@/components/fleet/EntityAvatar";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// The forge is a playful surface — emoji read faster than lucide here, and match
+// the medal/patch icon vocabulary the award engines already assign.
+const EMOJI: Record<string, string> = {
+  crown: "👑", coins: "🪙", package: "📦", mountain: "⛰️", medal: "🥇",
+  trophy: "🏆", "stack-2": "📚", cash: "💰", feather: "🪶", flame: "🔥",
+  users: "🤝", gauge: "⏱️", "arrows-horizontal": "🔁", truck: "🚛",
+  route: "🛣️", road: "🛣️",
+};
+const emoji = (icon: string) => EMOJI[icon] ?? "🎖️";
+
+const TIER_RING = ["#33415a", "#b08d57", "#c9d3e0", "#f5b03a"]; // none/bronze/silver/gold
+const Bar = ({ pct, tone = "#f5b03a" }: { pct: number; tone?: string }) => (
+  <div className="h-[7px] rounded-[6px] mt-2 overflow-hidden" style={{ background: "#090d15", border: "1px solid #1a2436" }}>
+    <i className="block h-full rounded-[6px]" style={{ width: `${Math.round(Math.min(1, Math.max(0, pct)) * 100)}%`, background: `linear-gradient(90deg,#e8940a,${tone})` }} />
+  </div>
+);
+
+const RackHead = ({ title, right }: { title: string; right?: string }) => (
+  <div className="flex items-baseline gap-3 mt-8 mb-3">
+    <h2 className="font-forge font-bold text-[15px] tracking-[2.5px] text-amber-hi whitespace-nowrap">{title}</h2>
+    <span className="flex-1 h-px" style={{ background: "linear-gradient(90deg,rgba(34,48,74,.9),transparent)" }} />
+    {right && <span className="text-[11px] tracking-[1.5px] uppercase text-faint">{right}</span>}
+  </div>
+);
+
+const NextCard = ({ icon, name, gap, sub, pct }: { icon: string; name: string; gap: string; sub?: string; pct: number }) => (
+  <div className="relative rounded-[12px] p-[13px_14px] overflow-hidden" style={{ background: "linear-gradient(180deg,rgba(20,27,40,.8),#090d15)", border: "1px solid #22304a" }}>
+    <span className="absolute left-0 top-0 bottom-0 w-[3px] bg-amber" />
+    <div className="text-[19px]">{icon}</div>
+    <div className="text-[14.5px] font-bold text-cream mt-[3px]" style={{ color: "#f5e6c8" }}>{name}</div>
+    <div className="text-[12px] font-semibold text-amber-hi">{gap}</div>
+    {sub && <div className="text-[11px] text-faint mt-[2px]">{sub}</div>}
+    <Bar pct={pct} />
+  </div>
+);
+
+const Coin = ({ m }: { m: Medal }) => {
+  const on = m.tier > 0;
+  return (
+    <div className="text-center rounded-[11px] p-[12px_10px_10px]" style={{ background: "#090d15", border: "1px solid #22304a" }}>
+      <div
+        className="w-[70px] h-[70px] rounded-full mx-auto mb-[7px] flex items-center justify-center text-[26px] relative"
+        style={{
+          background: "radial-gradient(circle at 38% 30%,#20293a,#0c1017)",
+          border: `${on ? 3 : 2}px ${on ? "solid" : "dashed"} ${TIER_RING[on ? Math.min(3, m.tier) : 0]}`,
+          filter: on ? undefined : "grayscale(1) brightness(.5)",
+          boxShadow: on ? `0 0 18px ${TIER_RING[Math.min(3, m.tier)]}66` : undefined,
+        }}
+      >
+        {emoji(m.icon)}
+        {!on && <span className="absolute -bottom-1 -right-1 text-[13px] opacity-70">🔒</span>}
+      </div>
+      <div className={`text-[12px] font-semibold ${on ? "text-ink" : "text-faint"}`}>{m.name}</div>
+      <div className="text-[10px] uppercase tracking-[.5px]" style={{ color: on ? TIER_RING[Math.min(3, m.tier)] : "#5a6880" }}>
+        {on ? `Tier ${m.tierLabel} · ${m.hint.split(" · ")[0]}` : m.hint}
+      </div>
+      <div className="text-[10px] leading-[1.35] text-faint mt-1 pt-1" style={{ borderTop: "1px dashed #223049" }}>
+        {howToEarn(m.key)}
+      </div>
+    </div>
+  );
+};
+
+const Tag = ({ p }: { p: GrindPatch }) => (
+  <div className={`rounded-[10px] p-[10px_12px] ${p.earned ? "" : "opacity-60"}`} style={{ background: "#090d15", border: "1px solid #22304a" }}>
+    <div className="grid grid-cols-[auto_1fr] gap-[11px] items-center">
+      <div className="w-[34px] h-[34px] rounded-[8px] flex items-center justify-center text-[17px]" style={{ background: p.earned ? "rgba(232,148,10,.10)" : "rgba(90,104,123,.1)", border: `1px solid ${p.earned ? "rgba(232,148,10,.3)" : "#2b384f"}` }}>
+        {emoji(p.icon)}
+      </div>
+      <div className="min-w-0">
+        <div className="text-[13.5px] font-semibold" style={{ color: "#f5e6c8" }}>{p.name}</div>
+        <div className={`text-[11.5px] font-semibold ${p.earned ? "text-amber-hi" : "text-faint"}`}>{p.badge} · {p.hint}</div>
+      </div>
+    </div>
+    <Bar pct={p.progress} />
+    <div className="text-[10.5px] text-faint mt-[3px]">{howToEarn(p.key)}</div>
+  </div>
+);
+
+const Crown = ({ t, period }: { t: SeasonTrophy; period: string }) => (
+  <div className={`rounded-[13px] p-[15px] text-center ${t.earned ? "" : ""}`} style={{ background: "linear-gradient(180deg,rgba(20,27,40,.8),#090d15)", border: `1px solid ${t.earned ? "rgba(245,176,58,.5)" : "#22304a"}`, boxShadow: t.earned ? "0 0 22px rgba(232,148,10,.16) inset" : undefined }}>
+    <div className="text-[32px]" style={{ filter: t.earned ? undefined : "grayscale(1) brightness(.55)" }}>👑</div>
+    <div className="text-[14.5px] font-bold mt-[5px]" style={{ color: "#f5e6c8" }}>{t.name}</div>
+    <div className={`text-[11.5px] mt-[2px] ${t.earned ? "text-amber-hi" : "text-dim"}`}>{t.detail}</div>
+    <div className="text-[10.5px] text-faint mt-[6px] pt-[6px]" style={{ borderTop: "1px dashed #223049" }}>
+      {howToEarn(t.key)} · {period}
+    </div>
+  </div>
+);
+
+const DispatchForgePage = () => {
+  const { loads, isLoading, error } = useLoads(0);
+  const targets = useRateTargets(loads);
+  const now = useMemo(() => new Date(), []);
+
+  const selfId = localStorage.getItem("user_id") ?? "";
+  const mine = useMemo(
+    () => (selfId ? loads.filter((l) => l.booked_by === selfId) : []),
+    [loads, selfId],
+  );
+  // Iron Booker rides her personal-pace booking streak (graded against her own
+  // typical week), matching the dispatch board.
+  const grind = usePersonalGrind(mine);
+
+  const [member, setMember] = useState<TeamMember | null>(null);
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [freeHours, setFreeHours] = useState(3);
+
+  useEffect(() => {
+    if (!selfId) return;
+    getUser(selfId)
+      .then((u) => {
+        setMember(u);
+        setAvatarUrl(u.avatar_url);
+      })
+      .catch(() => {});
+    getSettlementSchedule()
+      .then((s) => setFreeHours(s.detention_free_hours))
+      .catch(() => {});
+  }, [selfId]);
+
+  const awardInput: DispatcherAwardInput | null =
+    selfId && targets.bookingLadder.walkAway != null
+      ? {
+          loads,
+          userId: selfId,
+          ladder: targets.bookingLadder,
+          scoreBasis: {
+            costPerDrivenMile: targets.basis.costPerTotalMile,
+            payTake: targets.basis.payTake,
+          },
+          freeHours,
+          streak: grind?.bestStreak ?? 0,
+          tiers: targets.tiers,
+          specTiers: targets.specTiers,
+        }
+      : null;
+  const pops = useDispatcherAwardPops(awardInput);
+
+  if (isLoading)
+    return (
+      <div className="p-6 text-ink font-body min-h-screen">
+        <Skeleton className="h-40" style={{ borderRadius: 16 }} />
+        <Skeleton className="h-56 mt-6" style={{ borderRadius: 16 }} />
+      </div>
+    );
+  if (error)
+    return (
+      <div className="p-6 text-ink min-h-screen">
+        <p className="text-destructive">{error}</p>
+      </div>
+    );
+
+  const input: DispatcherAwardInput = awardInput ?? {
+    loads,
+    userId: selfId,
+    ladder: targets.bookingLadder,
+    scoreBasis: { costPerDrivenMile: targets.basis.costPerTotalMile, payTake: targets.basis.payTake },
+    freeHours,
+    streak: grind?.bestStreak ?? 0,
+    tiers: targets.tiers,
+    specTiers: targets.specTiers,
+  };
+
+  const card = getDispatcherCard(loads, selfId, targets.bookingLadder, freeHours, now);
+  const medals = dispatcherMedals(input);
+  const patches = dispatcherPatches(input);
+  const season = currentSeason(loads, selfId, "quarter", targets.bookingLadder, freeHours, now);
+  const name = member ? member.display_name || member.email : "Dispatcher";
+
+  const earnedMedals = medals.filter((m) => m.tier > 0).length;
+  const earnedPatches = patches.filter((p) => p.reached > 0).length;
+  const crowns = season.trophies.filter((t) => t.earned).length;
+
+  // NEXT UP — the closest not-yet-maxed achievements, most-progressed first, so
+  // there's always a concrete next thing to chase.
+  type Cand = { icon: string; name: string; gap: string; sub?: string; pct: number };
+  const cands: Cand[] = [];
+  if (card.rank.next)
+    cands.push({
+      icon: "🎖️",
+      name: card.rank.next.name,
+      gap: `${Math.max(0, card.rank.next.min - card.rank.count)} loads to the next rank`,
+      sub: `${card.rank.count} of ${card.rank.next.min} booked`,
+      pct: card.rank.pct,
+    });
+  for (const m of medals)
+    if (m.next != null)
+      cands.push({ icon: emoji(m.icon), name: `${m.name} · Tier ${m.tier + 1}`, gap: howToEarn(m.key), sub: m.hint, pct: m.progress });
+  for (const p of patches)
+    if (p.progress < 1)
+      cands.push({ icon: emoji(p.icon), name: `${p.name} · ${p.hint.replace(/^next: /, "")}`, gap: howToEarn(p.key), sub: `at ${p.badge}`, pct: p.progress });
+  const nextUp = cands.sort((a, b) => b.pct - a.pct).slice(0, 4);
+
+  return (
+    <div
+      className="min-h-screen text-ink font-body"
+      style={{ background: "radial-gradient(1200px 500px at 50% -6%, rgba(232,148,10,.10), transparent 60%)" }}
+    >
+      <AwardPopHost pops={pops} />
+      <div className="max-w-[960px] mx-auto px-4 sm:px-6 pb-12">
+        <div className="flex items-center gap-x-[14px] gap-y-2 flex-wrap pt-5 pb-3.5">
+          <SidebarTrigger className="text-dim hover:text-ink -ml-1" />
+          <span className="font-condensed font-medium text-[13px] tracking-[.14em] text-faint uppercase">
+            Delgado Trucking · Dispatch Floor
+          </span>
+        </div>
+
+        {/* HERO */}
+        <div
+          className="grid grid-cols-[auto_1fr] gap-[22px] items-center rounded-[16px] p-[20px_22px]"
+          style={{ border: "1px solid #22304a", background: "linear-gradient(180deg, rgba(18,24,36,.7), rgba(10,13,19,.5))" }}
+        >
+          <div className="shrink-0">
+            {/* key remounts the avatar when the URL arrives — EntityAvatar seeds
+                its image state once and ignores later prop changes. */}
+            <EntityAvatar key={avatarUrl ?? "none"} kind="user" id={selfId} avatarUrl={avatarUrl} size={96} allowVariant onUpdated={setAvatarUrl} />
+          </div>
+          <div className="min-w-0">
+            <h1
+              className="font-forge font-extrabold leading-[.86] mb-[10px]"
+              style={{ fontSize: "clamp(34px,6vw,58px)", color: "#f5b03a", textShadow: "3px 4px 0 #0a0d13, 0 0 30px rgba(232,148,10,.45)" }}
+            >
+              THE DISPATCH FORGE
+            </h1>
+            <div className="flex items-center gap-3 flex-wrap">
+              <span className="inline-flex items-center gap-2 text-[15px] font-bold rounded-full px-[14px] py-[5px]" style={{ color: "#f5e6c8", background: "rgba(232,148,10,.12)", border: "1px solid rgba(232,148,10,.4)" }}>
+                <span className="text-gold" style={{ color: "#f5b03a" }}>★</span> {card.rank.name}
+              </span>
+              <span className="text-[12px] text-dim">
+                <b className="text-amber-hi">{earnedMedals}</b> medals · <b className="text-amber-hi">{earnedPatches}</b> patches · <b className="text-amber-hi">{crowns}</b> season {crowns === 1 ? "crown" : "crowns"}
+              </span>
+            </div>
+            {card.rank.next && (
+              <div className="mt-[11px] max-w-[420px]">
+                <div className="flex justify-between text-[11.5px] text-faint mb-[5px]">
+                  <span>{card.rank.count} loads booked · {name}</span>
+                  <span><b className="text-cream" style={{ color: "#f5e6c8" }}>{Math.max(0, card.rank.next.min - card.rank.count)}</b> to {card.rank.next.name}</span>
+                </div>
+                <Bar pct={card.rank.pct} />
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* NEXT UP */}
+        {nextUp.length > 0 && (
+          <>
+            <RackHead title="NEXT UP — WITHIN REACH" right="chase these" />
+            <div className="grid gap-[11px]" style={{ gridTemplateColumns: "repeat(auto-fit,minmax(210px,1fr))" }}>
+              {nextUp.map((c, i) => (
+                <NextCard key={i} {...c} />
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* COINS */}
+        <RackHead title="COINS — STRUCK AT THE PRESS" right="Bronze → Silver → Gold" />
+        <div className="grid gap-[14px_12px]" style={{ gridTemplateColumns: "repeat(auto-fill,minmax(148px,1fr))" }}>
+          {medals.map((m) => (
+            <Coin key={m.key} m={m} />
+          ))}
+        </div>
+
+        {/* TAGS */}
+        <RackHead title="TAGS — PUNCHED EVERY RE-EARN" />
+        <div className="grid gap-[10px]" style={{ gridTemplateColumns: "repeat(auto-fill,minmax(220px,1fr))" }}>
+          {patches.map((p) => (
+            <Tag key={p.key} p={p} />
+          ))}
+        </div>
+
+        {/* SEASON CROWNS */}
+        <RackHead title="SEASON CROWNS — THIS QUARTER" right={season.label} />
+        <div className="grid gap-[12px]" style={{ gridTemplateColumns: "repeat(auto-fit,minmax(230px,1fr))" }}>
+          {season.trophies.map((t) => (
+            <Crown key={t.key} t={t} period={season.label} />
+          ))}
+        </div>
+
+        <p className="text-[11.5px] text-faint mt-8 text-center max-w-[70ch] mx-auto">
+          Your room, your numbers — everything counts only the loads <b>you</b> booked. Every achievement shows how to
+          earn it; booking a steal, running a clean week, or extending your streak fires a celebration right here.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default DispatchForgePage;

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -414,6 +414,7 @@ const NAV: { group: string; items: string[] }[] = [
       "The Dispatcher Card",
       "Dispatcher achievements — patches &amp; medals",
       "Dispatcher season &amp; trophies",
+      "The Dispatch Forge",
     ],
   },
 ];
@@ -2256,6 +2257,41 @@ const GuidePage = () => {
               head-to-head "champion" would just be the same name every period —
               these reward your own best month instead. Earn one and it pops like
               a patch does.
+            </Why>
+          </Section>
+
+          <Section
+            title="The Dispatch Forge"
+            sources={[{ label: "The Forge", to: "/forge" }]}
+          >
+            <p className="text-sm text-muted-text">
+              Everything a dispatcher earns lives in one place —{" "}
+              <span className="text-light">The Dispatch Forge</span>, her own room
+              reached from the <span className="text-light">Forge</span> entry in
+              the menu. It gathers her rank and progress to the next tier, her{" "}
+              <span className="text-light">coins</span> (medals) and{" "}
+              <span className="text-light">tags</span> (patches), and this
+              quarter's <span className="text-light">season crowns</span> — all
+              scored on the loads she booked.
+            </p>
+            <p className="text-sm text-muted-text mt-3">
+              It leads with{" "}
+              <span className="text-light">Next up — within reach</span>: the
+              handful of achievements she's closest to, most-progressed first, so
+              there's always a concrete next thing to chase. Every award — earned
+              or locked — carries a short line on exactly{" "}
+              <span className="text-light">how to earn it</span>, and booking a
+              steal, running a clean week, or extending her streak fires the same
+              celebration the owner gets.
+            </p>
+            <Why>
+              Her <span className="text-light">HEAT</span> streak is graded
+              against her own typical week — the median of her recent weekly
+              booked gross over the trailing quarter — not the shop's cost
+              target. A week at three-quarters of her usual keeps it hot. That
+              keeps the streak winnable and seasonal: the bar tracks the market
+              she's actually booking in, and it's hers, not the whole
+              operation's.
             </Why>
           </Section>
         </main>


### PR DESCRIPTION
## The problem
The dispatcher gamification was fully built but **starved of data**: new loads defaulted their booker to the **owner**, so a dispatcher's rank/medals/patches/season stayed empty and nothing ever popped.

## Make it fire
- **A load's booker now defaults to whoever creates it** (`self_id`), not the owner — the picker still overrides. The keystone: her bookings finally credit to her.
- The dispatch board scopes her **vitals + week pace** to loads she booked. The shared agent race stays account-wide; **deadhead** stays account-wide (trips carry no booker, so pairing her loads with fleet trips would mis-charge empty miles).

## The Dispatch Forge — new page `/forge` + Forge nav entry
Her own gamified room, mirroring the owner's Forge: rank + progress to the next tier, **coins** (7 medals), **tags** (11 patches), and this quarter's **season crowns** — all scored on the loads she booked. Leads with **"Next up — within reach"** (closest achievements, most-progressed first) and a **how-to-earn line on every award**.

## Personal-pace streak
The HEAT streak / **Iron Booker** is graded against **her own typical week** — the median of her recent weekly booked gross over the trailing quarter — so it's winnable and **seasonal**, not the shop's cost target. A week at ≥75% of her usual keeps it hot. `computeGrind` refactored to a shared core (`grindFrom`) feeding both the owner target and the personal pace; `GrindMeter` split into a mode-aware view. +4 engine tests.

## Fixed from the 11-agent adversarial review
Deadhead mis-attribution · avatar remount race · `/forge` full-bleed (dup sidebar toggle) · broken-session fallback.

**655 tests pass · strict build clean · Guide entry added.**

> Note: I couldn't produce a live render from here (login is blocked in this environment) — the Vercel preview on this PR is the render to eyeball, especially `/forge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)